### PR TITLE
feat(api): implement user-facing jobs API (#51)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "@aws-sdk/client-s3": "^3.1039.0",
     "@aws-sdk/s3-request-presigner": "^3.1039.0",
     "@cherrygraph/auth-core": "workspace:*",
+    "@cherrygraph/job-core": "workspace:*",
     "@cherrygraph/shared": "workspace:*",
     "@nestjs/common": "^11.1.19",
     "@nestjs/core": "^11.1.19",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './auth/auth.module.js';
 import { DrizzleModule } from './database/drizzle.module.js';
 import { GroupModule } from './groups/group.module.js';
 import { HealthModule } from './health/health.module.js';
+import { JobsModule } from './jobs/jobs.module.js';
 import { ModelConfigModule } from './models/model-config.module.js';
 import { SpaceModule } from './spaces/space.module.js';
 import { StorageModule } from './storage/storage.module.js';
@@ -25,6 +26,7 @@ import { UserModule } from './users/user.module.js';
     UserModule,
     GroupModule,
     SpaceModule,
+    JobsModule,
     ModelConfigModule,
     StorageModule,
     HealthModule,

--- a/apps/api/src/jobs/__tests__/jobs.service.test.ts
+++ b/apps/api/src/jobs/__tests__/jobs.service.test.ts
@@ -1,0 +1,323 @@
+import { ErrorCode } from '@cherrygraph/shared';
+import { JobRepository, JobStatus, type JobRow } from '@cherrygraph/job-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  TEST_SPACE_ID,
+  TEST_TENANT_ID,
+  TEST_USER_ID,
+  ScriptedDb,
+  getHttpExceptionCode,
+  getRejectedHttpException,
+  requireRecord,
+} from '../../users/__tests__/user-group-service-test-utils.js';
+import { AdminJobListQueryDto } from '../jobs.dto.js';
+import { JobsService, type JobContext } from '../jobs.service.js';
+
+describe('JobsService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns full job details for the creator', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createJobRow()]);
+    db.queueSelect([createJobEventRow({ event_type: 'progress_updated', detail_json: { percent: 65, stage: 'chunking' } })]);
+
+    const result = await service.getJob('job-1', createCreatorContext());
+
+    expect(result).toMatchObject({
+      job_id: 'job-1',
+      type: 'graphify',
+      status: JobStatus.PENDING,
+      space_id: TEST_SPACE_ID,
+      created_by: TEST_USER_ID,
+      progress: {
+        percent: 65,
+        stage: 'chunking',
+      },
+      payload_json: { source_id: 'source-1' },
+    });
+  });
+
+  it('returns 404 for a non-creator without space access', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createJobRow({ created_by: 'creator-2' })]);
+    db.queueSelect([]);
+
+    const err = await getRejectedHttpException(service.getJob('job-1', createViewerContext()));
+
+    expect(err.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.NOT_FOUND);
+  });
+
+  it('returns the job event timeline in chronological order', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createJobRow()]);
+    db.queueSelect([
+      createJobEventRow({
+        id: 'event-1',
+        event_type: 'status_changed',
+        detail_json: { from: 'pending', to: 'running' },
+        created_at: new Date('2026-04-10T00:00:00.000Z'),
+      }),
+      createJobEventRow({
+        id: 'event-2',
+        event_type: 'progress_updated',
+        detail_json: { percent: 35, stage: 'chunking' },
+        created_at: new Date('2026-04-10T00:01:00.000Z'),
+      }),
+    ]);
+
+    const result = await service.getJobEvents('job-1', createCreatorContext());
+
+    expect(result).toEqual([
+      {
+        event: 'status_changed',
+        timestamp: new Date('2026-04-10T00:00:00.000Z'),
+        detail: { from: 'pending', to: 'running' },
+      },
+      {
+        event: 'progress_updated',
+        timestamp: new Date('2026-04-10T00:01:00.000Z'),
+        detail: { percent: 35, stage: 'chunking' },
+      },
+    ]);
+  });
+
+  it('cancels a pending job immediately', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createJobRow({ status: JobStatus.PENDING })]);
+    db.queueUpdate([
+      createJobRow({
+        status: JobStatus.CANCELLED,
+        completed_at: new Date('2026-04-10T02:00:00.000Z'),
+      }),
+    ]);
+
+    const result = await service.cancelJob('job-1', createCreatorContext());
+
+    expect(result.job_id).toBe('job-1');
+    expect(result.status).toBe(JobStatus.CANCELLED);
+    expect(result.cancel_requested_at).toBeNull();
+
+    const updateValue = requireRecord(db.updates[0]?.value);
+    expect(updateValue.status).toBe(JobStatus.CANCELLED);
+    expect(updateValue.completed_at).toBeInstanceOf(Date);
+
+    const eventValue = requireRecord(db.inserts[0]?.value);
+    expect(eventValue).toMatchObject({
+      job_id: 'job-1',
+      event_type: 'status_changed',
+    });
+  });
+
+  it('sets cancel_requested_at for a running job', async () => {
+    const { service, db } = createServiceContext();
+    const cancelRequestedAt = new Date('2026-04-10T03:00:00.000Z');
+    db.queueSelect([createJobRow({ status: JobStatus.RUNNING, started_at: new Date('2026-04-10T02:00:00.000Z') })]);
+    db.queueUpdate([
+      createJobRow({
+        status: JobStatus.RUNNING,
+        cancel_requested_at: cancelRequestedAt,
+        started_at: new Date('2026-04-10T02:00:00.000Z'),
+      }),
+    ]);
+
+    const result = await service.cancelJob('job-1', createCreatorContext());
+
+    expect(result).toEqual({
+      job_id: 'job-1',
+      status: JobStatus.RUNNING,
+      cancel_requested_at: cancelRequestedAt,
+    });
+
+    const updateValue = requireRecord(db.updates[0]?.value);
+    expect(updateValue.cancel_requested_at).toBeInstanceOf(Date);
+
+    const eventValue = requireRecord(db.inserts[0]?.value);
+    expect(eventValue).toMatchObject({
+      job_id: 'job-1',
+      event_type: 'cancel_requested',
+    });
+  });
+
+  it('returns current state when cancelling an already cancelled job', async () => {
+    const { service, db } = createServiceContext();
+    const completedAt = new Date('2026-04-10T04:00:00.000Z');
+    db.queueSelect([
+      createJobRow({
+        status: JobStatus.CANCELLED,
+        completed_at: completedAt,
+      }),
+    ]);
+
+    await expect(service.cancelJob('job-1', createCreatorContext())).resolves.toEqual({
+      job_id: 'job-1',
+      status: JobStatus.CANCELLED,
+      cancel_requested_at: null,
+    });
+    expect(db.updates).toHaveLength(0);
+  });
+
+  it.each([JobStatus.SUCCEEDED, JobStatus.FAILED] as const)(
+    'returns 409 when cancelling a %s job',
+    async (status) => {
+      const { service, db } = createServiceContext();
+      db.queueSelect([createJobRow({ status })]);
+
+      const err = await getRejectedHttpException(service.cancelJob('job-1', createCreatorContext()));
+
+      expect(err.getStatus()).toBe(409);
+      expect(getHttpExceptionCode(err)).toBe(ErrorCode.CONFLICT);
+    },
+  );
+
+  it('lists admin jobs with filters and pagination', async () => {
+    const { service, db } = createServiceContext();
+    const findByFilterSpy = vi.spyOn(JobRepository, 'findByFilter').mockResolvedValue({
+      items: [createJobRow({ status: JobStatus.RUNNING })],
+      total: 1,
+      page: 2,
+      perPage: 5,
+    });
+    db.queueSelect([
+      createJobEventRow({
+        event_type: 'progress_updated',
+        detail_json: { percent: 80, stage: 'embedding' },
+      }),
+    ]);
+
+    const query = Object.assign(new AdminJobListQueryDto(), {
+      page: 2,
+      per_page: 5,
+      sort: '-created_at',
+      type: 'graphify' as const,
+      status: JobStatus.RUNNING,
+      space_id: TEST_SPACE_ID,
+    });
+    const result = await service.listAdminJobs(query, createAdminContext());
+
+    expect(findByFilterSpy).toHaveBeenCalledWith(
+      db.asDrizzle(),
+      expect.objectContaining({
+        tenant_id: TEST_TENANT_ID,
+        type: 'graphify',
+        status: JobStatus.RUNNING,
+        space_id: TEST_SPACE_ID,
+        page: 2,
+        perPage: 5,
+        sort: {
+          field: 'created_at',
+          direction: 'desc',
+        },
+      }),
+    );
+    expect(result.data).toMatchObject([
+      {
+        job_id: 'job-1',
+        status: JobStatus.RUNNING,
+        progress: {
+          percent: 80,
+          stage: 'embedding',
+        },
+      },
+    ]);
+    expect(result.pagination).toEqual({
+      page: 2,
+      per_page: 5,
+      total: 1,
+      has_next: false,
+    });
+  });
+});
+
+function createServiceContext(): { service: JobsService; db: ScriptedDb } {
+  const db = new ScriptedDb();
+  const service = new JobsService(db.asDrizzle());
+
+  return { service, db };
+}
+
+function createCreatorContext(overrides: Partial<JobContext> = {}): JobContext {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: TEST_USER_ID,
+    userId: TEST_USER_ID,
+    actorRole: 'viewer',
+    ...overrides,
+  };
+}
+
+function createViewerContext(overrides: Partial<JobContext> = {}): JobContext {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: 'viewer-2',
+    userId: 'viewer-2',
+    actorRole: 'viewer',
+    ...overrides,
+  };
+}
+
+function createAdminContext(overrides: Partial<JobContext> = {}): JobContext {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: 'admin-1',
+    userId: 'admin-1',
+    actorRole: 'admin',
+    ...overrides,
+  };
+}
+
+function createJobRow(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-1',
+    tenant_id: TEST_TENANT_ID,
+    space_id: TEST_SPACE_ID,
+    queue_name: 'ingestion',
+    type: 'graphify',
+    priority: 100,
+    status: JobStatus.PENDING,
+    attempt_count: 0,
+    max_attempts: 3,
+    timeout_seconds: 600,
+    locked_by: null,
+    locked_at: null,
+    next_run_at: null,
+    cancel_requested_at: null,
+    payload_json: { source_id: 'source-1' },
+    result_json: null,
+    error_json: null,
+    idempotency_key: null,
+    created_by: TEST_USER_ID,
+    created_at: new Date('2026-04-10T00:00:00.000Z'),
+    started_at: null,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function createJobEventRow(
+  overrides: Partial<{
+    id: string;
+    job_id: string;
+    event_type: string;
+    detail_json: unknown;
+    created_at: Date;
+  }> = {},
+): {
+  id: string;
+  job_id: string;
+  event_type: string;
+  detail_json: unknown;
+  created_at: Date;
+} {
+  return {
+    id: 'event-1',
+    job_id: 'job-1',
+    event_type: 'status_changed',
+    detail_json: {},
+    created_at: new Date('2026-04-10T00:00:00.000Z'),
+    ...overrides,
+  };
+}

--- a/apps/api/src/jobs/__tests__/jobs.service.test.ts
+++ b/apps/api/src/jobs/__tests__/jobs.service.test.ts
@@ -11,7 +11,7 @@ import {
   getRejectedHttpException,
   requireRecord,
 } from '../../users/__tests__/user-group-service-test-utils.js';
-import { AdminJobListQueryDto } from '../jobs.dto.js';
+import { AdminJobListQueryDto, JobEventsQueryDto } from '../jobs.dto.js';
 import { JobsService, type JobContext } from '../jobs.service.js';
 
 describe('JobsService', () => {
@@ -85,6 +85,37 @@ describe('JobsService', () => {
     ]);
   });
 
+  it('auditor with admin:audit_view can access job detail and events', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createJobRow({ created_by: 'creator-2' })]);
+    db.queueSelect([]);
+    db.queueSelect([createJobRow({ created_by: 'creator-2' })]);
+    db.queueSelect([
+      createJobEventRow({
+        id: 'event-1',
+        event_type: 'status_changed',
+        detail_json: { from: 'pending', to: 'running' },
+      }),
+    ]);
+
+    const context = createAuditContext();
+    const job = await service.getJob('job-1', context);
+    const events = await service.getJobEvents('job-1', context);
+
+    expect(job).toMatchObject({
+      job_id: 'job-1',
+      created_by: 'creator-2',
+      status: JobStatus.PENDING,
+    });
+    expect(events).toEqual([
+      {
+        event: 'status_changed',
+        timestamp: new Date('2026-04-10T00:00:00.000Z'),
+        detail: { from: 'pending', to: 'running' },
+      },
+    ]);
+  });
+
   it('cancels a pending job immediately', async () => {
     const { service, db } = createServiceContext();
     db.queueSelect([createJobRow({ status: JobStatus.PENDING })]);
@@ -142,6 +173,56 @@ describe('JobsService', () => {
     });
   });
 
+  it('cancel retries when job transitions pending->running during cancel attempt', async () => {
+    const { service, db } = createServiceContext();
+    const cancelRequestedAt = new Date('2026-04-10T03:00:00.000Z');
+    db.queueSelect([createJobRow({ status: JobStatus.PENDING })]);
+    db.queueUpdate([]);
+    db.queueSelect([
+      createJobRow({
+        status: JobStatus.RUNNING,
+        started_at: new Date('2026-04-10T02:00:00.000Z'),
+      }),
+    ]);
+    db.queueSelect([
+      createJobRow({
+        status: JobStatus.RUNNING,
+        started_at: new Date('2026-04-10T02:00:00.000Z'),
+      }),
+    ]);
+    db.queueSelect([
+      createJobRow({
+        status: JobStatus.RUNNING,
+        started_at: new Date('2026-04-10T02:00:00.000Z'),
+      }),
+    ]);
+    db.queueUpdate([
+      createJobRow({
+        status: JobStatus.RUNNING,
+        cancel_requested_at: cancelRequestedAt,
+        started_at: new Date('2026-04-10T02:00:00.000Z'),
+      }),
+    ]);
+
+    const result = await service.cancelJob('job-1', createCreatorContext());
+
+    expect(result).toEqual({
+      job_id: 'job-1',
+      status: JobStatus.RUNNING,
+      cancel_requested_at: cancelRequestedAt,
+    });
+    expect(db.updates).toHaveLength(2);
+    expect(requireRecord(db.updates[0]?.value)).toMatchObject({
+      status: JobStatus.CANCELLED,
+    });
+    expect(requireRecord(db.updates[1]?.value).cancel_requested_at).toBeInstanceOf(Date);
+    expect(db.inserts).toHaveLength(1);
+    expect(requireRecord(db.inserts[0]?.value)).toMatchObject({
+      job_id: 'job-1',
+      event_type: 'cancel_requested',
+    });
+  });
+
   it('returns current state when cancelling an already cancelled job', async () => {
     const { service, db } = createServiceContext();
     const completedAt = new Date('2026-04-10T04:00:00.000Z');
@@ -172,6 +253,21 @@ describe('JobsService', () => {
       expect(getHttpExceptionCode(err)).toBe(ErrorCode.CONFLICT);
     },
   );
+
+  it('applies pagination when fetching job events', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createJobRow()]);
+    db.queueSelect([createJobEventRow()]);
+
+    const query = Object.assign(new JobEventsQueryDto(), {
+      limit: 25,
+      offset: 10,
+    });
+    await service.getJobEvents('job-1', createCreatorContext(), query);
+
+    expect(db.limitCalls).toContain(25);
+    expect(db.offsetCalls).toEqual([10]);
+  });
 
   it('lists admin jobs with filters and pagination', async () => {
     const { service, db } = createServiceContext();
@@ -265,6 +361,17 @@ function createAdminContext(overrides: Partial<JobContext> = {}): JobContext {
     actorUserId: 'admin-1',
     userId: 'admin-1',
     actorRole: 'admin',
+    ...overrides,
+  };
+}
+
+function createAuditContext(overrides: Partial<JobContext> = {}): JobContext {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: 'auditor-1',
+    userId: 'auditor-1',
+    actorRole: 'auditor',
+    actorPermissions: ['admin:audit_view'],
     ...overrides,
   };
 }

--- a/apps/api/src/jobs/jobs.controller.ts
+++ b/apps/api/src/jobs/jobs.controller.ts
@@ -1,0 +1,94 @@
+import { Controller, Get, HttpCode, HttpException, HttpStatus, Param, Post, Query, Req } from '@nestjs/common';
+import { Permissions, type AuthenticatedRequestUser } from '@cherrygraph/auth-core';
+import { ErrorCode } from '@cherrygraph/shared';
+
+import {
+  AdminJobListQueryDto,
+  type CancelJobResponseDto,
+  type JobDto,
+  type JobEventDto,
+} from './jobs.dto.js';
+import { JobsService } from './jobs.service.js';
+
+type RequestWithAuth = {
+  user?: AuthenticatedRequestUser;
+};
+
+@Controller('jobs')
+export class JobsController {
+  constructor(private readonly jobsService: JobsService) {}
+
+  @Get(':job_id')
+  async getJob(@Param('job_id') jobId: string, @Req() request: RequestWithAuth): Promise<JobDto> {
+    const user = getAuthenticatedUser(request);
+    return this.jobsService.getJob(jobId, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+      userId: user.sub,
+    });
+  }
+
+  @Get(':job_id/events')
+  async getJobEvents(
+    @Param('job_id') jobId: string,
+    @Req() request: RequestWithAuth,
+  ): Promise<JobEventDto[]> {
+    const user = getAuthenticatedUser(request);
+    return this.jobsService.getJobEvents(jobId, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+      userId: user.sub,
+    });
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post(':job_id/cancel')
+  async cancelJob(
+    @Param('job_id') jobId: string,
+    @Req() request: RequestWithAuth,
+  ): Promise<CancelJobResponseDto> {
+    const user = getAuthenticatedUser(request);
+    return this.jobsService.cancelJob(jobId, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+      userId: user.sub,
+    });
+  }
+}
+
+@Permissions('admin:audit_view')
+@Controller('admin/jobs')
+export class AdminJobsController {
+  constructor(private readonly jobsService: JobsService) {}
+
+  @Get()
+  async listJobs(
+    @Query() query: AdminJobListQueryDto,
+    @Req() request: RequestWithAuth,
+  ): ReturnType<JobsService['listAdminJobs']> {
+    const user = getAuthenticatedUser(request);
+    return this.jobsService.listAdminJobs(query, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+      userId: user.sub,
+    });
+  }
+}
+
+function getAuthenticatedUser(request: RequestWithAuth): AuthenticatedRequestUser {
+  if (request.user === undefined) {
+    throw new HttpException(
+      {
+        code: ErrorCode.UNAUTHENTICATED,
+        message: 'Unauthenticated',
+      },
+      HttpStatus.UNAUTHORIZED,
+    );
+  }
+
+  return request.user;
+}

--- a/apps/api/src/jobs/jobs.controller.ts
+++ b/apps/api/src/jobs/jobs.controller.ts
@@ -7,11 +7,15 @@ import {
   type CancelJobResponseDto,
   type JobDto,
   type JobEventDto,
+  JobEventsQueryDto,
 } from './jobs.dto.js';
-import { JobsService } from './jobs.service.js';
+import { JobsService, type JobContext } from './jobs.service.js';
 
 type RequestWithAuth = {
-  user?: AuthenticatedRequestUser;
+  user?: AuthenticatedRequestUser & {
+    permissions?: string[];
+  };
+  permissions?: string[];
 };
 
 @Controller('jobs')
@@ -21,26 +25,17 @@ export class JobsController {
   @Get(':job_id')
   async getJob(@Param('job_id') jobId: string, @Req() request: RequestWithAuth): Promise<JobDto> {
     const user = getAuthenticatedUser(request);
-    return this.jobsService.getJob(jobId, {
-      tenantId: user.tenant_id,
-      actorUserId: user.sub,
-      actorRole: user.role,
-      userId: user.sub,
-    });
+    return this.jobsService.getJob(jobId, buildJobContext(request, user));
   }
 
   @Get(':job_id/events')
   async getJobEvents(
     @Param('job_id') jobId: string,
+    @Query() query: JobEventsQueryDto,
     @Req() request: RequestWithAuth,
   ): Promise<JobEventDto[]> {
     const user = getAuthenticatedUser(request);
-    return this.jobsService.getJobEvents(jobId, {
-      tenantId: user.tenant_id,
-      actorUserId: user.sub,
-      actorRole: user.role,
-      userId: user.sub,
-    });
+    return this.jobsService.getJobEvents(jobId, buildJobContext(request, user), query);
   }
 
   @HttpCode(HttpStatus.OK)
@@ -50,12 +45,7 @@ export class JobsController {
     @Req() request: RequestWithAuth,
   ): Promise<CancelJobResponseDto> {
     const user = getAuthenticatedUser(request);
-    return this.jobsService.cancelJob(jobId, {
-      tenantId: user.tenant_id,
-      actorUserId: user.sub,
-      actorRole: user.role,
-      userId: user.sub,
-    });
+    return this.jobsService.cancelJob(jobId, buildJobContext(request, user));
   }
 }
 
@@ -91,4 +81,19 @@ function getAuthenticatedUser(request: RequestWithAuth): AuthenticatedRequestUse
   }
 
   return request.user;
+}
+
+function buildJobContext(
+  request: RequestWithAuth,
+  user: AuthenticatedRequestUser & { permissions?: string[] },
+): JobContext {
+  const actorPermissions = request.permissions ?? user.permissions;
+
+  return {
+    tenantId: user.tenant_id,
+    actorUserId: user.sub,
+    actorRole: user.role,
+    userId: user.sub,
+    ...(actorPermissions !== undefined ? { actorPermissions } : {}),
+  };
 }

--- a/apps/api/src/jobs/jobs.dto.ts
+++ b/apps/api/src/jobs/jobs.dto.ts
@@ -1,5 +1,6 @@
+import { Type } from 'class-transformer';
 import { JobStatus } from '@cherrygraph/job-core';
-import { IsEnum, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsEnum, IsIn, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 
 import { PaginationQueryDto } from '../common/dto/pagination.dto.js';
 
@@ -21,6 +22,21 @@ export class AdminJobListQueryDto extends PaginationQueryDto {
   @IsString()
   @MaxLength(200)
   space_id?: string;
+}
+
+export class JobEventsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  limit = 100;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset = 0;
 }
 
 export class JobProgressDto {

--- a/apps/api/src/jobs/jobs.dto.ts
+++ b/apps/api/src/jobs/jobs.dto.ts
@@ -1,0 +1,59 @@
+import { JobStatus } from '@cherrygraph/job-core';
+import { IsEnum, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+
+import { PaginationQueryDto } from '../common/dto/pagination.dto.js';
+
+export const JOB_TYPES = ['ingestion', 'graphify', 'reindex', 'rebuild', 'wiki_sync'] as const;
+export const JOB_SORT_FIELDS = ['created_at', 'priority', 'next_run_at'] as const;
+
+export type JobType = (typeof JOB_TYPES)[number];
+
+export class AdminJobListQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsIn(JOB_TYPES)
+  type?: JobType;
+
+  @IsOptional()
+  @IsEnum(JobStatus)
+  status?: JobStatus;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  space_id?: string;
+}
+
+export class JobProgressDto {
+  percent?: number;
+  stage?: string;
+}
+
+export class JobDto {
+  job_id!: string;
+  type!: string;
+  status!: string;
+  space_id!: string | null;
+  progress!: JobProgressDto | null;
+  created_by!: string | null;
+  payload_json!: unknown;
+  result_json!: unknown;
+  error_json!: unknown;
+  cancel_requested_at!: Date | null;
+  attempt_count!: number;
+  max_attempts!: number;
+  created_at!: Date;
+  started_at!: Date | null;
+  completed_at!: Date | null;
+}
+
+export class JobEventDto {
+  event!: string;
+  timestamp!: Date;
+  detail!: unknown;
+}
+
+export class CancelJobResponseDto {
+  job_id!: string;
+  status!: string;
+  cancel_requested_at!: Date | null;
+}

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { AdminJobsController, JobsController } from './jobs.controller.js';
+import { JobsService } from './jobs.service.js';
+
+@Module({
+  controllers: [JobsController, AdminJobsController],
+  providers: [JobsService],
+  exports: [JobsService],
+})
+export class JobsModule {}

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -1,0 +1,433 @@
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import {
+  JobConflictError,
+  JobEventRepository,
+  JobRepository,
+  JobStateMachine,
+  JobStatus,
+  job_events,
+  jobs,
+  type JobEventRow,
+  type JobRow,
+} from '@cherrygraph/job-core';
+import { ROLES, normalizeRole } from '@cherrygraph/auth-core';
+import { ErrorCode, group_members, space_permissions } from '@cherrygraph/shared';
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNull,
+} from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import {
+  buildPaginationMeta,
+  paginatedResponse,
+  parseSortField,
+  type PaginatedResponse,
+} from '../common/dto/pagination.dto.js';
+import { DRIZZLE } from '../database/drizzle.constants.js';
+import {
+  JOB_SORT_FIELDS,
+  type AdminJobListQueryDto,
+  type CancelJobResponseDto,
+  type JobDto,
+  type JobEventDto,
+  type JobProgressDto,
+} from './jobs.dto.js';
+
+type JobsDatabase = NodePgDatabase;
+type JobSortField = (typeof JOB_SORT_FIELDS)[number];
+type JobSortDirection = 'asc' | 'desc';
+type ParsedJobSort = {
+  field: JobSortField;
+  direction: JobSortDirection;
+};
+
+export type JobContext = {
+  tenantId?: string;
+  actorUserId?: string;
+  actorRole?: string;
+  userId?: string;
+};
+
+type JobAccessMode = 'view' | 'cancel';
+
+const VIEW_SATISFYING_PERMISSIONS = ['space:view', 'space:edit', 'space:admin'] as const;
+const CANCEL_SATISFYING_PERMISSIONS = ['space:admin'] as const;
+const PROGRESS_UPDATED_EVENT_TYPE = 'progress_updated';
+const JOB_SORT_FIELD_SET = new Set<string>(JOB_SORT_FIELDS);
+const JOB_STATUS_SET = new Set<string>(Object.values(JobStatus));
+
+@Injectable()
+export class JobsService {
+  constructor(@Inject(DRIZZLE) private readonly db: JobsDatabase) {}
+
+  async getJob(jobId: string, context: JobContext = {}): Promise<JobDto> {
+    const job = await this.getAccessibleJob(jobId, context, 'view');
+    const progressByJobId = await this.loadProgressByJobIds([job.id]);
+
+    return toJobDto(job, progressByJobId.get(job.id) ?? null);
+  }
+
+  async getJobEvents(jobId: string, context: JobContext = {}): Promise<JobEventDto[]> {
+    const job = await this.getAccessibleJob(jobId, context, 'view');
+    const events = await JobEventRepository.queryByJobId(this.db, job.id);
+
+    return events.map(toJobEventDto);
+  }
+
+  async cancelJob(jobId: string, context: JobContext = {}): Promise<CancelJobResponseDto> {
+    const actorUserId = resolveContextUserId(context);
+    const job = await this.getAccessibleJob(jobId, context, 'cancel');
+    const jobStatus = normalizeJobStatus(job.status);
+
+    if (jobStatus === JobStatus.CANCELLED) {
+      return toCancelJobResponse(job);
+    }
+
+    if (jobStatus === JobStatus.SUCCEEDED || jobStatus === JobStatus.FAILED) {
+      throwJobConflict('Job is already in a terminal state');
+    }
+
+    if (jobStatus === JobStatus.RUNNING && job.cancel_requested_at !== null) {
+      return toCancelJobResponse(job);
+    }
+
+    try {
+      return await this.db.transaction(async (tx) => {
+        const txDb = tx as JobsDatabase;
+
+        if (jobStatus === JobStatus.PENDING) {
+          const completedAt = new Date();
+          const cancelledJob = await JobStateMachine.transition(
+            txDb,
+            job.id,
+            JobStatus.PENDING,
+            JobStatus.CANCELLED,
+            {
+              completed_at: completedAt,
+            },
+          );
+
+          await JobEventRepository.create(txDb, {
+            job_id: job.id,
+            event_type: 'status_changed',
+            detail_json: {
+              from: JobStatus.PENDING,
+              to: JobStatus.CANCELLED,
+              requested_by: actorUserId,
+            },
+          });
+
+          return toCancelJobResponse(cancelledJob);
+        }
+
+        if (jobStatus !== JobStatus.RUNNING) {
+          throw new JobConflictError(`Unsupported job status for cancellation: ${job.status}`);
+        }
+
+        const cancelRequestedAt = new Date();
+        const [updated] = await txDb
+          .update(jobs)
+          .set({
+            cancel_requested_at: cancelRequestedAt,
+          })
+          .where(
+            and(
+              eq(jobs.id, job.id),
+              eq(jobs.status, JobStatus.RUNNING),
+              isNull(jobs.cancel_requested_at),
+            ),
+          )
+          .returning();
+
+        if (updated === undefined) {
+          throw new JobConflictError(`Job ${job.id} changed while cancellation was requested`);
+        }
+
+        await JobEventRepository.create(txDb, {
+          job_id: job.id,
+          event_type: 'cancel_requested',
+          detail_json: {
+            requested_by: actorUserId,
+          },
+        });
+
+        return toCancelJobResponse(updated);
+      });
+    } catch (err) {
+      if (err instanceof JobConflictError) {
+        return this.resolveCancellationConflict(jobId, context);
+      }
+
+      throw err;
+    }
+  }
+
+  async listAdminJobs(
+    query: AdminJobListQueryDto,
+    context: JobContext = {},
+  ): Promise<PaginatedResponse<JobDto>> {
+    const tenantId = resolveTenantId(context);
+    const result = await JobRepository.findByFilter(this.db, {
+      tenant_id: tenantId,
+      ...(normalizeFilterValue(query.type) !== undefined ? { type: query.type } : {}),
+      ...(query.status !== undefined ? { status: query.status } : {}),
+      ...(normalizeFilterValue(query.space_id) !== undefined ? { space_id: query.space_id } : {}),
+      page: query.page,
+      perPage: query.per_page,
+      sort: parseJobSort(query.sort ?? '-created_at'),
+    });
+    const progressByJobId = await this.loadProgressByJobIds(
+      result.items.map((item: JobRow) => item.id),
+    );
+
+    return paginatedResponse(
+      result.items.map((item: JobRow) => toJobDto(item, progressByJobId.get(item.id) ?? null)),
+      buildPaginationMeta(result.page, result.perPage, result.total),
+    );
+  }
+
+  private async getAccessibleJob(
+    jobId: string,
+    context: JobContext,
+    mode: JobAccessMode,
+  ): Promise<JobRow> {
+    const tenantId = resolveTenantId(context);
+    const userId = resolveContextUserId(context);
+    const job = await JobRepository.findById(this.db, jobId);
+
+    if (job === undefined || job.tenant_id !== tenantId) {
+      throwJobNotFound();
+    }
+
+    if (job.created_by === userId || hasImplicitSpaceAccess(context.actorRole)) {
+      return job;
+    }
+
+    if (job.space_id === null) {
+      throwJobNotFound();
+    }
+
+    const permissions =
+      mode === 'cancel' ? [...CANCEL_SATISFYING_PERMISSIONS] : [...VIEW_SATISFYING_PERMISSIONS];
+    const allowed = await this.hasSpacePermission(tenantId, userId, job.space_id, permissions);
+
+    if (!allowed) {
+      throwJobNotFound();
+    }
+
+    return job;
+  }
+
+  private async hasSpacePermission(
+    tenantId: string,
+    userId: string,
+    spaceId: string,
+    permissions: string[],
+  ): Promise<boolean> {
+    const rows = await this.db
+      .select({
+        permission: space_permissions.permission,
+      })
+      .from(group_members)
+      .innerJoin(
+        space_permissions,
+        and(
+          eq(space_permissions.tenant_id, group_members.tenant_id),
+          eq(space_permissions.group_id, group_members.group_id),
+        ),
+      )
+      .where(
+        and(
+          eq(group_members.tenant_id, tenantId),
+          eq(group_members.user_id, userId),
+          eq(space_permissions.space_id, spaceId),
+          inArray(space_permissions.permission, permissions),
+        ),
+      )
+      .limit(1);
+
+    return rows.length > 0;
+  }
+
+  private async loadProgressByJobIds(jobIds: string[]): Promise<Map<string, JobProgressDto | null>> {
+    if (jobIds.length === 0) {
+      return new Map();
+    }
+
+    const rows = await this.db
+      .select()
+      .from(job_events)
+      .where(
+        and(
+          inArray(job_events.job_id, jobIds),
+          eq(job_events.event_type, PROGRESS_UPDATED_EVENT_TYPE),
+        ),
+      )
+      .orderBy(desc(job_events.created_at));
+
+    const progressByJobId = new Map<string, JobProgressDto | null>();
+
+    for (const row of rows) {
+      if (progressByJobId.has(row.job_id)) {
+        continue;
+      }
+
+      progressByJobId.set(row.job_id, toJobProgress(row.detail_json));
+    }
+
+    return progressByJobId;
+  }
+
+  private async resolveCancellationConflict(
+    jobId: string,
+    context: JobContext,
+  ): Promise<CancelJobResponseDto> {
+    const current = await this.getAccessibleJob(jobId, context, 'cancel');
+    const currentStatus = normalizeJobStatus(current.status);
+
+    if (currentStatus === JobStatus.CANCELLED) {
+      return toCancelJobResponse(current);
+    }
+
+    if (currentStatus === JobStatus.RUNNING && current.cancel_requested_at !== null) {
+      return toCancelJobResponse(current);
+    }
+
+    if (currentStatus === JobStatus.SUCCEEDED || currentStatus === JobStatus.FAILED) {
+      throwJobConflict('Job is already in a terminal state');
+    }
+
+    throwJobConflict('Job state changed while cancellation was requested');
+  }
+}
+
+function parseJobSort(sort: string): ParsedJobSort {
+  const parsed = parseSortSafely(sort);
+
+  if (!isJobSortField(parsed.field)) {
+    throwApiError(ErrorCode.VALIDATION_ERROR, 'Invalid sort field', HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+
+  return {
+    field: parsed.field,
+    direction: parsed.direction,
+  };
+}
+
+function parseSortSafely(sort: string): ReturnType<typeof parseSortField> {
+  try {
+    return parseSortField(sort);
+  } catch {
+    throwApiError(ErrorCode.VALIDATION_ERROR, 'Invalid sort field', HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+}
+
+function resolveTenantId(context: JobContext): string {
+  if (context.tenantId !== undefined && context.tenantId.trim().length > 0) {
+    return context.tenantId.trim();
+  }
+
+  throwApiError(ErrorCode.UNAUTHENTICATED, 'Unauthenticated', HttpStatus.UNAUTHORIZED);
+}
+
+function resolveContextUserId(context: JobContext): string {
+  const userId = context.userId ?? context.actorUserId;
+  if (userId !== undefined && userId.trim().length > 0) {
+    return userId.trim();
+  }
+
+  throwApiError(ErrorCode.UNAUTHENTICATED, 'Unauthenticated', HttpStatus.UNAUTHORIZED);
+}
+
+function hasImplicitSpaceAccess(role: string | undefined): boolean {
+  const normalizedRole = role === undefined ? undefined : normalizeRole(role);
+  return normalizedRole === ROLES.OWNER || normalizedRole === ROLES.ADMIN;
+}
+
+function normalizeFilterValue(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeJobStatus(status: string): JobStatus | undefined {
+  return JOB_STATUS_SET.has(status) ? (status as JobStatus) : undefined;
+}
+
+function isJobSortField(field: string): field is JobSortField {
+  return JOB_SORT_FIELD_SET.has(field);
+}
+
+function toJobDto(job: JobRow, progress: JobProgressDto | null): JobDto {
+  return {
+    job_id: job.id,
+    type: job.type,
+    status: job.status,
+    space_id: job.space_id,
+    progress,
+    created_by: job.created_by,
+    payload_json: job.payload_json,
+    result_json: job.result_json,
+    error_json: job.error_json,
+    cancel_requested_at: job.cancel_requested_at,
+    attempt_count: job.attempt_count,
+    max_attempts: job.max_attempts,
+    created_at: job.created_at,
+    started_at: job.started_at,
+    completed_at: job.completed_at,
+  };
+}
+
+function toJobProgress(detail: unknown): JobProgressDto | null {
+  if (typeof detail !== 'object' || detail === null) {
+    return null;
+  }
+
+  const detailRecord = detail as Record<string, unknown>;
+  const progress: JobProgressDto = {};
+
+  if (typeof detailRecord.percent === 'number' && Number.isFinite(detailRecord.percent)) {
+    progress.percent = Math.trunc(detailRecord.percent);
+  }
+
+  if (typeof detailRecord.stage === 'string' && detailRecord.stage.trim().length > 0) {
+    progress.stage = detailRecord.stage;
+  }
+
+  return progress.percent === undefined && progress.stage === undefined ? null : progress;
+}
+
+function toJobEventDto(jobEvent: JobEventRow): JobEventDto {
+  return {
+    event: jobEvent.event_type,
+    timestamp: jobEvent.created_at,
+    detail: jobEvent.detail_json,
+  };
+}
+
+function toCancelJobResponse(job: JobRow): CancelJobResponseDto {
+  return {
+    job_id: job.id,
+    status: job.status,
+    cancel_requested_at: job.cancel_requested_at,
+  };
+}
+
+function throwJobNotFound(): never {
+  throwApiError(ErrorCode.NOT_FOUND, 'Job not found', HttpStatus.NOT_FOUND);
+}
+
+function throwJobConflict(message: string): never {
+  throwApiError(ErrorCode.CONFLICT, message, HttpStatus.CONFLICT);
+}
+
+function throwApiError(code: ErrorCode, message: string, status: HttpStatus): never {
+  throw new HttpException({ code, message }, status);
+}

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -10,9 +10,10 @@ import {
   type JobEventRow,
   type JobRow,
 } from '@cherrygraph/job-core';
-import { ROLES, normalizeRole } from '@cherrygraph/auth-core';
+import { ROLE_PERMISSIONS, ROLES, normalizeRole } from '@cherrygraph/auth-core';
 import { ErrorCode, group_members, space_permissions } from '@cherrygraph/shared';
 import {
+  asc,
   and,
   desc,
   eq,
@@ -34,6 +35,7 @@ import {
   type CancelJobResponseDto,
   type JobDto,
   type JobEventDto,
+  JobEventsQueryDto,
   type JobProgressDto,
 } from './jobs.dto.js';
 
@@ -48,6 +50,7 @@ type ParsedJobSort = {
 export type JobContext = {
   tenantId?: string;
   actorUserId?: string;
+  actorPermissions?: string[];
   actorRole?: string;
   userId?: string;
 };
@@ -56,6 +59,8 @@ type JobAccessMode = 'view' | 'cancel';
 
 const VIEW_SATISFYING_PERMISSIONS = ['space:view', 'space:edit', 'space:admin'] as const;
 const CANCEL_SATISFYING_PERMISSIONS = ['space:admin'] as const;
+const AUDIT_VIEW_PERMISSION = 'admin:audit_view';
+const MAX_CANCELLATION_RETRIES = 3;
 const PROGRESS_UPDATED_EVENT_TYPE = 'progress_updated';
 const JOB_SORT_FIELD_SET = new Set<string>(JOB_SORT_FIELDS);
 const JOB_STATUS_SET = new Set<string>(Object.values(JobStatus));
@@ -71,14 +76,32 @@ export class JobsService {
     return toJobDto(job, progressByJobId.get(job.id) ?? null);
   }
 
-  async getJobEvents(jobId: string, context: JobContext = {}): Promise<JobEventDto[]> {
+  async getJobEvents(
+    jobId: string,
+    context: JobContext = {},
+    query: JobEventsQueryDto = new JobEventsQueryDto(),
+  ): Promise<JobEventDto[]> {
     const job = await this.getAccessibleJob(jobId, context, 'view');
-    const events = await JobEventRepository.queryByJobId(this.db, job.id);
+    const events = await this.db
+      .select()
+      .from(job_events)
+      .where(eq(job_events.job_id, job.id))
+      .orderBy(asc(job_events.created_at))
+      .limit(query.limit)
+      .offset(query.offset);
 
     return events.map(toJobEventDto);
   }
 
   async cancelJob(jobId: string, context: JobContext = {}): Promise<CancelJobResponseDto> {
+    return this.cancelJobInternal(jobId, context, 0);
+  }
+
+  private async cancelJobInternal(
+    jobId: string,
+    context: JobContext,
+    retryCount: number,
+  ): Promise<CancelJobResponseDto> {
     const actorUserId = resolveContextUserId(context);
     const job = await this.getAccessibleJob(jobId, context, 'cancel');
     const jobStatus = normalizeJobStatus(job.status);
@@ -159,7 +182,7 @@ export class JobsService {
       });
     } catch (err) {
       if (err instanceof JobConflictError) {
-        return this.resolveCancellationConflict(jobId, context);
+        return this.resolveCancellationConflict(jobId, context, retryCount);
       }
 
       throw err;
@@ -204,6 +227,10 @@ export class JobsService {
     }
 
     if (job.created_by === userId || hasImplicitSpaceAccess(context.actorRole)) {
+      return job;
+    }
+
+    if (mode === 'view' && hasAuditViewAccess(context.actorRole, context.actorPermissions)) {
       return job;
     }
 
@@ -285,6 +312,7 @@ export class JobsService {
   private async resolveCancellationConflict(
     jobId: string,
     context: JobContext,
+    retryCount: number,
   ): Promise<CancelJobResponseDto> {
     const current = await this.getAccessibleJob(jobId, context, 'cancel');
     const currentStatus = normalizeJobStatus(current.status);
@@ -299,6 +327,13 @@ export class JobsService {
 
     if (currentStatus === JobStatus.SUCCEEDED || currentStatus === JobStatus.FAILED) {
       throwJobConflict('Job is already in a terminal state');
+    }
+
+    if (
+      (currentStatus === JobStatus.PENDING || currentStatus === JobStatus.RUNNING) &&
+      retryCount < MAX_CANCELLATION_RETRIES
+    ) {
+      return this.cancelJobInternal(jobId, context, retryCount + 1);
     }
 
     throwJobConflict('Job state changed while cancellation was requested');
@@ -346,6 +381,20 @@ function resolveContextUserId(context: JobContext): string {
 function hasImplicitSpaceAccess(role: string | undefined): boolean {
   const normalizedRole = role === undefined ? undefined : normalizeRole(role);
   return normalizedRole === ROLES.OWNER || normalizedRole === ROLES.ADMIN;
+}
+
+function hasAuditViewAccess(role: string | undefined, permissions: string[] | undefined): boolean {
+  if (permissions?.includes(AUDIT_VIEW_PERMISSION) === true) {
+    return true;
+  }
+
+  const normalizedRole = role === undefined ? undefined : normalizeRole(role);
+  if (normalizedRole === undefined) {
+    return false;
+  }
+
+  const rolePermissions = ROLE_PERMISSIONS[normalizedRole] as readonly string[];
+  return rolePermissions.includes(AUDIT_VIEW_PERMISSION);
 }
 
 function normalizeFilterValue(value: string | undefined): string | undefined {

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -106,6 +106,10 @@ export class JobsService {
     const job = await this.getAccessibleJob(jobId, context, 'cancel');
     const jobStatus = normalizeJobStatus(job.status);
 
+    if (jobStatus === undefined) {
+      throwJobConflict(`Unknown job status: ${job.status}`);
+    }
+
     if (jobStatus === JobStatus.CANCELLED) {
       return toCancelJobResponse(job);
     }
@@ -317,6 +321,10 @@ export class JobsService {
     const current = await this.getAccessibleJob(jobId, context, 'cancel');
     const currentStatus = normalizeJobStatus(current.status);
 
+    if (currentStatus === undefined) {
+      throwJobConflict(`Unknown job status: ${current.status}`);
+    }
+
     if (currentStatus === JobStatus.CANCELLED) {
       return toCancelJobResponse(current);
     }
@@ -333,6 +341,7 @@ export class JobsService {
       (currentStatus === JobStatus.PENDING || currentStatus === JobStatus.RUNNING) &&
       retryCount < MAX_CANCELLATION_RETRIES
     ) {
+      await delay(50 * (retryCount + 1));
       return this.cancelJobInternal(jobId, context, retryCount + 1);
     }
 
@@ -404,6 +413,10 @@ function normalizeFilterValue(value: string | undefined): string | undefined {
 
   const normalized = value.trim();
   return normalized.length > 0 ? normalized : undefined;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function normalizeJobStatus(status: string): JobStatus | undefined {

--- a/apps/api/src/users/__tests__/user-group-service-test-utils.ts
+++ b/apps/api/src/users/__tests__/user-group-service-test-utils.ts
@@ -41,6 +41,8 @@ export class ScriptedDb {
   readonly updates: OperationRecord[] = [];
   readonly deletes: OperationRecord[] = [];
   readonly selectFields: unknown[] = [];
+  readonly limitCalls: number[] = [];
+  readonly offsetCalls: number[] = [];
   readonly selectResults: unknown[][] = [];
   readonly insertResults: unknown[][] = [];
   readonly updateResults: unknown[][] = [];
@@ -77,7 +79,7 @@ export class ScriptedDb {
 
   select(fields?: unknown): ScriptedQueryBuilder {
     this.selectFields.push(fields);
-    return new ScriptedQueryBuilder(this.selectResults.shift() ?? []);
+    return new ScriptedQueryBuilder(this, this.selectResults.shift() ?? []);
   }
 
   insert(table?: unknown): { values: (value: unknown) => ScriptedMutationBuilder } {
@@ -108,7 +110,10 @@ export class ScriptedDb {
 }
 
 export class ScriptedQueryBuilder implements PromiseLike<unknown[]> {
-  constructor(private readonly result: unknown[]) {}
+  constructor(
+    private readonly db: ScriptedDb,
+    private readonly result: unknown[],
+  ) {}
 
   from(): this {
     return this;
@@ -130,11 +135,13 @@ export class ScriptedQueryBuilder implements PromiseLike<unknown[]> {
     return this;
   }
 
-  limit(): this {
+  limit(limit: number): this {
+    this.db.limitCalls.push(limit);
     return this;
   }
 
-  offset(): Promise<unknown[]> {
+  offset(offset: number): Promise<unknown[]> {
+    this.db.offsetCalls.push(offset);
     return Promise.resolve(this.result);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@cherrygraph/auth-core':
         specifier: workspace:*
         version: link:../../packages/auth-core
+      '@cherrygraph/job-core':
+        specifier: workspace:*
+        version: link:../../packages/job-core
       '@cherrygraph/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## Summary
- Implement user-facing Job API: GET job details, GET event timeline, POST cancel
- Implement admin GET /api/admin/jobs with pagination/sort/filters
- Creator-or-space permission checks + admin:audit_view access
- Idempotent cancel with race-safe retry + backoff
- Events endpoint paginated (default 100, max 500)

## Test plan
- [x] Build + Lint pass
- [x] 284 tests pass (48 test files)

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `bf41093ff12e8de378a9b1430e5e0aeee01b7a59`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/59#issuecomment-4350687082) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/59#issuecomment-4350687269)
- Key findings addressed: Cancel race retry, auditor detail access, events pagination, unknown status guard, retry backoff

Closes #51