### PR TITLE
feat(api): implement MinIO/S3 storage service (#53)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,8 @@
     "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1039.0",
+    "@aws-sdk/s3-request-presigner": "^3.1039.0",
     "@cherrygraph/auth-core": "workspace:*",
     "@cherrygraph/shared": "workspace:*",
     "@nestjs/common": "^11.1.19",

--- a/apps/api/src/admin/__tests__/admin-health.test.ts
+++ b/apps/api/src/admin/__tests__/admin-health.test.ts
@@ -1,34 +1,36 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AdminHealthController } from '../admin-health.controller.js';
+import type { StorageService } from '../../storage/storage.service.js';
 
 type DbQuery = ReturnType<typeof vi.fn<(queryText: string) => Promise<unknown>>>;
 type RedisPing = ReturnType<typeof vi.fn<() => Promise<unknown>>>;
-
-const originalMinioEndpoint = process.env.MINIO_ENDPOINT;
+type StorageConfigured = ReturnType<typeof vi.fn<() => boolean>>;
+type StorageHealthCheck = ReturnType<
+  typeof vi.fn<() => Promise<{ status: 'healthy' | 'unhealthy'; latency_ms: number; error?: string }>>
+>;
 
 describe('AdminHealthController', () => {
   afterEach(() => {
-    restoreMinioEndpoint();
     vi.restoreAllMocks();
   });
 
   it('returns healthy when configured components are healthy', async () => {
-    process.env.MINIO_ENDPOINT = 'http://localhost:9000';
-    const { controller, dbQuery, redisPing } = createController();
+    const { controller, dbQuery, redisPing, storageHealthCheck } = createController();
 
     const result = await controller.getHealth();
 
     expect(result.status).toBe('healthy');
     expect(result.components.database.status).toBe('healthy');
     expect(result.components.redis.status).toBe('healthy');
-    expect(result.components.minio).toEqual({ status: 'healthy', latency_ms: 0 });
+    expect(result.components.minio).toEqual({ status: 'healthy', latency_ms: 12 });
     expect(result.components.vector_store.status).toBe('not_configured');
     expect(result.components.graph_store.status).toBe('not_configured');
     expect(result.components.docmost_bridge.status).toBe('not_configured');
     expect(result.uptime).toBeGreaterThanOrEqual(1);
     expect(dbQuery).toHaveBeenCalledWith('select 1');
     expect(redisPing).toHaveBeenCalledTimes(1);
+    expect(storageHealthCheck).toHaveBeenCalledTimes(1);
   });
 
   it('returns degraded when Redis is configured but unavailable', async () => {
@@ -65,7 +67,7 @@ describe('AdminHealthController', () => {
   });
 
   it('marks undeployed or absent components as not_configured', async () => {
-    const { controller } = createController({ redisPing: undefined });
+    const { controller } = createController({ redisPing: undefined, storageConfigured: vi.fn(() => false) });
 
     const result = await controller.getHealth();
 
@@ -82,31 +84,41 @@ function createController(
   overrides: Partial<{
     dbQuery: DbQuery;
     redisPing: RedisPing | undefined;
+    storageConfigured: StorageConfigured;
+    storageHealthCheck: StorageHealthCheck;
   }> = {},
-): { controller: AdminHealthController; dbQuery: DbQuery; redisPing: RedisPing | undefined } {
+): {
+  controller: AdminHealthController;
+  dbQuery: DbQuery;
+  redisPing: RedisPing | undefined;
+  storageConfigured: StorageConfigured;
+  storageHealthCheck: StorageHealthCheck;
+} {
   const dbQuery =
     overrides.dbQuery ?? vi.fn<(queryText: string) => Promise<unknown>>(() => Promise.resolve({ rows: [{ '?column?': 1 }] }));
   const redisPing =
     Object.hasOwn(overrides, 'redisPing') ? overrides.redisPing : vi.fn<() => Promise<unknown>>(() => Promise.resolve('PONG'));
+  const storageConfigured = overrides.storageConfigured ?? vi.fn(() => true);
+  const storageHealthCheck =
+    overrides.storageHealthCheck ?? vi.fn<() => Promise<{ status: 'healthy'; latency_ms: number }>>(() =>
+      Promise.resolve({ status: 'healthy', latency_ms: 12 }),
+    );
   const db = {
     $client: {
       query: dbQuery,
     },
   };
   const redis = redisPing === undefined ? undefined : { ping: redisPing };
+  const storage = {
+    isConfigured: storageConfigured,
+    healthCheck: storageHealthCheck,
+  };
 
   return {
-    controller: new AdminHealthController(db, redis),
+    controller: new AdminHealthController(db, redis, storage as unknown as StorageService),
     dbQuery,
     redisPing,
+    storageConfigured,
+    storageHealthCheck,
   };
-}
-
-function restoreMinioEndpoint(): void {
-  if (originalMinioEndpoint === undefined) {
-    delete process.env.MINIO_ENDPOINT;
-    return;
-  }
-
-  process.env.MINIO_ENDPOINT = originalMinioEndpoint;
 }

--- a/apps/api/src/admin/admin-health.controller.ts
+++ b/apps/api/src/admin/admin-health.controller.ts
@@ -3,6 +3,7 @@ import { Permissions } from '@cherrygraph/auth-core';
 
 import { REDIS_CLIENT } from '../common/redis/redis.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
+import { StorageService } from '../storage/storage.service.js';
 
 type HealthStatus = 'healthy' | 'degraded' | 'unhealthy';
 type ComponentStatus = 'healthy' | 'unhealthy' | 'not_configured';
@@ -36,12 +37,12 @@ export class AdminHealthController {
   constructor(
     @Inject(DRIZZLE) private readonly db: DatabaseHealthClient,
     @Optional() @Inject(REDIS_CLIENT) private readonly redis?: RedisHealthClient,
+    @Optional() private readonly storage?: StorageService,
   ) {}
 
   @Get('health')
   async getHealth(): Promise<AdminSystemHealthResponse> {
-    const [database, redis] = await Promise.all([this.checkDatabase(), this.checkRedis()]);
-    const minio = checkMinioConfigured();
+    const [database, redis, minio] = await Promise.all([this.checkDatabase(), this.checkRedis(), this.checkStorage()]);
     const components: Record<ComponentName, HealthComponent> = {
       database,
       redis,
@@ -73,6 +74,14 @@ export class AdminHealthController {
       await this.redis?.ping();
     });
   }
+
+  private async checkStorage(): Promise<HealthComponent> {
+    if (this.storage === undefined || !this.storage.isConfigured()) {
+      return { status: 'not_configured' };
+    }
+
+    return this.storage.healthCheck();
+  }
 }
 
 async function measureComponent(check: () => Promise<void>): Promise<HealthComponent> {
@@ -91,18 +100,6 @@ async function measureComponent(check: () => Promise<void>): Promise<HealthCompo
       error: toSafeErrorMessage(err),
     };
   }
-}
-
-function checkMinioConfigured(): HealthComponent {
-  const endpoint = process.env.MINIO_ENDPOINT;
-  if (endpoint === undefined || endpoint.trim().length === 0) {
-    return { status: 'not_configured' };
-  }
-
-  return {
-    status: 'healthy',
-    latency_ms: 0,
-  };
 }
 
 function getOverallStatus(components: Record<ComponentName, HealthComponent>): HealthStatus {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { GroupModule } from './groups/group.module.js';
 import { HealthModule } from './health/health.module.js';
 import { ModelConfigModule } from './models/model-config.module.js';
 import { SpaceModule } from './spaces/space.module.js';
+import { StorageModule } from './storage/storage.module.js';
 import { UserModule } from './users/user.module.js';
 
 @Module({
@@ -25,6 +26,7 @@ import { UserModule } from './users/user.module.js';
     GroupModule,
     SpaceModule,
     ModelConfigModule,
+    StorageModule,
     HealthModule,
     AdminHealthModule,
   ],

--- a/apps/api/src/storage/__tests__/storage.service.test.ts
+++ b/apps/api/src/storage/__tests__/storage.service.test.ts
@@ -1,0 +1,337 @@
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { sendMock, getSignedUrlMock, clientConfigs } = vi.hoisted(() => ({
+  sendMock: vi.fn<(command: { input: unknown }, options?: unknown) => Promise<unknown>>(),
+  getSignedUrlMock: vi.fn<
+    (client: unknown, command: { input: unknown }, options: { expiresIn: number }) => Promise<string>
+  >(),
+  clientConfigs: [] as unknown[],
+}));
+
+vi.mock('@aws-sdk/client-s3', () => {
+  class MockS3Client {
+    readonly config: unknown;
+
+    constructor(config: unknown) {
+      this.config = config;
+      clientConfigs.push(config);
+    }
+
+    send = sendMock;
+  }
+
+  class PutObjectCommand {
+    constructor(readonly input: unknown) {}
+  }
+
+  class GetObjectCommand {
+    constructor(readonly input: unknown) {}
+  }
+
+  class DeleteObjectCommand {
+    constructor(readonly input: unknown) {}
+  }
+
+  class HeadBucketCommand {
+    constructor(readonly input: unknown) {}
+  }
+
+  class CreateBucketCommand {
+    constructor(readonly input: unknown) {}
+  }
+
+  return {
+    CreateBucketCommand,
+    DeleteObjectCommand,
+    GetObjectCommand,
+    HeadBucketCommand,
+    PutObjectCommand,
+    S3Client: MockS3Client,
+  };
+});
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: getSignedUrlMock,
+}));
+
+import {
+  CreateBucketCommand as AwsCreateBucketCommand,
+  DeleteObjectCommand as AwsDeleteObjectCommand,
+  GetObjectCommand as AwsGetObjectCommand,
+  HeadBucketCommand as AwsHeadBucketCommand,
+  PutObjectCommand as AwsPutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+import { PRIMARY_STORAGE_BUCKET, REQUIRED_STORAGE_BUCKETS } from '../storage.constants.js';
+import { StorageService, createStorageClient } from '../storage.service.js';
+
+const originalStorageEnv = {
+  MINIO_ENDPOINT: process.env.MINIO_ENDPOINT,
+  MINIO_ACCESS_KEY: process.env.MINIO_ACCESS_KEY,
+  MINIO_SECRET_KEY: process.env.MINIO_SECRET_KEY,
+  S3_REGION: process.env.S3_REGION,
+  S3_ENDPOINT: process.env.S3_ENDPOINT,
+  AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+describe('StorageService', () => {
+  beforeEach(() => {
+    clientConfigs.length = 0;
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    restoreStorageEnv();
+  });
+
+  it('uploads objects with the expected S3 params', async () => {
+    const { service } = createConfiguredService();
+    const body = Buffer.from('hello world');
+    sendMock.mockResolvedValue({});
+
+    await service.upload('uploads', 'docs/file.txt', body, 'text/plain');
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const [command] = sendMock.mock.calls[0] ?? [];
+    expect(command).toBeInstanceOf(AwsPutObjectCommand);
+    expect(command?.input).toEqual({
+      Bucket: 'uploads',
+      Key: 'docs/file.txt',
+      Body: body,
+      ContentType: 'text/plain',
+    });
+  });
+
+  it('downloads objects as readable streams', async () => {
+    const { service } = createConfiguredService();
+    const stream = Readable.from(['payload']);
+    sendMock.mockResolvedValue({ Body: stream });
+
+    const result = await service.download('uploads', 'docs/file.txt');
+
+    expect(result).toBe(stream);
+    const [command] = sendMock.mock.calls[0] ?? [];
+    expect(command).toBeInstanceOf(AwsGetObjectCommand);
+    expect(command?.input).toEqual({
+      Bucket: 'uploads',
+      Key: 'docs/file.txt',
+    });
+  });
+
+  it('throws STORAGE_NOT_FOUND when downloading a missing object', async () => {
+    const { service } = createConfiguredService();
+    sendMock.mockRejectedValue(Object.assign(new Error('missing object'), { name: 'NoSuchKey' }));
+
+    await expect(service.download('uploads', 'docs/missing.txt')).rejects.toMatchObject({
+      code: 'STORAGE_NOT_FOUND',
+    });
+  });
+
+  it('deletes objects with the expected S3 params', async () => {
+    const { service } = createConfiguredService();
+    sendMock.mockResolvedValue({});
+
+    await service.delete('uploads', 'docs/file.txt');
+
+    const [command] = sendMock.mock.calls[0] ?? [];
+    expect(command).toBeInstanceOf(AwsDeleteObjectCommand);
+    expect(command?.input).toEqual({
+      Bucket: 'uploads',
+      Key: 'docs/file.txt',
+    });
+  });
+
+  it('generates presigned upload and download URLs', async () => {
+    const { service, client } = createConfiguredService();
+    getSignedUrlMock.mockResolvedValueOnce('https://example.test/download');
+    getSignedUrlMock.mockResolvedValueOnce('https://example.test/upload');
+
+    const downloadUrl = await service.getPresignedDownloadUrl('uploads', 'docs/file.txt', 120);
+    const uploadUrl = await service.getPresignedUploadUrl('uploads', 'docs/file.txt', 'text/plain', 240);
+
+    expect(downloadUrl).toBe('https://example.test/download');
+    expect(uploadUrl).toBe('https://example.test/upload');
+    expect(getSignedUrl).toHaveBeenNthCalledWith(
+      1,
+      client,
+      expect.any(AwsGetObjectCommand),
+      { expiresIn: 120 },
+    );
+    expect(getSignedUrl).toHaveBeenNthCalledWith(
+      2,
+      client,
+      expect.any(AwsPutObjectCommand),
+      { expiresIn: 240 },
+    );
+  });
+
+  it('creates missing buckets during ensureBuckets()', async () => {
+    const { service } = createConfiguredService();
+    sendMock.mockImplementation((command) => {
+      if (command instanceof AwsHeadBucketCommand && command.input === undefined) {
+        return Promise.resolve({});
+      }
+
+      if (command instanceof AwsHeadBucketCommand && isBucketInput(command.input, PRIMARY_STORAGE_BUCKET)) {
+        return Promise.reject(Object.assign(new Error('missing bucket'), { name: 'NotFound' }));
+      }
+
+      return Promise.resolve({});
+    });
+
+    await service.ensureBuckets();
+
+    const createCalls = sendMock.mock.calls.filter(([command]) => command instanceof AwsCreateBucketCommand);
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0]?.[0].input).toEqual({ Bucket: PRIMARY_STORAGE_BUCKET });
+  });
+
+  it('skips bucket creation when buckets already exist', async () => {
+    const { service } = createConfiguredService();
+    sendMock.mockResolvedValue({});
+
+    await service.ensureBuckets();
+
+    expect(sendMock).toHaveBeenCalledTimes(REQUIRED_STORAGE_BUCKETS.length);
+    const createCalls = sendMock.mock.calls.filter(([command]) => command instanceof AwsCreateBucketCommand);
+    expect(createCalls).toHaveLength(0);
+  });
+
+  it('returns healthy storage health with latency', async () => {
+    const { service } = createConfiguredService();
+    sendMock.mockResolvedValue({});
+
+    const result = await service.healthCheck();
+
+    expect(result.status).toBe('healthy');
+    expect(result.latency_ms).toBeGreaterThanOrEqual(1);
+    const [command, options] = sendMock.mock.calls[0] ?? [];
+    expect(command).toBeInstanceOf(AwsHeadBucketCommand);
+    expect(command?.input).toEqual({ Bucket: PRIMARY_STORAGE_BUCKET });
+    expect(hasAbortSignal(options)).toBe(true);
+  });
+
+  it('returns unhealthy storage health on timeout or other errors', async () => {
+    const { service } = createConfiguredService();
+    sendMock.mockRejectedValue(Object.assign(new Error('timed out'), { name: 'AbortError' }));
+
+    const result = await service.healthCheck();
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 'unhealthy',
+        error: 'timed out',
+      }),
+    );
+    expect(result.latency_ms).toBeGreaterThanOrEqual(1);
+  });
+
+  it('throws STORAGE_NOT_CONFIGURED when storage env vars are absent', async () => {
+    clearStorageEnv();
+    const service = new StorageService();
+
+    await expect(service.upload('uploads', 'docs/file.txt', Buffer.from('hello'), 'text/plain')).rejects.toMatchObject({
+      code: 'STORAGE_NOT_CONFIGURED',
+    });
+    await expect(service.download('uploads', 'docs/file.txt')).rejects.toMatchObject({
+      code: 'STORAGE_NOT_CONFIGURED',
+    });
+    await expect(service.delete('uploads', 'docs/file.txt')).rejects.toMatchObject({
+      code: 'STORAGE_NOT_CONFIGURED',
+    });
+    await expect(service.getPresignedDownloadUrl('uploads', 'docs/file.txt')).rejects.toMatchObject({
+      code: 'STORAGE_NOT_CONFIGURED',
+    });
+    await expect(service.getPresignedUploadUrl('uploads', 'docs/file.txt', 'text/plain')).rejects.toMatchObject({
+      code: 'STORAGE_NOT_CONFIGURED',
+    });
+    await expect(service.ensureBuckets()).rejects.toMatchObject({
+      code: 'STORAGE_NOT_CONFIGURED',
+    });
+    await expect(service.healthCheck()).rejects.toMatchObject({
+      code: 'STORAGE_NOT_CONFIGURED',
+    });
+  });
+
+  it('creates a path-style S3 client for MinIO config', () => {
+    configureMinioEnv();
+
+    const client = createStorageClient();
+
+    expect(client).toBeInstanceOf(S3Client);
+    expect(clientConfigs).toEqual([
+      {
+        region: 'us-east-1',
+        endpoint: 'http://localhost:9000',
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: 'minio-access',
+          secretAccessKey: 'minio-secret',
+        },
+      },
+    ]);
+  });
+});
+
+function createConfiguredService(): { service: StorageService; client: S3Client } {
+  configureMinioEnv();
+  const client = new S3Client({ region: 'us-east-1' });
+  return {
+    service: new StorageService(client),
+    client,
+  };
+}
+
+function configureMinioEnv(): void {
+  process.env.MINIO_ENDPOINT = 'http://localhost:9000';
+  process.env.MINIO_ACCESS_KEY = 'minio-access';
+  process.env.MINIO_SECRET_KEY = 'minio-secret';
+  delete process.env.S3_REGION;
+  delete process.env.S3_ENDPOINT;
+  delete process.env.AWS_ACCESS_KEY_ID;
+  delete process.env.AWS_SECRET_ACCESS_KEY;
+}
+
+function clearStorageEnv(): void {
+  delete process.env.MINIO_ENDPOINT;
+  delete process.env.MINIO_ACCESS_KEY;
+  delete process.env.MINIO_SECRET_KEY;
+  delete process.env.S3_REGION;
+  delete process.env.S3_ENDPOINT;
+  delete process.env.AWS_ACCESS_KEY_ID;
+  delete process.env.AWS_SECRET_ACCESS_KEY;
+}
+
+function restoreStorageEnv(): void {
+  restoreEnvVar('MINIO_ENDPOINT', originalStorageEnv.MINIO_ENDPOINT);
+  restoreEnvVar('MINIO_ACCESS_KEY', originalStorageEnv.MINIO_ACCESS_KEY);
+  restoreEnvVar('MINIO_SECRET_KEY', originalStorageEnv.MINIO_SECRET_KEY);
+  restoreEnvVar('S3_REGION', originalStorageEnv.S3_REGION);
+  restoreEnvVar('S3_ENDPOINT', originalStorageEnv.S3_ENDPOINT);
+  restoreEnvVar('AWS_ACCESS_KEY_ID', originalStorageEnv.AWS_ACCESS_KEY_ID);
+  restoreEnvVar('AWS_SECRET_ACCESS_KEY', originalStorageEnv.AWS_SECRET_ACCESS_KEY);
+  restoreEnvVar('NODE_ENV', originalStorageEnv.NODE_ENV);
+}
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+function isBucketInput(value: unknown, bucket: string): boolean {
+  return typeof value === 'object' && value !== null && 'Bucket' in value && value.Bucket === bucket;
+}
+
+function hasAbortSignal(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && 'abortSignal' in value;
+}

--- a/apps/api/src/storage/__tests__/storage.service.test.ts
+++ b/apps/api/src/storage/__tests__/storage.service.test.ts
@@ -65,7 +65,11 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
-import { PRIMARY_STORAGE_BUCKET, REQUIRED_STORAGE_BUCKETS } from '../storage.constants.js';
+import {
+  PRIMARY_STORAGE_BUCKET,
+  REQUIRED_STORAGE_BUCKETS,
+  getBucketName,
+} from '../storage.constants.js';
 import { StorageService, createStorageClient } from '../storage.service.js';
 
 const originalStorageEnv = {
@@ -76,6 +80,7 @@ const originalStorageEnv = {
   S3_ENDPOINT: process.env.S3_ENDPOINT,
   AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
   AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+  STORAGE_BUCKET_PREFIX: process.env.STORAGE_BUCKET_PREFIX,
   NODE_ENV: process.env.NODE_ENV,
 };
 
@@ -92,16 +97,17 @@ describe('StorageService', () => {
 
   it('uploads objects with the expected S3 params', async () => {
     const { service } = createConfiguredService();
+    const bucket = getPrimaryBucketName();
     const body = Buffer.from('hello world');
     sendMock.mockResolvedValue({});
 
-    await service.upload('uploads', 'docs/file.txt', body, 'text/plain');
+    await service.upload(bucket, 'docs/file.txt', body, 'text/plain');
 
     expect(sendMock).toHaveBeenCalledTimes(1);
     const [command] = sendMock.mock.calls[0] ?? [];
     expect(command).toBeInstanceOf(AwsPutObjectCommand);
     expect(command?.input).toEqual({
-      Bucket: 'uploads',
+      Bucket: bucket,
       Key: 'docs/file.txt',
       Body: body,
       ContentType: 'text/plain',
@@ -110,50 +116,54 @@ describe('StorageService', () => {
 
   it('downloads objects as readable streams', async () => {
     const { service } = createConfiguredService();
+    const bucket = getPrimaryBucketName();
     const stream = Readable.from(['payload']);
     sendMock.mockResolvedValue({ Body: stream });
 
-    const result = await service.download('uploads', 'docs/file.txt');
+    const result = await service.download(bucket, 'docs/file.txt');
 
     expect(result).toBe(stream);
     const [command] = sendMock.mock.calls[0] ?? [];
     expect(command).toBeInstanceOf(AwsGetObjectCommand);
     expect(command?.input).toEqual({
-      Bucket: 'uploads',
+      Bucket: bucket,
       Key: 'docs/file.txt',
     });
   });
 
   it('throws STORAGE_NOT_FOUND when downloading a missing object', async () => {
     const { service } = createConfiguredService();
+    const bucket = getPrimaryBucketName();
     sendMock.mockRejectedValue(Object.assign(new Error('missing object'), { name: 'NoSuchKey' }));
 
-    await expect(service.download('uploads', 'docs/missing.txt')).rejects.toMatchObject({
+    await expect(service.download(bucket, 'docs/missing.txt')).rejects.toMatchObject({
       code: 'STORAGE_NOT_FOUND',
     });
   });
 
   it('deletes objects with the expected S3 params', async () => {
     const { service } = createConfiguredService();
+    const bucket = getPrimaryBucketName();
     sendMock.mockResolvedValue({});
 
-    await service.delete('uploads', 'docs/file.txt');
+    await service.delete(bucket, 'docs/file.txt');
 
     const [command] = sendMock.mock.calls[0] ?? [];
     expect(command).toBeInstanceOf(AwsDeleteObjectCommand);
     expect(command?.input).toEqual({
-      Bucket: 'uploads',
+      Bucket: bucket,
       Key: 'docs/file.txt',
     });
   });
 
   it('generates presigned upload and download URLs', async () => {
     const { service, client } = createConfiguredService();
+    const bucket = getPrimaryBucketName();
     getSignedUrlMock.mockResolvedValueOnce('https://example.test/download');
     getSignedUrlMock.mockResolvedValueOnce('https://example.test/upload');
 
-    const downloadUrl = await service.getPresignedDownloadUrl('uploads', 'docs/file.txt', 120);
-    const uploadUrl = await service.getPresignedUploadUrl('uploads', 'docs/file.txt', 'text/plain', 240);
+    const downloadUrl = await service.getPresignedDownloadUrl(bucket, 'docs/file.txt', 120);
+    const uploadUrl = await service.getPresignedUploadUrl(bucket, 'docs/file.txt', 'text/plain', 240);
 
     expect(downloadUrl).toBe('https://example.test/download');
     expect(uploadUrl).toBe('https://example.test/upload');
@@ -171,14 +181,17 @@ describe('StorageService', () => {
     );
   });
 
+  it('returns prefixed bucket names from STORAGE_BUCKET_PREFIX', () => {
+    process.env.STORAGE_BUCKET_PREFIX = 'tenant-a';
+
+    expect(getBucketName(PRIMARY_STORAGE_BUCKET)).toBe('tenant-a-uploads');
+  });
+
   it('creates missing buckets during ensureBuckets()', async () => {
     const { service } = createConfiguredService();
+    const primaryBucket = getPrimaryBucketName();
     sendMock.mockImplementation((command) => {
-      if (command instanceof AwsHeadBucketCommand && command.input === undefined) {
-        return Promise.resolve({});
-      }
-
-      if (command instanceof AwsHeadBucketCommand && isBucketInput(command.input, PRIMARY_STORAGE_BUCKET)) {
+      if (command instanceof AwsHeadBucketCommand && isBucketInput(command.input, primaryBucket)) {
         return Promise.reject(Object.assign(new Error('missing bucket'), { name: 'NotFound' }));
       }
 
@@ -189,7 +202,7 @@ describe('StorageService', () => {
 
     const createCalls = sendMock.mock.calls.filter(([command]) => command instanceof AwsCreateBucketCommand);
     expect(createCalls).toHaveLength(1);
-    expect(createCalls[0]?.[0].input).toEqual({ Bucket: PRIMARY_STORAGE_BUCKET });
+    expect(createCalls[0]?.[0].input).toEqual({ Bucket: primaryBucket });
   });
 
   it('skips bucket creation when buckets already exist', async () => {
@@ -203,6 +216,27 @@ describe('StorageService', () => {
     expect(createCalls).toHaveLength(0);
   });
 
+  it.each(['BucketAlreadyOwnedByYou', 'BucketAlreadyExists'])(
+    'treats %s bucket creation races as success',
+    async (errorName) => {
+      const { service } = createConfiguredService();
+      const primaryBucket = getPrimaryBucketName();
+      sendMock.mockImplementation((command) => {
+        if (command instanceof AwsHeadBucketCommand && isBucketInput(command.input, primaryBucket)) {
+          return Promise.reject(Object.assign(new Error('missing bucket'), { name: 'NotFound' }));
+        }
+
+        if (command instanceof AwsCreateBucketCommand && isBucketInput(command.input, primaryBucket)) {
+          return Promise.reject(Object.assign(new Error('created elsewhere'), { name: errorName }));
+        }
+
+        return Promise.resolve({});
+      });
+
+      await expect(service.ensureBuckets()).resolves.toBeUndefined();
+    },
+  );
+
   it('returns healthy storage health with latency', async () => {
     const { service } = createConfiguredService();
     sendMock.mockResolvedValue({});
@@ -213,42 +247,117 @@ describe('StorageService', () => {
     expect(result.latency_ms).toBeGreaterThanOrEqual(1);
     const [command, options] = sendMock.mock.calls[0] ?? [];
     expect(command).toBeInstanceOf(AwsHeadBucketCommand);
-    expect(command?.input).toEqual({ Bucket: PRIMARY_STORAGE_BUCKET });
+    expect(command?.input).toEqual({ Bucket: getPrimaryBucketName() });
     expect(hasAbortSignal(options)).toBe(true);
   });
 
-  it('returns unhealthy storage health on timeout or other errors', async () => {
+  it.each([
+    {
+      description: 'timeouts',
+      error: Object.assign(new Error('timed out'), { name: 'AbortError' }),
+      expected: 'timeout',
+    },
+    {
+      description: 'network failures',
+      error: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:9000'), { code: 'ECONNREFUSED' }),
+      expected: 'unreachable',
+    },
+    {
+      description: 'credential failures',
+      error: Object.assign(new Error('invalid access key'), { name: 'InvalidAccessKeyId' }),
+      expected: 'auth_failed',
+    },
+    {
+      description: 'unexpected failures',
+      error: new Error('mystery'),
+      expected: 'unknown',
+    },
+  ])('sanitizes storage health errors for $description', async ({ error, expected }) => {
     const { service } = createConfiguredService();
-    sendMock.mockRejectedValue(Object.assign(new Error('timed out'), { name: 'AbortError' }));
+    sendMock.mockRejectedValue(error);
 
     const result = await service.healthCheck();
 
     expect(result).toEqual(
       expect.objectContaining({
         status: 'unhealthy',
-        error: 'timed out',
+        error: expected,
       }),
     );
     expect(result.latency_ms).toBeGreaterThanOrEqual(1);
+  });
+
+  it('rejects uploads larger than maxBytes', async () => {
+    const { service } = createConfiguredService();
+
+    await expect(
+      service.upload(getPrimaryBucketName(), 'docs/file.txt', Buffer.alloc(6), 'application/octet-stream', 5),
+    ).rejects.toThrow('Storage upload exceeds the maximum allowed size');
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '/docs/file.txt', '../docs/file.txt', 'docs/../file.txt'])(
+    'rejects invalid upload keys: %j',
+    async (key) => {
+      const { service } = createConfiguredService();
+
+      await expect(service.upload(getPrimaryBucketName(), key, Buffer.from('hello'), 'text/plain')).rejects.toThrow(
+        'Invalid storage key',
+      );
+
+      expect(sendMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      description: 'download',
+      run: (service: StorageService) => service.download(getPrimaryBucketName(), '../docs/file.txt'),
+    },
+    {
+      description: 'delete',
+      run: (service: StorageService) => service.delete(getPrimaryBucketName(), '../docs/file.txt'),
+    },
+    {
+      description: 'presigned download',
+      run: (service: StorageService) => service.getPresignedDownloadUrl(getPrimaryBucketName(), '../docs/file.txt'),
+    },
+    {
+      description: 'presigned upload',
+      run: (service: StorageService) =>
+        service.getPresignedUploadUrl(getPrimaryBucketName(), '../docs/file.txt', 'text/plain'),
+    },
+  ])('rejects invalid keys for $description', async ({ run }) => {
+    const { service } = createConfiguredService();
+
+    await expect(run(service)).rejects.toThrow('Invalid storage key');
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(getSignedUrlMock).not.toHaveBeenCalled();
   });
 
   it('throws STORAGE_NOT_CONFIGURED when storage env vars are absent', async () => {
     clearStorageEnv();
     const service = new StorageService();
 
-    await expect(service.upload('uploads', 'docs/file.txt', Buffer.from('hello'), 'text/plain')).rejects.toMatchObject({
+    await expect(
+      service.upload(getPrimaryBucketName(), 'docs/file.txt', Buffer.from('hello'), 'text/plain'),
+    ).rejects.toMatchObject({
       code: 'STORAGE_NOT_CONFIGURED',
     });
-    await expect(service.download('uploads', 'docs/file.txt')).rejects.toMatchObject({
+    await expect(service.download(getPrimaryBucketName(), 'docs/file.txt')).rejects.toMatchObject({
       code: 'STORAGE_NOT_CONFIGURED',
     });
-    await expect(service.delete('uploads', 'docs/file.txt')).rejects.toMatchObject({
+    await expect(service.delete(getPrimaryBucketName(), 'docs/file.txt')).rejects.toMatchObject({
       code: 'STORAGE_NOT_CONFIGURED',
     });
-    await expect(service.getPresignedDownloadUrl('uploads', 'docs/file.txt')).rejects.toMatchObject({
+    await expect(service.getPresignedDownloadUrl(getPrimaryBucketName(), 'docs/file.txt')).rejects.toMatchObject({
       code: 'STORAGE_NOT_CONFIGURED',
     });
-    await expect(service.getPresignedUploadUrl('uploads', 'docs/file.txt', 'text/plain')).rejects.toMatchObject({
+    await expect(
+      service.getPresignedUploadUrl(getPrimaryBucketName(), 'docs/file.txt', 'text/plain'),
+    ).rejects.toMatchObject({
       code: 'STORAGE_NOT_CONFIGURED',
     });
     await expect(service.ensureBuckets()).rejects.toMatchObject({
@@ -296,6 +405,7 @@ function configureMinioEnv(): void {
   delete process.env.S3_ENDPOINT;
   delete process.env.AWS_ACCESS_KEY_ID;
   delete process.env.AWS_SECRET_ACCESS_KEY;
+  delete process.env.STORAGE_BUCKET_PREFIX;
 }
 
 function clearStorageEnv(): void {
@@ -306,6 +416,7 @@ function clearStorageEnv(): void {
   delete process.env.S3_ENDPOINT;
   delete process.env.AWS_ACCESS_KEY_ID;
   delete process.env.AWS_SECRET_ACCESS_KEY;
+  delete process.env.STORAGE_BUCKET_PREFIX;
 }
 
 function restoreStorageEnv(): void {
@@ -316,6 +427,7 @@ function restoreStorageEnv(): void {
   restoreEnvVar('S3_ENDPOINT', originalStorageEnv.S3_ENDPOINT);
   restoreEnvVar('AWS_ACCESS_KEY_ID', originalStorageEnv.AWS_ACCESS_KEY_ID);
   restoreEnvVar('AWS_SECRET_ACCESS_KEY', originalStorageEnv.AWS_SECRET_ACCESS_KEY);
+  restoreEnvVar('STORAGE_BUCKET_PREFIX', originalStorageEnv.STORAGE_BUCKET_PREFIX);
   restoreEnvVar('NODE_ENV', originalStorageEnv.NODE_ENV);
 }
 
@@ -334,4 +446,8 @@ function isBucketInput(value: unknown, bucket: string): boolean {
 
 function hasAbortSignal(value: unknown): boolean {
   return typeof value === 'object' && value !== null && 'abortSignal' in value;
+}
+
+function getPrimaryBucketName(): string {
+  return getBucketName(PRIMARY_STORAGE_BUCKET);
 }

--- a/apps/api/src/storage/storage.constants.ts
+++ b/apps/api/src/storage/storage.constants.ts
@@ -1,0 +1,22 @@
+export const STORAGE_SERVICE = Symbol('STORAGE_SERVICE');
+export const STORAGE_CLIENT = Symbol('STORAGE_CLIENT');
+
+export const STORAGE_BUCKET_NAMES = {
+  UPLOADS: 'uploads',
+  ARCHIVES: 'archives',
+  GRAPHIFY_OUTPUT: 'graphify-output',
+  WIKI_REPO: 'wiki-repo',
+} as const;
+
+export const REQUIRED_STORAGE_BUCKETS = [
+  STORAGE_BUCKET_NAMES.UPLOADS,
+  STORAGE_BUCKET_NAMES.ARCHIVES,
+  STORAGE_BUCKET_NAMES.GRAPHIFY_OUTPUT,
+  STORAGE_BUCKET_NAMES.WIKI_REPO,
+] as const;
+
+export const PRIMARY_STORAGE_BUCKET = STORAGE_BUCKET_NAMES.UPLOADS;
+export const DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS = 3_600;
+export const STORAGE_HEALTH_TIMEOUT_MS = 5_000;
+
+export type StorageBucketName = (typeof REQUIRED_STORAGE_BUCKETS)[number];

--- a/apps/api/src/storage/storage.constants.ts
+++ b/apps/api/src/storage/storage.constants.ts
@@ -16,7 +16,28 @@ export const REQUIRED_STORAGE_BUCKETS = [
 ] as const;
 
 export const PRIMARY_STORAGE_BUCKET = STORAGE_BUCKET_NAMES.UPLOADS;
+export const DEFAULT_STORAGE_BUCKET_PREFIX = 'cherrywiki';
+export const DEFAULT_STORAGE_MAX_UPLOAD_BYTES = 104_857_600;
 export const DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS = 3_600;
+export const STORAGE_BUCKET_INIT_TIMEOUT_MS = 10_000;
 export const STORAGE_HEALTH_TIMEOUT_MS = 5_000;
 
-export type StorageBucketName = (typeof REQUIRED_STORAGE_BUCKETS)[number];
+export type StorageBucketPurpose = (typeof REQUIRED_STORAGE_BUCKETS)[number];
+export type StorageBucketName = StorageBucketPurpose;
+
+export function getBucketName(
+  purpose: StorageBucketPurpose,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const prefix = readEnvVar(env.STORAGE_BUCKET_PREFIX) ?? DEFAULT_STORAGE_BUCKET_PREFIX;
+  return `${prefix}-${purpose}`;
+}
+
+function readEnvVar(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}

--- a/apps/api/src/storage/storage.module.ts
+++ b/apps/api/src/storage/storage.module.ts
@@ -1,0 +1,21 @@
+import { Global, Module } from '@nestjs/common';
+
+import { STORAGE_CLIENT, STORAGE_SERVICE } from './storage.constants.js';
+import { createStorageClient, StorageService } from './storage.service.js';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: STORAGE_CLIENT,
+      useFactory: createStorageClient,
+    },
+    StorageService,
+    {
+      provide: STORAGE_SERVICE,
+      useExisting: StorageService,
+    },
+  ],
+  exports: [StorageService, STORAGE_SERVICE],
+})
+export class StorageModule {}

--- a/apps/api/src/storage/storage.service.ts
+++ b/apps/api/src/storage/storage.service.ts
@@ -15,11 +15,14 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 import { getApiLogger } from '../common/logger/logger.module.js';
 import {
+  DEFAULT_STORAGE_MAX_UPLOAD_BYTES,
   DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS,
   PRIMARY_STORAGE_BUCKET,
   REQUIRED_STORAGE_BUCKETS,
+  STORAGE_BUCKET_INIT_TIMEOUT_MS,
   STORAGE_CLIENT,
   STORAGE_HEALTH_TIMEOUT_MS,
+  getBucketName,
 } from './storage.constants.js';
 
 type StorageProvider = 'minio' | 's3';
@@ -72,8 +75,18 @@ export class StorageService implements OnModuleInit {
     await this.ensureBuckets();
   }
 
-  async upload(bucket: string, key: string, body: Buffer, contentType: string): Promise<void> {
-    await this.getClient().send(
+  async upload(
+    bucket: string,
+    key: string,
+    body: Buffer,
+    contentType: string,
+    maxBytes = DEFAULT_STORAGE_MAX_UPLOAD_BYTES,
+  ): Promise<void> {
+    const client = this.getClient();
+    this.validateKey(key);
+    this.validateUploadSize(body, maxBytes);
+
+    await client.send(
       new PutObjectCommand({
         Bucket: bucket,
         Key: key,
@@ -84,8 +97,11 @@ export class StorageService implements OnModuleInit {
   }
 
   async download(bucket: string, key: string): Promise<Readable> {
+    const client = this.getClient();
+    this.validateKey(key);
+
     try {
-      const output = await this.getClient().send(
+      const output = await client.send(
         new GetObjectCommand({
           Bucket: bucket,
           Key: key,
@@ -106,7 +122,10 @@ export class StorageService implements OnModuleInit {
   }
 
   async delete(bucket: string, key: string): Promise<void> {
-    await this.getClient().send(
+    const client = this.getClient();
+    this.validateKey(key);
+
+    await client.send(
       new DeleteObjectCommand({
         Bucket: bucket,
         Key: key,
@@ -119,8 +138,11 @@ export class StorageService implements OnModuleInit {
     key: string,
     expiresInSeconds = DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS,
   ): Promise<string> {
+    const client = this.getClient();
+    this.validateKey(key);
+
     return getSignedUrl(
-      this.getClient(),
+      client,
       new GetObjectCommand({
         Bucket: bucket,
         Key: key,
@@ -135,8 +157,11 @@ export class StorageService implements OnModuleInit {
     contentType: string,
     expiresInSeconds = DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS,
   ): Promise<string> {
+    const client = this.getClient();
+    this.validateKey(key);
+
     return getSignedUrl(
-      this.getClient(),
+      client,
       new PutObjectCommand({
         Bucket: bucket,
         Key: key,
@@ -150,16 +175,28 @@ export class StorageService implements OnModuleInit {
     const client = this.getClient();
     const config = this.getConfig();
 
-    for (const bucket of REQUIRED_STORAGE_BUCKETS) {
+    for (const purpose of REQUIRED_STORAGE_BUCKETS) {
+      const bucket = getBucketName(purpose);
+
       try {
-        await client.send(new HeadBucketCommand({ Bucket: bucket }));
+        await client.send(new HeadBucketCommand({ Bucket: bucket }), {
+          abortSignal: AbortSignal.timeout(STORAGE_BUCKET_INIT_TIMEOUT_MS),
+        });
       } catch (err) {
         if (!isBucketMissingError(err)) {
           throw err;
         }
 
-        await client.send(new CreateBucketCommand(createBucketInput(bucket, config)));
-        getApiLogger().info({ bucket, storage_provider: config.provider }, 'Storage bucket created');
+        try {
+          await client.send(new CreateBucketCommand(createBucketInput(bucket, config)), {
+            abortSignal: AbortSignal.timeout(STORAGE_BUCKET_INIT_TIMEOUT_MS),
+          });
+          getApiLogger().info({ bucket, storage_provider: config.provider }, 'Storage bucket created');
+        } catch (createErr) {
+          if (!isBucketCreationRaceError(createErr)) {
+            throw createErr;
+          }
+        }
       }
     }
   }
@@ -169,7 +206,7 @@ export class StorageService implements OnModuleInit {
     const startedAt = performance.now();
 
     try {
-      await client.send(new HeadBucketCommand({ Bucket: PRIMARY_STORAGE_BUCKET }), {
+      await client.send(new HeadBucketCommand({ Bucket: getBucketName(PRIMARY_STORAGE_BUCKET) }), {
         abortSignal: AbortSignal.timeout(STORAGE_HEALTH_TIMEOUT_MS),
       });
 
@@ -181,7 +218,7 @@ export class StorageService implements OnModuleInit {
       return {
         status: 'unhealthy',
         latency_ms: elapsedMs(startedAt),
-        error: toSafeErrorMessage(err),
+        error: toStorageHealthErrorCode(err),
       };
     }
   }
@@ -200,6 +237,18 @@ export class StorageService implements OnModuleInit {
     }
 
     return this.config;
+  }
+
+  private validateKey(key: string): void {
+    if (key.length === 0 || key.startsWith('/') || key.includes('..')) {
+      throw new Error('Invalid storage key: keys must be non-empty, must not start with "/", and must not contain ".."');
+    }
+  }
+
+  private validateUploadSize(body: Buffer, maxBytes: number): void {
+    if (body.length > maxBytes) {
+      throw new Error(`Storage upload exceeds the maximum allowed size of ${maxBytes} bytes`);
+    }
   }
 }
 
@@ -330,6 +379,10 @@ function isBucketMissingError(err: unknown): boolean {
   return hasStorageErrorCode(err, 'NotFound') || hasStorageErrorCode(err, 'NoSuchBucket') || hasHttpStatusCode(err, 404);
 }
 
+function isBucketCreationRaceError(err: unknown): boolean {
+  return hasStorageErrorCode(err, 'BucketAlreadyOwnedByYou') || hasStorageErrorCode(err, 'BucketAlreadyExists');
+}
+
 function isObjectNotFoundError(err: unknown): boolean {
   return hasStorageErrorCode(err, 'NoSuchKey') || hasStorageErrorCode(err, 'NotFound') || hasHttpStatusCode(err, 404);
 }
@@ -339,7 +392,11 @@ function hasStorageErrorCode(err: unknown, code: string): boolean {
     return false;
   }
 
-  return err.code === code || err.Code === code || err.name === code;
+  return err.code === code || err.Code === code || err.name === code || hasStorageErrorCauseCode(err.cause, code);
+}
+
+function hasStorageErrorCauseCode(cause: unknown, code: string): boolean {
+  return cause !== undefined && hasStorageErrorCode(cause, code);
 }
 
 function hasHttpStatusCode(err: unknown, statusCode: number): boolean {
@@ -354,8 +411,51 @@ function elapsedMs(startedAt: number): number {
   return Math.max(1, Math.round(performance.now() - startedAt));
 }
 
-function toSafeErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+function toStorageHealthErrorCode(err: unknown): string {
+  if (hasStorageErrorCode(err, 'AbortError')) {
+    return 'timeout';
+  }
+
+  if (isCredentialError(err)) {
+    return 'auth_failed';
+  }
+
+  if (isNetworkError(err)) {
+    return 'unreachable';
+  }
+
+  return 'unknown';
+}
+
+function isCredentialError(err: unknown): boolean {
+  return (
+    hasHttpStatusCode(err, 401) ||
+    hasHttpStatusCode(err, 403) ||
+    hasStorageErrorCode(err, 'AccessDenied') ||
+    hasStorageErrorCode(err, 'AuthorizationHeaderMalformed') ||
+    hasStorageErrorCode(err, 'CredentialsProviderError') ||
+    hasStorageErrorCode(err, 'ExpiredToken') ||
+    hasStorageErrorCode(err, 'InvalidAccessKeyId') ||
+    hasStorageErrorCode(err, 'InvalidToken') ||
+    hasStorageErrorCode(err, 'SignatureDoesNotMatch') ||
+    hasStorageErrorCode(err, 'Unauthorized')
+  );
+}
+
+function isNetworkError(err: unknown): boolean {
+  return (
+    hasStorageErrorCode(err, 'ECONNABORTED') ||
+    hasStorageErrorCode(err, 'ECONNREFUSED') ||
+    hasStorageErrorCode(err, 'ECONNRESET') ||
+    hasStorageErrorCode(err, 'EAI_AGAIN') ||
+    hasStorageErrorCode(err, 'EHOSTUNREACH') ||
+    hasStorageErrorCode(err, 'ENETUNREACH') ||
+    hasStorageErrorCode(err, 'ENOTFOUND') ||
+    hasStorageErrorCode(err, 'ETIMEDOUT') ||
+    hasStorageErrorCode(err, 'NetworkingError') ||
+    hasStorageErrorCode(err, 'TimeoutError') ||
+    hasStorageErrorCode(err, 'UnknownEndpoint')
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/api/src/storage/storage.service.ts
+++ b/apps/api/src/storage/storage.service.ts
@@ -1,0 +1,363 @@
+import { Readable } from 'node:stream';
+import { Inject, Injectable, Optional, type OnModuleInit } from '@nestjs/common';
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadBucketCommand,
+  PutObjectCommand,
+  S3Client,
+  type BucketLocationConstraint,
+  type CreateBucketCommandInput,
+  type S3ClientConfig,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+import { getApiLogger } from '../common/logger/logger.module.js';
+import {
+  DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS,
+  PRIMARY_STORAGE_BUCKET,
+  REQUIRED_STORAGE_BUCKETS,
+  STORAGE_CLIENT,
+  STORAGE_HEALTH_TIMEOUT_MS,
+} from './storage.constants.js';
+
+type StorageProvider = 'minio' | 's3';
+type StorageErrorCode = 'STORAGE_NOT_CONFIGURED' | 'STORAGE_NOT_FOUND';
+type StorageHealthStatus = 'healthy' | 'unhealthy';
+type StorageCredentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+};
+type StorageResolvedConfig = {
+  provider: StorageProvider;
+  region: string;
+  endpoint?: string;
+  forcePathStyle: boolean;
+  credentials: StorageCredentials;
+};
+type StorageHealthComponent = {
+  status: StorageHealthStatus;
+  latency_ms: number;
+  error?: string;
+};
+
+const DEFAULT_MINIO_REGION = 'us-east-1';
+
+export class StorageServiceError extends Error {
+  readonly code: StorageErrorCode;
+
+  constructor(code: StorageErrorCode, message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = 'StorageServiceError';
+    this.code = code;
+  }
+}
+
+@Injectable()
+export class StorageService implements OnModuleInit {
+  private readonly config = resolveStorageConfig();
+
+  constructor(@Optional() @Inject(STORAGE_CLIENT) private readonly client?: S3Client) {}
+
+  isConfigured(): boolean {
+    return this.client !== undefined && this.config !== undefined;
+  }
+
+  async onModuleInit(): Promise<void> {
+    if (!this.isConfigured()) {
+      return;
+    }
+
+    await this.ensureBuckets();
+  }
+
+  async upload(bucket: string, key: string, body: Buffer, contentType: string): Promise<void> {
+    await this.getClient().send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: body,
+        ContentType: contentType,
+      }),
+    );
+  }
+
+  async download(bucket: string, key: string): Promise<Readable> {
+    try {
+      const output = await this.getClient().send(
+        new GetObjectCommand({
+          Bucket: bucket,
+          Key: key,
+        }),
+      );
+      if (!isReadableStream(output.Body)) {
+        throw new Error(`Storage object ${bucket}/${key} did not return a readable stream`);
+      }
+
+      return output.Body;
+    } catch (err) {
+      if (isObjectNotFoundError(err)) {
+        throw new StorageServiceError('STORAGE_NOT_FOUND', `Storage object ${bucket}/${key} was not found`, err);
+      }
+
+      throw err;
+    }
+  }
+
+  async delete(bucket: string, key: string): Promise<void> {
+    await this.getClient().send(
+      new DeleteObjectCommand({
+        Bucket: bucket,
+        Key: key,
+      }),
+    );
+  }
+
+  async getPresignedDownloadUrl(
+    bucket: string,
+    key: string,
+    expiresInSeconds = DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS,
+  ): Promise<string> {
+    return getSignedUrl(
+      this.getClient(),
+      new GetObjectCommand({
+        Bucket: bucket,
+        Key: key,
+      }),
+      { expiresIn: expiresInSeconds },
+    );
+  }
+
+  async getPresignedUploadUrl(
+    bucket: string,
+    key: string,
+    contentType: string,
+    expiresInSeconds = DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS,
+  ): Promise<string> {
+    return getSignedUrl(
+      this.getClient(),
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        ContentType: contentType,
+      }),
+      { expiresIn: expiresInSeconds },
+    );
+  }
+
+  async ensureBuckets(): Promise<void> {
+    const client = this.getClient();
+    const config = this.getConfig();
+
+    for (const bucket of REQUIRED_STORAGE_BUCKETS) {
+      try {
+        await client.send(new HeadBucketCommand({ Bucket: bucket }));
+      } catch (err) {
+        if (!isBucketMissingError(err)) {
+          throw err;
+        }
+
+        await client.send(new CreateBucketCommand(createBucketInput(bucket, config)));
+        getApiLogger().info({ bucket, storage_provider: config.provider }, 'Storage bucket created');
+      }
+    }
+  }
+
+  async healthCheck(): Promise<StorageHealthComponent> {
+    const client = this.getClient();
+    const startedAt = performance.now();
+
+    try {
+      await client.send(new HeadBucketCommand({ Bucket: PRIMARY_STORAGE_BUCKET }), {
+        abortSignal: AbortSignal.timeout(STORAGE_HEALTH_TIMEOUT_MS),
+      });
+
+      return {
+        status: 'healthy',
+        latency_ms: elapsedMs(startedAt),
+      };
+    } catch (err) {
+      return {
+        status: 'unhealthy',
+        latency_ms: elapsedMs(startedAt),
+        error: toSafeErrorMessage(err),
+      };
+    }
+  }
+
+  private getClient(): S3Client {
+    if (this.client === undefined || this.config === undefined) {
+      throw new StorageServiceError('STORAGE_NOT_CONFIGURED', 'Storage service is not configured');
+    }
+
+    return this.client;
+  }
+
+  private getConfig(): StorageResolvedConfig {
+    if (this.config === undefined) {
+      throw new StorageServiceError('STORAGE_NOT_CONFIGURED', 'Storage service is not configured');
+    }
+
+    return this.config;
+  }
+}
+
+export function createStorageClient(): S3Client | undefined {
+  const config = resolveStorageConfig();
+  if (config === undefined) {
+    logIncompleteStorageConfiguration();
+    return undefined;
+  }
+
+  return new S3Client(createS3ClientConfig(config));
+}
+
+function resolveStorageConfig(env: Record<string, string | undefined> = process.env): StorageResolvedConfig | undefined {
+  const minioEndpoint = readEnvVar(env.MINIO_ENDPOINT);
+  if (minioEndpoint !== undefined) {
+    const accessKeyId = readEnvVar(env.MINIO_ACCESS_KEY);
+    const secretAccessKey = readEnvVar(env.MINIO_SECRET_KEY);
+    if (accessKeyId === undefined || secretAccessKey === undefined) {
+      return undefined;
+    }
+
+    return {
+      provider: 'minio',
+      region: readEnvVar(env.S3_REGION) ?? DEFAULT_MINIO_REGION,
+      endpoint: minioEndpoint,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+      },
+    };
+  }
+
+  const region = readEnvVar(env.S3_REGION);
+  if (region === undefined) {
+    return undefined;
+  }
+
+  const accessKeyId = readEnvVar(env.AWS_ACCESS_KEY_ID);
+  const secretAccessKey = readEnvVar(env.AWS_SECRET_ACCESS_KEY);
+  if (accessKeyId === undefined || secretAccessKey === undefined) {
+    return undefined;
+  }
+
+  const endpoint = readEnvVar(env.S3_ENDPOINT);
+  return endpoint === undefined
+    ? {
+        provider: 's3',
+        region,
+        forcePathStyle: false,
+        credentials: {
+          accessKeyId,
+          secretAccessKey,
+        },
+      }
+    : {
+        provider: 's3',
+        region,
+        endpoint,
+        forcePathStyle: false,
+        credentials: {
+          accessKeyId,
+          secretAccessKey,
+        },
+      };
+}
+
+function createS3ClientConfig(config: StorageResolvedConfig): S3ClientConfig {
+  return config.endpoint === undefined
+    ? {
+        region: config.region,
+        forcePathStyle: config.forcePathStyle,
+        credentials: config.credentials,
+      }
+    : {
+        region: config.region,
+        endpoint: config.endpoint,
+        forcePathStyle: config.forcePathStyle,
+        credentials: config.credentials,
+      };
+}
+
+function createBucketInput(bucket: string, config: StorageResolvedConfig): CreateBucketCommandInput {
+  if (config.provider === 'minio' || config.region === DEFAULT_MINIO_REGION) {
+    return { Bucket: bucket };
+  }
+
+  return {
+    Bucket: bucket,
+    CreateBucketConfiguration: {
+      LocationConstraint: config.region as BucketLocationConstraint,
+    },
+  };
+}
+
+function logIncompleteStorageConfiguration(): void {
+  if (process.env.NODE_ENV === 'test') {
+    return;
+  }
+
+  const hasStorageInputs =
+    readEnvVar(process.env.MINIO_ENDPOINT) !== undefined ||
+    readEnvVar(process.env.S3_REGION) !== undefined ||
+    readEnvVar(process.env.S3_ENDPOINT) !== undefined;
+
+  if (!hasStorageInputs) {
+    return;
+  }
+
+  getApiLogger().warn({ storage_configured: false }, 'Storage disabled because configuration is incomplete');
+}
+
+function readEnvVar(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+function isReadableStream(value: unknown): value is Readable {
+  return typeof value === 'object' && value !== null && 'pipe' in value && typeof value.pipe === 'function';
+}
+
+function isBucketMissingError(err: unknown): boolean {
+  return hasStorageErrorCode(err, 'NotFound') || hasStorageErrorCode(err, 'NoSuchBucket') || hasHttpStatusCode(err, 404);
+}
+
+function isObjectNotFoundError(err: unknown): boolean {
+  return hasStorageErrorCode(err, 'NoSuchKey') || hasStorageErrorCode(err, 'NotFound') || hasHttpStatusCode(err, 404);
+}
+
+function hasStorageErrorCode(err: unknown, code: string): boolean {
+  if (!isRecord(err)) {
+    return false;
+  }
+
+  return err.code === code || err.Code === code || err.name === code;
+}
+
+function hasHttpStatusCode(err: unknown, statusCode: number): boolean {
+  if (!isRecord(err) || !isRecord(err.$metadata)) {
+    return false;
+  }
+
+  return err.$metadata.httpStatusCode === statusCode;
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.max(1, Math.round(performance.now() - startedAt));
+}
+
+function toSafeErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,12 @@ importers:
 
   apps/api:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1039.0
+        version: 3.1039.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1039.0
+        version: 3.1039.0
       '@cherrygraph/auth-core':
         specifier: workspace:*
         version: link:../../packages/auth-core
@@ -304,6 +310,173 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1039.0':
+    resolution: {integrity: sha512-PVH9v0pHYBQnBADSR/m88NgcuJcYqPXfpmkcME66vRF75Y4swwbEVVFbTBFuvxu0YcZiLFXu3lw0FDK00vEa3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.7':
+    resolution: {integrity: sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.7':
+    resolution: {integrity: sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.33':
+    resolution: {integrity: sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.35':
+    resolution: {integrity: sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.37':
+    resolution: {integrity: sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.37':
+    resolution: {integrity: sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.38':
+    resolution: {integrity: sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.33':
+    resolution: {integrity: sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.37':
+    resolution: {integrity: sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.37':
+    resolution: {integrity: sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    resolution: {integrity: sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    resolution: {integrity: sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.15':
+    resolution: {integrity: sha512-j4Zp7rA1HfhDTteICnx/tPax4N/v5wmytgguXExUGyEwQ8Ug4EBA4kjp9puFAN1UZoBVpxoiXMiuTFvjaHjeEw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.36':
+    resolution: {integrity: sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.37':
+    resolution: {integrity: sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.5':
+    resolution: {integrity: sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1039.0':
+    resolution: {integrity: sha512-UPgDgAca+gBEfE/6uV+5CQNlSGakLybDld84HBppAMTREpljJ88pTOIEqP6hI16FMl1NeQZqei8HNc3j+kyK5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.24':
+    resolution: {integrity: sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1039.0':
+    resolution: {integrity: sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.10':
+    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.23':
+    resolution: {integrity: sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1494,6 +1667,218 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.15':
+    resolution: {integrity: sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.14':
+    resolution: {integrity: sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.14':
+    resolution: {integrity: sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.6':
+    resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.3.0':
+    resolution: {integrity: sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1895,6 +2280,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -4045,6 +4433,471 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1039.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-node': 3.972.38
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.10
+      '@aws-sdk/middleware-expect-continue': 3.972.10
+      '@aws-sdk/middleware-flexible-checksums': 3.974.15
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-location-constraint': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.36
+      '@aws-sdk/middleware-ssec': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.24
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.23
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/eventstream-serde-config-resolver': 4.3.14
+      '@smithy/eventstream-serde-node': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-blob-browser': 4.2.15
+      '@smithy/hash-node': 4.2.14
+      '@smithy/hash-stream-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/md5-js': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.7':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-login': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.38':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-ini': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/token-providers': 3.1039.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.15':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/crc64-nvme': 3.972.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.6
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.5':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.24
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.23
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1039.0':
+    dependencies:
+      '@aws-sdk/signature-v4-multi-region': 3.996.24
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-format-url': 3.972.10
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.24':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.36
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1039.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.23':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5018,6 +5871,339 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    dependencies:
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.15':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.32':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.7':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.20':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.6.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.3.1':
+    dependencies:
+      '@smithy/types': 4.14.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.13':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.6':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.3.0':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@testing-library/dom@10.4.1':
@@ -5502,6 +6688,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.14:
     dependencies:


### PR DESCRIPTION
## Summary
- Implement `StorageService` wrapping `@aws-sdk/client-s3` for MinIO/S3 compatible storage
- Support upload (with 100MB size limit), download, delete, presigned URLs
- Auto-create required buckets on startup with STORAGE_BUCKET_PREFIX + race handling
- Key validation against path traversal attacks
- Integrate actual health check into AdminHealthController with sanitized errors
- Support dual config: MINIO_ENDPOINT for dev, S3_REGION for prod

## Test plan
- [x] Build passes
- [x] Lint passes (zero warnings)
- [x] 272 tests pass (47 test files)
- [x] Storage service unit tests with mocked S3 client

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `f5d655568111345b7042560d3c535583baa62249`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/58#issuecomment-4350379465) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/58#issuecomment-4350379667)
- Key findings addressed: Bucket prefix, race handling, key validation, upload size limit, error sanitization, startup timeout

Closes #53