### PR TITLE
feat(api): audit infrastructure — AuditModule, AuditService, @Audited

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,6 +4,7 @@ import { PinoHttpLoggerMiddleware, LoggerModule } from './common/logger/logger.m
 import { IdempotencyMiddleware } from './common/middleware/idempotency.middleware.js';
 import { RequestContextMiddleware } from './common/middleware/request-context.middleware.js';
 import { RedisModule } from './common/redis/redis.module.js';
+import { AuditModule } from './audit/audit.module.js';
 import { DrizzleModule } from './database/drizzle.module.js';
 import { HealthModule } from './health/health.module.js';
 
@@ -12,6 +13,7 @@ import { HealthModule } from './health/health.module.js';
     LoggerModule,
     RedisModule,
     DrizzleModule.forRoot({ connectionCheck: process.env.NODE_ENV !== 'test' }),
+    AuditModule,
     HealthModule,
   ],
 })

--- a/apps/api/src/audit/__tests__/audit-events.test.ts
+++ b/apps/api/src/audit/__tests__/audit-events.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { AUDIT_EVENTS } from '../audit-events.js';
+
+const EXPECTED_AUDIT_EVENTS = [
+  'auth.login',
+  'auth.logout',
+  'auth.token_refresh',
+  'auth.failed_login',
+  'auth.password_change',
+  'auth.session_revoke',
+  'admin.user.create',
+  'admin.user.update',
+  'admin.user.disable',
+  'admin.group.create',
+  'user.group_change',
+  'space.create',
+  'space.update',
+  'space.permission_change',
+  'admin.model.create',
+  'admin.model.update',
+  'admin.model.test',
+] as const;
+
+describe('AUDIT_EVENTS', () => {
+  it('defines all 17 mandatory audit events', () => {
+    const values = Object.values(AUDIT_EVENTS);
+
+    expect(values).toHaveLength(17);
+    expect(new Set(values).size).toBe(17);
+  });
+
+  it('matches the expected event strings', () => {
+    expect(Object.values(AUDIT_EVENTS)).toEqual(EXPECTED_AUDIT_EVENTS);
+  });
+});

--- a/apps/api/src/audit/__tests__/audit.interceptor.test.ts
+++ b/apps/api/src/audit/__tests__/audit.interceptor.test.ts
@@ -5,6 +5,7 @@ import type { RequestContext } from '@cherrygraph/shared';
 import { lastValueFrom, of, throwError } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { getApiLogger } from '../../common/logger/logger.module.js';
 import { requestContextStorage } from '../../common/middleware/request-context.middleware.js';
 import { Audited } from '../audit.decorator.js';
 import { AuditInterceptor } from '../audit.interceptor.js';
@@ -88,6 +89,18 @@ describe('AuditInterceptor', () => {
     });
 
     expect(push).not.toHaveBeenCalled();
+  });
+
+  it('does not push an audit entry when tenant_id is empty', async () => {
+    const { interceptor, push } = createInterceptor();
+    const debug = vi.spyOn(getApiLogger(), 'debug').mockImplementation(() => undefined);
+
+    await requestContextStorage.run(createRequestContext({ tenant_id: '' }), async () => {
+      await lastValueFrom(interceptor.intercept(createContext(AuthController.prototype.login), createNext()));
+    });
+
+    expect(push).not.toHaveBeenCalled();
+    expect(debug).toHaveBeenCalledWith({ action: 'auth.login' }, 'Audit interceptor skipped entry without tenant context');
   });
 });
 

--- a/apps/api/src/audit/__tests__/audit.interceptor.test.ts
+++ b/apps/api/src/audit/__tests__/audit.interceptor.test.ts
@@ -1,0 +1,146 @@
+import 'reflect-metadata';
+
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+import type { RequestContext } from '@cherrygraph/shared';
+import { lastValueFrom, of, throwError } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { requestContextStorage } from '../../common/middleware/request-context.middleware.js';
+import { Audited } from '../audit.decorator.js';
+import { AuditInterceptor } from '../audit.interceptor.js';
+import { AuditService, type AuditEntry } from '../audit.service.js';
+
+class AuthController {
+  @Audited('auth.login')
+  login(this: void): void {
+    return undefined;
+  }
+
+  notAudited(this: void): void {
+    return undefined;
+  }
+}
+
+describe('AuditInterceptor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pushes an audit entry after a successful handler marked with @Audited('auth.login')", async () => {
+    const { interceptor, push } = createInterceptor();
+
+    await requestContextStorage.run(createRequestContext(), async () => {
+      await lastValueFrom(interceptor.intercept(createContext(AuthController.prototype.login), createNext()));
+    });
+
+    expect(push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenant_id: 'tenant-1',
+        actor_user_id: 'user-1',
+        action: 'auth.login',
+        resource_type: 'auth',
+      }),
+    );
+  });
+
+  it('does not push an audit entry for handlers without @Audited()', async () => {
+    const { interceptor, push } = createInterceptor();
+
+    await requestContextStorage.run(createRequestContext(), async () => {
+      await lastValueFrom(interceptor.intercept(createContext(AuthController.prototype.notAudited), createNext()));
+    });
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('includes ip, user_agent, and request_id from request context', async () => {
+    const { interceptor, push } = createInterceptor();
+
+    await requestContextStorage.run(createRequestContext({ request_id: 'req-interceptor-123' }), async () => {
+      await lastValueFrom(
+        interceptor.intercept(
+          createContext(AuthController.prototype.login, {
+            ip: '198.51.100.7',
+            headers: { 'user-agent': 'Vitest Agent' },
+          }),
+          createNext(),
+        ),
+      );
+    });
+
+    expect(push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ip: '198.51.100.7',
+        user_agent: 'Vitest Agent',
+        request_id: 'req-interceptor-123',
+      }),
+    );
+  });
+
+  it('does not audit failed handler responses', async () => {
+    const { interceptor, push } = createInterceptor();
+    const error = new Error('handler failed');
+
+    await requestContextStorage.run(createRequestContext(), async () => {
+      await expect(
+        lastValueFrom(interceptor.intercept(createContext(AuthController.prototype.login), createNextError(error))),
+      ).rejects.toThrow(error);
+    });
+
+    expect(push).not.toHaveBeenCalled();
+  });
+});
+
+type RequestOverrides = {
+  headers?: Record<string, string>;
+  ip?: string;
+};
+
+function createInterceptor(): {
+  interceptor: AuditInterceptor;
+  push: ReturnType<typeof vi.fn<(entry: AuditEntry) => void>>;
+} {
+  const push = vi.fn<(entry: AuditEntry) => void>();
+  const auditService = { push } as unknown as AuditService;
+  return {
+    interceptor: new AuditInterceptor(auditService),
+    push,
+  };
+}
+
+function createContext(handler: () => void, requestOverrides: RequestOverrides = {}): ExecutionContext {
+  return {
+    getHandler: () => handler,
+    getClass: () => AuthController,
+    switchToHttp: () => ({
+      getRequest: () => ({
+        headers: requestOverrides.headers ?? { 'user-agent': 'Vitest' },
+        ip: requestOverrides.ip ?? '203.0.113.10',
+      }),
+      getResponse: () => undefined,
+      getNext: () => undefined,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function createNext(): CallHandler {
+  return {
+    handle: () => of({ ok: true }),
+  };
+}
+
+function createNextError(error: Error): CallHandler {
+  return {
+    handle: () => throwError(() => error),
+  };
+}
+
+function createRequestContext(overrides: Partial<RequestContext> = {}): RequestContext {
+  return {
+    request_id: 'req-default',
+    tenant_id: 'tenant-1',
+    user_id: 'user-1',
+    space_id: null,
+    ...overrides,
+  };
+}

--- a/apps/api/src/audit/__tests__/audit.service.test.ts
+++ b/apps/api/src/audit/__tests__/audit.service.test.ts
@@ -1,0 +1,199 @@
+import { audit_logs, type RequestContext } from '@cherrygraph/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { requestContextStorage } from '../../common/middleware/request-context.middleware.js';
+import { AuditService, type AuditEntry } from '../audit.service.js';
+
+type AuditLogInsert = typeof audit_logs.$inferInsert;
+type ValuesMock = ReturnType<typeof vi.fn<(values: AuditLogInsert[]) => Promise<unknown>>>;
+type InsertMock = ReturnType<typeof vi.fn<(table: typeof audit_logs) => { values: ValuesMock }>>;
+
+type DbMock = {
+  db: {
+    insert: InsertMock;
+  };
+  insert: InsertMock;
+  values: ValuesMock;
+};
+
+let service: AuditService | undefined;
+
+describe('AuditService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await service?.onModuleDestroy();
+    service = undefined;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('flushes queued entries on the 1 second timer', async () => {
+    const { db, insert, values } = createDbMock();
+    service = new AuditService(db);
+
+    service.push(createEntry({ resource_id: 'session-1' }));
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(insert).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(insert).toHaveBeenCalledWith(audit_logs);
+    const batch = getOnlyBatch(values);
+    expect(batch).toHaveLength(1);
+    const row = requireValue(batch[0]);
+    expect(typeof row.id).toBe('string');
+    expect(row).toMatchObject({
+      tenant_id: 'tenant-1',
+      action: 'auth.login',
+      resource_type: 'session',
+      resource_id: 'session-1',
+      metadata_json: {},
+    });
+  });
+
+  it('flushes immediately when the queue reaches 50 entries', async () => {
+    const { db, values } = createDbMock();
+    service = new AuditService(db);
+
+    for (let index = 0; index < 50; index += 1) {
+      service.push(createEntry({ resource_id: `session-${index}` }));
+    }
+
+    await Promise.resolve();
+
+    const batch = getOnlyBatch(values);
+    expect(batch).toHaveLength(50);
+    expect(batch[49]?.resource_id).toBe('session-49');
+  });
+
+  it('does not write when the timer fires with an empty queue', async () => {
+    const { db, insert } = createDbMock();
+    service = new AuditService(db);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('drains remaining entries on module destroy', async () => {
+    const { db, values } = createDbMock();
+    service = new AuditService(db);
+    service.push(createEntry({ resource_id: 'session-1' }));
+
+    await service.onModuleDestroy();
+    service = undefined;
+
+    const batch = getOnlyBatch(values);
+    expect(batch).toHaveLength(1);
+    expect(batch[0]?.resource_id).toBe('session-1');
+  });
+
+  it('captures request_id from AsyncLocalStorage when entries are pushed', async () => {
+    const { db, values } = createDbMock();
+    service = new AuditService(db);
+
+    requestContextStorage.run(createRequestContext({ request_id: 'req-audit-123' }), () => {
+      service?.push(createEntry());
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const batch = getOnlyBatch(values);
+    expect(batch[0]?.request_id).toBe('req-audit-123');
+  });
+
+  it('strips sensitive metadata keys before persisting', async () => {
+    const { db, values } = createDbMock();
+    service = new AuditService(db);
+
+    service.push(
+      createEntry({
+        metadata_json: {
+          email: 'user@example.com',
+          password: 'p@ssw0rd',
+          access_token: 'access-token',
+          nested: {
+            apiKey: 'api-key',
+            visible: true,
+          },
+          array: [
+            {
+              refreshSecret: 'refresh-secret',
+              safe: 'value',
+            },
+          ],
+        },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const batch = getOnlyBatch(values);
+    expect(batch[0]?.metadata_json).toEqual({
+      email: 'user@example.com',
+      nested: {
+        visible: true,
+      },
+      array: [
+        {
+          safe: 'value',
+        },
+      ],
+    });
+  });
+});
+
+function createDbMock(): DbMock {
+  const values: ValuesMock = vi.fn(() => Promise.resolve());
+  const insert: InsertMock = vi.fn(() => ({ values }));
+
+  return {
+    db: { insert },
+    insert,
+    values,
+  };
+}
+
+function createEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    tenant_id: 'tenant-1',
+    actor_user_id: 'user-1',
+    action: 'auth.login',
+    resource_type: 'session',
+    ip: '203.0.113.10',
+    user_agent: 'Vitest',
+    ...overrides,
+  };
+}
+
+function createRequestContext(overrides: Partial<RequestContext> = {}): RequestContext {
+  return {
+    request_id: 'req-default',
+    tenant_id: 'tenant-1',
+    user_id: 'user-1',
+    space_id: null,
+    ...overrides,
+  };
+}
+
+function getOnlyBatch(values: ValuesMock): AuditLogInsert[] {
+  expect(values).toHaveBeenCalledTimes(1);
+  const call = values.mock.calls[0];
+  if (call === undefined) {
+    throw new Error('Expected values() to be called');
+  }
+
+  return call[0];
+}
+
+function requireValue<T>(value: T | undefined): T {
+  if (value === undefined) {
+    throw new Error('Expected value');
+  }
+
+  return value;
+}

--- a/apps/api/src/audit/__tests__/audit.service.test.ts
+++ b/apps/api/src/audit/__tests__/audit.service.test.ts
@@ -1,6 +1,7 @@
 import { audit_logs, type RequestContext } from '@cherrygraph/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getApiLogger } from '../../common/logger/logger.module.js';
 import { requestContextStorage } from '../../common/middleware/request-context.middleware.js';
 import { AuditService, type AuditEntry } from '../audit.service.js';
 
@@ -70,6 +71,48 @@ describe('AuditService', () => {
     expect(batch[49]?.resource_id).toBe('session-49');
   });
 
+  it('flushes queued entries in chunks and caps overflow by dropping the oldest queued entry', async () => {
+    let firstInsertResolve: (() => void) | undefined;
+    let valuesCallCount = 0;
+    const { db, values } = createDbMock(() => {
+      valuesCallCount += 1;
+
+      if (valuesCallCount === 1) {
+        return new Promise<unknown>((resolve) => {
+          firstInsertResolve = () => {
+            resolve(undefined);
+          };
+        });
+      }
+
+      return Promise.resolve();
+    });
+    const warn = vi.spyOn(getApiLogger(), 'warn').mockImplementation(() => undefined);
+    service = new AuditService(db);
+
+    for (let index = 0; index < 10_051; index += 1) {
+      service.push(createEntry({ resource_id: `session-${index}` }));
+    }
+
+    expect(values).toHaveBeenCalledTimes(1);
+
+    requireValue(firstInsertResolve)();
+    await service.onModuleDestroy();
+    service = undefined;
+
+    const persistedResourceIds = values.mock.calls.flatMap(([batch]) => batch.map((row) => row.resource_id));
+    expect(persistedResourceIds).toHaveLength(10_050);
+    expect(persistedResourceIds).toContain('session-0');
+    expect(persistedResourceIds).not.toContain('session-50');
+    expect(persistedResourceIds).toContain('session-10050');
+    expect(values.mock.calls.every(([batch]) => batch.length <= 50)).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ audit_max_queue_size: 10_000 }),
+      'Audit queue full; dropped oldest entry',
+    );
+  });
+
   it('does not write when the timer fires with an empty queue', async () => {
     const { db, insert } = createDbMock();
     service = new AuditService(db);
@@ -106,6 +149,58 @@ describe('AuditService', () => {
     expect(batch[0]?.request_id).toBe('req-audit-123');
   });
 
+  it('requeues failed flush batches and retries them', async () => {
+    let valuesCallCount = 0;
+    const { db, values } = createDbMock(() => {
+      valuesCallCount += 1;
+      return valuesCallCount === 1 ? Promise.reject(new Error('database unavailable')) : Promise.resolve();
+    });
+    const warn = vi.spyOn(getApiLogger(), 'warn').mockImplementation(() => undefined);
+    service = new AuditService(db);
+
+    for (let index = 0; index < 50; index += 1) {
+      service.push(createEntry({ resource_id: `session-${index}` }));
+    }
+
+    await service.onModuleDestroy();
+    service = undefined;
+
+    expect(values).toHaveBeenCalledTimes(2);
+    const failedBatch = requireValue(values.mock.calls[0])[0];
+    const retriedBatch = requireValue(values.mock.calls[1])[0];
+    expect(retriedBatch.map((row) => row.resource_id)).toEqual(failedBatch.map((row) => row.resource_id));
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: { message: 'database unavailable' },
+        audit_log_count: 50,
+        retry_count: 1,
+      }),
+      'Audit log flush failed',
+    );
+  });
+
+  it('drops a failed flush batch after two retries', async () => {
+    const { db, values } = createDbMock(() => Promise.reject(new Error('database unavailable')));
+    const warn = vi.spyOn(getApiLogger(), 'warn').mockImplementation(() => undefined);
+    service = new AuditService(db);
+
+    for (let index = 0; index < 50; index += 1) {
+      service.push(createEntry({ resource_id: `session-${index}` }));
+    }
+
+    await service.onModuleDestroy();
+    service = undefined;
+
+    expect(values).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        err: { message: 'database unavailable' },
+        audit_log_count: 50,
+      }),
+      'Audit log batch dropped after retry limit',
+    );
+  });
+
   it('strips sensitive metadata keys before persisting', async () => {
     const { db, values } = createDbMock();
     service = new AuditService(db);
@@ -115,14 +210,18 @@ describe('AuditService', () => {
         metadata_json: {
           email: 'user@example.com',
           password: 'p@ssw0rd',
+          password_hash: 'hash',
           access_token: 'access-token',
+          authorization: 'Bearer token',
+          encrypted_api_key_ref: 'safe-reference',
           nested: {
-            apiKey: 'api-key',
+            api_secret: 'api-secret',
+            encrypted_api_key_ref: 'nested-safe-reference',
             visible: true,
           },
           array: [
             {
-              refreshSecret: 'refresh-secret',
+              secret_value: 'secret-value',
               safe: 'value',
             },
           ],
@@ -135,7 +234,9 @@ describe('AuditService', () => {
     const batch = getOnlyBatch(values);
     expect(batch[0]?.metadata_json).toEqual({
       email: 'user@example.com',
+      encrypted_api_key_ref: 'safe-reference',
       nested: {
+        encrypted_api_key_ref: 'nested-safe-reference',
         visible: true,
       },
       array: [
@@ -145,10 +246,50 @@ describe('AuditService', () => {
       ],
     });
   });
+
+  it('truncates metadata beyond the sanitization depth limit', async () => {
+    const { db, values } = createDbMock();
+    service = new AuditService(db);
+
+    service.push(
+      createEntry({
+        metadata_json: {
+          level1: {
+            level2: {
+              level3: {
+                level4: {
+                  level5: {
+                    level6: 'too deep',
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const batch = getOnlyBatch(values);
+    expect(batch[0]?.metadata_json).toEqual({
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: {
+                level6: '[truncated]',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
 });
 
-function createDbMock(): DbMock {
-  const values: ValuesMock = vi.fn(() => Promise.resolve());
+function createDbMock(valuesImplementation: (values: AuditLogInsert[]) => Promise<unknown> = () => Promise.resolve()): DbMock {
+  const values: ValuesMock = vi.fn(valuesImplementation);
   const insert: InsertMock = vi.fn(() => ({ values }));
 
   return {

--- a/apps/api/src/audit/audit-events.ts
+++ b/apps/api/src/audit/audit-events.ts
@@ -1,0 +1,21 @@
+export const AUDIT_EVENTS = {
+  AUTH_LOGIN: 'auth.login',
+  AUTH_LOGOUT: 'auth.logout',
+  AUTH_TOKEN_REFRESH: 'auth.token_refresh',
+  AUTH_FAILED_LOGIN: 'auth.failed_login',
+  AUTH_PASSWORD_CHANGE: 'auth.password_change',
+  AUTH_SESSION_REVOKE: 'auth.session_revoke',
+  ADMIN_USER_CREATE: 'admin.user.create',
+  ADMIN_USER_UPDATE: 'admin.user.update',
+  ADMIN_USER_DISABLE: 'admin.user.disable',
+  ADMIN_GROUP_CREATE: 'admin.group.create',
+  USER_GROUP_CHANGE: 'user.group_change',
+  SPACE_CREATE: 'space.create',
+  SPACE_UPDATE: 'space.update',
+  SPACE_PERMISSION_CHANGE: 'space.permission_change',
+  ADMIN_MODEL_CREATE: 'admin.model.create',
+  ADMIN_MODEL_UPDATE: 'admin.model.update',
+  ADMIN_MODEL_TEST: 'admin.model.test',
+} as const;
+
+export type AuditEventType = (typeof AUDIT_EVENTS)[keyof typeof AUDIT_EVENTS];

--- a/apps/api/src/audit/audit.decorator.ts
+++ b/apps/api/src/audit/audit.decorator.ts
@@ -1,0 +1,18 @@
+import 'reflect-metadata';
+
+export const AUDIT_METADATA_KEY = Symbol('AUDIT_METADATA_KEY');
+
+export function Audited(action: string): MethodDecorator & ClassDecorator {
+  return (target: object, _propertyKey?: string | symbol, descriptor?: PropertyDescriptor): void => {
+    Reflect.defineMetadata(AUDIT_METADATA_KEY, action, getMetadataTarget(target, descriptor));
+  };
+}
+
+function getMetadataTarget(target: object, descriptor: PropertyDescriptor | undefined): object {
+  if (descriptor === undefined) {
+    return target;
+  }
+
+  const descriptorValue: unknown = descriptor.value;
+  return typeof descriptorValue === 'function' ? descriptorValue : target;
+}

--- a/apps/api/src/audit/audit.interceptor.ts
+++ b/apps/api/src/audit/audit.interceptor.ts
@@ -1,0 +1,112 @@
+import type { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { IncomingHttpHeaders } from 'node:http';
+import type { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+import { getApiLogger } from '../common/logger/logger.module.js';
+import { requestContextStorage } from '../common/middleware/request-context.middleware.js';
+import { AUDIT_METADATA_KEY } from './audit.decorator.js';
+import { AuditService, type AuditEntry } from './audit.service.js';
+
+type RequestLike = {
+  headers?: IncomingHttpHeaders;
+  ip?: string;
+  raw?: {
+    headers?: IncomingHttpHeaders;
+    ip?: string;
+    socket?: {
+      remoteAddress?: string;
+    };
+  };
+  socket?: {
+    remoteAddress?: string;
+  };
+};
+
+@Injectable()
+export class AuditInterceptor implements NestInterceptor {
+  constructor(private readonly auditService: AuditService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const action = getAuditAction(context);
+    if (action === undefined) {
+      return next.handle();
+    }
+
+    return next.handle().pipe(
+      tap(() => {
+        this.pushAuditEntry(context, action);
+      }),
+    );
+  }
+
+  private pushAuditEntry(context: ExecutionContext, action: string): void {
+    try {
+      this.auditService.push(buildAuditEntry(context, action));
+    } catch (err) {
+      getApiLogger().warn({ err, action }, 'Audit interceptor failed to enqueue entry');
+    }
+  }
+}
+
+function getAuditAction(context: ExecutionContext): string | undefined {
+  const handlerAction = Reflect.getMetadata(AUDIT_METADATA_KEY, context.getHandler()) as unknown;
+  if (typeof handlerAction === 'string' && handlerAction.length > 0) {
+    return handlerAction;
+  }
+
+  const classAction = Reflect.getMetadata(AUDIT_METADATA_KEY, context.getClass()) as unknown;
+  return typeof classAction === 'string' && classAction.length > 0 ? classAction : undefined;
+}
+
+function buildAuditEntry(context: ExecutionContext, action: string): AuditEntry {
+  const request = context.switchToHttp().getRequest<RequestLike>();
+  const requestContext = requestContextStorage.getStore();
+  const userId = requestContext?.user_id;
+  const spaceId = requestContext?.space_id;
+  const ip = getRequestIp(request);
+  const userAgent = getUserAgent(request);
+
+  return {
+    tenant_id: requestContext?.tenant_id ?? '',
+    action,
+    resource_type: getResourceType(context.getClass()),
+    ...(userId !== undefined && userId !== null && userId.length > 0 ? { actor_user_id: userId } : {}),
+    ...(spaceId !== undefined && spaceId !== null && spaceId.length > 0 ? { space_id: spaceId } : {}),
+    ...(requestContext?.request_id !== undefined ? { request_id: requestContext.request_id } : {}),
+    ...(ip !== undefined ? { ip } : {}),
+    ...(userAgent !== undefined ? { user_agent: userAgent } : {}),
+  };
+}
+
+function getResourceType(controller: { name: string }): string {
+  const controllerName = controller.name.replace(/Controller$/, '');
+  if (controllerName.length === 0) {
+    return 'unknown';
+  }
+
+  return controllerName
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+function getRequestIp(request: RequestLike): string | undefined {
+  return request.ip ?? request.raw?.ip ?? request.socket?.remoteAddress ?? request.raw?.socket?.remoteAddress;
+}
+
+function getUserAgent(request: RequestLike): string | undefined {
+  const headers = request.headers ?? request.raw?.headers;
+  const value = headers?.['user-agent'];
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const firstValue = value[0];
+    return typeof firstValue === 'string' ? firstValue : undefined;
+  }
+
+  return undefined;
+}

--- a/apps/api/src/audit/audit.interceptor.ts
+++ b/apps/api/src/audit/audit.interceptor.ts
@@ -43,6 +43,12 @@ export class AuditInterceptor implements NestInterceptor {
 
   private pushAuditEntry(context: ExecutionContext, action: string): void {
     try {
+      const requestContext = requestContextStorage.getStore();
+      if (requestContext?.tenant_id === undefined || requestContext.tenant_id.trim().length === 0) {
+        getApiLogger().debug({ action }, 'Audit interceptor skipped entry without tenant context');
+        return;
+      }
+
       this.auditService.push(buildAuditEntry(context, action));
     } catch (err) {
       getApiLogger().warn({ err, action }, 'Audit interceptor failed to enqueue entry');

--- a/apps/api/src/audit/audit.module.ts
+++ b/apps/api/src/audit/audit.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+
+import { AuditInterceptor } from './audit.interceptor.js';
+import { AuditService } from './audit.service.js';
+
+@Global()
+@Module({
+  providers: [
+    AuditService,
+    AuditInterceptor,
+    {
+      provide: APP_INTERCEPTOR,
+      useExisting: AuditInterceptor,
+    },
+  ],
+  exports: [AuditService, AuditInterceptor],
+})
+export class AuditModule {}

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -1,0 +1,159 @@
+import { Inject, Injectable, type OnModuleDestroy } from '@nestjs/common';
+import { audit_logs } from '@cherrygraph/shared';
+import { randomUUID } from 'node:crypto';
+
+import { DRIZZLE } from '../database/drizzle.constants.js';
+import { getApiLogger } from '../common/logger/logger.module.js';
+import { requestContextStorage } from '../common/middleware/request-context.middleware.js';
+
+export interface AuditEntry {
+  tenant_id: string;
+  actor_user_id?: string;
+  action: string;
+  resource_type: string;
+  resource_id?: string;
+  space_id?: string;
+  ip?: string;
+  user_agent?: string;
+  request_id?: string;
+  metadata_json?: Record<string, unknown>;
+}
+
+type AuditLogInsert = typeof audit_logs.$inferInsert;
+
+type AuditDatabase = {
+  insert: (table: typeof audit_logs) => {
+    values: (values: AuditLogInsert[]) => Promise<unknown>;
+  };
+};
+
+const AUDIT_FLUSH_INTERVAL_MS = 1_000;
+const AUDIT_FLUSH_BATCH_SIZE = 50;
+const SENSITIVE_KEY_PARTS = ['password', 'token', 'secret', 'key'] as const;
+
+@Injectable()
+export class AuditService implements OnModuleDestroy {
+  private readonly queue: AuditLogInsert[] = [];
+  private readonly flushTimer: NodeJS.Timeout;
+  private flushPromise: Promise<void> | undefined;
+
+  constructor(@Inject(DRIZZLE) private readonly db: AuditDatabase) {
+    this.flushTimer = setInterval(() => {
+      void this.flush();
+    }, AUDIT_FLUSH_INTERVAL_MS);
+  }
+
+  push(entry: AuditEntry): void {
+    this.queue.push(toAuditLogInsert(entry));
+
+    if (this.queue.length >= AUDIT_FLUSH_BATCH_SIZE) {
+      void this.flush();
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    clearInterval(this.flushTimer);
+
+    if (this.flushPromise !== undefined) {
+      await this.flushPromise;
+    }
+
+    while (this.queue.length > 0) {
+      await this.flush();
+    }
+  }
+
+  private async flush(): Promise<void> {
+    if (this.flushPromise !== undefined) {
+      return this.flushPromise;
+    }
+
+    this.flushPromise = this.flushQueuedBatch();
+
+    try {
+      await this.flushPromise;
+    } finally {
+      this.flushPromise = undefined;
+    }
+  }
+
+  private async flushQueuedBatch(): Promise<void> {
+    if (this.queue.length === 0) {
+      return;
+    }
+
+    const batch = this.queue.splice(0, this.queue.length);
+
+    try {
+      await this.db.insert(audit_logs).values(batch);
+    } catch (err) {
+      getApiLogger().warn({ err, audit_log_count: batch.length }, 'Audit log flush failed');
+    }
+  }
+}
+
+function toAuditLogInsert(entry: AuditEntry): AuditLogInsert {
+  const requestId = entry.request_id ?? requestContextStorage.getStore()?.request_id;
+
+  return {
+    id: randomUUID(),
+    tenant_id: entry.tenant_id,
+    action: entry.action,
+    resource_type: entry.resource_type,
+    metadata_json: sanitizeMetadata(entry.metadata_json),
+    ...(entry.actor_user_id !== undefined ? { actor_user_id: entry.actor_user_id } : {}),
+    ...(entry.resource_id !== undefined ? { resource_id: entry.resource_id } : {}),
+    ...(entry.space_id !== undefined ? { space_id: entry.space_id } : {}),
+    ...(entry.ip !== undefined ? { ip: entry.ip } : {}),
+    ...(entry.user_agent !== undefined ? { user_agent: entry.user_agent } : {}),
+    ...(requestId !== undefined ? { request_id: requestId } : {}),
+  };
+}
+
+function sanitizeMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (metadata === undefined) {
+    return {};
+  }
+
+  return sanitizeRecord(metadata);
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeValue);
+  }
+
+  if (isPlainRecord(value)) {
+    return sanitizeRecord(value);
+  }
+
+  return value;
+}
+
+function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    if (isSensitiveKey(key) || value === undefined) {
+      continue;
+    }
+
+    sanitized[key] = sanitizeValue(value);
+  }
+
+  return sanitized;
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalizedKey = key.toLowerCase();
+  return SENSITIVE_KEY_PARTS.some((part) => normalizedKey.includes(part));
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -27,15 +27,34 @@ type AuditDatabase = {
   };
 };
 
+type QueuedAuditLogInsert = {
+  insert: AuditLogInsert;
+  retryCount: number;
+};
+
 const AUDIT_FLUSH_INTERVAL_MS = 1_000;
 const AUDIT_FLUSH_BATCH_SIZE = 50;
-const SENSITIVE_KEY_PARTS = ['password', 'token', 'secret', 'key'] as const;
+const AUDIT_MAX_QUEUE_SIZE = 10_000;
+const AUDIT_MAX_FLUSH_RETRIES = 2;
+const AUDIT_METADATA_MAX_DEPTH = 5;
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'password_hash',
+  'access_token',
+  'refresh_token',
+  'authorization',
+  'cookie',
+  'jwt',
+]);
+const SENSITIVE_PREFIXES = ['secret_', 'api_secret'] as const;
 
 @Injectable()
 export class AuditService implements OnModuleDestroy {
-  private readonly queue: AuditLogInsert[] = [];
+  private readonly queue: QueuedAuditLogInsert[] = [];
   private readonly flushTimer: NodeJS.Timeout;
   private flushPromise: Promise<void> | undefined;
+  private _retryCount = 0;
+  private queueOverflowWarningLogged = false;
 
   constructor(@Inject(DRIZZLE) private readonly db: AuditDatabase) {
     this.flushTimer = setInterval(() => {
@@ -44,7 +63,21 @@ export class AuditService implements OnModuleDestroy {
   }
 
   push(entry: AuditEntry): void {
-    this.queue.push(toAuditLogInsert(entry));
+    if (this.queue.length >= AUDIT_MAX_QUEUE_SIZE) {
+      this.queue.shift();
+
+      if (!this.queueOverflowWarningLogged) {
+        getApiLogger().warn(
+          { audit_queue_size: this.queue.length, audit_max_queue_size: AUDIT_MAX_QUEUE_SIZE },
+          'Audit queue full; dropped oldest entry',
+        );
+        this.queueOverflowWarningLogged = true;
+      }
+    } else {
+      this.queueOverflowWarningLogged = false;
+    }
+
+    this.queue.push({ insert: toAuditLogInsert(entry), retryCount: 0 });
 
     if (this.queue.length >= AUDIT_FLUSH_BATCH_SIZE) {
       void this.flush();
@@ -68,7 +101,7 @@ export class AuditService implements OnModuleDestroy {
       return this.flushPromise;
     }
 
-    this.flushPromise = this.flushQueuedBatch();
+    this.flushPromise = this.flushQueuedBatches();
 
     try {
       await this.flushPromise;
@@ -77,17 +110,35 @@ export class AuditService implements OnModuleDestroy {
     }
   }
 
+  private async flushQueuedBatches(): Promise<void> {
+    do {
+      await this.flushQueuedBatch();
+    } while (this.queue.length >= AUDIT_FLUSH_BATCH_SIZE);
+  }
+
   private async flushQueuedBatch(): Promise<void> {
     if (this.queue.length === 0) {
       return;
     }
 
-    const batch = this.queue.splice(0, this.queue.length);
+    const batch = this.queue.splice(0, Math.min(this.queue.length, AUDIT_FLUSH_BATCH_SIZE));
+    const insertBatch = batch.map(({ insert }) => insert);
 
     try {
-      await this.db.insert(audit_logs).values(batch);
+      await this.db.insert(audit_logs).values(insertBatch);
+      this._retryCount = 0;
     } catch (err) {
-      getApiLogger().warn({ err, audit_log_count: batch.length }, 'Audit log flush failed');
+      this._retryCount = Math.max(0, ...batch.map(({ retryCount }) => retryCount)) + 1;
+      const logContext = { err: toSafeLogError(err), audit_log_count: insertBatch.length };
+
+      if (this._retryCount > AUDIT_MAX_FLUSH_RETRIES) {
+        getApiLogger().warn({ ...logContext, retry_count: this._retryCount }, 'Audit log batch dropped after retry limit');
+        this._retryCount = 0;
+        return;
+      }
+
+      this.queue.unshift(...batch.map((queuedEntry) => ({ ...queuedEntry, retryCount: this._retryCount })));
+      getApiLogger().warn({ ...logContext, retry_count: this._retryCount }, 'Audit log flush failed');
     }
   }
 }
@@ -115,22 +166,26 @@ function sanitizeMetadata(metadata: Record<string, unknown> | undefined): Record
     return {};
   }
 
-  return sanitizeRecord(metadata);
+  return sanitizeRecord(metadata, AUDIT_METADATA_MAX_DEPTH, 0);
 }
 
-function sanitizeValue(value: unknown): unknown {
+function sanitizeValue(value: unknown, maxDepth = AUDIT_METADATA_MAX_DEPTH, depth = 0): unknown {
+  if (depth > maxDepth) {
+    return '[truncated]';
+  }
+
   if (Array.isArray(value)) {
-    return value.map(sanitizeValue);
+    return value.map((item) => sanitizeValue(item, maxDepth, depth + 1));
   }
 
   if (isPlainRecord(value)) {
-    return sanitizeRecord(value);
+    return sanitizeRecord(value, maxDepth, depth);
   }
 
   return value;
 }
 
-function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown> {
+function sanitizeRecord(record: Record<string, unknown>, maxDepth: number, depth: number): Record<string, unknown> {
   const sanitized: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(record)) {
@@ -138,7 +193,7 @@ function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown
       continue;
     }
 
-    sanitized[key] = sanitizeValue(value);
+    sanitized[key] = sanitizeValue(value, maxDepth, depth + 1);
   }
 
   return sanitized;
@@ -146,7 +201,15 @@ function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown
 
 function isSensitiveKey(key: string): boolean {
   const normalizedKey = key.toLowerCase();
-  return SENSITIVE_KEY_PARTS.some((part) => normalizedKey.includes(part));
+  return (
+    SENSITIVE_KEYS.has(normalizedKey) ||
+    normalizedKey === 'secret' ||
+    SENSITIVE_PREFIXES.some((prefix) => normalizedKey.startsWith(prefix))
+  );
+}
+
+function toSafeLogError(err: unknown): { message: string } {
+  return { message: err instanceof Error ? err.message : String(err) };
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/api/src/database/drizzle.module.ts
+++ b/apps/api/src/database/drizzle.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Inject, Injectable, Module, type OnModuleDestroy } from '@nestjs/common';
+import { DynamicModule, Global, Inject, Injectable, Module, type OnModuleDestroy } from '@nestjs/common';
 import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import pg from 'pg';
 import type { Pool as PgPool, PoolConfig } from 'pg';
@@ -27,6 +27,7 @@ class PgPoolShutdown implements OnModuleDestroy {
   }
 }
 
+@Global()
 @Module({})
 export class DrizzleModule {
   static forRoot(options: DrizzleModuleOptions = {}): DynamicModule {

--- a/openspec/changes/stage1-auth-rbac-space-admin/tasks.md
+++ b/openspec/changes/stage1-auth-rbac-space-admin/tasks.md
@@ -32,6 +32,15 @@
 - [ ] 2.2 创建 NestJS AuditInterceptor：自动捕获标记了 @Audited() 的请求，推入 AuditService 队列
 - [ ] 2.3 定义审计事件常量枚举：auth.login, auth.logout, auth.token_refresh, auth.failed_login, auth.password_change, auth.session_revoke, admin.user.create, admin.user.update, admin.user.disable, admin.group.create, user.group_change, space.create, space.update, space.permission_change, admin.model.create, admin.model.update, admin.model.test
 
+### 2.T Audit Infrastructure Tests
+
+- [ ] 2.T1 AuditService 队列测试：push 事件到队列后 1s 内 flush 到 DB mock，满 50 条提前 flush，空队列不产生 DB 调用
+- [ ] 2.T2 AuditService graceful drain 测试：onModuleDestroy 时 flush 队列中所有剩余事件
+- [ ] 2.T3 @Audited() 装饰器 + AuditInterceptor 测试：标记了 @Audited('action') 的 controller 方法被拦截并推入审计队列，未标记的方法不触发审计
+- [ ] 2.T4 审计事件枚举完整性测试：验证 17 种必记事件全部定义，枚举值无拼写错误
+- [ ] 2.T5 审计日志 request_id 关联测试：审计条目包含来自 AsyncLocalStorage 的 request_id
+- [ ] 2.T6 审计日志敏感信息排除测试：push 含 password/token 字段的 metadata 时，这些字段被 sanitize 或剥离
+
 ## 3. Auth Core (packages/auth-core)
 
 - [ ] 3.1 实现 argon2id 密码哈希工具（hash / verify），fallback bcrypt 支持


### PR DESCRIPTION
## Summary
- AuditService with async memory queue (1s interval / 50-item chunked batch flush), graceful drain, bounded retry on failure
- @Audited() method/class decorator + AuditInterceptor for automatic success-only audit capture
- 17 audit event constants covering auth, user, space, and model operations
- Explicit denylist metadata sanitization with 5-level depth limit
- 10K queue cap with drop-oldest policy, safe error logging
- Global AuditModule registered as APP_INTERCEPTOR

Closes #19

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `294670d7cfe9e9d9e8e8cb93e7479fda5491e9bb`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/31#issuecomment-4345481727) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/31#issuecomment-4345482038)
- Key findings addressed: flush requeue with bounded retry, explicit sanitization denylist preserving encrypted_api_key_ref, 10K queue cap with chunked flush, depth-limited sanitization, empty tenant_id skip, safe error logging

## Test plan
- [x] `pnpm build` — all packages and apps compile
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test` — 22 test files / 94 tests pass
- [x] AuditService: 1s timer flush, 50-item batch, empty queue no-op, graceful drain, request_id propagation
- [x] Metadata sanitization: denylist stripping, encrypted_api_key_ref preserved, depth truncation
- [x] Flush reliability: requeue on failure, drop after max retries, queue overflow handling
- [x] AuditInterceptor: @Audited triggers push, non-audited skips, empty tenant_id skips
- [x] All 17 audit event constants verified