### PR TITLE
docs: tokenize UI descriptions in requirement/project docs

### DIFF
--- a/docs/project/16_实施路线图与里程碑.md
+++ b/docs/project/16_实施路线图与里程碑.md
@@ -21,8 +21,8 @@ Phase 4  知识治理与高级能力 + 审计 + 安全增强 + MCP Gateway
 
 | 模块 | 交付物 |
 |---|---|
-| Cherry Web | 登录、Space 切换、只读 Wiki、Chat 页面、引用展示。 |
-| Admin | 用户、Group、Space、模型、任务管理。 |
+| Cherry Web | 登录、Space 切换、只读 Wiki、Chat 页面、引用展示。遵循 UI 设计规范（`docs/design/12_UI设计规范`）。 |
+| Admin | 用户、Group、Space、模型、任务管理。遵循 UI 设计规范。 |
 | Upload | 文件上传、去重、Source Archive、上传进度。 |
 | Ingestion | 文件校验、解析、归档元数据、Graphify job 触发。 |
 | Graphify Worker | 自动执行 `graphify --wiki`，保存 `graphify-out`。 |

--- a/docs/project/16_实施路线图与里程碑.md
+++ b/docs/project/16_实施路线图与里程碑.md
@@ -21,7 +21,7 @@ Phase 4  知识治理与高级能力 + 审计 + 安全增强 + MCP Gateway
 
 | 模块 | 交付物 |
 |---|---|
-| Cherry Web | 登录、Space 切换、只读 Wiki、Chat 页面、引用展示。遵循 UI 设计规范（`docs/design/12_UI设计规范`）。 |
+| Cherry Web | 登录、Space 切换、只读 Wiki、Chat 页面、引用展示。遵循 UI 设计规范（`docs/design/12_UI设计规范_CherryStudio风格对齐.md`）。 |
 | Admin | 用户、Group、Space、模型、任务管理。遵循 UI 设计规范。 |
 | Upload | 文件上传、去重、Source Archive、上传进度。 |
 | Ingestion | 文件校验、解析、归档元数据、Graphify job 触发。 |

--- a/docs/project/25_Phase1_Scope_Lock.md
+++ b/docs/project/25_Phase1_Scope_Lock.md
@@ -23,6 +23,7 @@
 | Admin Console | 用户/Group/Space/模型/任务/审计 |
 | Docker Compose 部署 | 一键启动 Phase 1 全部服务 |
 | 健康检查 | 所有服务 healthcheck |
+| UI 视觉规范合规 | 所有前端页面遵循 `docs/design/12_UI设计规范`，使用 CSS token 体系，支持暗色模式 |
 
 ## 3. Phase 1 不做什么
 

--- a/docs/project/25_Phase1_Scope_Lock.md
+++ b/docs/project/25_Phase1_Scope_Lock.md
@@ -23,7 +23,7 @@
 | Admin Console | 用户/Group/Space/模型/任务/审计 |
 | Docker Compose 部署 | 一键启动 Phase 1 全部服务 |
 | 健康检查 | 所有服务 healthcheck |
-| UI 视觉规范合规 | 所有前端页面遵循 `docs/design/12_UI设计规范`，使用 CSS token 体系，支持暗色模式 |
+| UI 视觉规范合规 | 所有前端页面遵循 `docs/design/12_UI设计规范_CherryStudio风格对齐.md`，使用 CSS token 体系，支持暗色模式 |
 
 ## 3. Phase 1 不做什么
 

--- a/docs/requirements/03_产品需求_PRD.md
+++ b/docs/requirements/03_产品需求_PRD.md
@@ -146,6 +146,8 @@ CherryGraph Studio 是一个 Docker 化部署的多用户 AI 工作台，基于 
 
 ## 7. 页面需求
 
+> **视觉规范**: 所有页面实现须遵循 `docs/design/12_UI设计规范_CherryStudio风格对齐.md`。
+
 ### 7.1 Cherry Web 首页
 
 - 最近会话。

--- a/docs/requirements/04_模块需求_CherryWeb_Chat_Admin.md
+++ b/docs/requirements/04_模块需求_CherryWeb_Chat_Admin.md
@@ -127,7 +127,7 @@ generating → aborted（用户主动取消）
 - 引用卡片显示页面标题、段落标题、版本、更新时间。
 - 点击引用跳转 Docmost 页面或 Cherry 内置 Wiki 只读视图。
 - 如果引用来自图谱节点，应展示节点所在页面和源段落。
-- 如果引用关系为 `INFERRED` 或 `AMBIGUOUS`，必须使用 `--color-status-degraded-text` 色标签 + `--color-warning-soft` 背景明确标注置信度等级。
+- 如果引用关系为 `INFERRED` 或 `AMBIGUOUS`，必须使用 `--color-status-degraded-text` 色标签 + `--color-status-degraded-bg` 背景明确标注置信度等级。
 
 #### 图谱解释展示
 

--- a/docs/requirements/04_模块需求_CherryWeb_Chat_Admin.md
+++ b/docs/requirements/04_模块需求_CherryWeb_Chat_Admin.md
@@ -6,6 +6,8 @@ Cherry Web 是用户进入平台的主入口，负责 AI 聊天、Agent、GraphR
 
 ## 2. Cherry Web 前端
 
+> **视觉规范**: 所有前端 UI 实现须遵循 `docs/design/12_UI设计规范_CherryStudio风格对齐.md`，使用 CSS token 体系，禁止硬编码色值。
+
 ### 2.1 基础页面
 
 | 页面 | 功能 |
@@ -43,11 +45,11 @@ generating → aborted（用户主动取消）
 
 | 状态 | UI 表现 |
 |---|---|
-| `pending_retrieval` | 显示"正在检索知识库..."动画 |
-| `generating` | 显示流式文字 + 打字光标 |
-| `completed` | 回答完整展示，引用卡片可点击 |
-| `failed` | 显示错误信息 + 重试按钮 |
-| `aborted` | 显示已生成的部分内容 + "已中止"标记 |
+| `pending_retrieval` | 显示"正在检索知识库..."动画（使用 `--color-primary` 色调的脉冲加载指示器） |
+| `generating` | 显示流式文字 + 打字光标（光标色 `--color-primary`） |
+| `completed` | 回答完整展示，引用卡片可点击（卡片使用 `--color-surface` 背景、`--color-border` 边框） |
+| `failed` | 显示错误信息（`--color-error` 文字、`--color-error-soft` 背景）+ 重试按钮（`--color-primary` 主按钮） |
+| `aborted` | 显示已生成的部分内容 + "已中止"标记（`--color-warning` 色标签） |
 
 ##### 回答结构
 
@@ -87,10 +89,10 @@ generating → aborted（用户主动取消）
 
 | 值 | 含义 | UI 标注 | 条件 |
 |---|---|---|---|
-| `knowledge_base` | 基于 Published Wiki 检索 | 默认，显示引用卡片 | — |
-| `model_knowledge` | 知识库无命中，基于模型自有知识 | 显示醒目标注"⚠ 此回答基于模型通用知识，非知识库引用，准确性未经验证" | 仅当 `strict_knowledge_only = false` |
-| `mixed` | 部分基于知识库、部分基于模型补充 | 引用部分正常显示，模型补充部分单独标注 | 仅当 `strict_knowledge_only = false` |
-| `no_hit` | 知识库无命中且严格模式 | 显示"当前知识库没有可引用资料，请上传或发布相关 Wiki" | 当 `strict_knowledge_only = true` |
+| `knowledge_base` | 基于 Published Wiki 检索 | 默认，显示引用卡片（`--color-surface` 背景、`--color-border` 边框） | — |
+| `model_knowledge` | 知识库无命中，基于模型自有知识 | 显示 `--color-warning-soft` 背景 + `--color-warning` 文字的警告横幅："⚠ 此回答基于模型通用知识，非知识库引用，准确性未经验证" | 仅当 `strict_knowledge_only = false` |
+| `mixed` | 部分基于知识库、部分基于模型补充 | 引用部分正常显示，模型补充部分使用 `--color-warning-soft` 背景单独标注 | 仅当 `strict_knowledge_only = false` |
+| `no_hit` | 知识库无命中且严格模式 | 显示 `--color-info` 色调引导卡片："当前知识库没有可引用资料，请上传或发布相关 Wiki" | 当 `strict_knowledge_only = true` |
 
 ##### 无知识命中策略
 
@@ -118,14 +120,14 @@ generating → aborted（用户主动取消）
 
 - 标注文字："引用历史版本 v{page_version}，当前已更新至 v{current_page_version}"
 - 提供"查看最新版本"链接
-- 引用卡片使用视觉区分（如淡黄色背景或虚线边框）
+- 引用卡片使用 `--color-warning-soft` 背景 + `--color-border-strong` 虚线边框进行视觉区分
 
 #### 引用展示
 
 - 引用卡片显示页面标题、段落标题、版本、更新时间。
 - 点击引用跳转 Docmost 页面或 Cherry 内置 Wiki 只读视图。
 - 如果引用来自图谱节点，应展示节点所在页面和源段落。
-- 如果引用关系为 `INFERRED` 或 `AMBIGUOUS`，必须明显标注。
+- 如果引用关系为 `INFERRED` 或 `AMBIGUOUS`，必须使用 `--color-status-degraded-text` 色标签 + `--color-warning-soft` 背景明确标注置信度等级。
 
 #### 图谱解释展示
 


### PR DESCRIPTION
## Summary

Closes #44

需求/项目文档 UI 描述 token 化对齐：
- `04_模块需求` §2 添加 UI 规范引用，Chat 状态/引用卡片/置信度标注全部 token 化
- `03_PRD` §7 添加 UI 规范引用
- `16_路线图` 交付物表追加 UI 规范合规要求
- `25_Scope_Lock` 功能表新增 UI 视觉规范合规行
- 消除全部模糊视觉词（淡黄色、醒目标注）

Review 后修复：补全 UI 规范文件路径、统一 INFERRED/AMBIGUOUS 使用 degraded badge token pair。

## Agent Review

- Reviewer agents used: Correctness Reviewer, Consistency Reviewer
- Reviewed head SHA: `26d1c568072df78a545b615765bb2fe416a0b989`
- Review evidence: See PR comments below
- Key findings addressed: UI spec path corrected to full filename, INFERRED/AMBIGUOUS badge fixed to use --color-status-degraded-bg instead of --color-warning-soft

## Test plan

- [ ] 04_模块需求 含 '视觉规范' 引用且无 '淡黄色'/'醒目标注'
- [ ] 03_PRD §7 含 '视觉规范' 引用
- [ ] 16_路线图 Cherry Web 行含完整 UI 规范文件路径
- [ ] 25_Scope_Lock 含 'UI 视觉规范合规' 行