### PR TITLE
feat(api): add space module — CRUD, permission-filtered list, stats (#23)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './auth/auth.module.js';
 import { DrizzleModule } from './database/drizzle.module.js';
 import { GroupModule } from './groups/group.module.js';
 import { HealthModule } from './health/health.module.js';
+import { SpaceModule } from './spaces/space.module.js';
 import { UserModule } from './users/user.module.js';
 
 @Module({
@@ -20,6 +21,7 @@ import { UserModule } from './users/user.module.js';
     AuthModule,
     UserModule,
     GroupModule,
+    SpaceModule,
     HealthModule,
   ],
 })

--- a/apps/api/src/groups/group.module.ts
+++ b/apps/api/src/groups/group.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
 
-import { SpacePermissionController } from '../spaces/space-permission.controller.js';
 import { GroupController } from './group.controller.js';
 import { GroupService } from './group.service.js';
 
 @Module({
-  controllers: [GroupController, SpacePermissionController],
+  controllers: [GroupController],
   providers: [GroupService],
   exports: [GroupService],
 })

--- a/apps/api/src/spaces/__tests__/space.service.test.ts
+++ b/apps/api/src/spaces/__tests__/space.service.test.ts
@@ -200,6 +200,7 @@ describe('SpaceService', () => {
   it('gets placeholder stats', async () => {
     const { service, db } = createServiceContext();
     db.queueSelect([createSpaceRow({ index_consistency_status: 'stale' })]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID }]);
 
     await expect(service.getStats(TEST_SPACE_ID, createViewerContext())).resolves.toEqual({
       space_id: TEST_SPACE_ID,

--- a/apps/api/src/spaces/__tests__/space.service.test.ts
+++ b/apps/api/src/spaces/__tests__/space.service.test.ts
@@ -1,0 +1,262 @@
+import { ErrorCode } from '@cherrygraph/shared';
+import { describe, expect, it } from 'vitest';
+
+import { AUDIT_EVENTS } from '../../audit/audit-events.js';
+import {
+  TEST_ACTOR_ID,
+  TEST_SPACE_ID,
+  TEST_TENANT_ID,
+  TEST_USER_ID,
+  ScriptedDb,
+  createAuditMock,
+  createSpaceRow,
+  getHttpExceptionCode,
+  getRejectedHttpException,
+  requireRecord,
+} from '../../users/__tests__/user-group-service-test-utils.js';
+import { SpaceService, type SpaceContext } from '../space.service.js';
+
+describe('SpaceService', () => {
+  it('lists only spaces the user has view permission for', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([{ space_id: TEST_SPACE_ID }, { space_id: 'space-2' }]);
+    db.queueSelect([createSpaceRow(), createSpaceRow({ id: 'space-2', slug: 'product' })]);
+    db.queueSelect([{ total: 2 }]);
+
+    const result = await service.listSpaces({ page: 1, per_page: 20 }, createViewerContext());
+
+    expect(result.data.map((space) => space.id)).toEqual([TEST_SPACE_ID, 'space-2']);
+    expect(result.data[0]?.stats).toEqual({
+      page_count: 0,
+      source_count: 0,
+      node_count: 0,
+    });
+    expect(result.pagination.total).toBe(2);
+  });
+
+  it.each(['owner', 'admin'] as const)('lists all spaces for %s role', async (role) => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createSpaceRow(), createSpaceRow({ id: 'space-2', slug: 'product' })]);
+    db.queueSelect([{ total: 2 }]);
+
+    const result = await service.listSpaces(
+      { page: 1, per_page: 20 },
+      createViewerContext({ actorRole: role }),
+    );
+
+    expect(result.data.map((space) => space.id)).toEqual([TEST_SPACE_ID, 'space-2']);
+    expect(result.pagination.total).toBe(2);
+  });
+
+  it('lists spaces with search filter', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([{ space_id: TEST_SPACE_ID }]);
+    db.queueSelect([createSpaceRow({ name: 'Research Knowledge' })]);
+    db.queueSelect([{ total: 1 }]);
+
+    const result = await service.listSpaces(
+      { page: 1, per_page: 20, search: 'Research' },
+      createViewerContext(),
+    );
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.name).toBe('Research Knowledge');
+  });
+
+  it('creates a space with auto wiki repo path and audit event', async () => {
+    const { service, db, audit } = createServiceContext();
+    db.queueSelect([]);
+
+    const result = await service.createSpace(
+      { name: 'Product', slug: 'product', description: 'Product knowledge' },
+      createAdminContext(),
+    );
+
+    const inserted = getInsertValue(db, 0);
+    expect(result.id).toBe(inserted.id);
+    expect(result.status).toBe('active');
+    expect(result.strict_knowledge_only).toBe(true);
+    expect(result.graphify_config).toEqual({});
+    expect(result.wiki_repo_path).toBe(`/data/wiki/${result.id}`);
+    expect(inserted.wiki_repo_path).toBe(`/data/wiki/${String(inserted.id)}`);
+    expect(audit.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_EVENTS.SPACE_CREATE,
+        resource_type: 'space',
+        resource_id: result.id,
+        space_id: result.id,
+      }),
+    );
+  });
+
+  it('maps create slug conflict to SPACE_SLUG_CONFLICT', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([{ id: TEST_SPACE_ID }]);
+
+    const err = await getRejectedHttpException(
+      service.createSpace({ name: 'Knowledge', slug: 'knowledge' }, createAdminContext()),
+    );
+
+    expect(err.getStatus()).toBe(409);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.SPACE_SLUG_CONFLICT);
+  });
+
+  it('gets space details when user has view permission', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID }]);
+
+    const result = await service.getSpace(TEST_SPACE_ID, createViewerContext());
+
+    expect(result).toMatchObject({
+      id: TEST_SPACE_ID,
+      name: 'Knowledge',
+      wiki_repo_path: '/data/wiki/space-1',
+      index_consistency_status: 'healthy',
+      stats: {
+        page_count: 0,
+        source_count: 0,
+        node_count: 0,
+      },
+    });
+  });
+
+  it('returns 404 for get space without permission', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([]);
+
+    const err = await getRejectedHttpException(service.getSpace(TEST_SPACE_ID, createViewerContext()));
+
+    expect(err.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.SPACE_NOT_FOUND);
+  });
+
+  it('returns 404 for nonexistent space', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([]);
+
+    const err = await getRejectedHttpException(service.getSpace('missing-space', createViewerContext()));
+
+    expect(err.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.SPACE_NOT_FOUND);
+  });
+
+  it('updates a space and ignores wiki_repo_path from input', async () => {
+    const { service, db } = createServiceContext();
+    const updatedRow = createSpaceRow({
+      name: 'Updated Knowledge',
+      wiki_repo_path: '/data/wiki/space-1',
+    });
+    db.queueSelect([createSpaceRow()]);
+    db.queueUpdate([updatedRow]);
+
+    const result = await service.updateSpace(
+      TEST_SPACE_ID,
+      { name: 'Updated Knowledge', wiki_repo_path: '/custom/path' },
+      createAdminContext(),
+    );
+
+    const updateValue = getUpdateValue(db, 0);
+    expect(updateValue.name).toBe('Updated Knowledge');
+    expect(updateValue).not.toHaveProperty('wiki_repo_path');
+    expect(result.wiki_repo_path).toBe('/data/wiki/space-1');
+  });
+
+  it('maps update slug conflict to SPACE_SLUG_CONFLICT', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([{ id: 'space-2' }]);
+
+    const err = await getRejectedHttpException(
+      service.updateSpace(TEST_SPACE_ID, { slug: 'product' }, createAdminContext()),
+    );
+
+    expect(err.getStatus()).toBe(409);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.SPACE_SLUG_CONFLICT);
+    expect(db.updates).toHaveLength(0);
+  });
+
+  it('records audit event for updates', async () => {
+    const { service, db, audit } = createServiceContext();
+    db.queueSelect([createSpaceRow()]);
+    db.queueUpdate([createSpaceRow({ strict_knowledge_only: false })]);
+
+    await service.updateSpace(TEST_SPACE_ID, { strict_knowledge_only: false }, createAdminContext());
+
+    expect(audit.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_EVENTS.SPACE_UPDATE,
+        resource_type: 'space',
+        resource_id: TEST_SPACE_ID,
+        space_id: TEST_SPACE_ID,
+        metadata_json: {
+          changed_fields: ['strict_knowledge_only'],
+        },
+      }),
+    );
+  });
+
+  it('gets placeholder stats', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createSpaceRow({ index_consistency_status: 'stale' })]);
+
+    await expect(service.getStats(TEST_SPACE_ID, createViewerContext())).resolves.toEqual({
+      space_id: TEST_SPACE_ID,
+      page_count: 0,
+      source_count: 0,
+      node_count: 0,
+      edge_count: 0,
+      index_consistency: 'stale',
+    });
+  });
+});
+
+function createServiceContext(): {
+  service: SpaceService;
+  db: ScriptedDb;
+  audit: ReturnType<typeof createAuditMock>;
+} {
+  const db = new ScriptedDb();
+  const audit = createAuditMock();
+  const service = new SpaceService(db.asDrizzle(), audit.service);
+
+  return { service, db, audit };
+}
+
+function createViewerContext(overrides: Partial<SpaceContext> = {}): SpaceContext {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: TEST_USER_ID,
+    userId: TEST_USER_ID,
+    actorRole: 'viewer',
+    ...overrides,
+  };
+}
+
+function createAdminContext(): SpaceContext {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: TEST_ACTOR_ID,
+    userId: TEST_ACTOR_ID,
+    actorRole: 'admin',
+  };
+}
+
+function getInsertValue(db: ScriptedDb, index: number): Record<string, unknown> {
+  const operation = db.inserts[index];
+  if (operation === undefined) {
+    throw new Error(`Missing insert at index ${index}`);
+  }
+
+  return requireRecord(operation.value);
+}
+
+function getUpdateValue(db: ScriptedDb, index: number): Record<string, unknown> {
+  const operation = db.updates[index];
+  if (operation === undefined) {
+    throw new Error(`Missing update at index ${index}`);
+  }
+
+  return requireRecord(operation.value);
+}

--- a/apps/api/src/spaces/space.controller.ts
+++ b/apps/api/src/spaces/space.controller.ts
@@ -111,7 +111,7 @@ export class SpaceController {
     });
   }
 
-  @Permissions('space:admin')
+  @Permissions('admin:user_manage')
   @Post()
   async createSpace(
     @Body() body: CreateSpaceDto,

--- a/apps/api/src/spaces/space.controller.ts
+++ b/apps/api/src/spaces/space.controller.ts
@@ -1,0 +1,187 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { Permissions, type AuthenticatedRequestUser } from '@cherrygraph/auth-core';
+import { ErrorCode } from '@cherrygraph/shared';
+import {
+  IsBoolean,
+  IsIn,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+
+import { PaginationQueryDto } from '../common/dto/pagination.dto.js';
+import { SpaceService, type SpaceDetail, type SpaceStatsResponse } from './space.service.js';
+
+class ListSpacesQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsIn(['active', 'archived'])
+  status?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  search?: string;
+}
+
+class CreateSpaceDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  name!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+  slug!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(5000)
+  description?: string;
+}
+
+class UpdateSpaceDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+  slug?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(5000)
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  strict_knowledge_only?: boolean;
+
+  @IsOptional()
+  @IsObject()
+  graphify_config?: Record<string, unknown>;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2048)
+  wiki_repo_path?: string;
+}
+
+type RequestWithAuth = {
+  user?: AuthenticatedRequestUser;
+};
+
+@Controller('spaces')
+export class SpaceController {
+  constructor(private readonly spaceService: SpaceService) {}
+
+  @Get()
+  async listSpaces(
+    @Query() query: ListSpacesQueryDto,
+    @Req() request: RequestWithAuth,
+  ): ReturnType<SpaceService['listSpaces']> {
+    const user = getAuthenticatedUser(request);
+    return this.spaceService.listSpaces(query, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+      userId: user.sub,
+    });
+  }
+
+  @Permissions('space:admin')
+  @Post()
+  async createSpace(
+    @Body() body: CreateSpaceDto,
+    @Req() request: RequestWithAuth,
+  ): Promise<SpaceDetail> {
+    const user = getAuthenticatedUser(request);
+    return this.spaceService.createSpace(body, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+    });
+  }
+
+  @Permissions('space:view')
+  @Get(':space_id/stats')
+  async getStats(
+    @Param('space_id') spaceId: string,
+    @Req() request: RequestWithAuth,
+  ): Promise<SpaceStatsResponse> {
+    const user = getAuthenticatedUser(request);
+    return this.spaceService.getStats(spaceId, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+      userId: user.sub,
+    });
+  }
+
+  @Get(':space_id')
+  async getSpace(
+    @Param('space_id') spaceId: string,
+    @Req() request: RequestWithAuth,
+  ): Promise<SpaceDetail> {
+    const user = getAuthenticatedUser(request);
+    return this.spaceService.getSpace(spaceId, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+      userId: user.sub,
+    });
+  }
+
+  @Permissions('space:admin')
+  @HttpCode(HttpStatus.OK)
+  @Patch(':space_id')
+  async updateSpace(
+    @Param('space_id') spaceId: string,
+    @Body() body: UpdateSpaceDto,
+    @Req() request: RequestWithAuth,
+  ): Promise<SpaceDetail> {
+    const user = getAuthenticatedUser(request);
+    return this.spaceService.updateSpace(spaceId, body, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+      userId: user.sub,
+    });
+  }
+}
+
+function getAuthenticatedUser(request: RequestWithAuth): AuthenticatedRequestUser {
+  if (request.user === undefined) {
+    throw new HttpException(
+      {
+        code: ErrorCode.UNAUTHENTICATED,
+        message: 'Unauthenticated',
+      },
+      HttpStatus.UNAUTHORIZED,
+    );
+  }
+
+  return request.user;
+}

--- a/apps/api/src/spaces/space.module.ts
+++ b/apps/api/src/spaces/space.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { GroupModule } from '../groups/group.module.js';
+import { SpaceController } from './space.controller.js';
+import { SpacePermissionController } from './space-permission.controller.js';
+import { SpaceService } from './space.service.js';
+
+@Module({
+  imports: [GroupModule],
+  controllers: [SpaceController, SpacePermissionController],
+  providers: [SpaceService],
+  exports: [SpaceService],
+})
+export class SpaceModule {}

--- a/apps/api/src/spaces/space.service.ts
+++ b/apps/api/src/spaces/space.service.ts
@@ -1,0 +1,581 @@
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { ROLES, normalizeRole } from '@cherrygraph/auth-core';
+import { ErrorCode, group_members, space_permissions, spaces, tenants } from '@cherrygraph/shared';
+import { and, asc, count, desc, eq, ilike, inArray, ne, or, type SQL } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { randomUUID } from 'node:crypto';
+
+import { AUDIT_EVENTS } from '../audit/audit-events.js';
+import { AuditService } from '../audit/audit.service.js';
+import {
+  buildPaginationMeta,
+  paginatedResponse,
+  parseSortField,
+  type PaginatedResponse,
+} from '../common/dto/pagination.dto.js';
+import { DRIZZLE } from '../database/drizzle.constants.js';
+
+type SpaceDatabase = NodePgDatabase;
+type SpaceRow = typeof spaces.$inferSelect;
+type JsonRecord = Record<string, unknown>;
+
+export type SpaceContext = {
+  tenantId?: string;
+  actorUserId?: string;
+  actorRole?: string;
+  userId?: string;
+};
+
+export type ListSpacesInput = {
+  page?: number;
+  per_page?: number;
+  sort?: string;
+  status?: string;
+  search?: string;
+};
+
+export type CreateSpaceInput = {
+  name: string;
+  slug: string;
+  description?: string;
+};
+
+export type UpdateSpaceInput = {
+  name?: string;
+  slug?: string;
+  description?: string;
+  strict_knowledge_only?: boolean;
+  graphify_config?: JsonRecord;
+  wiki_repo_path?: string;
+};
+
+export type SpaceStatsSummary = {
+  page_count: number;
+  source_count: number;
+  node_count: number;
+};
+
+export type SpaceListItem = {
+  id: string;
+  name: string;
+  slug: string;
+  status: string;
+  description: string | null;
+  stats: SpaceStatsSummary;
+  created_at: Date;
+  updated_at: Date;
+};
+
+export type SpaceDetail = SpaceListItem & {
+  docmost_space_id: string | null;
+  wiki_repo_path: string;
+  active_graphify_run_id: string | null;
+  active_index_snapshot_id: string | null;
+  index_consistency_status: string;
+  strict_knowledge_only: boolean;
+  graphify_config: unknown;
+  default_publish_policy: string;
+};
+
+export type SpaceStatsResponse = {
+  space_id: string;
+  page_count: number;
+  source_count: number;
+  node_count: number;
+  edge_count: number;
+  index_consistency: string;
+};
+
+type SpaceSortField = keyof Pick<typeof spaces, 'created_at' | 'updated_at' | 'name' | 'slug' | 'status'>;
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PER_PAGE = 20;
+const MAX_PER_PAGE = 100;
+const VIEW_PERMISSION = 'space:view';
+
+@Injectable()
+export class SpaceService {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: SpaceDatabase,
+    private readonly auditService: AuditService,
+  ) {}
+
+  async listSpaces(
+    input: ListSpacesInput = {},
+    context: SpaceContext = {},
+  ): Promise<PaginatedResponse<SpaceListItem>> {
+    const tenantId = await this.resolveTenantId(context);
+    const page = normalizePage(input.page);
+    const perPage = normalizePerPage(input.per_page);
+    const filters = await this.buildListFilters(tenantId, input, context);
+
+    if (filters === undefined) {
+      return paginatedResponse([], buildPaginationMeta(page, perPage, 0));
+    }
+
+    const where = and(...filters);
+    const order = buildSpaceOrder(input.sort ?? '-created_at');
+    const rows = await this.db
+      .select()
+      .from(spaces)
+      .where(where)
+      .orderBy(order)
+      .limit(perPage)
+      .offset((page - 1) * perPage);
+    const [countRow] = await this.db.select({ total: count() }).from(spaces).where(where);
+
+    return paginatedResponse(
+      rows.map(toSpaceListItem),
+      buildPaginationMeta(page, perPage, normalizeCount(countRow?.total)),
+    );
+  }
+
+  async createSpace(input: CreateSpaceInput, context: SpaceContext = {}): Promise<SpaceDetail> {
+    const tenantId = await this.resolveTenantId(context);
+    const slug = normalizeSlug(input.slug);
+    const existing = await findSpaceBySlug(this.db, tenantId, slug);
+    if (existing !== undefined) {
+      throwApiError(ErrorCode.SPACE_SLUG_CONFLICT, 'Space slug already exists', HttpStatus.CONFLICT);
+    }
+
+    const id = randomUUID();
+    const now = new Date();
+
+    try {
+      const [created] = await this.db
+        .insert(spaces)
+        .values({
+          id,
+          tenant_id: tenantId,
+          name: input.name.trim(),
+          slug,
+          description: input.description?.trim() ?? null,
+          status: 'active',
+          docmost_space_id: null,
+          wiki_repo_path: `/data/wiki/${id}`,
+          active_graphify_run_id: null,
+          active_index_snapshot_id: null,
+          index_consistency_status: 'healthy',
+          permission_version: 1,
+          strict_knowledge_only: true,
+          graphify_config: {},
+          default_publish_policy: 'editor_publish',
+          created_at: now,
+          updated_at: now,
+        })
+        .returning();
+
+      if (created === undefined) {
+        throw new Error('Failed to create space');
+      }
+
+      this.auditService.push({
+        tenant_id: tenantId,
+        ...(context.actorUserId !== undefined ? { actor_user_id: context.actorUserId } : {}),
+        action: AUDIT_EVENTS.SPACE_CREATE,
+        resource_type: 'space',
+        resource_id: created.id,
+        space_id: created.id,
+        metadata_json: {
+          name: created.name,
+          slug: created.slug,
+        },
+      });
+
+      return toSpaceDetail(created);
+    } catch (err) {
+      if (isUniqueViolation(err, 'spaces_tenant_id_slug_unique')) {
+        throwApiError(ErrorCode.SPACE_SLUG_CONFLICT, 'Space slug already exists', HttpStatus.CONFLICT);
+      }
+
+      throw err;
+    }
+  }
+
+  async getSpace(spaceId: string, context: SpaceContext = {}): Promise<SpaceDetail> {
+    const tenantId = await this.resolveTenantId(context);
+    const space = await findSpaceById(this.db, tenantId, spaceId);
+    if (space === undefined) {
+      throwSpaceNotFound();
+    }
+
+    if (!hasImplicitSpaceAccess(context.actorRole)) {
+      const userId = resolveContextUserId(context);
+      const allowed = await this.hasSpaceViewPermission(tenantId, userId, spaceId);
+      if (!allowed) {
+        throwSpaceNotFound();
+      }
+    }
+
+    return toSpaceDetail(space);
+  }
+
+  async updateSpace(
+    spaceId: string,
+    input: UpdateSpaceInput,
+    context: SpaceContext = {},
+  ): Promise<SpaceDetail> {
+    const tenantId = await this.resolveTenantId(context);
+    const existing = await findSpaceById(this.db, tenantId, spaceId);
+    if (existing === undefined) {
+      throwSpaceNotFound();
+    }
+
+    const updateValues: Partial<typeof spaces.$inferInsert> = {
+      updated_at: new Date(),
+    };
+    const changedFields: string[] = [];
+
+    if (input.name !== undefined && input.name.trim() !== existing.name) {
+      updateValues.name = input.name.trim();
+      changedFields.push('name');
+    }
+
+    if (input.slug !== undefined) {
+      const slug = normalizeSlug(input.slug);
+      if (slug !== existing.slug) {
+        await this.assertSlugAvailable(tenantId, slug, spaceId);
+        updateValues.slug = slug;
+        changedFields.push('slug');
+      }
+    }
+
+    if (input.description !== undefined && input.description.trim() !== (existing.description ?? '')) {
+      updateValues.description = input.description.trim();
+      changedFields.push('description');
+    }
+
+    if (
+      input.strict_knowledge_only !== undefined &&
+      input.strict_knowledge_only !== existing.strict_knowledge_only
+    ) {
+      updateValues.strict_knowledge_only = input.strict_knowledge_only;
+      changedFields.push('strict_knowledge_only');
+    }
+
+    if (input.graphify_config !== undefined) {
+      updateValues.graphify_config = input.graphify_config;
+      changedFields.push('graphify_config');
+    }
+
+    if (changedFields.length === 0) {
+      return toSpaceDetail(existing);
+    }
+
+    try {
+      const [updated] = await this.db
+        .update(spaces)
+        .set(updateValues)
+        .where(and(eq(spaces.tenant_id, tenantId), eq(spaces.id, spaceId)))
+        .returning();
+
+      if (updated === undefined) {
+        throw new Error('Failed to update space');
+      }
+
+      this.auditService.push({
+        tenant_id: tenantId,
+        ...(context.actorUserId !== undefined ? { actor_user_id: context.actorUserId } : {}),
+        action: AUDIT_EVENTS.SPACE_UPDATE,
+        resource_type: 'space',
+        resource_id: updated.id,
+        space_id: updated.id,
+        metadata_json: {
+          changed_fields: changedFields,
+        },
+      });
+
+      return toSpaceDetail(updated);
+    } catch (err) {
+      if (isUniqueViolation(err, 'spaces_tenant_id_slug_unique')) {
+        throwApiError(ErrorCode.SPACE_SLUG_CONFLICT, 'Space slug already exists', HttpStatus.CONFLICT);
+      }
+
+      throw err;
+    }
+  }
+
+  async getStats(spaceId: string, context: SpaceContext = {}): Promise<SpaceStatsResponse> {
+    const tenantId = await this.resolveTenantId(context);
+    const space = await findSpaceById(this.db, tenantId, spaceId);
+    if (space === undefined) {
+      throwSpaceNotFound();
+    }
+
+    return toSpaceStats(space);
+  }
+
+  private async buildListFilters(
+    tenantId: string,
+    input: ListSpacesInput,
+    context: SpaceContext,
+  ): Promise<SQL[] | undefined> {
+    const filters: SQL[] = [eq(spaces.tenant_id, tenantId)];
+
+    if (!hasImplicitSpaceAccess(context.actorRole)) {
+      const userId = resolveContextUserId(context);
+      const accessibleSpaceIds = await this.getAccessibleSpaceIds(tenantId, userId);
+      if (accessibleSpaceIds.length === 0) {
+        return undefined;
+      }
+
+      filters.push(inArray(spaces.id, accessibleSpaceIds));
+    }
+
+    if (input.status !== undefined && input.status.trim().length > 0) {
+      filters.push(eq(spaces.status, input.status.trim()));
+    }
+
+    if (input.search !== undefined && input.search.trim().length > 0) {
+      const pattern = `%${input.search.trim()}%`;
+      const searchFilter = or(
+        ilike(spaces.name, pattern),
+        ilike(spaces.slug, pattern),
+        ilike(spaces.description, pattern),
+      );
+      if (searchFilter !== undefined) {
+        filters.push(searchFilter);
+      }
+    }
+
+    return filters;
+  }
+
+  private async getAccessibleSpaceIds(tenantId: string, userId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({
+        space_id: space_permissions.space_id,
+      })
+      .from(group_members)
+      .innerJoin(
+        space_permissions,
+        and(
+          eq(space_permissions.tenant_id, group_members.tenant_id),
+          eq(space_permissions.group_id, group_members.group_id),
+        ),
+      )
+      .where(
+        and(
+          eq(group_members.tenant_id, tenantId),
+          eq(group_members.user_id, userId),
+          eq(space_permissions.permission, VIEW_PERMISSION),
+        ),
+      );
+
+    return [...new Set(rows.map((row) => row.space_id))];
+  }
+
+  private async hasSpaceViewPermission(
+    tenantId: string,
+    userId: string,
+    spaceId: string,
+  ): Promise<boolean> {
+    const rows = await this.db
+      .select({
+        space_id: space_permissions.space_id,
+      })
+      .from(group_members)
+      .innerJoin(
+        space_permissions,
+        and(
+          eq(space_permissions.tenant_id, group_members.tenant_id),
+          eq(space_permissions.group_id, group_members.group_id),
+        ),
+      )
+      .where(
+        and(
+          eq(group_members.tenant_id, tenantId),
+          eq(group_members.user_id, userId),
+          eq(space_permissions.space_id, spaceId),
+          eq(space_permissions.permission, VIEW_PERMISSION),
+        ),
+      )
+      .limit(1);
+
+    return rows.length > 0;
+  }
+
+  private async assertSlugAvailable(
+    tenantId: string,
+    slug: string,
+    currentSpaceId: string,
+  ): Promise<void> {
+    const [conflict] = await this.db
+      .select({ id: spaces.id })
+      .from(spaces)
+      .where(and(eq(spaces.tenant_id, tenantId), eq(spaces.slug, slug), ne(spaces.id, currentSpaceId)))
+      .limit(1);
+
+    if (conflict !== undefined) {
+      throwApiError(ErrorCode.SPACE_SLUG_CONFLICT, 'Space slug already exists', HttpStatus.CONFLICT);
+    }
+  }
+
+  private async resolveTenantId(context: SpaceContext): Promise<string> {
+    if (context.tenantId !== undefined && context.tenantId.trim().length > 0) {
+      return context.tenantId.trim();
+    }
+
+    const configuredTenantId = process.env.DEFAULT_TENANT_ID;
+    if (configuredTenantId !== undefined && configuredTenantId.trim().length > 0) {
+      return configuredTenantId.trim();
+    }
+
+    const [tenant] = await this.db.select({ id: tenants.id }).from(tenants).limit(1);
+    if (tenant === undefined) {
+      throw new Error('No tenant configured');
+    }
+
+    return tenant.id;
+  }
+}
+
+function buildSpaceOrder(sort: string): SQL {
+  const parsed = parseSortSafely(sort);
+  const columns = {
+    created_at: spaces.created_at,
+    updated_at: spaces.updated_at,
+    name: spaces.name,
+    slug: spaces.slug,
+    status: spaces.status,
+  } as const satisfies Record<SpaceSortField, unknown>;
+  const column = columns[parsed.field as SpaceSortField];
+
+  if (column === undefined) {
+    throwApiError(ErrorCode.VALIDATION_ERROR, 'Invalid sort field', HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+
+  return parsed.direction === 'desc' ? desc(column) : asc(column);
+}
+
+function parseSortSafely(sort: string): ReturnType<typeof parseSortField> {
+  try {
+    return parseSortField(sort);
+  } catch {
+    throwApiError(ErrorCode.VALIDATION_ERROR, 'Invalid sort field', HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+}
+
+async function findSpaceById(
+  db: SpaceDatabase,
+  tenantId: string,
+  spaceId: string,
+): Promise<SpaceRow | undefined> {
+  const [space] = await db
+    .select()
+    .from(spaces)
+    .where(and(eq(spaces.tenant_id, tenantId), eq(spaces.id, spaceId)))
+    .limit(1);
+
+  return space;
+}
+
+async function findSpaceBySlug(
+  db: SpaceDatabase,
+  tenantId: string,
+  slug: string,
+): Promise<Pick<SpaceRow, 'id'> | undefined> {
+  const [space] = await db
+    .select({ id: spaces.id })
+    .from(spaces)
+    .where(and(eq(spaces.tenant_id, tenantId), eq(spaces.slug, slug)))
+    .limit(1);
+
+  return space;
+}
+
+function hasImplicitSpaceAccess(role: string | undefined): boolean {
+  const normalized = role === undefined ? undefined : normalizeRole(role);
+  return normalized === ROLES.OWNER || normalized === ROLES.ADMIN;
+}
+
+function resolveContextUserId(context: SpaceContext): string {
+  const userId = context.userId ?? context.actorUserId;
+  if (userId !== undefined && userId.trim().length > 0) {
+    return userId.trim();
+  }
+
+  throwApiError(ErrorCode.UNAUTHENTICATED, 'Unauthenticated', HttpStatus.UNAUTHORIZED);
+}
+
+function toSpaceListItem(row: SpaceRow): SpaceListItem {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    status: row.status,
+    description: row.description,
+    stats: {
+      page_count: 0,
+      source_count: 0,
+      node_count: 0,
+    },
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function toSpaceDetail(row: SpaceRow): SpaceDetail {
+  return {
+    ...toSpaceListItem(row),
+    docmost_space_id: row.docmost_space_id,
+    wiki_repo_path: row.wiki_repo_path,
+    active_graphify_run_id: row.active_graphify_run_id,
+    active_index_snapshot_id: row.active_index_snapshot_id,
+    index_consistency_status: row.index_consistency_status,
+    strict_knowledge_only: row.strict_knowledge_only,
+    graphify_config: row.graphify_config,
+    default_publish_policy: row.default_publish_policy,
+  };
+}
+
+function toSpaceStats(row: SpaceRow): SpaceStatsResponse {
+  return {
+    space_id: row.id,
+    page_count: 0,
+    source_count: 0,
+    node_count: 0,
+    edge_count: 0,
+    index_consistency: row.index_consistency_status,
+  };
+}
+
+function normalizeSlug(slug: string): string {
+  return slug.trim();
+}
+
+function normalizePage(value: number | undefined): number {
+  return Number.isInteger(value) && value !== undefined && value > 0 ? value : DEFAULT_PAGE;
+}
+
+function normalizePerPage(value: number | undefined): number {
+  if (!Number.isInteger(value) || value === undefined || value < 1) {
+    return DEFAULT_PER_PAGE;
+  }
+
+  return Math.min(value, MAX_PER_PAGE);
+}
+
+function normalizeCount(value: unknown): number {
+  return typeof value === 'number' ? value : Number(value ?? 0);
+}
+
+function throwSpaceNotFound(): never {
+  throwApiError(ErrorCode.SPACE_NOT_FOUND, 'Space not found', HttpStatus.NOT_FOUND);
+}
+
+function throwApiError(code: ErrorCode, message: string, status: HttpStatus): never {
+  throw new HttpException({ code, message }, status);
+}
+
+function isUniqueViolation(err: unknown, constraint: string): boolean {
+  if (!isRecord(err)) {
+    return false;
+  }
+
+  return err.code === '23505' && err.constraint === constraint;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/api/src/spaces/space.service.ts
+++ b/apps/api/src/spaces/space.service.ts
@@ -91,7 +91,7 @@ type SpaceSortField = keyof Pick<typeof spaces, 'created_at' | 'updated_at' | 'n
 const DEFAULT_PAGE = 1;
 const DEFAULT_PER_PAGE = 20;
 const MAX_PER_PAGE = 100;
-const VIEW_PERMISSION = 'space:view';
+const VIEW_SATISFYING_PERMISSIONS = ['space:view', 'space:edit', 'space:admin'] as const;
 
 @Injectable()
 export class SpaceService {
@@ -302,6 +302,14 @@ export class SpaceService {
       throwSpaceNotFound();
     }
 
+    if (!hasImplicitSpaceAccess(context.actorRole)) {
+      const userId = resolveContextUserId(context);
+      const allowed = await this.hasSpaceViewPermission(tenantId, userId, spaceId);
+      if (!allowed) {
+        throwSpaceNotFound();
+      }
+    }
+
     return toSpaceStats(space);
   }
 
@@ -327,7 +335,7 @@ export class SpaceService {
     }
 
     if (input.search !== undefined && input.search.trim().length > 0) {
-      const pattern = `%${input.search.trim()}%`;
+      const pattern = `%${escapeLikePattern(input.search.trim())}%`;
       const searchFilter = or(
         ilike(spaces.name, pattern),
         ilike(spaces.slug, pattern),
@@ -358,7 +366,7 @@ export class SpaceService {
         and(
           eq(group_members.tenant_id, tenantId),
           eq(group_members.user_id, userId),
-          eq(space_permissions.permission, VIEW_PERMISSION),
+          inArray(space_permissions.permission, [...VIEW_SATISFYING_PERMISSIONS]),
         ),
       );
 
@@ -387,7 +395,7 @@ export class SpaceService {
           eq(group_members.tenant_id, tenantId),
           eq(group_members.user_id, userId),
           eq(space_permissions.space_id, spaceId),
-          eq(space_permissions.permission, VIEW_PERMISSION),
+          inArray(space_permissions.permission, [...VIEW_SATISFYING_PERMISSIONS]),
         ),
       )
       .limit(1);
@@ -538,6 +546,10 @@ function toSpaceStats(row: SpaceRow): SpaceStatsResponse {
     edge_count: 0,
     index_consistency: row.index_consistency_status,
   };
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
 }
 
 function normalizeSlug(slug: string): string {


### PR DESCRIPTION
## Summary
- Implement SpaceModule with permission-filtered space list, create (auto wiki_repo_path), get (404 on no-permission), update (ignore wiki_repo_path), stats endpoint
- Accept space:admin/space:edit as view-satisfying permissions
- Service-layer permission check in getStats
- LIKE wildcard escaping in search
- 4 new files, ~1060 lines, 192 tests passing

## Agent Review
- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `fdca159c219f9b7075bcaa7eaf5804e7bc4c98f7`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/35#issuecomment-4347088774) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/35#issuecomment-4347089129)
- Key findings addressed: View-satisfying permissions expanded, stats permission check, LIKE escape, create guard corrected

## Test plan
- [x] pnpm run build/lint/test — 34 files, 192 tests passed
- [x] Permission-filtered list
- [x] 404 on no-permission (not 403)
- [x] Auto wiki_repo_path
- [x] Slug conflict detection
- [x] Stats placeholder (all zero)
- [x] Update ignores wiki_repo_path

Closes #23