### PR TITLE
feat(api): request infrastructure — pagination, idempotency, rate limit (#17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build
+        run: pnpm build
+
       - name: Lint
         run: pnpm lint
 
       - name: Typecheck
         run: pnpm typecheck
-
-      - name: Build
-        run: pnpm build
 
       - name: Test with coverage
         run: pnpm test -- --coverage

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,150 @@
+name: Repo Governance
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: governance-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-review-evidence:
+    name: PR Review Evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate review evidence
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const headSha = pr.head.sha;
+            const errors = [];
+
+            // --- 1. Check Agent Review section exists ---
+            if (!body.includes('## Agent Review')) {
+              errors.push('PR body missing "## Agent Review" section');
+            }
+
+            // --- 2. Check required fields (plain text, no bold markdown) ---
+            const fields = {
+              'Reviewer agents used': /^- Reviewer agents used:\s*(.+)$/m,
+              'Reviewed head SHA':    /^- Reviewed head SHA:\s*`?([0-9a-f]{40})`?$/m,
+              'Review evidence':      /^- Review evidence:\s*(.+)$/m,
+              'Key findings addressed': /^- Key findings addressed:\s*(.+)$/m,
+            };
+
+            const parsed = {};
+            for (const [name, regex] of Object.entries(fields)) {
+              const match = body.match(regex);
+              if (!match) {
+                errors.push(`Missing or malformed field: "${name}"`);
+              } else {
+                parsed[name] = match[1].trim();
+              }
+            }
+
+            // --- 3. Validate SHA matches current HEAD ---
+            if (parsed['Reviewed head SHA'] && parsed['Reviewed head SHA'] !== headSha) {
+              errors.push(
+                `Reviewed head SHA (${parsed['Reviewed head SHA'].slice(0, 12)}) ` +
+                `does not match current HEAD (${headSha.slice(0, 12)}). ` +
+                `Review comments may be stale — re-post after pushing fixes.`
+              );
+            }
+
+            // --- 4. Validate review evidence links ---
+            if (parsed['Review evidence']) {
+              const linkPattern = /\[.*?\]\((https:\/\/github\.com\/[^)]+#issuecomment-\d+)\)/g;
+              const links = [...parsed['Review evidence'].matchAll(linkPattern)].map(m => m[1]);
+
+              if (links.length < 2) {
+                errors.push(
+                  `Review evidence must contain at least 2 comment links ` +
+                  `(found ${links.length}). Format: [Review 1](url) | [Review 2](url)`
+                );
+              }
+
+              // Fetch each comment and validate format
+              for (const link of links) {
+                const commentMatch = link.match(/\/pull\/(\d+)#issuecomment-(\d+)/);
+                if (!commentMatch) continue;
+
+                const commentId = commentMatch[2];
+                try {
+                  const comment = await github.rest.issues.getComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: Number(commentId),
+                  });
+
+                  const commentBody = comment.data.body || '';
+
+                  // Check required review comment fields
+                  if (!commentBody.includes('Reviewer agent:')) {
+                    errors.push(`Comment ${commentId}: missing "Reviewer agent:" field`);
+                  }
+                  if (!commentBody.includes('Reviewed head SHA:')) {
+                    errors.push(`Comment ${commentId}: missing "Reviewed head SHA:" field`);
+                  }
+                  if (!commentBody.includes('Findings:')) {
+                    errors.push(`Comment ${commentId}: missing "Findings:" field`);
+                  }
+
+                  // Validate SHA in comment matches HEAD
+                  const commentShaMatch = commentBody.match(/Reviewed head SHA:\s*`?([0-9a-f]{40})`?/);
+                  if (commentShaMatch && commentShaMatch[1] !== headSha) {
+                    errors.push(
+                      `Comment ${commentId}: SHA (${commentShaMatch[1].slice(0, 12)}) ` +
+                      `does not match HEAD (${headSha.slice(0, 12)})`
+                    );
+                  }
+
+                  // Validate Findings uses bullet syntax
+                  const findingsSection = commentBody.split('Findings:')[1];
+                  if (findingsSection) {
+                    const trimmed = findingsSection.trim();
+                    if (trimmed !== '' && !trimmed.startsWith('- ')) {
+                      errors.push(
+                        `Comment ${commentId}: Findings must use "- " bullet syntax`
+                      );
+                    }
+                  }
+                } catch (e) {
+                  errors.push(`Comment ${commentId}: failed to fetch (${e.message})`);
+                }
+              }
+            }
+
+            // --- 5. Report ---
+            if (errors.length > 0) {
+              const message = [
+                '## PR Review Evidence — Validation Failed',
+                '',
+                ...errors.map(e => `- ${e}`),
+                '',
+                '### Required PR body format',
+                '```',
+                '## Agent Review',
+                '',
+                '- Reviewer agents used: <name1>, <name2>',
+                '- Reviewed head SHA: `<40-char-sha>`',
+                '- Review evidence: [Review 1](<comment-url>) | [Review 2](<comment-url>)',
+                '- Key findings addressed: <summary>',
+                '```',
+              ].join('\n');
+
+              core.setFailed(message);
+            } else {
+              core.info('PR Review Evidence validation passed');
+              core.info(`Reviewer agents: ${parsed['Reviewer agents used']}`);
+              core.info(`Reviewed SHA: ${parsed['Reviewed head SHA']}`);
+            }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "drizzle-orm": "^0.45.2",
+    "ioredis": "^5.10.1",
     "pg": "^8.20.0",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,13 +1,16 @@
 import { MiddlewareConsumer, Module, RequestMethod, type NestModule } from '@nestjs/common';
 
 import { PinoHttpLoggerMiddleware, LoggerModule } from './common/logger/logger.module.js';
+import { IdempotencyMiddleware } from './common/middleware/idempotency.middleware.js';
 import { RequestContextMiddleware } from './common/middleware/request-context.middleware.js';
+import { RedisModule } from './common/redis/redis.module.js';
 import { DrizzleModule } from './database/drizzle.module.js';
 import { HealthModule } from './health/health.module.js';
 
 @Module({
   imports: [
     LoggerModule,
+    RedisModule,
     DrizzleModule.forRoot({ connectionCheck: process.env.NODE_ENV !== 'test' }),
     HealthModule,
   ],
@@ -15,7 +18,7 @@ import { HealthModule } from './health/health.module.js';
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {
     consumer
-      .apply(RequestContextMiddleware, PinoHttpLoggerMiddleware)
+      .apply(RequestContextMiddleware, PinoHttpLoggerMiddleware, IdempotencyMiddleware)
       .forRoutes({ path: '{*path}', method: RequestMethod.ALL });
   }
 }

--- a/apps/api/src/common/dto/__tests__/pagination.test.ts
+++ b/apps/api/src/common/dto/__tests__/pagination.test.ts
@@ -4,7 +4,7 @@ import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import { describe, expect, it } from 'vitest';
 
-import { buildPaginationMeta, PaginationQueryDto } from '../pagination.dto.js';
+import { buildPaginationMeta, PaginationQueryDto, parseSortField } from '../pagination.dto.js';
 
 describe('PaginationQueryDto', () => {
   it('uses default values', async () => {
@@ -46,5 +46,27 @@ describe('buildPaginationMeta', () => {
       total: 100,
       has_next: false,
     });
+  });
+});
+
+describe('parseSortField', () => {
+  it('parses ascending sort fields', () => {
+    expect(parseSortField('created_at')).toEqual({
+      field: 'created_at',
+      direction: 'asc',
+    });
+  });
+
+  it('parses descending sort fields', () => {
+    expect(parseSortField('-created_at')).toEqual({
+      field: 'created_at',
+      direction: 'desc',
+    });
+  });
+
+  it('rejects invalid sort field names', () => {
+    expect(() => parseSortField('-')).toThrow('Invalid sort field');
+    expect(() => parseSortField('created-at')).toThrow('Invalid sort field');
+    expect(() => parseSortField('created at')).toThrow('Invalid sort field');
   });
 });

--- a/apps/api/src/common/dto/__tests__/pagination.test.ts
+++ b/apps/api/src/common/dto/__tests__/pagination.test.ts
@@ -1,0 +1,50 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { describe, expect, it } from 'vitest';
+
+import { buildPaginationMeta, PaginationQueryDto } from '../pagination.dto.js';
+
+describe('PaginationQueryDto', () => {
+  it('uses default values', async () => {
+    const dto = plainToInstance(PaginationQueryDto, {});
+
+    expect(dto.page).toBe(1);
+    expect(dto.per_page).toBe(20);
+    expect(dto.sort).toBe('-created_at');
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('rejects page values below 1', async () => {
+    const dto = plainToInstance(PaginationQueryDto, { page: '0' });
+
+    await expect(validate(dto)).resolves.not.toHaveLength(0);
+  });
+
+  it('rejects per_page values above 100', async () => {
+    const dto = plainToInstance(PaginationQueryDto, { per_page: '101' });
+
+    await expect(validate(dto)).resolves.not.toHaveLength(0);
+  });
+});
+
+describe('buildPaginationMeta', () => {
+  it('calculates has_next when more records remain', () => {
+    expect(buildPaginationMeta(1, 20, 100)).toEqual({
+      page: 1,
+      per_page: 20,
+      total: 100,
+      has_next: true,
+    });
+  });
+
+  it('calculates has_next as false on the final page', () => {
+    expect(buildPaginationMeta(5, 20, 100)).toEqual({
+      page: 5,
+      per_page: 20,
+      total: 100,
+      has_next: false,
+    });
+  });
+});

--- a/apps/api/src/common/dto/pagination.dto.ts
+++ b/apps/api/src/common/dto/pagination.dto.ts
@@ -27,7 +27,15 @@ export type PaginationMeta = {
   has_next: boolean;
 };
 
+export type SortDirection = 'asc' | 'desc';
+
+export type ParsedSortField = {
+  field: string;
+  direction: SortDirection;
+};
+
 const PAGINATED_RESPONSE_MARKER = Symbol('PAGINATED_RESPONSE_MARKER');
+const SORT_FIELD_PATTERN = /^[A-Za-z0-9_]+$/;
 
 export type PaginatedResponse<T> = {
   readonly [PAGINATED_RESPONSE_MARKER]: true;
@@ -42,6 +50,17 @@ export function buildPaginationMeta(page: number, perPage: number, total: number
     total,
     has_next: page * perPage < total,
   };
+}
+
+export function parseSortField(sort: string): ParsedSortField {
+  const direction: SortDirection = sort.startsWith('-') ? 'desc' : 'asc';
+  const field = direction === 'desc' ? sort.slice(1) : sort;
+
+  if (!SORT_FIELD_PATTERN.test(field)) {
+    throw new Error('Invalid sort field');
+  }
+
+  return { field, direction };
 }
 
 export function paginatedResponse<T>(data: T[], pagination: PaginationMeta): PaginatedResponse<T> {

--- a/apps/api/src/common/dto/pagination.dto.ts
+++ b/apps/api/src/common/dto/pagination.dto.ts
@@ -1,0 +1,61 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  per_page = 20;
+
+  @IsOptional()
+  @IsString()
+  sort = '-created_at';
+}
+
+export type PaginationMeta = {
+  page: number;
+  per_page: number;
+  total: number;
+  has_next: boolean;
+};
+
+const PAGINATED_RESPONSE_MARKER = Symbol('PAGINATED_RESPONSE_MARKER');
+
+export type PaginatedResponse<T> = {
+  readonly [PAGINATED_RESPONSE_MARKER]: true;
+  readonly data: T[];
+  readonly pagination: PaginationMeta;
+};
+
+export function buildPaginationMeta(page: number, perPage: number, total: number): PaginationMeta {
+  return {
+    page,
+    per_page: perPage,
+    total,
+    has_next: page * perPage < total,
+  };
+}
+
+export function paginatedResponse<T>(data: T[], pagination: PaginationMeta): PaginatedResponse<T> {
+  return {
+    [PAGINATED_RESPONSE_MARKER]: true,
+    data,
+    pagination,
+  };
+}
+
+export function isPaginatedResponse(value: unknown): value is PaginatedResponse<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Partial<PaginatedResponse<unknown>>)[PAGINATED_RESPONSE_MARKER] === true
+  );
+}

--- a/apps/api/src/common/filters/__tests__/http-exception.filter.test.ts
+++ b/apps/api/src/common/filters/__tests__/http-exception.filter.test.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   ForbiddenException,
   Get,
+  HttpException,
+  HttpStatus,
   Module,
   NotFoundException,
   Post,
@@ -37,6 +39,17 @@ class ErrorTestController {
   @Get('forbidden')
   forbidden(): never {
     throw new ForbiddenException('Access denied');
+  }
+
+  @Get('invalid-credentials')
+  invalidCredentials(): never {
+    throw new HttpException(
+      {
+        code: ErrorCode.INVALID_CREDENTIALS,
+        message: 'Invalid credentials',
+      },
+      HttpStatus.UNAUTHORIZED,
+    );
   }
 
   @Get('unknown')
@@ -90,6 +103,19 @@ describe('HttpExceptionFilter', () => {
     const error = getErrorPayload(response.text);
     expect(error.code).toBe(ErrorCode.PERMISSION_DENIED);
     expect(error.message).toBe('Access denied');
+    expect(getMetaPayload(response.text).request_id).toBe(REQUEST_ID);
+  });
+
+  it('preserves valid custom error codes from HttpException response bodies', async () => {
+    app = await createTestApp();
+    const response = await request(app.getHttpAdapter().getInstance().server)
+      .get('/api/error-test/invalid-credentials')
+      .set('X-Request-Id', REQUEST_ID)
+      .expect(401);
+
+    const error = getErrorPayload(response.text);
+    expect(error.code).toBe(ErrorCode.INVALID_CREDENTIALS);
+    expect(error.message).toBe('Invalid credentials');
     expect(getMetaPayload(response.text).request_id).toBe(REQUEST_ID);
   });
 

--- a/apps/api/src/common/filters/__tests__/http-exception.filter.test.ts
+++ b/apps/api/src/common/filters/__tests__/http-exception.filter.test.ts
@@ -77,7 +77,7 @@ describe('HttpExceptionFilter', () => {
     const error = getErrorPayload(response.text);
     expect(error.code).toBe(ErrorCode.NOT_FOUND);
     expect(error.message).toBe('Missing resource');
-    expect(error.request_id).toBe(REQUEST_ID);
+    expect(getMetaPayload(response.text).request_id).toBe(REQUEST_ID);
   });
 
   it('maps HttpException 403 to PERMISSION_DENIED response format', async () => {
@@ -90,7 +90,7 @@ describe('HttpExceptionFilter', () => {
     const error = getErrorPayload(response.text);
     expect(error.code).toBe(ErrorCode.PERMISSION_DENIED);
     expect(error.message).toBe('Access denied');
-    expect(error.request_id).toBe(REQUEST_ID);
+    expect(getMetaPayload(response.text).request_id).toBe(REQUEST_ID);
   });
 
   it('maps unknown exceptions to INTERNAL_ERROR without leaking stack details', async () => {
@@ -103,7 +103,7 @@ describe('HttpExceptionFilter', () => {
     const error = getErrorPayload(response.text);
     expect(error.code).toBe(ErrorCode.INTERNAL_ERROR);
     expect(error.message).toBe('Internal server error');
-    expect(error.request_id).toBe(REQUEST_ID);
+    expect(getMetaPayload(response.text).request_id).toBe(REQUEST_ID);
     expect(response.text).not.toContain('secret implementation detail');
     expect(response.text).not.toContain('ErrorTestController');
   });
@@ -119,7 +119,7 @@ describe('HttpExceptionFilter', () => {
     const error = getErrorPayload(response.text);
     expect(error.code).toBe(ErrorCode.VALIDATION_ERROR);
     expect(error.message).toBe('Validation failed');
-    expect(error.request_id).toBe(REQUEST_ID);
+    expect(getMetaPayload(response.text).request_id).toBe(REQUEST_ID);
     expect(Array.isArray(error.details)).toBe(true);
     expect(Array.isArray(error.details) && error.details.length > 0).toBe(true);
   });
@@ -135,7 +135,7 @@ describe('HttpExceptionFilter', () => {
 
     const responses = await Promise.all(cases);
     for (const response of responses) {
-      expect(getErrorPayload(response.text).request_id).toBe(REQUEST_ID);
+      expect(getMetaPayload(response.text).request_id).toBe(REQUEST_ID);
     }
   });
 
@@ -148,7 +148,7 @@ describe('HttpExceptionFilter', () => {
 
     const error = getErrorPayload(response.text);
     expect(error.code).toBe(ErrorCode.NOT_FOUND);
-    expect(error.request_id).toBe(REQUEST_ID);
+    expect(getMetaPayload(response.text).request_id).toBe(REQUEST_ID);
   });
 
   it('stops validation error detail recursion at the depth limit', () => {
@@ -183,6 +183,16 @@ function getErrorPayload(text: string): Record<string, unknown> {
   }
 
   return error;
+}
+
+function getMetaPayload(text: string): Record<string, unknown> {
+  const body = parseJsonObject(text);
+  const meta = body.meta;
+  if (!isRecord(meta)) {
+    throw new Error('Expected meta payload');
+  }
+
+  return meta;
 }
 
 function createNestedValidationError(maxLevel: number, currentLevel = 0): ValidationError {

--- a/apps/api/src/common/filters/http-exception.filter.ts
+++ b/apps/api/src/common/filters/http-exception.filter.ts
@@ -35,6 +35,7 @@ type HttpResponseLike = {
 };
 
 type HttpExceptionResponse = {
+  code?: unknown;
   message?: unknown;
   error?: unknown;
   details?: unknown;
@@ -49,6 +50,7 @@ const ERROR_CODE_BY_STATUS = new Map<number, ErrorCode>([
   [HttpStatus.TOO_MANY_REQUESTS, ErrorCode.RATE_LIMITED],
   [HttpStatus.UNPROCESSABLE_ENTITY, ErrorCode.VALIDATION_ERROR],
 ]);
+const ERROR_CODE_VALUES = new Set<ErrorCode>(Object.values(ErrorCode));
 
 @Catch()
 export class HttpExceptionFilter implements ExceptionFilter {
@@ -91,7 +93,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
       response.status(status).send({
         error: {
-          code: mapStatusToErrorCode(status),
+          code: getHttpExceptionErrorCode(status, exceptionResponse),
           message: getHttpExceptionMessage(exception, exceptionResponse),
           ...(details === undefined ? {} : { details }),
         },
@@ -141,6 +143,10 @@ function mapStatusToErrorCode(status: number): ErrorCode {
   return ERROR_CODE_BY_STATUS.get(status) ?? (status >= 500 ? ErrorCode.INTERNAL_ERROR : ErrorCode.VALIDATION_ERROR);
 }
 
+function getHttpExceptionErrorCode(status: number, response: HttpExceptionResponse): ErrorCode {
+  return isErrorCode(response.code) ? response.code : mapStatusToErrorCode(status);
+}
+
 function getHttpExceptionMessage(exception: HttpException, response: HttpExceptionResponse): string {
   if (typeof response.message === 'string') {
     return response.message;
@@ -167,10 +173,15 @@ function normalizeHttpExceptionResponse(response: string | object): HttpExceptio
   }
 
   return {
+    code: response.code,
     message: response.message,
     error: response.error,
     details: response.details,
   };
+}
+
+function isErrorCode(value: unknown): value is ErrorCode {
+  return typeof value === 'string' && ERROR_CODE_VALUES.has(value as ErrorCode);
 }
 
 function normalizeValidationErrors(exception: ValidationError | ValidationError[]): ValidationError[] {

--- a/apps/api/src/common/filters/http-exception.filter.ts
+++ b/apps/api/src/common/filters/http-exception.filter.ts
@@ -21,8 +21,10 @@ type ErrorPayload = {
   error: {
     code: ErrorCode;
     message: string;
-    request_id: string;
     details?: unknown[];
+  };
+  meta: {
+    request_id: string;
   };
 };
 
@@ -62,9 +64,9 @@ export class HttpExceptionFilter implements ExceptionFilter {
         error: {
           code: ErrorCode.VALIDATION_ERROR,
           message: 'Validation failed',
-          request_id: requestId,
           details: validationErrorsToDetails(normalizeValidationErrors(exception)),
         },
+        meta: { request_id: requestId },
       });
       return;
     }
@@ -78,8 +80,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
           error: {
             code: mapStatusToErrorCode(status),
             message: 'Internal server error',
-            request_id: requestId,
           },
+          meta: { request_id: requestId },
         });
         return;
       }
@@ -91,9 +93,9 @@ export class HttpExceptionFilter implements ExceptionFilter {
         error: {
           code: mapStatusToErrorCode(status),
           message: getHttpExceptionMessage(exception, exceptionResponse),
-          request_id: requestId,
           ...(details === undefined ? {} : { details }),
         },
+        meta: { request_id: requestId },
       });
       return;
     }
@@ -103,8 +105,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
       error: {
         code: ErrorCode.INTERNAL_ERROR,
         message: 'Internal server error',
-        request_id: requestId,
       },
+      meta: { request_id: requestId },
     });
   }
 }

--- a/apps/api/src/common/guards/__tests__/rate-limit.guard.test.ts
+++ b/apps/api/src/common/guards/__tests__/rate-limit.guard.test.ts
@@ -1,0 +1,155 @@
+import { HttpException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ErrorCode } from '@cherrygraph/shared';
+import 'reflect-metadata';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  RATE_LIMIT_METADATA_KEY,
+  RateLimitGuard,
+  type RateLimitOptions,
+  type RateLimitRedisStore,
+} from '../rate-limit.guard.js';
+
+class MapRateLimitRedisStore implements RateLimitRedisStore {
+  readonly values = new Map<string, Array<{ score: number; member: string }>>();
+  readonly expirations = new Map<string, number>();
+
+  zremrangebyscore(key: string, min: number | string, max: number | string): Promise<number> {
+    const minScore = Number(min);
+    const maxScore = Number(max);
+    const entries = this.values.get(key) ?? [];
+    const kept = entries.filter((entry) => entry.score < minScore || entry.score > maxScore);
+    this.values.set(key, kept);
+    return Promise.resolve(entries.length - kept.length);
+  }
+
+  zcard(key: string): Promise<number> {
+    return Promise.resolve(this.values.get(key)?.length ?? 0);
+  }
+
+  zadd(key: string, score: number, member: string): Promise<number> {
+    const entries = this.values.get(key) ?? [];
+    entries.push({ score, member });
+    this.values.set(key, entries);
+    return Promise.resolve(1);
+  }
+
+  expire(key: string, seconds: number): Promise<number> {
+    this.expirations.set(key, seconds);
+    return Promise.resolve(1);
+  }
+}
+
+type FakeResponse = {
+  headers: Map<string, string>;
+  header: (name: string, value: string) => FakeResponse;
+};
+
+describe('RateLimitGuard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows normal requests and sets rate limit headers', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const redis = new MapRateLimitRedisStore();
+    const guard = new RateLimitGuard(new Reflector(), redis);
+    const response = createResponse();
+
+    await expect(guard.canActivate(createContext({ limit: 2, windowSec: 60, mode: 'ip' }, response))).resolves.toBe(
+      true,
+    );
+
+    expect(response.headers.get('x-ratelimit-limit')).toBe('2');
+    expect(response.headers.get('x-ratelimit-remaining')).toBe('1');
+    expect(response.headers.get('x-ratelimit-reset')).toBe('60');
+  });
+
+  it('throws 429 RATE_LIMITED when the limit is exceeded', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const redis = new MapRateLimitRedisStore();
+    const guard = new RateLimitGuard(new Reflector(), redis);
+    const response = createResponse();
+    const context = createContext({ limit: 1, windowSec: 60, mode: 'ip' }, response);
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    await expect(guard.canActivate(context)).rejects.toMatchObject({ status: 429 });
+
+    try {
+      await guard.canActivate(context);
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpException);
+      const responseBody = (err as HttpException).getResponse();
+      expect(isRecord(responseBody) ? responseBody.code : undefined).toBe(ErrorCode.RATE_LIMITED);
+    }
+  });
+
+  it('tracks different user identifiers independently', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const redis = new MapRateLimitRedisStore();
+    const guard = new RateLimitGuard(new Reflector(), redis);
+
+    await expect(
+      guard.canActivate(createContext({ limit: 1, windowSec: 60, mode: 'user' }, createResponse(), 'user-a')),
+    ).resolves.toBe(true);
+    await expect(
+      guard.canActivate(createContext({ limit: 1, windowSec: 60, mode: 'user' }, createResponse(), 'user-a')),
+    ).rejects.toMatchObject({ status: 429 });
+    await expect(
+      guard.canActivate(createContext({ limit: 1, windowSec: 60, mode: 'user' }, createResponse(), 'user-b')),
+    ).resolves.toBe(true);
+  });
+
+  it('allows requests again after the sliding window resets', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const redis = new MapRateLimitRedisStore();
+    const guard = new RateLimitGuard(new Reflector(), redis);
+    const options: RateLimitOptions = { limit: 1, windowSec: 60, mode: 'ip' };
+
+    await expect(guard.canActivate(createContext(options, createResponse()))).resolves.toBe(true);
+    await expect(guard.canActivate(createContext(options, createResponse()))).rejects.toMatchObject({ status: 429 });
+
+    vi.setSystemTime(61_000);
+    await expect(guard.canActivate(createContext(options, createResponse()))).resolves.toBe(true);
+  });
+});
+
+function createContext(options: RateLimitOptions, response: FakeResponse, userId?: string): ExecutionContext {
+  const handler = () => undefined;
+  Reflect.defineMetadata(RATE_LIMIT_METADATA_KEY, options, handler);
+
+  return {
+    getHandler: () => handler,
+    getClass: () => class TestController {},
+    switchToHttp: () => ({
+      getRequest: () => ({
+        ip: '203.0.113.10',
+        user: userId === undefined ? undefined : { user_id: userId },
+      }),
+      getResponse: () => response,
+      getNext: () => undefined,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function createResponse(): FakeResponse {
+  const response: FakeResponse = {
+    headers: new Map<string, string>(),
+    header(name: string, value: string): FakeResponse {
+      response.headers.set(name.toLowerCase(), value);
+      return response;
+    },
+  };
+
+  return response;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/api/src/common/guards/__tests__/rate-limit.guard.test.ts
+++ b/apps/api/src/common/guards/__tests__/rate-limit.guard.test.ts
@@ -16,29 +16,30 @@ class MapRateLimitRedisStore implements RateLimitRedisStore {
   readonly values = new Map<string, Array<{ score: number; member: string }>>();
   readonly expirations = new Map<string, number>();
 
-  zremrangebyscore(key: string, min: number | string, max: number | string): Promise<number> {
-    const minScore = Number(min);
-    const maxScore = Number(max);
+  eval(script: string, numberOfKeys: number, ...args: Array<string | number>): Promise<[number, number]> {
+    expect(script).toContain('ZREMRANGEBYSCORE');
+    expect(numberOfKeys).toBe(1);
+
+    const [key, nowValue, windowMsValue, limitValue, memberValue, ttlValue] = args;
+    if (typeof key !== 'string' || typeof memberValue !== 'string') {
+      return Promise.reject(new Error('Invalid eval arguments'));
+    }
+
+    const now = Number(nowValue);
+    const windowMs = Number(windowMsValue);
+    const limit = Number(limitValue);
+    const ttl = Number(ttlValue);
     const entries = this.values.get(key) ?? [];
-    const kept = entries.filter((entry) => entry.score < minScore || entry.score > maxScore);
+    const kept = entries.filter((entry) => entry.score < 0 || entry.score > now - windowMs);
     this.values.set(key, kept);
-    return Promise.resolve(entries.length - kept.length);
-  }
 
-  zcard(key: string): Promise<number> {
-    return Promise.resolve(this.values.get(key)?.length ?? 0);
-  }
+    if (kept.length >= limit) {
+      return Promise.resolve([0, kept.length]);
+    }
 
-  zadd(key: string, score: number, member: string): Promise<number> {
-    const entries = this.values.get(key) ?? [];
-    entries.push({ score, member });
-    this.values.set(key, entries);
-    return Promise.resolve(1);
-  }
-
-  expire(key: string, seconds: number): Promise<number> {
-    this.expirations.set(key, seconds);
-    return Promise.resolve(1);
+    kept.push({ score: now, member: memberValue });
+    this.expirations.set(key, ttl);
+    return Promise.resolve([1, kept.length]);
   }
 }
 
@@ -118,9 +119,38 @@ describe('RateLimitGuard', () => {
     vi.setSystemTime(61_000);
     await expect(guard.canActivate(createContext(options, createResponse()))).resolves.toBe(true);
   });
+
+  it('uses request.ip instead of trusting x-forwarded-for directly', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const redis = new MapRateLimitRedisStore();
+    const guard = new RateLimitGuard(new Reflector(), redis);
+
+    await expect(
+      guard.canActivate(
+        createContext({ limit: 2, windowSec: 60, mode: 'ip' }, createResponse(), undefined, {
+          headers: { 'x-forwarded-for': '198.51.100.200' },
+          ip: '203.0.113.10',
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    expect(redis.values.has('ratelimit::ip:203.0.113.10:60:2')).toBe(true);
+    expect(redis.values.has('ratelimit::ip:198.51.100.200:60:2')).toBe(false);
+  });
 });
 
-function createContext(options: RateLimitOptions, response: FakeResponse, userId?: string): ExecutionContext {
+type RequestOverrides = {
+  headers?: Record<string, string>;
+  ip?: string;
+};
+
+function createContext(
+  options: RateLimitOptions,
+  response: FakeResponse,
+  userId?: string,
+  requestOverrides: RequestOverrides = {},
+): ExecutionContext {
   const handler = () => undefined;
   Reflect.defineMetadata(RATE_LIMIT_METADATA_KEY, options, handler);
 
@@ -129,7 +159,8 @@ function createContext(options: RateLimitOptions, response: FakeResponse, userId
     getClass: () => class TestController {},
     switchToHttp: () => ({
       getRequest: () => ({
-        ip: '203.0.113.10',
+        ip: requestOverrides.ip ?? '203.0.113.10',
+        headers: requestOverrides.headers,
         user: userId === undefined ? undefined : { user_id: userId },
       }),
       getResponse: () => response,

--- a/apps/api/src/common/guards/rate-limit.guard.ts
+++ b/apps/api/src/common/guards/rate-limit.guard.ts
@@ -1,0 +1,185 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  Optional,
+  SetMetadata,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ErrorCode } from '@cherrygraph/shared';
+import type { IncomingHttpHeaders } from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+import { getApiLogger } from '../logger/logger.module.js';
+import { getRequestContext } from '../middleware/request-context.middleware.js';
+import { REDIS_CLIENT } from '../redis/redis.module.js';
+
+export type RateLimitMode = 'user' | 'ip';
+
+export type RateLimitOptions = {
+  limit: number;
+  windowSec: number;
+  mode: RateLimitMode;
+};
+
+export type RateLimitRedisStore = {
+  zremrangebyscore: (key: string, min: number | string, max: number | string) => Promise<number>;
+  zcard: (key: string) => Promise<number>;
+  zadd: (key: string, score: number, member: string) => Promise<number>;
+  expire: (key: string, seconds: number) => Promise<number>;
+};
+
+export const RATE_LIMIT_METADATA_KEY = Symbol('RATE_LIMIT_METADATA_KEY');
+export const PUBLIC_API_RATE_LIMIT: RateLimitOptions = { limit: 600, windowSec: 60, mode: 'user' };
+export const ADMIN_API_RATE_LIMIT: RateLimitOptions = { limit: 300, windowSec: 60, mode: 'user' };
+export const LOGIN_RATE_LIMIT: RateLimitOptions = { limit: 10, windowSec: 60, mode: 'ip' };
+
+type RequestLike = {
+  ip?: string;
+  headers?: IncomingHttpHeaders;
+  socket?: {
+    remoteAddress?: string;
+  };
+  raw?: {
+    ip?: string;
+    headers?: IncomingHttpHeaders;
+    socket?: {
+      remoteAddress?: string;
+    };
+  };
+  user?: unknown;
+};
+
+type ResponseLike = {
+  header?: (name: string, value: string) => unknown;
+  setHeader?: (name: string, value: string) => unknown;
+  raw?: {
+    setHeader?: (name: string, value: string) => unknown;
+  };
+};
+
+export function RateLimit(limit: number, windowSec: number, mode: RateLimitMode): MethodDecorator & ClassDecorator {
+  return SetMetadata(RATE_LIMIT_METADATA_KEY, { limit, windowSec, mode } satisfies RateLimitOptions);
+}
+
+@Injectable()
+export class RateLimitGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    @Optional() @Inject(REDIS_CLIENT) private readonly redis?: RateLimitRedisStore,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const options = this.reflector.getAllAndOverride<RateLimitOptions>(RATE_LIMIT_METADATA_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (options === undefined || this.redis === undefined) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<RequestLike>();
+    const response = context.switchToHttp().getResponse<ResponseLike>();
+    const identifier = getIdentifier(request, options.mode);
+    const now = Date.now();
+    const windowMs = options.windowSec * 1000;
+    const redisKey = `ratelimit:${options.mode}:${identifier}:${options.windowSec}`;
+    const resetAt = Math.ceil((now + windowMs) / 1000);
+
+    try {
+      await this.redis.zremrangebyscore(redisKey, 0, now - windowMs);
+      const currentCount = await this.redis.zcard(redisKey);
+
+      if (currentCount >= options.limit) {
+        setRateLimitHeaders(response, options.limit, 0, resetAt);
+        throw new HttpException(
+          {
+            code: ErrorCode.RATE_LIMITED,
+            message: 'Rate limit exceeded',
+          },
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+
+      await this.redis.zadd(redisKey, now, `${now}:${randomUUID()}`);
+      await this.redis.expire(redisKey, options.windowSec);
+      setRateLimitHeaders(response, options.limit, options.limit - currentCount - 1, resetAt);
+      return true;
+    } catch (err) {
+      if (err instanceof HttpException) {
+        throw err;
+      }
+
+      getApiLogger().warn({ err, redis_key: redisKey }, 'Rate limit check failed');
+      return true;
+    }
+  }
+}
+
+function getIdentifier(request: RequestLike, mode: RateLimitMode): string {
+  if (mode === 'user') {
+    return getUserIdentifier(request) ?? getIpIdentifier(request);
+  }
+
+  return getIpIdentifier(request);
+}
+
+function getUserIdentifier(request: RequestLike): string | undefined {
+  const contextUserId = getRequestContext()?.user_id;
+  if (contextUserId !== null && contextUserId !== undefined && contextUserId.length > 0) {
+    return contextUserId;
+  }
+
+  if (!isRecord(request.user)) {
+    return undefined;
+  }
+
+  for (const key of ['user_id', 'id', 'sub']) {
+    const value = request.user[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function getIpIdentifier(request: RequestLike): string {
+  const forwardedFor = extractHeaderValue((request.headers ?? request.raw?.headers)?.['x-forwarded-for']);
+  if (forwardedFor !== undefined && forwardedFor.length > 0) {
+    return forwardedFor.split(',')[0]?.trim() ?? 'unknown';
+  }
+
+  return request.ip ?? request.raw?.ip ?? request.socket?.remoteAddress ?? request.raw?.socket?.remoteAddress ?? 'unknown';
+}
+
+function setRateLimitHeaders(response: ResponseLike, limit: number, remaining: number, resetAt: number): void {
+  setResponseHeader(response, 'X-RateLimit-Limit', String(limit));
+  setResponseHeader(response, 'X-RateLimit-Remaining', String(Math.max(remaining, 0)));
+  setResponseHeader(response, 'X-RateLimit-Reset', String(resetAt));
+}
+
+function setResponseHeader(response: ResponseLike, name: string, value: string): void {
+  if (typeof response.header === 'function') {
+    response.header(name, value);
+    return;
+  }
+
+  if (typeof response.setHeader === 'function') {
+    response.setHeader(name, value);
+    return;
+  }
+
+  response.raw?.setHeader?.(name, value);
+}
+
+function extractHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/api/src/common/guards/rate-limit.guard.ts
+++ b/apps/api/src/common/guards/rate-limit.guard.ts
@@ -10,7 +10,6 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ErrorCode } from '@cherrygraph/shared';
-import type { IncomingHttpHeaders } from 'node:http';
 import { randomUUID } from 'node:crypto';
 
 import { getApiLogger } from '../logger/logger.module.js';
@@ -26,10 +25,7 @@ export type RateLimitOptions = {
 };
 
 export type RateLimitRedisStore = {
-  zremrangebyscore: (key: string, min: number | string, max: number | string) => Promise<number>;
-  zcard: (key: string) => Promise<number>;
-  zadd: (key: string, score: number, member: string) => Promise<number>;
-  expire: (key: string, seconds: number) => Promise<number>;
+  eval: (script: string, numberOfKeys: number, ...args: Array<string | number>) => Promise<unknown>;
 };
 
 export const RATE_LIMIT_METADATA_KEY = Symbol('RATE_LIMIT_METADATA_KEY');
@@ -37,18 +33,32 @@ export const PUBLIC_API_RATE_LIMIT: RateLimitOptions = { limit: 600, windowSec: 
 export const ADMIN_API_RATE_LIMIT: RateLimitOptions = { limit: 300, windowSec: 60, mode: 'user' };
 export const LOGIN_RATE_LIMIT: RateLimitOptions = { limit: 10, windowSec: 60, mode: 'ip' };
 
+const RATE_LIMIT_SCRIPT = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local window_ms = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local member = ARGV[4]
+local ttl_seconds = tonumber(ARGV[5])
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now - window_ms)
+local count = redis.call('ZCARD', key)
+if count >= limit then
+  return {0, count}
+end
+
+redis.call('ZADD', key, now, member)
+redis.call('EXPIRE', key, ttl_seconds)
+return {1, count + 1}
+`;
+
 type RequestLike = {
   ip?: string;
-  headers?: IncomingHttpHeaders;
   socket?: {
     remoteAddress?: string;
   };
   raw?: {
     ip?: string;
-    headers?: IncomingHttpHeaders;
-    socket?: {
-      remoteAddress?: string;
-    };
   };
   user?: unknown;
 };
@@ -86,14 +96,25 @@ export class RateLimitGuard implements CanActivate {
     const identifier = getIdentifier(request, options.mode);
     const now = Date.now();
     const windowMs = options.windowSec * 1000;
-    const redisKey = `ratelimit:${options.mode}:${identifier}:${options.windowSec}`;
+    const tenantId = getRequestContext()?.tenant_id ?? '';
+    const redisKey = `ratelimit:${tenantId}:${options.mode}:${identifier}:${options.windowSec}:${options.limit}`;
     const resetAt = Math.ceil((now + windowMs) / 1000);
 
     try {
-      await this.redis.zremrangebyscore(redisKey, 0, now - windowMs);
-      const currentCount = await this.redis.zcard(redisKey);
+      const result = parseRateLimitResult(
+        await this.redis.eval(
+          RATE_LIMIT_SCRIPT,
+          1,
+          redisKey,
+          now,
+          windowMs,
+          options.limit,
+          `${now}:${randomUUID()}`,
+          options.windowSec,
+        ),
+      );
 
-      if (currentCount >= options.limit) {
+      if (!result.allowed) {
         setRateLimitHeaders(response, options.limit, 0, resetAt);
         throw new HttpException(
           {
@@ -104,9 +125,7 @@ export class RateLimitGuard implements CanActivate {
         );
       }
 
-      await this.redis.zadd(redisKey, now, `${now}:${randomUUID()}`);
-      await this.redis.expire(redisKey, options.windowSec);
-      setRateLimitHeaders(response, options.limit, options.limit - currentCount - 1, resetAt);
+      setRateLimitHeaders(response, options.limit, options.limit - result.count, resetAt);
       return true;
     } catch (err) {
       if (err instanceof HttpException) {
@@ -148,12 +167,29 @@ function getUserIdentifier(request: RequestLike): string | undefined {
 }
 
 function getIpIdentifier(request: RequestLike): string {
-  const forwardedFor = extractHeaderValue((request.headers ?? request.raw?.headers)?.['x-forwarded-for']);
-  if (forwardedFor !== undefined && forwardedFor.length > 0) {
-    return forwardedFor.split(',')[0]?.trim() ?? 'unknown';
+  return request.ip || request.raw?.ip || request.socket?.remoteAddress || 'unknown';
+}
+
+type RateLimitResult = {
+  allowed: boolean;
+  count: number;
+};
+
+function parseRateLimitResult(result: unknown): RateLimitResult {
+  if (!Array.isArray(result) || result.length < 2) {
+    throw new Error('Invalid rate limit Redis result');
   }
 
-  return request.ip ?? request.raw?.ip ?? request.socket?.remoteAddress ?? request.raw?.socket?.remoteAddress ?? 'unknown';
+  const allowedValue = Number(result[0]);
+  const count = Number(result[1]);
+  if ((allowedValue !== 0 && allowedValue !== 1) || !Number.isFinite(count)) {
+    throw new Error('Invalid rate limit Redis result');
+  }
+
+  return {
+    allowed: allowedValue === 1,
+    count,
+  };
 }
 
 function setRateLimitHeaders(response: ResponseLike, limit: number, remaining: number, resetAt: number): void {
@@ -174,10 +210,6 @@ function setResponseHeader(response: ResponseLike, name: string, value: string):
   }
 
   response.raw?.setHeader?.(name, value);
-}
-
-function extractHeaderValue(value: string | string[] | undefined): string | undefined {
-  return Array.isArray(value) ? value[0] : value;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/api/src/common/interceptors/__tests__/response-wrapper.interceptor.test.ts
+++ b/apps/api/src/common/interceptors/__tests__/response-wrapper.interceptor.test.ts
@@ -1,0 +1,103 @@
+import { Controller, Get, Module, RequestMethod } from '@nestjs/common';
+import type { MiddlewareConsumer, NestModule } from '@nestjs/common';
+import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { configureApp } from '../../../main.js';
+import { buildPaginationMeta, paginatedResponse } from '../../dto/pagination.dto.js';
+import { RequestContextMiddleware } from '../../middleware/request-context.middleware.js';
+
+const REQUEST_ID = 'wrapper-test-request-id';
+
+@Controller('wrapper-test')
+class WrapperTestController {
+  @Get()
+  getValue(): { ok: true } {
+    return { ok: true };
+  }
+
+  @Get('paginated')
+  getPaginated(): ReturnType<typeof paginatedResponse<{ id: string }>> {
+    return paginatedResponse([{ id: 'item-1' }], buildPaginationMeta(1, 20, 100));
+  }
+}
+
+@Module({
+  controllers: [WrapperTestController],
+})
+class WrapperTestModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(RequestContextMiddleware).forRoutes({ path: '{*path}', method: RequestMethod.ALL });
+  }
+}
+
+let app: NestFastifyApplication | undefined;
+
+describe('ResponseWrapperInterceptor', () => {
+  afterEach(async () => {
+    await app?.close();
+    app = undefined;
+  });
+
+  it('wraps success responses in data and meta', async () => {
+    app = await createTestApp();
+
+    const response = await request(app.getHttpAdapter().getInstance().server)
+      .get('/api/wrapper-test')
+      .set('X-Request-Id', REQUEST_ID)
+      .expect(200);
+
+    expect(parseJsonObject(response.text)).toEqual({
+      data: { ok: true },
+      meta: { request_id: REQUEST_ID },
+    });
+  });
+
+  it('includes pagination meta when controllers return a paginated response', async () => {
+    app = await createTestApp();
+
+    const response = await request(app.getHttpAdapter().getInstance().server)
+      .get('/api/wrapper-test/paginated')
+      .set('X-Request-Id', REQUEST_ID)
+      .expect(200);
+
+    expect(parseJsonObject(response.text)).toEqual({
+      data: [{ id: 'item-1' }],
+      meta: {
+        request_id: REQUEST_ID,
+        pagination: {
+          page: 1,
+          per_page: 20,
+          total: 100,
+          has_next: true,
+        },
+      },
+    });
+  });
+});
+
+async function createTestApp(): Promise<NestFastifyApplication> {
+  const moduleRef = await Test.createTestingModule({
+    imports: [WrapperTestModule],
+  }).compile();
+  const testApp = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter({ logger: false }));
+  configureApp(testApp);
+  await testApp.init();
+  await testApp.getHttpAdapter().getInstance().ready();
+  return testApp;
+}
+
+function parseJsonObject(text: string): Record<string, unknown> {
+  const parsed = JSON.parse(text) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error('Expected a JSON object');
+  }
+
+  return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/api/src/common/interceptors/response-wrapper.interceptor.ts
+++ b/apps/api/src/common/interceptors/response-wrapper.interceptor.ts
@@ -1,0 +1,61 @@
+import type { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { isPaginatedResponse } from '../dto/pagination.dto.js';
+import { getRequestContext, getRequestIdFromRequest } from '../middleware/request-context.middleware.js';
+
+type WrappedResponse = {
+  data: unknown;
+  meta: {
+    request_id: string;
+    pagination?: unknown;
+  };
+};
+
+type RequestLike = {
+  url?: string;
+  raw?: {
+    url?: string;
+  };
+};
+
+@Injectable()
+export class ResponseWrapperInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<RequestLike>();
+    if (isHealthRequest(request)) {
+      return next.handle();
+    }
+
+    return next.handle().pipe(map((value) => wrapResponse(value, request)));
+  }
+}
+
+function wrapResponse(value: unknown, request: RequestLike): WrappedResponse {
+  const requestId = getRequestContext()?.request_id ?? getRequestIdFromRequest(request) ?? '';
+
+  if (isPaginatedResponse(value)) {
+    return {
+      data: value.data,
+      meta: {
+        request_id: requestId,
+        pagination: value.pagination,
+      },
+    };
+  }
+
+  return {
+    data: value === undefined ? null : value,
+    meta: {
+      request_id: requestId,
+    },
+  };
+}
+
+function isHealthRequest(request: RequestLike): boolean {
+  const url = request.url ?? request.raw?.url ?? '';
+  const path = url.split('?')[0];
+  return path === '/health' || path === '/health/' || path === '/api/health' || path === '/api/health/';
+}

--- a/apps/api/src/common/middleware/__tests__/idempotency.test.ts
+++ b/apps/api/src/common/middleware/__tests__/idempotency.test.ts
@@ -8,16 +8,35 @@ const IDEMPOTENCY_KEY = '123e4567-e89b-42d3-a456-426614174000';
 
 class MapRedisStore implements IdempotencyRedisStore {
   readonly values = new Map<string, string>();
-  ttlSeconds: number | null = null;
+  readonly ttlSeconds = new Map<string, number>();
 
   get(key: string): Promise<string | null> {
     return Promise.resolve(this.values.get(key) ?? null);
   }
 
+  set(key: string, value: string, condition: 'NX', expirationMode: 'EX', seconds: number): Promise<'OK' | null> {
+    expect(condition).toBe('NX');
+    expect(expirationMode).toBe('EX');
+
+    if (this.values.has(key)) {
+      return Promise.resolve(null);
+    }
+
+    this.values.set(key, value);
+    this.ttlSeconds.set(key, seconds);
+    return Promise.resolve('OK');
+  }
+
   setex(key: string, seconds: number, value: string): Promise<'OK'> {
-    this.ttlSeconds = seconds;
+    this.ttlSeconds.set(key, seconds);
     this.values.set(key, value);
     return Promise.resolve('OK');
+  }
+
+  del(key: string): Promise<number> {
+    const deleted = this.values.delete(key);
+    this.ttlSeconds.delete(key);
+    return Promise.resolve(deleted ? 1 : 0);
   }
 }
 
@@ -55,35 +74,106 @@ class FakeResponse extends EventEmitter {
 }
 
 describe('IdempotencyMiddleware', () => {
-  it('stores the first response and replays the second response for the same key', async () => {
+  it('stores the first response and replays the second response for the same scoped key', async () => {
     const redis = new MapRedisStore();
     const middleware = new IdempotencyMiddleware(redis);
+    const redisKey = scopedRedisKey('/widgets');
     const firstResponse = new FakeResponse();
     let firstNextCalled = false;
 
-    await middleware.use(createRequest(IDEMPOTENCY_KEY), asServerResponse(firstResponse), () => {
+    await middleware.use(createRequest({ idempotencyKey: IDEMPOTENCY_KEY, url: '/widgets' }), asServerResponse(firstResponse), () => {
       firstNextCalled = true;
       firstResponse.statusCode = 201;
-      firstResponse.setHeader('content-type', 'application/json');
+      firstResponse.setHeader('content-type', 'application/json; charset=utf-8');
       firstResponse.end('{"created":true}');
     });
     await flushPromises();
 
     expect(firstNextCalled).toBe(true);
-    expect(redis.values.has(`idempotency:${IDEMPOTENCY_KEY}`)).toBe(true);
-    expect(redis.ttlSeconds).toBe(86_400);
+    expect(redis.values.has(redisKey)).toBe(true);
+    expect(redis.ttlSeconds.get(redisKey)).toBe(86_400);
 
     const secondResponse = new FakeResponse();
     let secondNextCalled = false;
-    await middleware.use(createRequest(IDEMPOTENCY_KEY), asServerResponse(secondResponse), () => {
+    await middleware.use(createRequest({ idempotencyKey: IDEMPOTENCY_KEY, url: '/widgets' }), asServerResponse(secondResponse), () => {
       secondNextCalled = true;
     });
 
     expect(secondNextCalled).toBe(false);
-    expect(secondResponse.statusCode).toBe(201);
+    expect(secondResponse.statusCode).toBe(200);
     expect(secondResponse.getHeader('x-idempotent-replayed')).toBe('true');
-    expect(secondResponse.getHeader('content-type')).toBe('application/json');
+    expect(secondResponse.getHeader('content-type')).toBe('application/json; charset=utf-8');
     expect(secondResponse.body).toBe('{"created":true}');
+  });
+
+  it('keeps the same idempotency key independent across different paths', async () => {
+    const redis = new MapRedisStore();
+    const middleware = new IdempotencyMiddleware(redis);
+
+    const firstResponse = new FakeResponse();
+    await middleware.use(createRequest({ idempotencyKey: IDEMPOTENCY_KEY, url: '/alpha' }), asServerResponse(firstResponse), () => {
+      firstResponse.setHeader('content-type', 'application/json');
+      firstResponse.end('{"path":"alpha"}');
+    });
+
+    const secondResponse = new FakeResponse();
+    let secondNextCalled = false;
+    await middleware.use(createRequest({ idempotencyKey: IDEMPOTENCY_KEY, url: '/beta' }), asServerResponse(secondResponse), () => {
+      secondNextCalled = true;
+      secondResponse.setHeader('content-type', 'application/json');
+      secondResponse.end('{"path":"beta"}');
+    });
+
+    const replayResponse = new FakeResponse();
+    await middleware.use(createRequest({ idempotencyKey: IDEMPOTENCY_KEY, url: '/alpha' }), asServerResponse(replayResponse), () => {
+      throw new Error('Expected alpha response to replay');
+    });
+
+    expect(secondNextCalled).toBe(true);
+    expect(redis.values.has(scopedRedisKey('/alpha'))).toBe(true);
+    expect(redis.values.has(scopedRedisKey('/beta'))).toBe(true);
+    expect(replayResponse.body).toBe('{"path":"alpha"}');
+  });
+
+  it('reserves the key atomically and rejects concurrent processing requests', async () => {
+    const redis = new MapRedisStore();
+    const middleware = new IdempotencyMiddleware(redis);
+    const redisKey = scopedRedisKey('/slow');
+    const firstResponse = new FakeResponse();
+    let firstNextCalled = false;
+
+    await middleware.use(createRequest({ idempotencyKey: IDEMPOTENCY_KEY, url: '/slow' }), asServerResponse(firstResponse), () => {
+      firstNextCalled = true;
+    });
+
+    expect(firstNextCalled).toBe(true);
+    expect(redis.values.get(redisKey)).toBe('processing');
+    expect(redis.ttlSeconds.get(redisKey)).toBe(300);
+
+    const secondResponse = new FakeResponse();
+    let secondNextCalled = false;
+    await middleware.use(createRequest({ idempotencyKey: IDEMPOTENCY_KEY, url: '/slow' }), asServerResponse(secondResponse), () => {
+      secondNextCalled = true;
+    });
+
+    expect(secondNextCalled).toBe(false);
+    expect(secondResponse.statusCode).toBe(409);
+    expect(secondResponse.getHeader('content-type')).toBe('application/json');
+  });
+
+  it('does not cache responses exceeding the response size limit', async () => {
+    const redis = new MapRedisStore();
+    const middleware = new IdempotencyMiddleware(redis);
+    const redisKey = scopedRedisKey('/large');
+    const response = new FakeResponse();
+
+    await middleware.use(createRequest({ idempotencyKey: IDEMPOTENCY_KEY, url: '/large' }), asServerResponse(response), () => {
+      response.setHeader('content-type', 'application/json');
+      response.end(Buffer.alloc(1_048_577, 65));
+    });
+    await flushPromises();
+
+    expect(redis.values.has(redisKey)).toBe(false);
   });
 
   it('passes through without idempotency when no key is present', async () => {
@@ -108,7 +198,7 @@ describe('IdempotencyMiddleware', () => {
     const response = new FakeResponse();
     let nextCalled = false;
 
-    await middleware.use(createRequest('not-a-uuid'), asServerResponse(response), () => {
+    await middleware.use(createRequest({ idempotencyKey: 'not-a-uuid' }), asServerResponse(response), () => {
       nextCalled = true;
       response.end('ok');
     });
@@ -119,15 +209,29 @@ describe('IdempotencyMiddleware', () => {
   });
 });
 
-function createRequest(idempotencyKey?: string): IncomingMessage {
+type RequestOptions = {
+  idempotencyKey?: string;
+  method?: string;
+  url?: string;
+};
+
+function createRequest(options: RequestOptions = {}): IncomingMessage {
+  const headers =
+    options.idempotencyKey === undefined
+      ? {}
+      : {
+          'x-idempotency-key': options.idempotencyKey,
+        };
+
   return {
-    headers:
-      idempotencyKey === undefined
-        ? {}
-        : {
-            'x-idempotency-key': idempotencyKey,
-          },
+    headers,
+    method: options.method ?? 'POST',
+    url: options.url ?? '/widgets',
   } as IncomingMessage;
+}
+
+function scopedRedisKey(path: string, method = 'POST'): string {
+  return `idempotency:${method}:${path}:anon:${IDEMPOTENCY_KEY}`;
 }
 
 function asServerResponse(response: FakeResponse): ServerResponse {

--- a/apps/api/src/common/middleware/__tests__/idempotency.test.ts
+++ b/apps/api/src/common/middleware/__tests__/idempotency.test.ts
@@ -1,0 +1,139 @@
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { describe, expect, it } from 'vitest';
+
+import { IdempotencyMiddleware, type IdempotencyRedisStore } from '../idempotency.middleware.js';
+
+const IDEMPOTENCY_KEY = '123e4567-e89b-42d3-a456-426614174000';
+
+class MapRedisStore implements IdempotencyRedisStore {
+  readonly values = new Map<string, string>();
+  ttlSeconds: number | null = null;
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  setex(key: string, seconds: number, value: string): Promise<'OK'> {
+    this.ttlSeconds = seconds;
+    this.values.set(key, value);
+    return Promise.resolve('OK');
+  }
+}
+
+class FakeResponse extends EventEmitter {
+  statusCode = 200;
+  readonly headers = new Map<string, string>();
+  readonly chunks: Buffer[] = [];
+
+  setHeader(name: string, value: number | string | string[]): this {
+    this.headers.set(name.toLowerCase(), Array.isArray(value) ? String(value[0] ?? '') : String(value));
+    return this;
+  }
+
+  getHeader(name: string): string | undefined {
+    return this.headers.get(name.toLowerCase());
+  }
+
+  write(chunk: string | Uint8Array): boolean {
+    this.chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk));
+    return true;
+  }
+
+  end(chunk?: string | Uint8Array): this {
+    if (chunk !== undefined) {
+      this.write(chunk);
+    }
+
+    this.emit('finish');
+    return this;
+  }
+
+  get body(): string {
+    return Buffer.concat(this.chunks).toString('utf8');
+  }
+}
+
+describe('IdempotencyMiddleware', () => {
+  it('stores the first response and replays the second response for the same key', async () => {
+    const redis = new MapRedisStore();
+    const middleware = new IdempotencyMiddleware(redis);
+    const firstResponse = new FakeResponse();
+    let firstNextCalled = false;
+
+    await middleware.use(createRequest(IDEMPOTENCY_KEY), asServerResponse(firstResponse), () => {
+      firstNextCalled = true;
+      firstResponse.statusCode = 201;
+      firstResponse.setHeader('content-type', 'application/json');
+      firstResponse.end('{"created":true}');
+    });
+    await flushPromises();
+
+    expect(firstNextCalled).toBe(true);
+    expect(redis.values.has(`idempotency:${IDEMPOTENCY_KEY}`)).toBe(true);
+    expect(redis.ttlSeconds).toBe(86_400);
+
+    const secondResponse = new FakeResponse();
+    let secondNextCalled = false;
+    await middleware.use(createRequest(IDEMPOTENCY_KEY), asServerResponse(secondResponse), () => {
+      secondNextCalled = true;
+    });
+
+    expect(secondNextCalled).toBe(false);
+    expect(secondResponse.statusCode).toBe(201);
+    expect(secondResponse.getHeader('x-idempotent-replayed')).toBe('true');
+    expect(secondResponse.getHeader('content-type')).toBe('application/json');
+    expect(secondResponse.body).toBe('{"created":true}');
+  });
+
+  it('passes through without idempotency when no key is present', async () => {
+    const redis = new MapRedisStore();
+    const middleware = new IdempotencyMiddleware(redis);
+    const response = new FakeResponse();
+    let nextCalled = false;
+
+    await middleware.use(createRequest(), asServerResponse(response), () => {
+      nextCalled = true;
+      response.end('ok');
+    });
+    await flushPromises();
+
+    expect(nextCalled).toBe(true);
+    expect(redis.values.size).toBe(0);
+  });
+
+  it('passes through invalid idempotency key formats', async () => {
+    const redis = new MapRedisStore();
+    const middleware = new IdempotencyMiddleware(redis);
+    const response = new FakeResponse();
+    let nextCalled = false;
+
+    await middleware.use(createRequest('not-a-uuid'), asServerResponse(response), () => {
+      nextCalled = true;
+      response.end('ok');
+    });
+    await flushPromises();
+
+    expect(nextCalled).toBe(true);
+    expect(redis.values.size).toBe(0);
+  });
+});
+
+function createRequest(idempotencyKey?: string): IncomingMessage {
+  return {
+    headers:
+      idempotencyKey === undefined
+        ? {}
+        : {
+            'x-idempotency-key': idempotencyKey,
+          },
+  } as IncomingMessage;
+}
+
+function asServerResponse(response: FakeResponse): ServerResponse {
+  return response as unknown as ServerResponse;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+}

--- a/apps/api/src/common/middleware/__tests__/request-context.test.ts
+++ b/apps/api/src/common/middleware/__tests__/request-context.test.ts
@@ -48,7 +48,7 @@ describe('RequestContextMiddleware', () => {
 
     const requestId = getHeader(response.headers, 'x-request-id');
     expect(requestId).toMatch(UUID_V4_PATTERN);
-    expect(parseJsonObject(response.text).request_id).toBe(requestId);
+    expect(getWrappedData(response.text).request_id).toBe(requestId);
   });
 
   it('uses the provided X-Request-Id header value', async () => {
@@ -60,7 +60,7 @@ describe('RequestContextMiddleware', () => {
       .expect(200);
 
     expect(getHeader(response.headers, 'x-request-id')).toBe(providedRequestId);
-    expect(parseJsonObject(response.text).request_id).toBe(providedRequestId);
+    expect(getWrappedData(response.text).request_id).toBe(providedRequestId);
   });
 
   it('rejects oversized X-Request-Id values and generates a fresh UUID', () => {
@@ -160,6 +160,15 @@ function parseJsonObject(text: string): Record<string, unknown> {
   }
 
   return parsed;
+}
+
+function getWrappedData(text: string): Record<string, unknown> {
+  const body = parseJsonObject(text);
+  if (!isRecord(body.data)) {
+    throw new Error('Expected wrapped data payload');
+  }
+
+  return body.data;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/api/src/common/middleware/idempotency.middleware.ts
+++ b/apps/api/src/common/middleware/idempotency.middleware.ts
@@ -1,28 +1,52 @@
 import { Inject, Injectable, Optional, type NestMiddleware } from '@nestjs/common';
+import { ErrorCode } from '@cherrygraph/shared';
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'node:http';
 
 import { getApiLogger } from '../logger/logger.module.js';
 import { REDIS_CLIENT } from '../redis/redis.module.js';
+import { getRequestContext } from './request-context.middleware.js';
 
 const IDEMPOTENCY_HEADER = 'x-idempotency-key';
 const IDEMPOTENCY_REPLAYED_HEADER = 'X-Idempotent-Replayed';
 const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
+const IDEMPOTENCY_PROCESSING_TTL_SECONDS = 300;
+const IDEMPOTENCY_PROCESSING_VALUE = 'processing';
+const MAX_CACHED_RESPONSE_BYTES = 1_048_576;
 const IDEMPOTENCY_KEY_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export type IdempotencyRedisStore = {
   get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, condition: 'NX', expirationMode: 'EX', seconds: number) => Promise<'OK' | null>;
   setex: (key: string, seconds: number, value: string) => Promise<unknown>;
+  del?: (key: string) => Promise<unknown>;
 };
 
 type RequestWithHeaders = IncomingMessage & {
   headers: IncomingHttpHeaders;
+  path?: string;
+  raw?: {
+    path?: string;
+    url?: string;
+  };
 };
 
 type StoredIdempotentResponse = {
   statusCode: number;
   body: string;
   contentType?: string;
+};
+
+type IdempotencyReservation =
+  | { kind: 'reserved' }
+  | { kind: 'processing' }
+  | { kind: 'replay'; response: StoredIdempotentResponse }
+  | { kind: 'unavailable' };
+
+type CaptureState = {
+  chunks: Buffer[];
+  totalBytes: number;
+  exceededSizeLimit: boolean;
 };
 
 @Injectable()
@@ -36,14 +60,23 @@ export class IdempotencyMiddleware implements NestMiddleware {
       return;
     }
 
-    const redisKey = `idempotency:${idempotencyKey}`;
-    const cached = await readCachedResponse(this.redis, redisKey);
-    if (cached !== undefined) {
-      replayResponse(res, cached);
+    const redisKey = buildIdempotencyRedisKey(req, idempotencyKey);
+    const reservation = await reserveOrReadExisting(this.redis, redisKey);
+
+    if (reservation.kind === 'replay') {
+      replayResponse(res, reservation.response);
       return;
     }
 
-    captureAndStoreResponse(this.redis, redisKey, res);
+    if (reservation.kind === 'processing') {
+      sendProcessingConflict(res);
+      return;
+    }
+
+    if (reservation.kind === 'reserved') {
+      captureAndStoreResponse(this.redis, redisKey, res);
+    }
+
     next();
   }
 }
@@ -52,25 +85,59 @@ function extractHeaderValue(value: string | string[] | undefined): string | unde
   return Array.isArray(value) ? value[0] : value;
 }
 
-async function readCachedResponse(
+function buildIdempotencyRedisKey(req: RequestWithHeaders, idempotencyKey: string): string {
+  const method = (req.method ?? 'UNKNOWN').toUpperCase();
+  const path = getRequestPath(req);
+  const userId = getRequestContext()?.user_id || 'anon';
+  return `idempotency:${method}:${path}:${userId}:${idempotencyKey}`;
+}
+
+function getRequestPath(req: RequestWithHeaders): string {
+  const rawPath = req.path ?? req.raw?.path ?? req.url ?? req.raw?.url ?? '/';
+  try {
+    return new URL(rawPath, 'http://localhost').pathname || '/';
+  } catch {
+    const queryIndex = rawPath.indexOf('?');
+    const path = queryIndex === -1 ? rawPath : rawPath.slice(0, queryIndex);
+    return path.length > 0 ? path : '/';
+  }
+}
+
+async function reserveOrReadExisting(
   redis: IdempotencyRedisStore,
   redisKey: string,
-): Promise<StoredIdempotentResponse | undefined> {
+): Promise<IdempotencyReservation> {
   try {
-    const cached = await redis.get(redisKey);
-    if (cached === null) {
-      return undefined;
+    const reserved = await redis.set(
+      redisKey,
+      IDEMPOTENCY_PROCESSING_VALUE,
+      'NX',
+      'EX',
+      IDEMPOTENCY_PROCESSING_TTL_SECONDS,
+    );
+    if (reserved === 'OK') {
+      return { kind: 'reserved' };
     }
 
-    return parseStoredResponse(cached);
+    const cached = await redis.get(redisKey);
+    if (cached === null) {
+      return { kind: 'unavailable' };
+    }
+
+    if (cached === IDEMPOTENCY_PROCESSING_VALUE) {
+      return { kind: 'processing' };
+    }
+
+    const response = parseStoredResponse(cached);
+    return response === undefined ? { kind: 'unavailable' } : { kind: 'replay', response };
   } catch (err) {
-    getApiLogger().warn({ err, redis_key: redisKey }, 'Failed to read idempotency response');
-    return undefined;
+    getApiLogger().warn({ err, redis_key: redisKey }, 'Failed to reserve idempotency key');
+    return { kind: 'unavailable' };
   }
 }
 
 function replayResponse(res: ServerResponse, stored: StoredIdempotentResponse): void {
-  res.statusCode = stored.statusCode;
+  res.statusCode = 200;
   res.setHeader(IDEMPOTENCY_REPLAYED_HEADER, 'true');
   if (stored.contentType !== undefined) {
     res.setHeader('content-type', stored.contentType);
@@ -79,22 +146,40 @@ function replayResponse(res: ServerResponse, stored: StoredIdempotentResponse): 
   res.end(stored.body);
 }
 
+function sendProcessingConflict(res: ServerResponse): void {
+  res.statusCode = 409;
+  res.setHeader('content-type', 'application/json');
+  res.end(
+    JSON.stringify({
+      error: {
+        code: ErrorCode.CONFLICT,
+        message: 'Idempotency key is already processing',
+      },
+      meta: { request_id: getRequestContext()?.request_id ?? '' },
+    }),
+  );
+}
+
 function captureAndStoreResponse(redis: IdempotencyRedisStore, redisKey: string, res: ServerResponse): void {
-  const chunks: Buffer[] = [];
+  const capture: CaptureState = {
+    chunks: [],
+    totalBytes: 0,
+    exceededSizeLimit: false,
+  };
   const originalWrite = res.write.bind(res) as (...args: unknown[]) => boolean;
   const originalEnd = res.end.bind(res) as (...args: unknown[]) => ServerResponse;
   let forwardingEndChunk = false;
 
   res.write = ((...args: unknown[]): boolean => {
     if (!forwardingEndChunk) {
-      captureChunk(args[0], chunks);
+      captureChunk(args[0], capture, getChunkEncoding(args));
     }
 
     return originalWrite(...args);
   }) as ServerResponse['write'];
 
   res.end = ((...args: unknown[]): ServerResponse => {
-    captureChunk(args[0], chunks);
+    captureChunk(args[0], capture, getChunkEncoding(args));
     forwardingEndChunk = true;
     try {
       return originalEnd(...args);
@@ -104,8 +189,13 @@ function captureAndStoreResponse(redis: IdempotencyRedisStore, redisKey: string,
   }) as ServerResponse['end'];
 
   res.once('finish', () => {
-    const body = Buffer.concat(chunks).toString('utf8');
     const contentType = headerValueToString(res.getHeader('content-type'));
+    if (!isCacheableResponse(res.statusCode, contentType, capture)) {
+      void clearReservation(redis, redisKey);
+      return;
+    }
+
+    const body = Buffer.concat(capture.chunks).toString('utf8');
     const stored = createStoredResponse(res.statusCode, body, contentType);
 
     void redis.setex(redisKey, IDEMPOTENCY_TTL_SECONDS, JSON.stringify(stored)).catch((err: unknown) => {
@@ -114,19 +204,62 @@ function captureAndStoreResponse(redis: IdempotencyRedisStore, redisKey: string,
   });
 }
 
-function captureChunk(chunk: unknown, chunks: Buffer[]): void {
-  if (typeof chunk === 'string') {
-    chunks.push(Buffer.from(chunk));
+function captureChunk(chunk: unknown, capture: CaptureState, encoding: BufferEncoding | undefined): void {
+  if (capture.exceededSizeLimit) {
     return;
+  }
+
+  const buffer = chunkToBuffer(chunk, encoding);
+  if (buffer === undefined) {
+    return;
+  }
+
+  const totalBytes = capture.totalBytes + buffer.byteLength;
+  if (totalBytes > MAX_CACHED_RESPONSE_BYTES) {
+    capture.exceededSizeLimit = true;
+    capture.chunks = [];
+    return;
+  }
+
+  capture.totalBytes = totalBytes;
+  capture.chunks.push(buffer);
+}
+
+function getChunkEncoding(args: unknown[]): BufferEncoding | undefined {
+  return typeof args[1] === 'string' ? (args[1] as BufferEncoding) : undefined;
+}
+
+function chunkToBuffer(chunk: unknown, encoding: BufferEncoding | undefined): Buffer | undefined {
+  if (typeof chunk === 'string') {
+    return Buffer.from(chunk, encoding);
   }
 
   if (Buffer.isBuffer(chunk)) {
-    chunks.push(chunk);
-    return;
+    return chunk;
   }
 
   if (chunk instanceof Uint8Array) {
-    chunks.push(Buffer.from(chunk));
+    return Buffer.from(chunk);
+  }
+
+  return undefined;
+}
+
+function isCacheableResponse(statusCode: number, contentType: string | undefined, capture: CaptureState): boolean {
+  return (
+    statusCode >= 200 &&
+    statusCode < 300 &&
+    contentType !== undefined &&
+    contentType.toLowerCase().startsWith('application/json') &&
+    !capture.exceededSizeLimit
+  );
+}
+
+async function clearReservation(redis: IdempotencyRedisStore, redisKey: string): Promise<void> {
+  try {
+    await redis.del?.(redisKey);
+  } catch (err) {
+    getApiLogger().warn({ err, redis_key: redisKey }, 'Failed to clear idempotency reservation');
   }
 }
 
@@ -143,7 +276,13 @@ function createStoredResponse(
 }
 
 function parseStoredResponse(value: string): StoredIdempotentResponse | undefined {
-  const parsed = JSON.parse(value) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+
   if (!isRecord(parsed) || typeof parsed.statusCode !== 'number' || typeof parsed.body !== 'string') {
     return undefined;
   }

--- a/apps/api/src/common/middleware/idempotency.middleware.ts
+++ b/apps/api/src/common/middleware/idempotency.middleware.ts
@@ -1,0 +1,173 @@
+import { Inject, Injectable, Optional, type NestMiddleware } from '@nestjs/common';
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'node:http';
+
+import { getApiLogger } from '../logger/logger.module.js';
+import { REDIS_CLIENT } from '../redis/redis.module.js';
+
+const IDEMPOTENCY_HEADER = 'x-idempotency-key';
+const IDEMPOTENCY_REPLAYED_HEADER = 'X-Idempotent-Replayed';
+const IDEMPOTENCY_TTL_SECONDS = 24 * 60 * 60;
+const IDEMPOTENCY_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type IdempotencyRedisStore = {
+  get: (key: string) => Promise<string | null>;
+  setex: (key: string, seconds: number, value: string) => Promise<unknown>;
+};
+
+type RequestWithHeaders = IncomingMessage & {
+  headers: IncomingHttpHeaders;
+};
+
+type StoredIdempotentResponse = {
+  statusCode: number;
+  body: string;
+  contentType?: string;
+};
+
+@Injectable()
+export class IdempotencyMiddleware implements NestMiddleware {
+  constructor(@Optional() @Inject(REDIS_CLIENT) private readonly redis?: IdempotencyRedisStore) {}
+
+  async use(req: RequestWithHeaders, res: ServerResponse, next: () => void): Promise<void> {
+    const idempotencyKey = extractHeaderValue(req.headers[IDEMPOTENCY_HEADER]);
+    if (idempotencyKey === undefined || !IDEMPOTENCY_KEY_PATTERN.test(idempotencyKey) || this.redis === undefined) {
+      next();
+      return;
+    }
+
+    const redisKey = `idempotency:${idempotencyKey}`;
+    const cached = await readCachedResponse(this.redis, redisKey);
+    if (cached !== undefined) {
+      replayResponse(res, cached);
+      return;
+    }
+
+    captureAndStoreResponse(this.redis, redisKey, res);
+    next();
+  }
+}
+
+function extractHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function readCachedResponse(
+  redis: IdempotencyRedisStore,
+  redisKey: string,
+): Promise<StoredIdempotentResponse | undefined> {
+  try {
+    const cached = await redis.get(redisKey);
+    if (cached === null) {
+      return undefined;
+    }
+
+    return parseStoredResponse(cached);
+  } catch (err) {
+    getApiLogger().warn({ err, redis_key: redisKey }, 'Failed to read idempotency response');
+    return undefined;
+  }
+}
+
+function replayResponse(res: ServerResponse, stored: StoredIdempotentResponse): void {
+  res.statusCode = stored.statusCode;
+  res.setHeader(IDEMPOTENCY_REPLAYED_HEADER, 'true');
+  if (stored.contentType !== undefined) {
+    res.setHeader('content-type', stored.contentType);
+  }
+
+  res.end(stored.body);
+}
+
+function captureAndStoreResponse(redis: IdempotencyRedisStore, redisKey: string, res: ServerResponse): void {
+  const chunks: Buffer[] = [];
+  const originalWrite = res.write.bind(res) as (...args: unknown[]) => boolean;
+  const originalEnd = res.end.bind(res) as (...args: unknown[]) => ServerResponse;
+  let forwardingEndChunk = false;
+
+  res.write = ((...args: unknown[]): boolean => {
+    if (!forwardingEndChunk) {
+      captureChunk(args[0], chunks);
+    }
+
+    return originalWrite(...args);
+  }) as ServerResponse['write'];
+
+  res.end = ((...args: unknown[]): ServerResponse => {
+    captureChunk(args[0], chunks);
+    forwardingEndChunk = true;
+    try {
+      return originalEnd(...args);
+    } finally {
+      forwardingEndChunk = false;
+    }
+  }) as ServerResponse['end'];
+
+  res.once('finish', () => {
+    const body = Buffer.concat(chunks).toString('utf8');
+    const contentType = headerValueToString(res.getHeader('content-type'));
+    const stored = createStoredResponse(res.statusCode, body, contentType);
+
+    void redis.setex(redisKey, IDEMPOTENCY_TTL_SECONDS, JSON.stringify(stored)).catch((err: unknown) => {
+      getApiLogger().warn({ err, redis_key: redisKey }, 'Failed to store idempotency response');
+    });
+  });
+}
+
+function captureChunk(chunk: unknown, chunks: Buffer[]): void {
+  if (typeof chunk === 'string') {
+    chunks.push(Buffer.from(chunk));
+    return;
+  }
+
+  if (Buffer.isBuffer(chunk)) {
+    chunks.push(chunk);
+    return;
+  }
+
+  if (chunk instanceof Uint8Array) {
+    chunks.push(Buffer.from(chunk));
+  }
+}
+
+function createStoredResponse(
+  statusCode: number,
+  body: string,
+  contentType: string | undefined,
+): StoredIdempotentResponse {
+  if (contentType === undefined) {
+    return { statusCode, body };
+  }
+
+  return { statusCode, body, contentType };
+}
+
+function parseStoredResponse(value: string): StoredIdempotentResponse | undefined {
+  const parsed = JSON.parse(value) as unknown;
+  if (!isRecord(parsed) || typeof parsed.statusCode !== 'number' || typeof parsed.body !== 'string') {
+    return undefined;
+  }
+
+  const response: StoredIdempotentResponse = {
+    statusCode: parsed.statusCode,
+    body: parsed.body,
+  };
+
+  if (typeof parsed.contentType === 'string') {
+    response.contentType = parsed.contentType;
+  }
+
+  return response;
+}
+
+function headerValueToString(value: number | string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value === undefined ? undefined : String(value);
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/api/src/common/redis/redis.module.ts
+++ b/apps/api/src/common/redis/redis.module.ts
@@ -1,0 +1,57 @@
+import { Global, Inject, Injectable, Module, Optional, type OnModuleDestroy } from '@nestjs/common';
+import { Redis, type Redis as RedisClient } from 'ioredis';
+
+import { getApiLogger } from '../logger/logger.module.js';
+
+export const REDIS_CLIENT = Symbol('REDIS_CLIENT');
+
+export type OptionalRedisClient = RedisClient | undefined;
+
+@Injectable()
+class RedisShutdown implements OnModuleDestroy {
+  constructor(@Optional() @Inject(REDIS_CLIENT) private readonly redis?: OptionalRedisClient) {}
+
+  onModuleDestroy(): void {
+    this.redis?.disconnect();
+  }
+}
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: REDIS_CLIENT,
+      useFactory: createRedisClient,
+    },
+    RedisShutdown,
+  ],
+  exports: [REDIS_CLIENT],
+})
+export class RedisModule {}
+
+function createRedisClient(): OptionalRedisClient {
+  const redisUrl = process.env.REDIS_URL;
+  if (redisUrl === undefined || redisUrl.length === 0) {
+    if (process.env.NODE_ENV !== 'test') {
+      getApiLogger().warn({ redis_url_present: false }, 'Redis disabled because REDIS_URL is not configured');
+    }
+
+    return undefined;
+  }
+
+  const client = new Redis(redisUrl, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+  });
+
+  client.on('error', (err: Error) => {
+    getApiLogger().warn({ err }, 'Redis connection error');
+  });
+
+  void client.connect().catch((err: unknown) => {
+    getApiLogger().warn({ err }, 'Redis initial connection failed');
+  });
+
+  return client;
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { AppModule } from './app.module.js';
 import { HttpExceptionFilter, validationErrorsToDetails } from './common/filters/http-exception.filter.js';
+import { ResponseWrapperInterceptor } from './common/interceptors/response-wrapper.interceptor.js';
 import { createNestLogger } from './common/logger/logger.module.js';
 
 export function createValidationPipe(): ValidationPipe {
@@ -28,6 +29,7 @@ export function configureApp(app: NestFastifyApplication): void {
   app.setGlobalPrefix('api');
   app.useGlobalPipes(createValidationPipe());
   app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalInterceptors(new ResponseWrapperInterceptor());
 }
 
 function parsePort(value: string | undefined): number {

--- a/openspec/changes/stage1-auth-rbac-space-admin/tasks.md
+++ b/openspec/changes/stage1-auth-rbac-space-admin/tasks.md
@@ -6,6 +6,13 @@
 - [ ] 0.4 实现 X-Idempotency-Key 中间件：Redis 存储（TTL=24h），重复 key 返回 200 + X-Idempotent-Replayed: true
 - [ ] 0.5 实现通用 API rate limit guard：支持按 user 和按 IP 两种模式，配置项：public API 600 req/min/user、Admin API 300 req/min/user（login 单独 10 req/min/IP 在 Auth 模块实现）
 
+### 0.T Request Infrastructure Tests
+
+- [ ] 0.T1 统一响应格式测试：成功响应 `{ data, meta: { request_id } }`，错误响应 `{ error: { code, message }, meta: { request_id } }`，request_id 从 AsyncLocalStorage 正确获取
+- [ ] 0.T2 分页 DTO 测试：默认值（page=1, per_page=20, sort=-created_at），边界值（page=0 → 422, per_page > 100 → 422），排序方向解析（`-created_at` → DESC, `created_at` → ASC），响应 meta.pagination 含 page/per_page/total/has_next
+- [ ] 0.T3 幂等性中间件测试：首次请求正常处理返回 200，重复 key 返回 200 + `X-Idempotent-Replayed: true` header，不同 key 独立处理，无 key 的请求跳过幂等检查，key 格式校验（UUID）
+- [ ] 0.T4 Rate limit guard 测试：正常请求通过并返回 `X-RateLimit-Limit/Remaining/Reset` headers，超限返回 429 + RATE_LIMITED 错误码，不同用户独立计数（user 模式），不同 IP 独立计数（IP 模式），计数窗口滑动重置
+
 ## 1. Database Migration
 
 - [ ] 1.1 创建 Stage 1 Drizzle migration：tenants, users（含 password_hash, role, last_login_at）, groups, group_members, spaces（含 description, status）, space_permissions, model_configs, sessions（含 last_used_at）, audit_logs, permission_versions, system_settings 表及所有索引

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       pg:
         specifier: ^8.20.0
         version: 8.20.0


### PR DESCRIPTION
## Summary

- Align error response format with API spec: `request_id` moved from `error` to `meta` object
- Add global `ResponseWrapperInterceptor` wrapping success responses in `{ data, meta: { request_id, pagination? } }`
- Add `PaginationQueryDto` (class-validator) with `buildPaginationMeta`, `parseSortField`, and `paginatedResponse` helpers
- Add global `RedisModule` (ioredis, fail-open in test/no-Redis mode)
- Add `IdempotencyMiddleware`: atomic `SET NX` reservation, scoped by method/path/user, 1MB cap, JSON-only caching, replay with `200 + X-Idempotent-Replayed: true`
- Add `RateLimitGuard` with atomic Lua script, `@RateLimit(limit, windowSec, mode)` decorator, tenant-scoped keys, `X-RateLimit-*` headers
- `HttpExceptionFilter` preserves custom `ErrorCode` from exception response (e.g. `INVALID_CREDENTIALS`)
- CI: build before lint (type-checked rules need compiled declarations)
- CI: add Repo Governance workflow for PR review evidence validation

Closes #17

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `bfc38da7821cd6046a2dd4d7f322ccc7daa86a0e`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/29#issuecomment-4344930865) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/29#issuecomment-4344932238)
- Key findings addressed: Idempotency atomic reservation + scoped keys + size cap + JSON-only; Rate limit atomic Lua script + request.ip + tenant-scoped keys; HttpExceptionFilter custom error code pass-through; parseSortField direction parsing; parseStoredResponse JSON.parse guard; 409 conflict meta.request_id

## Test plan

- [x] All existing tests updated for new response format (meta.request_id)
- [x] Pagination DTO validation: defaults, boundaries, sort direction parsing
- [x] Response wrapper interceptor: wraps data, handles paginated response, excludes health
- [x] Idempotency middleware: atomic reservation, replay with 200, scoped keys, size limit, concurrent conflict 409
- [x] Rate limit guard: atomic Lua, headers set, 429 on exceed, independent user/IP tracking, window reset, tenant scoping
- [x] HttpExceptionFilter: custom error code preservation
- [x] `pnpm build && pnpm test && pnpm lint` all green (67 tests pass)