### PR TITLE
feat(web): add admin console frontend — login, auth, admin pages (#26)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,13 @@
-import { BrowserRouter, Route, Routes } from 'react-router';
-import Admin from './pages/Admin';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
+import AdminGuard from './components/AdminGuard';
+import AdminLayout from './components/AdminLayout';
+import { AuthProvider } from './lib/auth';
+import AuditPage from './pages/admin/AuditPage';
+import GroupsPage from './pages/admin/GroupsPage';
+import HealthPage from './pages/admin/HealthPage';
+import ModelsPage from './pages/admin/ModelsPage';
+import SpacesPage from './pages/admin/SpacesPage';
+import UsersPage from './pages/admin/UsersPage';
 import Chat from './pages/Chat';
 import Home from './pages/Home';
 import Login from './pages/Login';
@@ -15,12 +23,23 @@ export function AppRoutes() {
       <Route path="/chat/:id" element={<Chat />} />
       <Route path="/wiki/:spaceId" element={<Wiki />} />
       <Route path="/wiki/:spaceId/:pageId" element={<Wiki />} />
-      <Route path="/admin" element={<Admin />} />
-      <Route path="/admin/users" element={<Admin />} />
-      <Route path="/admin/spaces" element={<Admin />} />
-      <Route path="/admin/models" element={<Admin />} />
-      <Route path="/admin/jobs" element={<Admin />} />
-      <Route path="/admin/audit" element={<Admin />} />
+      <Route
+        path="/admin"
+        element={
+          <AdminGuard>
+            <AdminLayout />
+          </AdminGuard>
+        }
+      >
+        <Route index element={<Navigate to="/admin/users" replace />} />
+        <Route path="users" element={<UsersPage />} />
+        <Route path="groups" element={<GroupsPage />} />
+        <Route path="spaces" element={<SpacesPage />} />
+        <Route path="models" element={<ModelsPage />} />
+        <Route path="audit" element={<AuditPage />} />
+        <Route path="health" element={<HealthPage />} />
+        <Route path="jobs" element={<Navigate to="/admin/health" replace />} />
+      </Route>
       <Route path="*" element={<NotFound />} />
     </Routes>
   );
@@ -29,7 +48,9 @@ export function AppRoutes() {
 export default function App() {
   return (
     <BrowserRouter>
-      <AppRoutes />
+      <AuthProvider>
+        <AppRoutes />
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -1,16 +1,36 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AppRoutes } from '../App';
+import { AuthProvider, useAuth, type AuthUser } from '../lib/auth';
 
-function renderRoute(path: string) {
+const ADMIN_USER: AuthUser = {
+  id: 'user-admin',
+  email: 'admin@example.com',
+  name: 'Admin User',
+  role: 'admin',
+  groups: [],
+};
+
+function renderRoute(path: string, user?: AuthUser) {
+  const routes = <AppRoutes />;
+
   render(
     <MemoryRouter initialEntries={[path]}>
-      <AppRoutes />
+      {user === undefined ? (
+        <AuthProvider>{routes}</AuthProvider>
+      ) : (
+        <AuthProvider initialSession={{ user, accessToken: 'test-token' }}>{routes}</AuthProvider>
+      )}
     </MemoryRouter>,
   );
 }
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('App routing', () => {
   it('renders Home for /', () => {
@@ -37,10 +57,51 @@ describe('App routing', () => {
     expect(screen.getByRole('heading', { name: 'Wiki' })).toBeInTheDocument();
   });
 
-  it('renders Admin for /admin', () => {
+  it('redirects unauthenticated admin users to /login', () => {
     renderRoute('/admin');
 
-    expect(screen.getByRole('heading', { name: 'Admin' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Login' })).toBeInTheDocument();
+  });
+
+  it('shows 403 for authenticated non-admin users', () => {
+    renderRoute('/admin/users', {
+      ...ADMIN_USER,
+      role: 'viewer',
+    });
+
+    expect(screen.getByRole('heading', { name: 'Access denied' })).toBeInTheDocument();
+  });
+
+  it('renders Users for /admin and /admin/users when authorized', async () => {
+    mockAdminApi();
+    renderRoute('/admin', ADMIN_USER);
+
+    expect(await screen.findByRole('heading', { name: 'Users' })).toBeInTheDocument();
+  });
+
+  it('renders all admin sub-pages when authorized', async () => {
+    mockAdminApi();
+
+    const routes = [
+      ['/admin/users', 'Users'],
+      ['/admin/groups', 'Groups'],
+      ['/admin/spaces', 'Spaces'],
+      ['/admin/models', 'Models'],
+      ['/admin/audit', 'Audit Logs'],
+      ['/admin/health', 'System Health'],
+    ] as const;
+
+    for (const [path, heading] of routes) {
+      const { unmount } = render(
+        <MemoryRouter initialEntries={[path]}>
+          <AuthProvider initialSession={{ user: ADMIN_USER, accessToken: 'test-token' }}>
+            <AppRoutes />
+          </AuthProvider>
+        </MemoryRouter>,
+      );
+      expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
+      unmount();
+    }
   });
 
   it('renders Chat for /chat/:id', () => {
@@ -55,21 +116,217 @@ describe('App routing', () => {
     expect(screen.queryAllByRole('heading', { name: 'Wiki' }).length).toBeGreaterThan(0);
   });
 
-  it('renders Admin for /admin/users', () => {
-    renderRoute('/admin/users');
-
-    expect(screen.queryAllByRole('heading', { name: 'Admin' }).length).toBeGreaterThan(0);
-  });
-
-  it('renders Admin for /admin/models', () => {
-    renderRoute('/admin/models');
-
-    expect(screen.queryAllByRole('heading', { name: 'Admin' }).length).toBeGreaterThan(0);
-  });
-
   it('renders NotFound for /nonexistent', () => {
     renderRoute('/nonexistent');
 
     expect(screen.getByRole('heading', { name: '404 — Page Not Found' })).toBeInTheDocument();
   });
 });
+
+describe('AuthProvider', () => {
+  it('logs in, injects the access token, and logs out in memory', async () => {
+    const fetchMock = vi.fn<typeof fetch>((input, init) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/auth/login') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            access_token: 'access-123',
+            expires_in: 3600,
+            user: ADMIN_USER,
+          },
+          meta: { request_id: 'req-login' },
+        }));
+      }
+
+      if (path === '/api/auth/logout') {
+        expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer access-123');
+        return Promise.resolve(jsonResponse({ data: { success: true }, meta: { request_id: 'req-logout' } }));
+      }
+
+      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <AuthHarness />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Login' }));
+
+    expect(await screen.findByText('admin@example.com')).toBeInTheDocument();
+    expect(screen.getByText('authenticated')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Logout' }));
+
+    await waitFor(() => expect(screen.getByText('anonymous')).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+function AuthHarness() {
+  const { user, isAuthenticated, login, logout } = useAuth();
+
+  return (
+    <div>
+      <span>{isAuthenticated ? 'authenticated' : 'anonymous'}</span>
+      <span>{user?.email ?? 'No user'}</span>
+      <button
+        type="button"
+        onClick={() => {
+          void login('admin@example.com', 'password');
+        }}
+      >
+        Login
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void logout();
+        }}
+      >
+        Logout
+      </button>
+    </div>
+  );
+}
+
+function mockAdminApi(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path.startsWith('/api/admin/users')) {
+        return Promise.resolve(jsonResponse({
+          data: [
+            {
+              id: 'user-admin',
+              email: 'admin@example.com',
+              name: 'Admin User',
+              role: 'admin',
+              status: 'active',
+              groups: ['group-admin'],
+              last_login_at: null,
+              created_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+          meta: { request_id: 'req-users' },
+        }));
+      }
+
+      if (path.startsWith('/api/admin/groups')) {
+        return Promise.resolve(jsonResponse({
+          data: [
+            {
+              id: 'group-admin',
+              name: 'Administrators',
+              description: 'Admin group',
+              member_count: 1,
+              spaces: [{ space_id: 'space-main', permissions: ['space:admin'] }],
+              created_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+          meta: { request_id: 'req-groups' },
+        }));
+      }
+
+      if (path.startsWith('/api/spaces')) {
+        return Promise.resolve(jsonResponse({
+          data: [
+            {
+              id: 'space-main',
+              name: 'Main Space',
+              slug: 'main-space',
+              status: 'active',
+              description: 'Primary space',
+              stats: { page_count: 0, source_count: 0, node_count: 0 },
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+          meta: { request_id: 'req-spaces' },
+        }));
+      }
+
+      if (path.startsWith('/api/admin/models')) {
+        return Promise.resolve(jsonResponse({
+          data: [
+            {
+              id: 'model-1',
+              name: 'GPT',
+              provider: 'openai',
+              model_id: 'gpt-4.1',
+              model_type: 'chat',
+              status: 'active',
+              config: { base_url: null, embedding_dim: null, max_tokens: 4096, rate_limit_rpm: null },
+              visible_group_ids: [],
+            },
+          ],
+          meta: { request_id: 'req-models' },
+        }));
+      }
+
+      if (path.startsWith('/api/admin/audit-logs')) {
+        return Promise.resolve(jsonResponse({
+          data: [
+            {
+              id: 'audit-1',
+              actor_user_id: 'user-admin',
+              action: 'auth.login',
+              resource_type: 'auth',
+              resource_id: null,
+              space_id: null,
+              ip: null,
+              user_agent: null,
+              request_id: 'req-audit',
+              metadata_json: {},
+              created_at: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+          meta: { request_id: 'req-audit-list' },
+        }));
+      }
+
+      if (path.startsWith('/api/admin/system/health')) {
+        return Promise.resolve(jsonResponse({
+          data: {
+            status: 'healthy',
+            uptime: 120,
+            components: {
+              database: { status: 'healthy', latency_ms: 2 },
+              redis: { status: 'healthy', latency_ms: 1 },
+              minio: { status: 'not_configured' },
+            },
+          },
+          meta: { request_id: 'req-health' },
+        }));
+      }
+
+      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+    }),
+  );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function getRequestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input.split('?')[0] ?? input;
+  }
+
+  if (input instanceof URL) {
+    return input.pathname;
+  }
+
+  return input.url.split('?')[0] ?? input.url;
+}

--- a/apps/web/src/components/AdminGuard.tsx
+++ b/apps/web/src/components/AdminGuard.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router';
+import { useAuth } from '../lib/auth';
+
+export default function AdminGuard({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const { isAuthenticated, isAdmin, user } = useAuth();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+  }
+
+  if (!isAdmin) {
+    return (
+      <main className="forbidden-page">
+        <section className="forbidden-panel">
+          <p className="eyebrow">403</p>
+          <h1>Access denied</h1>
+          <p>
+            {user?.email ?? 'This user'} does not have the Admin or Owner role required to use the
+            admin console.
+          </p>
+        </section>
+      </main>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -1,0 +1,68 @@
+import { NavLink, Outlet } from 'react-router';
+import { useAuth } from '../lib/auth';
+import { formatLabel } from './adminUi';
+
+const NAV_ITEMS = [
+  { label: 'Users', to: '/admin/users' },
+  { label: 'Groups', to: '/admin/groups' },
+  { label: 'Spaces', to: '/admin/spaces' },
+  { label: 'Models', to: '/admin/models' },
+  { label: 'Audit Logs', to: '/admin/audit' },
+  { label: 'System Health', to: '/admin/health' },
+];
+
+export default function AdminLayout() {
+  const { user, logout } = useAuth();
+
+  return (
+    <div className="admin-shell">
+      <aside className="admin-sidebar" aria-label="Admin navigation">
+        <div className="admin-brand">
+          <span className="admin-brand-mark">C</span>
+          <div>
+            <strong>CherryWiki</strong>
+            <span>Admin Console</span>
+          </div>
+        </div>
+        <nav className="admin-nav">
+          {NAV_ITEMS.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) => (isActive ? 'admin-nav-link active' : 'admin-nav-link')}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+
+      <div className="admin-main">
+        <header className="admin-topbar">
+          <div>
+            <span className="eyebrow">Workspace Operations</span>
+            <strong>Administrative control plane</strong>
+          </div>
+          <div className="admin-user-block">
+            <div>
+              <strong>{user?.name ?? user?.email}</strong>
+              <span>{formatLabel(user?.role ?? 'unknown')}</span>
+            </div>
+            <button
+              className="button button-secondary"
+              type="button"
+              onClick={() => {
+                void logout();
+              }}
+            >
+              Logout
+            </button>
+          </div>
+        </header>
+        <main className="admin-content">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/adminUi.tsx
+++ b/apps/web/src/components/adminUi.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from 'react';
+import { ApiError } from '../lib/api';
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="admin-page-header">
+      <div>
+        <h1>{title}</h1>
+        {description !== undefined ? <p>{description}</p> : null}
+      </div>
+      {actions !== undefined ? <div className="admin-page-actions">{actions}</div> : null}
+    </div>
+  );
+}
+
+export function ErrorBanner({ error }: { error: string | null }) {
+  if (error === null) {
+    return null;
+  }
+
+  return (
+    <div className="alert alert-error" role="alert">
+      {error}
+    </div>
+  );
+}
+
+export function LoadingState({ label = 'Loading...' }: { label?: string }) {
+  return <div className="muted-state">{label}</div>;
+}
+
+export function EmptyState({ label }: { label: string }) {
+  return <div className="muted-state">{label}</div>;
+}
+
+export function StatusBadge({ status }: { status: string }) {
+  return <span className={`status-badge status-${normalizeStatusClass(status)}`}>{formatLabel(status)}</span>;
+}
+
+export function Modal({
+  title,
+  children,
+  onClose,
+}: {
+  title: string;
+  children: ReactNode;
+  onClose: () => void;
+}) {
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <div className="modal-panel" role="dialog" aria-modal="true" aria-label={title}>
+        <div className="modal-header">
+          <h2>{title}</h2>
+          <button className="icon-button" type="button" onClick={onClose} aria-label="Close dialog">
+            x
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function formatDate(value: string | null | undefined): string {
+  if (value === null || value === undefined || value.length === 0) {
+    return 'Never';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
+export function formatLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}` : part))
+    .join(' ');
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Something went wrong';
+}
+
+export function parseIdList(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function normalizeStatusClass(status: string): string {
+  if (status === 'healthy' || status === 'active' || status === 'enabled') {
+    return 'healthy';
+  }
+
+  if (status === 'degraded') {
+    return 'degraded';
+  }
+
+  if (status === 'not_configured') {
+    return 'neutral';
+  }
+
+  if (status === 'disabled') {
+    return 'neutral';
+  }
+
+  return 'unhealthy';
+}

--- a/apps/web/src/lib/adminTypes.ts
+++ b/apps/web/src/lib/adminTypes.ts
@@ -1,0 +1,116 @@
+export type Role = 'owner' | 'admin' | 'space_admin' | 'editor' | 'viewer' | 'auditor';
+
+export const ROLE_OPTIONS: Role[] = ['owner', 'admin', 'space_admin', 'editor', 'viewer', 'auditor'];
+
+export const SPACE_PERMISSION_OPTIONS = ['space:view', 'space:edit', 'space:admin'] as const;
+
+export type SpacePermission = (typeof SPACE_PERMISSION_OPTIONS)[number];
+
+export type AdminUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  status: string;
+  groups: string[];
+  last_login_at: string | null;
+  created_at: string;
+};
+
+export type GroupSpacePermissions = {
+  space_id: string;
+  permissions: string[];
+};
+
+export type AdminGroup = {
+  id: string;
+  name: string;
+  description: string | null;
+  member_count: number;
+  spaces: GroupSpacePermissions[];
+  created_at: string;
+};
+
+export type SpaceStatsSummary = {
+  page_count: number;
+  source_count: number;
+  node_count: number;
+};
+
+export type AdminSpace = {
+  id: string;
+  name: string;
+  slug: string;
+  status: string;
+  description: string | null;
+  stats: SpaceStatsSummary;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AdminSpaceDetail = AdminSpace & {
+  docmost_space_id: string | null;
+  wiki_repo_path: string;
+  active_graphify_run_id: string | null;
+  active_index_snapshot_id: string | null;
+  index_consistency_status: string;
+  strict_knowledge_only: boolean;
+  graphify_config: unknown;
+  default_publish_policy: string;
+};
+
+export type SpacePermissionGroup = {
+  group_id: string;
+  name: string;
+  permissions: string[];
+};
+
+export type AdminModel = {
+  id: string;
+  name: string | null;
+  provider: string;
+  model_id: string;
+  model_type: string;
+  status: 'active' | 'disabled';
+  config: {
+    base_url: string | null;
+    embedding_dim: number | null;
+    max_tokens: number | null;
+    rate_limit_rpm: number | null;
+  };
+  visible_group_ids: string[];
+};
+
+export type ModelConnectivityResult = {
+  reachable: boolean;
+  latency_ms: number;
+  error?: string;
+};
+
+export type AuditLog = {
+  id: string;
+  actor_user_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  space_id: string | null;
+  ip: string | null;
+  user_agent: string | null;
+  request_id: string | null;
+  metadata_json: unknown;
+  created_at: string;
+};
+
+export type HealthComponentStatus = 'healthy' | 'degraded' | 'unhealthy' | 'not_configured';
+
+export type HealthComponent = {
+  status: HealthComponentStatus;
+  latency_ms?: number;
+  error?: string;
+};
+
+export type SystemHealth = {
+  status: 'healthy' | 'degraded' | 'unhealthy';
+  components: Record<string, HealthComponent>;
+  uptime: number;
+};

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,180 @@
+export type ApiErrorBody = {
+  error?: {
+    code?: string;
+    message?: string;
+    details?: unknown;
+  };
+  message?: string;
+};
+
+export type ApiMeta = {
+  request_id?: string;
+  pagination?: {
+    page: number;
+    per_page: number;
+    total: number;
+    has_next: boolean;
+  };
+};
+
+export type ApiWrappedResponse<T> = {
+  data: T;
+  meta?: ApiMeta;
+};
+
+export type QueryParams = Record<string, string | number | boolean | null | undefined>;
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly details: unknown;
+
+  constructor(input: { status: number; code: string; message: string; details?: unknown }) {
+    super(input.message);
+    this.name = 'ApiError';
+    this.status = input.status;
+    this.code = input.code;
+    this.details = input.details;
+  }
+}
+
+type RequestOptions = {
+  body?: unknown;
+  query?: QueryParams | undefined;
+  headers?: HeadersInit | undefined;
+};
+
+type ApiClientConfig = {
+  getAccessToken?: () => string | null;
+  onUnauthorized?: () => void;
+};
+
+let accessTokenProvider: () => string | null = () => null;
+let unauthorizedHandler: (() => void) | undefined;
+
+export function configureApiClient(config: ApiClientConfig): void {
+  accessTokenProvider = config.getAccessToken ?? (() => null);
+  unauthorizedHandler = config.onUnauthorized;
+}
+
+export const api = {
+  get<T>(path: string, query?: QueryParams): Promise<T> {
+    return request<T>('GET', path, { query });
+  },
+  post<T>(path: string, body?: unknown): Promise<T> {
+    return request<T>('POST', path, { body });
+  },
+  put<T>(path: string, body?: unknown): Promise<T> {
+    return request<T>('PUT', path, { body });
+  },
+  patch<T>(path: string, body?: unknown): Promise<T> {
+    return request<T>('PATCH', path, { body });
+  },
+  delete<T>(path: string): Promise<T> {
+    return request<T>('DELETE', path);
+  },
+};
+
+async function request<T>(method: string, path: string, options: RequestOptions = {}): Promise<T> {
+  const headers = new Headers(options.headers);
+  headers.set('Accept', 'application/json');
+
+  const token = accessTokenProvider();
+  if (token !== null && token.length > 0) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const init: RequestInit = {
+    method,
+    credentials: 'include',
+    headers,
+  };
+
+  if (options.body !== undefined) {
+    headers.set('Content-Type', 'application/json');
+    init.body = JSON.stringify(options.body);
+  }
+
+  const response = await fetch(buildApiUrl(path, options.query), init);
+  const body = await readJson(response);
+
+  if (!response.ok) {
+    const error = createApiError(response.status, body);
+    if (response.status === 401) {
+      unauthorizedHandler?.();
+    }
+    throw error;
+  }
+
+  return unwrapResponse<T>(body);
+}
+
+function buildApiUrl(path: string, query?: QueryParams): string {
+  const basePath = path.startsWith('/api/') ? path : `/api${path.startsWith('/') ? path : `/${path}`}`;
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined && value !== null && value !== '') {
+      params.set(key, String(value));
+    }
+  }
+
+  const queryString = params.toString();
+  return queryString.length > 0 ? `${basePath}?${queryString}` : basePath;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return null;
+  }
+
+  const text = await response.text();
+  if (text.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function unwrapResponse<T>(body: unknown): T {
+  if (isRecord(body) && 'data' in body) {
+    return body.data as T;
+  }
+
+  return body as T;
+}
+
+function createApiError(status: number, body: unknown): ApiError {
+  const normalized = normalizeErrorBody(body);
+  return new ApiError({
+    status,
+    code: normalized.code,
+    message: normalized.message,
+    details: normalized.details,
+  });
+}
+
+function normalizeErrorBody(body: unknown): { code: string; message: string; details?: unknown } {
+  if (isRecord(body)) {
+    const error = body.error;
+    if (isRecord(error)) {
+      const code = typeof error.code === 'string' ? error.code : 'API_ERROR';
+      const message = typeof error.message === 'string' ? error.message : 'Request failed';
+      return { code, message, details: error.details };
+    }
+
+    if (typeof body.message === 'string') {
+      return { code: 'API_ERROR', message: body.message };
+    }
+  }
+
+  return { code: 'API_ERROR', message: 'Request failed' };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -1,0 +1,175 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useNavigate } from 'react-router';
+import { api, configureApiClient } from './api';
+
+export type AuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  groups: string[] | Array<{ id: string; name: string }>;
+};
+
+type LoginResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  user: AuthUser;
+};
+
+type TokenPairResponse = {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+};
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  accessToken: string | null;
+  login: (email: string, password: string) => Promise<AuthUser>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+};
+
+type InitialSession = {
+  user: AuthUser;
+  accessToken: string;
+  expiresIn?: number;
+};
+
+export type AuthProviderProps = {
+  children: ReactNode;
+  initialSession?: InitialSession;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+const REFRESH_LEEWAY_SECONDS = 5 * 60;
+const DEFAULT_EXPIRES_IN_SECONDS = 60 * 60;
+
+export function AuthProvider({ children, initialSession }: AuthProviderProps) {
+  const navigate = useNavigate();
+  const [user, setUser] = useState<AuthUser | null>(initialSession?.user ?? null);
+  const [accessToken, setAccessTokenState] = useState<string | null>(initialSession?.accessToken ?? null);
+  const accessTokenRef = useRef<string | null>(initialSession?.accessToken ?? null);
+  const refreshTimerRef = useRef<number | undefined>(undefined);
+
+  const clearRefreshTimer = useCallback(() => {
+    if (refreshTimerRef.current !== undefined) {
+      window.clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = undefined;
+    }
+  }, []);
+
+  const setAccessToken = useCallback((nextToken: string | null) => {
+    accessTokenRef.current = nextToken;
+    setAccessTokenState(nextToken);
+  }, []);
+
+  const clearSession = useCallback(() => {
+    clearRefreshTimer();
+    setAccessToken(null);
+    setUser(null);
+  }, [clearRefreshTimer, setAccessToken]);
+
+  const refresh = useCallback(async () => {
+    const tokenPair = await api.post<TokenPairResponse>('/auth/refresh');
+    setAccessToken(tokenPair.access_token);
+    scheduleRefresh(tokenPair.expires_in, refreshTimerRef, refresh);
+  }, [setAccessToken]);
+
+  const login = useCallback(
+    async (email: string, password: string): Promise<AuthUser> => {
+      const result = await api.post<LoginResponse>('/auth/login', { email, password });
+      setUser(result.user);
+      setAccessToken(result.access_token);
+      scheduleRefresh(result.expires_in, refreshTimerRef, refresh);
+      return result.user;
+    },
+    [refresh, setAccessToken],
+  );
+
+  const logout = useCallback(async () => {
+    try {
+      await api.post<{ success: true }>('/auth/logout');
+    } catch {
+      // Local session state must still be cleared if server-side logout fails.
+    } finally {
+      clearSession();
+      void navigate('/login', { replace: true });
+    }
+  }, [clearSession, navigate]);
+
+  useEffect(() => {
+    configureApiClient({
+      getAccessToken: () => accessTokenRef.current,
+      onUnauthorized: () => {
+        clearSession();
+        void navigate('/login', { replace: true });
+      },
+    });
+  }, [clearSession, navigate]);
+
+  useEffect(() => {
+    if (initialSession?.accessToken !== undefined) {
+      scheduleRefresh(initialSession.expiresIn ?? DEFAULT_EXPIRES_IN_SECONDS, refreshTimerRef, refresh);
+    }
+
+    return () => {
+      clearRefreshTimer();
+    };
+  }, [clearRefreshTimer, initialSession?.accessToken, initialSession?.expiresIn, refresh]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      accessToken,
+      login,
+      logout,
+      refresh,
+      isAuthenticated: accessToken !== null && user !== null,
+      isAdmin: user !== null && isAdminRole(user.role),
+    }),
+    [accessToken, login, logout, refresh, user],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+
+  return context;
+}
+
+export function isAdminRole(role: string): boolean {
+  return role === 'admin' || role === 'owner';
+}
+
+function scheduleRefresh(
+  expiresIn: number,
+  timerRef: React.MutableRefObject<number | undefined>,
+  refresh: () => Promise<void>,
+): void {
+  if (timerRef.current !== undefined) {
+    window.clearTimeout(timerRef.current);
+  }
+
+  const delaySeconds = Math.max(0, expiresIn - REFRESH_LEEWAY_SECONDS);
+  timerRef.current = window.setTimeout(() => {
+    void refresh().catch(() => undefined);
+  }, delaySeconds * 1000);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import './styles.css';
 
 const rootElement = document.getElementById('root');
 

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -1,3 +1,5 @@
+import { Navigate } from 'react-router';
+
 export default function Admin() {
-  return <h1>Admin</h1>;
+  return <Navigate to="/admin/users" replace />;
 }

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,3 +1,108 @@
+import { useState, type FormEvent } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { ApiError } from '../lib/api';
+import { isAdminRole, useAuth } from '../lib/auth';
+
+type LocationState = {
+  from?: string;
+};
+
 export default function Login() {
-  return <h1>Login</h1>;
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function submitLogin(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const user = await login(email, password);
+      const locationState = location.state as LocationState | null;
+      const fallbackPath = isAdminRole(user.role) ? '/admin' : '/';
+      void navigate(locationState?.from ?? fallbackPath, { replace: true });
+    } catch (err) {
+      setError(getLoginErrorMessage(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="login-page">
+      <section className="login-panel">
+        <div>
+          <p className="eyebrow">CherryWiki</p>
+          <h1>Login</h1>
+          <p className="login-copy">Sign in with an account that has access to this workspace.</p>
+        </div>
+
+        {error !== null ? (
+          <div className="alert alert-error" role="alert">
+            {error}
+          </div>
+        ) : null}
+
+        <form
+          className="login-form"
+          onSubmit={(event) => {
+            void submitLogin(event);
+          }}
+        >
+          <label>
+            Email
+            <input
+              required
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </label>
+          <label>
+            Password
+            <input
+              required
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+          <button className="button button-primary login-submit" type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}
+
+function getLoginErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.code === 'INVALID_CREDENTIALS') {
+      return 'Email or password is incorrect.';
+    }
+
+    if (error.code === 'ACCOUNT_LOCKED') {
+      return 'This account is temporarily locked. Try again later.';
+    }
+
+    if (error.code === 'ACCOUNT_DISABLED') {
+      return 'This account has been disabled.';
+    }
+
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unable to sign in.';
 }

--- a/apps/web/src/pages/admin/AuditPage.tsx
+++ b/apps/web/src/pages/admin/AuditPage.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  formatDate,
+  getErrorMessage,
+} from '../../components/adminUi';
+import { api } from '../../lib/api';
+import { type AuditLog } from '../../lib/adminTypes';
+
+export default function AuditPage() {
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [action, setAction] = useState('');
+  const [actor, setActor] = useState('');
+  const [space, setSpace] = useState('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadLogs = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await api.get<AuditLog[]>('/admin/audit-logs', {
+        action,
+        actor,
+        space,
+        from,
+        to,
+        per_page: 100,
+        sort: '-created_at',
+      });
+      setLogs(data);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [action, actor, from, space, to]);
+
+  useEffect(() => {
+    void loadLogs();
+  }, [loadLogs]);
+
+  return (
+    <>
+      <PageHeader
+        title="Audit Logs"
+        description="Review administrative and security-sensitive activity."
+        actions={
+          <button
+            className="button button-secondary"
+            type="button"
+            onClick={() => {
+              void loadLogs();
+            }}
+          >
+            Refresh
+          </button>
+        }
+      />
+      <ErrorBanner error={error} />
+
+      <section className="toolbar" aria-label="Audit filters">
+        <label>
+          Action
+          <input type="text" value={action} onChange={(event) => setAction(event.target.value)} placeholder="admin.user.update" />
+        </label>
+        <label>
+          Actor
+          <input type="text" value={actor} onChange={(event) => setActor(event.target.value)} placeholder="User ID" />
+        </label>
+        <label>
+          Space
+          <input type="text" value={space} onChange={(event) => setSpace(event.target.value)} placeholder="Space ID" />
+        </label>
+        <label>
+          From
+          <input type="datetime-local" value={from} onChange={(event) => setFrom(event.target.value)} />
+        </label>
+        <label>
+          To
+          <input type="datetime-local" value={to} onChange={(event) => setTo(event.target.value)} />
+        </label>
+      </section>
+
+      {isLoading ? (
+        <LoadingState />
+      ) : logs.length === 0 ? (
+        <EmptyState label="No audit logs match the current filters." />
+      ) : (
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Timestamp</th>
+                <th>Actor</th>
+                <th>Action</th>
+                <th>Resource</th>
+                <th>Space</th>
+                <th>Request</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((log) => (
+                <tr key={log.id}>
+                  <td>{formatDate(log.created_at)}</td>
+                  <td>{log.actor_user_id ?? 'System'}</td>
+                  <td>
+                    <code>{log.action}</code>
+                  </td>
+                  <td>
+                    {log.resource_type}
+                    {log.resource_id !== null ? <span className="subtle-id">{log.resource_id}</span> : null}
+                  </td>
+                  <td>{log.space_id ?? 'Global'}</td>
+                  <td>{log.request_id ?? 'Not recorded'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/pages/admin/GroupsPage.tsx
+++ b/apps/web/src/pages/admin/GroupsPage.tsx
@@ -1,0 +1,289 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  Modal,
+  PageHeader,
+  getErrorMessage,
+} from '../../components/adminUi';
+import { api } from '../../lib/api';
+import {
+  SPACE_PERMISSION_OPTIONS,
+  type AdminGroup,
+  type AdminSpace,
+  type AdminUser,
+} from '../../lib/adminTypes';
+
+type GroupForm = {
+  id?: string;
+  name: string;
+  description: string;
+  memberIds: string[];
+  permissionsBySpace: Record<string, string[]>;
+};
+
+export default function GroupsPage() {
+  const [groups, setGroups] = useState<AdminGroup[]>([]);
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [spaces, setSpaces] = useState<AdminSpace[]>([]);
+  const [form, setForm] = useState<GroupForm | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [nextGroups, nextUsers, nextSpaces] = await Promise.all([
+        api.get<AdminGroup[]>('/admin/groups', { per_page: 100, sort: 'name' }),
+        api.get<AdminUser[]>('/admin/users', { per_page: 100, sort: 'email' }),
+        api.get<AdminSpace[]>('/spaces', { per_page: 100, sort: 'name' }),
+      ]);
+      setGroups(nextGroups);
+      setUsers(nextUsers);
+      setSpaces(nextSpaces);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const modalTitle = form?.id === undefined ? 'Create Group' : 'Edit Group';
+
+  async function submitGroup(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (form === null) {
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    const body = {
+      name: form.name,
+      description: form.description,
+      member_ids: form.memberIds,
+      space_permissions: toSpacePermissions(form.permissionsBySpace),
+    };
+
+    try {
+      if (form.id === undefined) {
+        await api.post<AdminGroup>('/admin/groups', body);
+      } else {
+        await api.put<AdminGroup>(`/admin/groups/${form.id}`, body);
+      }
+      setForm(null);
+      await loadData();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function openCreateForm(): void {
+    setForm(createEmptyForm());
+  }
+
+  function openEditForm(group: AdminGroup): void {
+    setForm({
+      id: group.id,
+      name: group.name,
+      description: group.description ?? '',
+      memberIds: users.filter((user) => user.groups.includes(group.id)).map((user) => user.id),
+      permissionsBySpace: Object.fromEntries(group.spaces.map((space) => [space.space_id, space.permissions])),
+    });
+  }
+
+  function updatePermission(spaceId: string, permission: string, checked: boolean): void {
+    setForm((current) => {
+      if (current === null) {
+        return current;
+      }
+
+      const currentPermissions = current.permissionsBySpace[spaceId] ?? [];
+      const nextPermissions = checked
+        ? [...new Set([...currentPermissions, permission])]
+        : currentPermissions.filter((item) => item !== permission);
+
+      return {
+        ...current,
+        permissionsBySpace: {
+          ...current.permissionsBySpace,
+          [spaceId]: nextPermissions,
+        },
+      };
+    });
+  }
+
+  const memberSummary = useMemo(
+    () => new Map(groups.map((group) => [group.id, users.filter((user) => user.groups.includes(group.id)).length])),
+    [groups, users],
+  );
+
+  return (
+    <>
+      <PageHeader
+        title="Groups"
+        description="Create groups, assign members, and bind space permissions."
+        actions={
+          <button className="button button-primary" type="button" onClick={openCreateForm}>
+            Create Group
+          </button>
+        }
+      />
+      <ErrorBanner error={error} />
+
+      {isLoading ? (
+        <LoadingState />
+      ) : groups.length === 0 ? (
+        <EmptyState label="No groups have been created yet." />
+      ) : (
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th>Members</th>
+                <th>Spaces</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map((group) => (
+                <tr key={group.id}>
+                  <td>
+                    <strong>{group.name}</strong>
+                    <span className="subtle-id">{group.id}</span>
+                  </td>
+                  <td>{group.description ?? 'No description'}</td>
+                  <td>{memberSummary.get(group.id) ?? group.member_count}</td>
+                  <td>
+                    {group.spaces.length > 0
+                      ? group.spaces.map((space) => `${space.space_id}: ${space.permissions.join(', ')}`).join('; ')
+                      : 'No space permissions'}
+                  </td>
+                  <td>
+                    <button className="button button-secondary" type="button" onClick={() => openEditForm(group)}>
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {form !== null ? (
+        <Modal title={modalTitle} onClose={() => setForm(null)}>
+          <form
+            className="form-grid"
+            onSubmit={(event) => {
+              void submitGroup(event);
+            }}
+          >
+            <label>
+              Name *
+              <input
+                required
+                type="text"
+                value={form.name}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, name: event.target.value }))}
+              />
+            </label>
+            <label>
+              Description
+              <input
+                type="text"
+                value={form.description}
+                onChange={(event) =>
+                  setForm((current) => (current === null ? current : { ...current, description: event.target.value }))
+                }
+              />
+            </label>
+            <label className="span-2">
+              Members
+              <select
+                multiple
+                value={form.memberIds}
+                onChange={(event) =>
+                  setForm((current) =>
+                    current === null
+                      ? current
+                      : {
+                          ...current,
+                          memberIds: Array.from(event.target.selectedOptions).map((option) => option.value),
+                        },
+                  )
+                }
+              >
+                {users.map((user) => (
+                  <option key={user.id} value={user.id}>
+                    {user.email}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="span-2 permission-editor">
+              <h3>Space permissions</h3>
+              {spaces.length === 0 ? (
+                <p className="muted-copy">Create a space before assigning space permissions.</p>
+              ) : (
+                spaces.map((space) => (
+                  <fieldset key={space.id}>
+                    <legend>{space.name}</legend>
+                    {SPACE_PERMISSION_OPTIONS.map((permission) => (
+                      <label key={permission} className="checkbox-row">
+                        <input
+                          type="checkbox"
+                          checked={(form.permissionsBySpace[space.id] ?? []).includes(permission)}
+                          onChange={(event) => updatePermission(space.id, permission, event.target.checked)}
+                        />
+                        {permission}
+                      </label>
+                    ))}
+                  </fieldset>
+                ))
+              )}
+            </div>
+            <div className="form-actions span-2">
+              <button className="button button-secondary" type="button" onClick={() => setForm(null)}>
+                Cancel
+              </button>
+              <button className="button button-primary" type="submit" disabled={isSaving}>
+                {isSaving ? 'Saving...' : 'Save Group'}
+              </button>
+            </div>
+          </form>
+        </Modal>
+      ) : null}
+    </>
+  );
+}
+
+function createEmptyForm(): GroupForm {
+  return {
+    name: '',
+    description: '',
+    memberIds: [],
+    permissionsBySpace: {},
+  };
+}
+
+function toSpacePermissions(permissionsBySpace: Record<string, string[]>): Array<{ space_id: string; permissions: string[] }> {
+  return Object.entries(permissionsBySpace)
+    .map(([space_id, permissions]) => ({
+      space_id,
+      permissions,
+    }))
+    .filter((item) => item.permissions.length > 0);
+}

--- a/apps/web/src/pages/admin/HealthPage.tsx
+++ b/apps/web/src/pages/admin/HealthPage.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  StatusBadge,
+  formatLabel,
+  getErrorMessage,
+} from '../../components/adminUi';
+import { api } from '../../lib/api';
+import { type SystemHealth } from '../../lib/adminTypes';
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+export default function HealthPage() {
+  const [health, setHealth] = useState<SystemHealth | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadHealth = useCallback(async () => {
+    setError(null);
+
+    try {
+      const data = await api.get<SystemHealth>('/admin/system/health');
+      setHealth(data);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadHealth();
+    const intervalId = window.setInterval(() => {
+      void loadHealth();
+    }, REFRESH_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [loadHealth]);
+
+  return (
+    <>
+      <PageHeader
+        title="System Health"
+        description="Monitor API dependencies and configured infrastructure."
+        actions={
+          <button
+            className="button button-secondary"
+            type="button"
+            onClick={() => {
+              void loadHealth();
+            }}
+          >
+            Refresh
+          </button>
+        }
+      />
+      <ErrorBanner error={error} />
+
+      {isLoading ? (
+        <LoadingState />
+      ) : health === null ? (
+        <EmptyState label="System health is unavailable." />
+      ) : (
+        <>
+          <section className="health-summary">
+            <div>
+              <span className="eyebrow">Overall status</span>
+              <StatusBadge status={health.status} />
+            </div>
+            <div>
+              <span className="eyebrow">API uptime</span>
+              <strong>{formatUptime(health.uptime)}</strong>
+            </div>
+            <div>
+              <span className="eyebrow">Auto refresh</span>
+              <strong>Every 30 seconds</strong>
+            </div>
+          </section>
+
+          <section className="health-grid" aria-label="Component health">
+            {Object.entries(health.components).map(([name, component]) => (
+              <article key={name} className={`health-card health-${component.status}`}>
+                <div className="health-card-header">
+                  <h2>{formatLabel(name)}</h2>
+                  <StatusBadge status={component.status} />
+                </div>
+                <dl>
+                  <div>
+                    <dt>Latency</dt>
+                    <dd>{component.latency_ms !== undefined ? `${component.latency_ms} ms` : 'N/A'}</dd>
+                  </div>
+                  <div>
+                    <dt>Details</dt>
+                    <dd>{component.error ?? (component.status === 'not_configured' ? 'Not configured' : 'Operational')}</dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+          </section>
+        </>
+      )}
+    </>
+  );
+}
+
+function formatUptime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainingSeconds = seconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+
+  return `${remainingSeconds}s`;
+}

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -1,0 +1,414 @@
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  Modal,
+  PageHeader,
+  StatusBadge,
+  getErrorMessage,
+  parseIdList,
+} from '../../components/adminUi';
+import { api } from '../../lib/api';
+import { type AdminModel, type ModelConnectivityResult } from '../../lib/adminTypes';
+
+type ModelForm = {
+  id?: string;
+  provider: string;
+  model_id: string;
+  model_type: 'chat' | 'embedding' | 'rerank';
+  display_name: string;
+  base_url: string;
+  encrypted_api_key_ref: string;
+  embedding_dim: string;
+  max_tokens: string;
+  rate_limit_rpm: string;
+  enabled: boolean;
+  visible_group_ids: string;
+};
+
+type ModelRequest = {
+  provider: string;
+  model_id: string;
+  model_type: 'chat' | 'embedding' | 'rerank';
+  enabled: boolean;
+  visible_group_ids: string[];
+  display_name?: string;
+  base_url?: string;
+  encrypted_api_key_ref?: string;
+  embedding_dim?: number;
+  max_tokens?: number;
+  rate_limit_rpm?: number;
+};
+
+const EMPTY_MODEL_FORM: ModelForm = {
+  provider: '',
+  model_id: '',
+  model_type: 'chat',
+  display_name: '',
+  base_url: '',
+  encrypted_api_key_ref: '',
+  embedding_dim: '',
+  max_tokens: '',
+  rate_limit_rpm: '',
+  enabled: true,
+  visible_group_ids: '',
+};
+
+export default function ModelsPage() {
+  const [models, setModels] = useState<AdminModel[]>([]);
+  const [form, setForm] = useState<ModelForm | null>(null);
+  const [testResults, setTestResults] = useState<Record<string, ModelConnectivityResult>>({});
+  const [testingModelId, setTestingModelId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadModels = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await api.get<AdminModel[]>('/admin/models', { per_page: 100, sort: 'provider' });
+      setModels(data);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadModels();
+  }, [loadModels]);
+
+  async function submitModel(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (form === null) {
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      const body = toModelRequest(form);
+      if (form.id === undefined) {
+        await api.post<AdminModel>('/admin/models', body);
+      } else {
+        await api.patch<AdminModel>(`/admin/models/${form.id}`, body);
+      }
+      setForm(null);
+      await loadModels();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function toggleModel(model: AdminModel): Promise<void> {
+    setError(null);
+    try {
+      await api.patch<AdminModel>(`/admin/models/${model.id}`, {
+        enabled: model.status !== 'active',
+      });
+      await loadModels();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  }
+
+  async function testModel(model: AdminModel): Promise<void> {
+    setTestingModelId(model.id);
+    setError(null);
+    try {
+      const result = await api.post<ModelConnectivityResult>(`/admin/models/${model.id}/test`, {
+        test_prompt: 'Admin console connectivity test',
+      });
+      setTestResults((current) => ({ ...current, [model.id]: result }));
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setTestingModelId(null);
+    }
+  }
+
+  function openEditForm(model: AdminModel): void {
+    setForm({
+      id: model.id,
+      provider: model.provider,
+      model_id: model.model_id,
+      model_type: normalizeModelType(model.model_type),
+      display_name: model.name ?? '',
+      base_url: model.config.base_url ?? '',
+      encrypted_api_key_ref: '',
+      embedding_dim: model.config.embedding_dim?.toString() ?? '',
+      max_tokens: model.config.max_tokens?.toString() ?? '',
+      rate_limit_rpm: model.config.rate_limit_rpm?.toString() ?? '',
+      enabled: model.status === 'active',
+      visible_group_ids: model.visible_group_ids.join(', '),
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Models"
+        description="Manage model providers, visibility, limits, and connectivity."
+        actions={
+          <button className="button button-primary" type="button" onClick={() => setForm({ ...EMPTY_MODEL_FORM })}>
+            Add Model
+          </button>
+        }
+      />
+      <ErrorBanner error={error} />
+
+      {isLoading ? (
+        <LoadingState />
+      ) : models.length === 0 ? (
+        <EmptyState label="No models have been configured." />
+      ) : (
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Provider</th>
+                <th>Type</th>
+                <th>Status</th>
+                <th>Config</th>
+                <th>Test</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {models.map((model) => {
+                const testResult = testResults[model.id];
+                return (
+                  <tr key={model.id}>
+                    <td>
+                      <strong>{model.name ?? model.model_id}</strong>
+                      <span className="subtle-id">{model.model_id}</span>
+                    </td>
+                    <td>{model.provider}</td>
+                    <td>{model.model_type}</td>
+                    <td>
+                      <StatusBadge status={model.status} />
+                    </td>
+                    <td>
+                      {model.config.base_url ?? 'Default endpoint'}
+                      {model.config.max_tokens !== null ? `; ${model.config.max_tokens} max tokens` : ''}
+                    </td>
+                    <td>
+                      {testResult === undefined ? (
+                        <span className="muted-copy">Not tested</span>
+                      ) : (
+                        <span className={testResult.reachable ? 'test-ok' : 'test-fail'}>
+                          {testResult.reachable ? 'Reachable' : testResult.error ?? 'Failed'} ({testResult.latency_ms} ms)
+                        </span>
+                      )}
+                    </td>
+                    <td>
+                      <div className="row-actions">
+                        <button className="button button-secondary" type="button" onClick={() => openEditForm(model)}>
+                          Edit
+                        </button>
+                        <button
+                          className="button button-secondary"
+                          type="button"
+                          disabled={testingModelId === model.id}
+                          onClick={() => {
+                            void testModel(model);
+                          }}
+                        >
+                          {testingModelId === model.id ? 'Testing...' : 'Test'}
+                        </button>
+                        <button
+                          className="button button-danger"
+                          type="button"
+                          onClick={() => {
+                            void toggleModel(model);
+                          }}
+                        >
+                          {model.status === 'active' ? 'Disable' : 'Enable'}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {form !== null ? (
+        <Modal title={form.id === undefined ? 'Add Model' : 'Edit Model'} onClose={() => setForm(null)}>
+          <form
+            className="form-grid"
+            onSubmit={(event) => {
+              void submitModel(event);
+            }}
+          >
+            <label>
+              Provider *
+              <input
+                required
+                type="text"
+                value={form.provider}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, provider: event.target.value }))}
+              />
+            </label>
+            <label>
+              Model ID *
+              <input
+                required
+                type="text"
+                value={form.model_id}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, model_id: event.target.value }))}
+              />
+            </label>
+            <label>
+              Type *
+              <select
+                value={form.model_type}
+                onChange={(event) =>
+                  setForm((current) =>
+                    current === null
+                      ? current
+                      : { ...current, model_type: event.target.value as ModelForm['model_type'] },
+                  )
+                }
+              >
+                <option value="chat">chat</option>
+                <option value="embedding">embedding</option>
+                <option value="rerank">rerank</option>
+              </select>
+            </label>
+            <label>
+              Display name
+              <input
+                type="text"
+                value={form.display_name}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, display_name: event.target.value }))}
+              />
+            </label>
+            <label className="span-2">
+              Base URL
+              <input
+                type="url"
+                value={form.base_url}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, base_url: event.target.value }))}
+              />
+            </label>
+            <label>
+              API key ref
+              <input
+                type="text"
+                value={form.encrypted_api_key_ref}
+                onChange={(event) =>
+                  setForm((current) => (current === null ? current : { ...current, encrypted_api_key_ref: event.target.value }))
+                }
+              />
+            </label>
+            <label>
+              Visible group IDs
+              <input
+                type="text"
+                value={form.visible_group_ids}
+                onChange={(event) =>
+                  setForm((current) => (current === null ? current : { ...current, visible_group_ids: event.target.value }))
+                }
+                placeholder="Comma-separated group IDs"
+              />
+            </label>
+            <label>
+              Embedding dim
+              <input
+                type="number"
+                min="1"
+                value={form.embedding_dim}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, embedding_dim: event.target.value }))}
+              />
+            </label>
+            <label>
+              Max tokens
+              <input
+                type="number"
+                min="1"
+                value={form.max_tokens}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, max_tokens: event.target.value }))}
+              />
+            </label>
+            <label>
+              Rate limit rpm
+              <input
+                type="number"
+                min="1"
+                value={form.rate_limit_rpm}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, rate_limit_rpm: event.target.value }))}
+              />
+            </label>
+            <label className="checkbox-row model-enabled">
+              <input
+                type="checkbox"
+                checked={form.enabled}
+                onChange={(event) => setForm((current) => (current === null ? current : { ...current, enabled: event.target.checked }))}
+              />
+              Enabled
+            </label>
+            <div className="form-actions span-2">
+              <button className="button button-secondary" type="button" onClick={() => setForm(null)}>
+                Cancel
+              </button>
+              <button className="button button-primary" type="submit" disabled={isSaving}>
+                {isSaving ? 'Saving...' : 'Save Model'}
+              </button>
+            </div>
+          </form>
+        </Modal>
+      ) : null}
+    </>
+  );
+}
+
+function toModelRequest(form: ModelForm): ModelRequest {
+  const body: ModelRequest = {
+    provider: form.provider,
+    model_id: form.model_id,
+    model_type: form.model_type,
+    enabled: form.enabled,
+    visible_group_ids: parseIdList(form.visible_group_ids),
+  };
+
+  addOptionalString(body, 'display_name', form.display_name);
+  addOptionalString(body, 'base_url', form.base_url);
+  addOptionalString(body, 'encrypted_api_key_ref', form.encrypted_api_key_ref);
+  addOptionalNumber(body, 'embedding_dim', form.embedding_dim);
+  addOptionalNumber(body, 'max_tokens', form.max_tokens);
+  addOptionalNumber(body, 'rate_limit_rpm', form.rate_limit_rpm);
+
+  return body;
+}
+
+function addOptionalString<T extends Record<string, unknown>>(target: T, key: keyof T, value: string): void {
+  const trimmed = value.trim();
+  if (trimmed.length > 0) {
+    target[key] = trimmed as T[keyof T];
+  }
+}
+
+function addOptionalNumber<T extends Record<string, unknown>>(target: T, key: keyof T, value: string): void {
+  const trimmed = value.trim();
+  if (trimmed.length > 0) {
+    target[key] = Number(trimmed) as T[keyof T];
+  }
+}
+
+function normalizeModelType(value: string): ModelForm['model_type'] {
+  if (value === 'embedding' || value === 'rerank') {
+    return value;
+  }
+
+  return 'chat';
+}

--- a/apps/web/src/pages/admin/SpacesPage.tsx
+++ b/apps/web/src/pages/admin/SpacesPage.tsx
@@ -1,0 +1,349 @@
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  Modal,
+  PageHeader,
+  StatusBadge,
+  getErrorMessage,
+} from '../../components/adminUi';
+import { api } from '../../lib/api';
+import {
+  SPACE_PERMISSION_OPTIONS,
+  type AdminGroup,
+  type AdminSpace,
+  type AdminSpaceDetail,
+  type SpacePermissionGroup,
+} from '../../lib/adminTypes';
+
+type CreateSpaceForm = {
+  name: string;
+  slug: string;
+  description: string;
+};
+
+const EMPTY_SPACE_FORM: CreateSpaceForm = {
+  name: '',
+  slug: '',
+  description: '',
+};
+
+export default function SpacesPage() {
+  const [spaces, setSpaces] = useState<AdminSpace[]>([]);
+  const [groups, setGroups] = useState<AdminGroup[]>([]);
+  const [selectedSpace, setSelectedSpace] = useState<AdminSpaceDetail | null>(null);
+  const [permissionsByGroup, setPermissionsByGroup] = useState<Record<string, string[]>>({});
+  const [createForm, setCreateForm] = useState<CreateSpaceForm | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadSpaces = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [nextSpaces, nextGroups] = await Promise.all([
+        api.get<AdminSpace[]>('/spaces', { per_page: 100, sort: 'name' }),
+        api.get<AdminGroup[]>('/admin/groups', { per_page: 100, sort: 'name' }),
+      ]);
+      setSpaces(nextSpaces);
+      setGroups(nextGroups);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSpaces();
+  }, [loadSpaces]);
+
+  async function submitCreateSpace(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (createForm === null) {
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      await api.post<AdminSpaceDetail>('/spaces', {
+        name: createForm.name,
+        slug: createForm.slug,
+        description: createForm.description,
+      });
+      setCreateForm(null);
+      await loadSpaces();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function openDetails(space: AdminSpace): Promise<void> {
+    setIsDetailLoading(true);
+    setError(null);
+
+    try {
+      const [detail, permissions] = await Promise.all([
+        api.get<AdminSpaceDetail>(`/spaces/${space.id}`),
+        api.get<SpacePermissionGroup[]>(`/spaces/${space.id}/permissions`),
+      ]);
+      setSelectedSpace(detail);
+      setPermissionsByGroup(Object.fromEntries(permissions.map((item) => [item.group_id, item.permissions])));
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsDetailLoading(false);
+    }
+  }
+
+  async function saveStrictMode(strictKnowledgeOnly: boolean): Promise<void> {
+    if (selectedSpace === null) {
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      const updated = await api.patch<AdminSpaceDetail>(`/spaces/${selectedSpace.id}`, {
+        strict_knowledge_only: strictKnowledgeOnly,
+      });
+      setSelectedSpace(updated);
+      await loadSpaces();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function savePermissions(): Promise<void> {
+    if (selectedSpace === null) {
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      const permissions = Object.entries(permissionsByGroup)
+        .map(([group_id, groupPermissions]) => ({ group_id, permissions: groupPermissions }))
+        .filter((item) => item.permissions.length > 0);
+      const updated = await api.put<SpacePermissionGroup[]>(`/spaces/${selectedSpace.id}/permissions`, { permissions });
+      setPermissionsByGroup(Object.fromEntries(updated.map((item) => [item.group_id, item.permissions])));
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function updatePermission(groupId: string, permission: string, checked: boolean): void {
+    setPermissionsByGroup((current) => {
+      const currentPermissions = current[groupId] ?? [];
+      const nextPermissions = checked
+        ? [...new Set([...currentPermissions, permission])]
+        : currentPermissions.filter((item) => item !== permission);
+
+      return {
+        ...current,
+        [groupId]: nextPermissions,
+      };
+    });
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Spaces"
+        description="Create knowledge spaces and manage their access controls."
+        actions={
+          <button className="button button-primary" type="button" onClick={() => setCreateForm({ ...EMPTY_SPACE_FORM })}>
+            Create Space
+          </button>
+        }
+      />
+      <ErrorBanner error={error} />
+
+      {isLoading ? (
+        <LoadingState />
+      ) : spaces.length === 0 ? (
+        <EmptyState label="No spaces are available to administer." />
+      ) : (
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Slug</th>
+                <th>Status</th>
+                <th>Pages</th>
+                <th>Sources</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {spaces.map((space) => (
+                <tr key={space.id}>
+                  <td>
+                    <strong>{space.name}</strong>
+                    <span className="subtle-id">{space.id}</span>
+                  </td>
+                  <td>
+                    <code>{space.slug}</code>
+                  </td>
+                  <td>
+                    <StatusBadge status={space.status} />
+                  </td>
+                  <td>{space.stats.page_count}</td>
+                  <td>{space.stats.source_count}</td>
+                  <td>
+                    <button
+                      className="button button-secondary"
+                      type="button"
+                      onClick={() => {
+                        void openDetails(space);
+                      }}
+                    >
+                      Configure
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {isDetailLoading ? <LoadingState label="Loading space details..." /> : null}
+
+      {selectedSpace !== null ? (
+        <section className="detail-panel" aria-label="Space configuration">
+          <div className="detail-panel-header">
+            <div>
+              <h2>{selectedSpace.name}</h2>
+              <p>{selectedSpace.description ?? 'No description'}</p>
+            </div>
+            <button className="button button-secondary" type="button" onClick={() => setSelectedSpace(null)}>
+              Close
+            </button>
+          </div>
+
+          <div className="settings-grid">
+            <label className="toggle-row">
+              <input
+                type="checkbox"
+                checked={selectedSpace.strict_knowledge_only}
+                disabled={isSaving}
+                onChange={(event) => {
+                  void saveStrictMode(event.target.checked);
+                }}
+              />
+              <span>
+                <strong>Strict knowledge only</strong>
+                <small>Restrict answers to indexed space knowledge.</small>
+              </span>
+            </label>
+            <div>
+              <span className="eyebrow">Repository path</span>
+              <code>{selectedSpace.wiki_repo_path}</code>
+            </div>
+            <div>
+              <span className="eyebrow">Index status</span>
+              <StatusBadge status={selectedSpace.index_consistency_status} />
+            </div>
+          </div>
+
+          <div className="permission-editor">
+            <div className="section-heading-row">
+              <h3>Group permissions</h3>
+              <button
+                className="button button-primary"
+                type="button"
+                disabled={isSaving}
+                onClick={() => {
+                  void savePermissions();
+                }}
+              >
+                Save Permissions
+              </button>
+            </div>
+            {groups.length === 0 ? (
+              <p className="muted-copy">Create a group before assigning permissions.</p>
+            ) : (
+              groups.map((group) => (
+                <fieldset key={group.id}>
+                  <legend>{group.name}</legend>
+                  {SPACE_PERMISSION_OPTIONS.map((permission) => (
+                    <label key={permission} className="checkbox-row">
+                      <input
+                        type="checkbox"
+                        checked={(permissionsByGroup[group.id] ?? []).includes(permission)}
+                        onChange={(event) => updatePermission(group.id, permission, event.target.checked)}
+                      />
+                      {permission}
+                    </label>
+                  ))}
+                </fieldset>
+              ))
+            )}
+          </div>
+        </section>
+      ) : null}
+
+      {createForm !== null ? (
+        <Modal title="Create Space" onClose={() => setCreateForm(null)}>
+          <form
+            className="form-grid"
+            onSubmit={(event) => {
+              void submitCreateSpace(event);
+            }}
+          >
+            <label>
+              Name *
+              <input
+                required
+                type="text"
+                value={createForm.name}
+                onChange={(event) => setCreateForm((current) => (current === null ? current : { ...current, name: event.target.value }))}
+              />
+            </label>
+            <label>
+              Slug *
+              <input
+                required
+                type="text"
+                pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                value={createForm.slug}
+                onChange={(event) => setCreateForm((current) => (current === null ? current : { ...current, slug: event.target.value }))}
+              />
+            </label>
+            <label className="span-2">
+              Description
+              <textarea
+                rows={4}
+                value={createForm.description}
+                onChange={(event) =>
+                  setCreateForm((current) => (current === null ? current : { ...current, description: event.target.value }))
+                }
+              />
+            </label>
+            <div className="form-actions span-2">
+              <button className="button button-secondary" type="button" onClick={() => setCreateForm(null)}>
+                Cancel
+              </button>
+              <button className="button button-primary" type="submit" disabled={isSaving}>
+                {isSaving ? 'Creating...' : 'Create Space'}
+              </button>
+            </div>
+          </form>
+        </Modal>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/pages/admin/UsersPage.tsx
+++ b/apps/web/src/pages/admin/UsersPage.tsx
@@ -1,0 +1,354 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  Modal,
+  PageHeader,
+  StatusBadge,
+  formatDate,
+  getErrorMessage,
+  parseIdList,
+} from '../../components/adminUi';
+import { api } from '../../lib/api';
+import { ROLE_OPTIONS, type AdminUser } from '../../lib/adminTypes';
+
+type CreateUserForm = {
+  email: string;
+  name: string;
+  password: string;
+  role: string;
+  groups: string;
+};
+
+type EditUserForm = {
+  id: string;
+  display_name: string;
+  role: string;
+};
+
+const EMPTY_CREATE_FORM: CreateUserForm = {
+  email: '',
+  name: '',
+  password: '',
+  role: 'viewer',
+  groups: '',
+};
+
+export default function UsersPage() {
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [search, setSearch] = useState('');
+  const [role, setRole] = useState('');
+  const [status, setStatus] = useState('');
+  const deferredSearch = useDeferredValue(search);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [createForm, setCreateForm] = useState<CreateUserForm>(EMPTY_CREATE_FORM);
+  const [editForm, setEditForm] = useState<EditUserForm | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+
+  const loadUsers = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await api.get<AdminUser[]>('/admin/users', {
+        search: deferredSearch,
+        role,
+        status,
+        sort: 'email',
+        per_page: 100,
+      });
+      setUsers(data);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [deferredSearch, role, status]);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  const visibleUsers = useMemo(() => users, [users]);
+
+  async function submitCreateUser(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      await api.post<AdminUser>('/admin/users', {
+        email: createForm.email,
+        name: createForm.name,
+        password: createForm.password,
+        role: createForm.role,
+        groups: parseIdList(createForm.groups),
+      });
+      setCreateForm(EMPTY_CREATE_FORM);
+      await loadUsers();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  async function submitEditUser(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    if (editForm === null) {
+      return;
+    }
+
+    setError(null);
+    try {
+      await api.patch<AdminUser>(`/admin/users/${editForm.id}`, {
+        display_name: editForm.display_name,
+        role: editForm.role,
+      });
+      setEditForm(null);
+      await loadUsers();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  }
+
+  async function toggleStatus(user: AdminUser): Promise<void> {
+    setError(null);
+    try {
+      await api.patch<AdminUser>(`/admin/users/${user.id}`, {
+        status: user.status === 'disabled' ? 'active' : 'disabled',
+      });
+      await loadUsers();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Users"
+        description="Manage accounts, roles, group membership, and account status."
+        actions={
+          <button className="button button-primary" type="button" onClick={() => setCreateForm({ ...EMPTY_CREATE_FORM })}>
+            Create User
+          </button>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      <section className="toolbar" aria-label="User filters">
+        <label>
+          Search
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Email or name"
+          />
+        </label>
+        <label>
+          Role
+          <select value={role} onChange={(event) => setRole(event.target.value)}>
+            <option value="">All roles</option>
+            {ROLE_OPTIONS.map((item) => (
+              <option key={item} value={item}>
+                {item}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Status
+          <select value={status} onChange={(event) => setStatus(event.target.value)}>
+            <option value="">All statuses</option>
+            <option value="active">Active</option>
+            <option value="disabled">Disabled</option>
+          </select>
+        </label>
+      </section>
+
+      {isLoading ? (
+        <LoadingState />
+      ) : visibleUsers.length === 0 ? (
+        <EmptyState label="No users match the current filters." />
+      ) : (
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Name</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Groups</th>
+                <th>Last login</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleUsers.map((user) => (
+                <tr key={user.id}>
+                  <td>
+                    <code>{user.email}</code>
+                  </td>
+                  <td>{user.name}</td>
+                  <td>{user.role}</td>
+                  <td>
+                    <StatusBadge status={user.status} />
+                  </td>
+                  <td>{user.groups.length > 0 ? user.groups.join(', ') : 'None'}</td>
+                  <td>{formatDate(user.last_login_at)}</td>
+                  <td>
+                    <div className="row-actions">
+                      <button
+                        className="button button-secondary"
+                        type="button"
+                        onClick={() =>
+                          setEditForm({
+                            id: user.id,
+                            display_name: user.name,
+                            role: user.role,
+                          })
+                        }
+                      >
+                        Edit
+                      </button>
+                      <button
+                        className="button button-danger"
+                        type="button"
+                        onClick={() => {
+                          void toggleStatus(user);
+                        }}
+                      >
+                        {user.status === 'disabled' ? 'Enable' : 'Disable'}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {createForm !== EMPTY_CREATE_FORM || isCreating ? (
+        <Modal title="Create User" onClose={() => setCreateForm(EMPTY_CREATE_FORM)}>
+          <form
+            className="form-grid"
+            onSubmit={(event) => {
+              void submitCreateUser(event);
+            }}
+          >
+            <label>
+              Email *
+              <input
+                required
+                type="email"
+                autoComplete="email"
+                value={createForm.email}
+                onChange={(event) => setCreateForm((current) => ({ ...current, email: event.target.value }))}
+              />
+            </label>
+            <label>
+              Name *
+              <input
+                required
+                type="text"
+                value={createForm.name}
+                onChange={(event) => setCreateForm((current) => ({ ...current, name: event.target.value }))}
+              />
+            </label>
+            <label>
+              Password *
+              <input
+                required
+                type="password"
+                autoComplete="new-password"
+                value={createForm.password}
+                onChange={(event) => setCreateForm((current) => ({ ...current, password: event.target.value }))}
+              />
+            </label>
+            <label>
+              Role *
+              <select
+                required
+                value={createForm.role}
+                onChange={(event) => setCreateForm((current) => ({ ...current, role: event.target.value }))}
+              >
+                {ROLE_OPTIONS.map((item) => (
+                  <option key={item} value={item}>
+                    {item}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="span-2">
+              Groups
+              <input
+                type="text"
+                value={createForm.groups}
+                onChange={(event) => setCreateForm((current) => ({ ...current, groups: event.target.value }))}
+                placeholder="Comma-separated group IDs"
+              />
+            </label>
+            <div className="form-actions span-2">
+              <button className="button button-secondary" type="button" onClick={() => setCreateForm(EMPTY_CREATE_FORM)}>
+                Cancel
+              </button>
+              <button className="button button-primary" type="submit" disabled={isCreating}>
+                {isCreating ? 'Creating...' : 'Create User'}
+              </button>
+            </div>
+          </form>
+        </Modal>
+      ) : null}
+
+      {editForm !== null ? (
+        <Modal title="Edit User" onClose={() => setEditForm(null)}>
+          <form
+            className="form-grid"
+            onSubmit={(event) => {
+              void submitEditUser(event);
+            }}
+          >
+            <label>
+              Display name *
+              <input
+                required
+                type="text"
+                value={editForm.display_name}
+                onChange={(event) => setEditForm((current) => (current === null ? current : { ...current, display_name: event.target.value }))}
+              />
+            </label>
+            <label>
+              Role *
+              <select
+                required
+                value={editForm.role}
+                onChange={(event) => setEditForm((current) => (current === null ? current : { ...current, role: event.target.value }))}
+              >
+                {ROLE_OPTIONS.map((item) => (
+                  <option key={item} value={item}>
+                    {item}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="form-actions span-2">
+              <button className="button button-secondary" type="button" onClick={() => setEditForm(null)}>
+                Cancel
+              </button>
+              <button className="button button-primary" type="submit">
+                Save Changes
+              </button>
+            </div>
+          </form>
+        </Modal>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,732 @@
+:root {
+  color: #1e293b;
+  background: #f8fafc;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  margin: 0;
+  background: #f8fafc;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+a {
+  color: inherit;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.85rem;
+}
+
+.login-page,
+.forbidden-page {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 24px;
+  background:
+    linear-gradient(135deg, rgba(59, 130, 246, 0.12), transparent 42%),
+    linear-gradient(315deg, rgba(249, 115, 22, 0.12), transparent 36%),
+    #f8fafc;
+}
+
+.login-panel,
+.forbidden-panel {
+  width: min(100%, 430px);
+  padding: 32px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.12);
+}
+
+.login-panel h1,
+.forbidden-panel h1,
+.admin-page-header h1 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 2rem;
+  line-height: 1.15;
+  letter-spacing: 0;
+}
+
+.login-copy,
+.admin-page-header p,
+.detail-panel-header p,
+.muted-copy {
+  margin: 8px 0 0;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.login-form,
+.form-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.login-form label,
+.form-grid label,
+.toolbar label {
+  display: grid;
+  gap: 7px;
+  color: #334155;
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 9px 11px;
+  outline: none;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+select[multiple] {
+  min-height: 126px;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.18);
+}
+
+.button {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 8px 13px;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.button-primary {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.button-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.button-secondary {
+  border-color: #cbd5e1;
+  background: #ffffff;
+  color: #1e293b;
+}
+
+.button-secondary:hover:not(:disabled) {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+.button-danger {
+  border-color: #fecaca;
+  background: #fff7ed;
+  color: #b91c1c;
+}
+
+.button-danger:hover:not(:disabled) {
+  border-color: #f87171;
+  background: #fee2e2;
+}
+
+.login-submit {
+  width: 100%;
+}
+
+.alert {
+  margin-top: 16px;
+  border-radius: 6px;
+  padding: 12px 14px;
+  line-height: 1.45;
+}
+
+.alert-error {
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.eyebrow {
+  display: block;
+  margin: 0 0 6px;
+  color: #64748b;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.admin-shell {
+  display: grid;
+  min-height: 100vh;
+  grid-template-columns: 252px minmax(0, 1fr);
+  background: #f8fafc;
+}
+
+.admin-sidebar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  height: 100vh;
+  flex-direction: column;
+  gap: 22px;
+  border-right: 1px solid #e2e8f0;
+  background: #ffffff;
+  padding: 22px 16px;
+}
+
+.admin-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 6px;
+}
+
+.admin-brand-mark {
+  display: inline-grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 7px;
+  background: #0f172a;
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.admin-brand strong,
+.admin-topbar strong {
+  display: block;
+  color: #0f172a;
+}
+
+.admin-brand span,
+.admin-user-block span {
+  display: block;
+  color: #64748b;
+  font-size: 0.86rem;
+}
+
+.admin-nav {
+  display: grid;
+  gap: 5px;
+}
+
+.admin-nav-link {
+  border-radius: 6px;
+  color: #334155;
+  font-weight: 700;
+  padding: 10px 11px;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.admin-nav-link:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+.admin-nav-link.active {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.admin-main {
+  min-width: 0;
+}
+
+.admin-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  min-height: 72px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  border-bottom: 1px solid #e2e8f0;
+  background: rgba(248, 250, 252, 0.94);
+  padding: 14px 28px;
+  backdrop-filter: blur(12px);
+}
+
+.admin-user-block {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  text-align: right;
+}
+
+.admin-content {
+  display: grid;
+  gap: 20px;
+  padding: 28px;
+}
+
+.admin-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.admin-page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 14px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid #e2e8f0;
+  padding: 13px 14px;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: #f8fafc;
+  color: #475569;
+  font-size: 0.78rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+tbody tr:hover {
+  background: #f8fafc;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.status-badge {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  border-radius: 999px;
+  padding: 3px 9px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.status-healthy {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-degraded {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-neutral {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.status-unhealthy {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.muted-state {
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #64748b;
+  padding: 26px;
+  text-align: center;
+}
+
+.subtle-id {
+  display: block;
+  max-width: 360px;
+  overflow-wrap: anywhere;
+  color: #64748b;
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.42);
+  padding: 24px;
+}
+
+.modal-panel {
+  width: min(100%, 760px);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 22px;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.28);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.modal-header h2,
+.detail-panel h2,
+.health-card h2 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1.2rem;
+  letter-spacing: 0;
+}
+
+.icon-button {
+  display: inline-grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #334155;
+  font-weight: 800;
+}
+
+.icon-button:hover {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+.form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.span-2 {
+  grid-column: 1 / -1;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.permission-editor {
+  display: grid;
+  gap: 12px;
+}
+
+.permission-editor h3,
+.section-heading-row h3 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+fieldset {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+legend {
+  padding: 0 5px;
+  color: #334155;
+  font-weight: 800;
+}
+
+.checkbox-row,
+.toggle-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #334155;
+  font-weight: 650;
+}
+
+.checkbox-row input,
+.toggle-row input {
+  width: 16px;
+  min-height: 16px;
+}
+
+.model-enabled {
+  align-content: end;
+  min-height: 68px;
+}
+
+.detail-panel,
+.health-summary {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 18px;
+}
+
+.detail-panel {
+  display: grid;
+  gap: 18px;
+}
+
+.detail-panel-header,
+.section-heading-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.settings-grid > div,
+.toggle-row {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 12px;
+}
+
+.toggle-row small {
+  display: block;
+  margin-top: 4px;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.test-ok {
+  color: #166534;
+  font-weight: 800;
+}
+
+.test-fail {
+  color: #991b1b;
+  font-weight: 800;
+}
+
+.health-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 16px;
+}
+
+.health-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 14px;
+}
+
+.health-card {
+  border: 1px solid #e2e8f0;
+  border-left: 5px solid #94a3b8;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 16px;
+}
+
+.health-healthy {
+  border-left-color: #22c55e;
+}
+
+.health-degraded {
+  border-left-color: #f59e0b;
+}
+
+.health-unhealthy {
+  border-left-color: #ef4444;
+}
+
+.health-not_configured {
+  border-left-color: #94a3b8;
+}
+
+.health-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+dl {
+  display: grid;
+  gap: 10px;
+  margin: 14px 0 0;
+}
+
+dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+dt {
+  color: #64748b;
+  font-weight: 700;
+}
+
+dd {
+  margin: 0;
+  color: #0f172a;
+  text-align: right;
+}
+
+@media (max-width: 820px) {
+  .admin-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-sidebar {
+    position: static;
+    height: auto;
+  }
+
+  .admin-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .admin-topbar,
+  .admin-page-header,
+  .detail-panel-header,
+  .section-heading-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .admin-user-block {
+    justify-content: space-between;
+    text-align: left;
+  }
+
+  .admin-content {
+    padding: 20px;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .span-2 {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .login-panel,
+  .forbidden-panel,
+  .modal-panel {
+    padding: 20px;
+  }
+
+  .admin-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-topbar,
+  .admin-content {
+    padding: 16px;
+  }
+
+  .row-actions,
+  .form-actions {
+    flex-direction: column;
+  }
+
+  .button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Implement complete Admin Console with auth context, login page, admin route guard, sidebar layout
- 6 admin pages: Users, Groups, Spaces, Models, Audit Logs, System Health
- Auth context with token management, auto-refresh, 401 redirect
- 14 new files, ~3500 lines, all tests passing

## Agent Review
- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `b4d4716a6da97d3ba87ca41b6555a8a60d958d6a`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/38#issuecomment-4347455431) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/38#issuecomment-4347455607)
- Key findings addressed: No critical findings — clean frontend review

## Test plan
- [x] pnpm run build/lint/test — all passing
- [x] Login form with error handling
- [x] Admin route guard
- [x] All 6 admin pages render

Closes #26