### PR TITLE
feat(api): implement internal worker API (#52)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "@nestjs/common": "^11.1.19",
     "@nestjs/core": "^11.1.19",
     "@nestjs/platform-fastify": "^11.1.19",
+    "@nestjs/schedule": "^6.1.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "drizzle-orm": "^0.45.2",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './auth/auth.module.js';
 import { DrizzleModule } from './database/drizzle.module.js';
 import { GroupModule } from './groups/group.module.js';
 import { HealthModule } from './health/health.module.js';
+import { InternalModule } from './internal/internal.module.js';
 import { JobsModule } from './jobs/jobs.module.js';
 import { ModelConfigModule } from './models/model-config.module.js';
 import { SpaceModule } from './spaces/space.module.js';
@@ -27,6 +28,7 @@ import { UserModule } from './users/user.module.js';
     GroupModule,
     SpaceModule,
     JobsModule,
+    InternalModule,
     ModelConfigModule,
     StorageModule,
     HealthModule,

--- a/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
+++ b/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
@@ -1,0 +1,344 @@
+import {
+  JobEventRepository,
+  JobRepository,
+  JobStateMachine,
+  JobStatus,
+  RedisJobLock,
+  type JobRow,
+} from '@cherrygraph/job-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { InternalJobsService } from '../internal-jobs.service.js';
+
+describe('InternalJobsService', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('polls pending jobs by type and returns an empty array when none exist', async () => {
+    const service = createService();
+    const findPendingByTypeSpy = vi.spyOn(JobRepository, 'findPendingByType').mockResolvedValueOnce([createJobRow()]);
+
+    await expect(service.pollPendingJobs('graphify', 2)).resolves.toEqual([
+      expect.objectContaining({
+        job_id: 'job-1',
+        type: 'graphify',
+        status: JobStatus.PENDING,
+      }),
+    ]);
+    expect(findPendingByTypeSpy).toHaveBeenCalledWith(expect.anything(), '', 'graphify', 2);
+
+    findPendingByTypeSpy.mockResolvedValueOnce([]);
+    await expect(service.pollPendingJobs('graphify', 1)).resolves.toEqual([]);
+  });
+
+  it('records progress for the worker that owns the running job', async () => {
+    const service = createService();
+    vi.spyOn(JobRepository, 'findById').mockResolvedValue(
+      createJobRow({
+        status: JobStatus.RUNNING,
+        locked_by: 'worker-1',
+        locked_at: new Date('2026-04-30T11:55:00.000Z'),
+        started_at: new Date('2026-04-30T11:55:00.000Z'),
+      }),
+    );
+    vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(true);
+    const eventSpy = vi
+      .spyOn(JobEventRepository, 'create')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+
+    const result = await service.reportProgress('job-1', {
+      worker_id: 'worker-1',
+      percent: 45,
+      stage: 'chunking',
+    });
+
+    expect(result).toMatchObject({
+      job_id: 'job-1',
+      status: JobStatus.RUNNING,
+      progress: {
+        percent: 45,
+        stage: 'chunking',
+      },
+    });
+    expect(eventSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        job_id: 'job-1',
+        event_type: 'progress_updated',
+        detail_json: {
+          percent: 45,
+          stage: 'chunking',
+        },
+      }),
+    );
+  });
+
+  it('rejects progress reports when the worker does not own the job lock', async () => {
+    const service = createService();
+    vi.spyOn(JobRepository, 'findById').mockResolvedValue(
+      createJobRow({
+        status: JobStatus.RUNNING,
+        locked_by: 'worker-2',
+        locked_at: new Date('2026-04-30T11:55:00.000Z'),
+        started_at: new Date('2026-04-30T11:55:00.000Z'),
+      }),
+    );
+
+    await expect(
+      service.reportProgress('job-1', {
+        worker_id: 'worker-1',
+        percent: 50,
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it('transitions a running job to succeeded, releases the lock, and writes an event', async () => {
+    const service = createService();
+    const runningJob = createJobRow({
+      status: JobStatus.RUNNING,
+      locked_by: 'worker-1',
+      locked_at: new Date('2026-04-30T11:55:00.000Z'),
+      started_at: new Date('2026-04-30T11:55:00.000Z'),
+    });
+    const completedJob = createJobRow({
+      status: JobStatus.SUCCEEDED,
+      locked_by: null,
+      locked_at: null,
+      result_json: { output: 'done' },
+      completed_at: new Date('2026-04-30T12:00:00.000Z'),
+      started_at: new Date('2026-04-30T11:55:00.000Z'),
+    });
+
+    vi.spyOn(JobRepository, 'findById').mockResolvedValue(runningJob);
+    vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(true);
+    const transitionSpy = vi.spyOn(JobStateMachine, 'transition').mockResolvedValue(completedJob);
+    const eventSpy = vi
+      .spyOn(JobEventRepository, 'create')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+    const releaseSpy = vi.spyOn(RedisJobLock, 'release').mockResolvedValue(true);
+
+    const result = await service.reportComplete('job-1', {
+      worker_id: 'worker-1',
+      result_json: { output: 'done' },
+    });
+
+    expect(result).toMatchObject({
+      job_id: 'job-1',
+      status: JobStatus.SUCCEEDED,
+      result_json: { output: 'done' },
+    });
+    expect(transitionSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'job-1',
+      JobStatus.RUNNING,
+      JobStatus.SUCCEEDED,
+      expect.objectContaining({
+        result_json: { output: 'done' },
+        locked_by: null,
+        locked_at: null,
+      }),
+    );
+    expect(eventSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        job_id: 'job-1',
+        event_type: 'status_changed',
+      }),
+    );
+    expect(releaseSpy).toHaveBeenCalledWith(expect.anything(), 'job-1', 'worker-1');
+  });
+
+  it('fails a running job and schedules a retry when attempts remain', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T12:00:00.000Z'));
+
+    const service = createService();
+    const runningJob = createJobRow({
+      status: JobStatus.RUNNING,
+      attempt_count: 0,
+      max_attempts: 3,
+      locked_by: 'worker-1',
+      locked_at: new Date('2026-04-30T11:55:00.000Z'),
+      started_at: new Date('2026-04-30T11:55:00.000Z'),
+    });
+    const failedJob = createJobRow({
+      status: JobStatus.FAILED,
+      attempt_count: 1,
+      locked_by: null,
+      locked_at: null,
+      error_json: { code: 'PARSE_ERROR', message: 'boom' },
+      completed_at: new Date('2026-04-30T12:00:00.000Z'),
+      started_at: new Date('2026-04-30T11:55:00.000Z'),
+    });
+    const retriedJob = createJobRow({
+      status: JobStatus.PENDING,
+      attempt_count: 1,
+      locked_by: null,
+      locked_at: null,
+      next_run_at: new Date('2026-04-30T12:01:00.000Z'),
+      error_json: { code: 'PARSE_ERROR', message: 'boom' },
+      completed_at: null,
+      started_at: null,
+    });
+
+    vi.spyOn(JobRepository, 'findById').mockResolvedValue(runningJob);
+    vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(true);
+    const transitionSpy = vi
+      .spyOn(JobStateMachine, 'transition')
+      .mockResolvedValueOnce(failedJob)
+      .mockResolvedValueOnce(retriedJob);
+    const eventSpy = vi
+      .spyOn(JobEventRepository, 'create')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+    vi.spyOn(RedisJobLock, 'release').mockResolvedValue(true);
+
+    const result = await service.reportFailure('job-1', {
+      worker_id: 'worker-1',
+      error_json: { code: 'PARSE_ERROR', message: 'boom' },
+      retryable: true,
+    });
+
+    expect(result.job).toMatchObject({
+      job_id: 'job-1',
+      status: JobStatus.PENDING,
+    });
+    expect(result.will_retry).toBe(true);
+    expect(transitionSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      'job-1',
+      JobStatus.RUNNING,
+      JobStatus.FAILED,
+      expect.objectContaining({
+        attempt_count: 1,
+        error_json: { code: 'PARSE_ERROR', message: 'boom' },
+      }),
+    );
+    expect(transitionSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      'job-1',
+      JobStatus.FAILED,
+      JobStatus.PENDING,
+      expect.objectContaining({
+        next_run_at: retriedJob.next_run_at,
+      }),
+    );
+    expect(eventSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns cancel_requested jobs on heartbeat', async () => {
+    const db = new SelectableDb([{ job_id: 'job-1' }, { job_id: 'job-2' }]);
+    const redis = createRedisMock();
+    const service = new InternalJobsService(db.asDb() as never, redis.asClient() as never);
+    const renewSpy = vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(true);
+
+    const result = await service.recordHeartbeat({
+      worker_id: 'worker-1',
+      active_jobs: ['job-1', 'job-2'],
+      system_info: { cpu_percent: 10 },
+    });
+
+    expect(result).toEqual({
+      ack: true,
+      cancel_requested: ['job-1', 'job-2'],
+    });
+    expect(redis.values.get('worker:heartbeat:worker-1')).toContain('"seen_at"');
+    expect(renewSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+function createService(): InternalJobsService {
+  return new InternalJobsService(createTransactionalDb() as never, createRedisMock().asClient() as never);
+}
+
+function createTransactionalDb(): {
+  transaction: <T>(callback: (tx: unknown) => Promise<T>) => Promise<T>;
+} {
+  return {
+    transaction: async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => callback({}),
+  };
+}
+
+class SelectableDb {
+  constructor(private readonly rows: Array<{ job_id: string }>) {}
+
+  select(): this {
+    return this;
+  }
+
+  from(): this {
+    return this;
+  }
+
+  where(): Promise<Array<{ job_id: string }>> {
+    return Promise.resolve(this.rows);
+  }
+
+  asDb(): unknown {
+    return this;
+  }
+}
+
+class RedisMemoryStore {
+  readonly values = new Map<string, string>();
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  set(key: string, value: string): Promise<'OK'> {
+    this.values.set(key, value);
+    return Promise.resolve('OK');
+  }
+
+  eval(): Promise<number> {
+    return Promise.resolve(1);
+  }
+
+  asClient(): {
+    get: (key: string) => Promise<string | null>;
+    set: (key: string, value: string, ...args: Array<string | number>) => Promise<string | null>;
+    eval: (script: string, numKeys: number, ...args: Array<string | number>) => Promise<number>;
+  } {
+    return {
+      get: this.get.bind(this),
+      set: async (key: string, value: string): Promise<string | null> => this.set(key, value),
+      eval: this.eval.bind(this),
+    };
+  }
+}
+
+function createRedisMock(): RedisMemoryStore {
+  return new RedisMemoryStore();
+}
+
+function createJobRow(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    queue_name: 'graphify',
+    type: 'graphify',
+    priority: 100,
+    status: JobStatus.PENDING,
+    attempt_count: 0,
+    max_attempts: 3,
+    timeout_seconds: 600,
+    locked_by: null,
+    locked_at: null,
+    next_run_at: null,
+    cancel_requested_at: null,
+    payload_json: { source_id: 'source-1' },
+    result_json: null,
+    error_json: null,
+    idempotency_key: null,
+    created_by: 'user-1',
+    created_at: new Date('2026-04-30T11:50:00.000Z'),
+    started_at: null,
+    completed_at: null,
+    ...overrides,
+  };
+}

--- a/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
+++ b/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
@@ -94,6 +94,41 @@ describe('InternalJobsService', () => {
     ).rejects.toMatchObject({ status: 409 });
   });
 
+  it('rolls back pending job activation when the worker loses the Redis lock before commit', async () => {
+    const service = createService();
+    const runningJob = createJobRow({
+      status: JobStatus.RUNNING,
+      locked_by: 'worker-1',
+      locked_at: new Date('2026-04-30T11:55:00.000Z'),
+      started_at: new Date('2026-04-30T11:55:00.000Z'),
+    });
+
+    vi.spyOn(JobRepository, 'findById').mockResolvedValue(createJobRow());
+    const transitionSpy = vi.spyOn(JobStateMachine, 'transition').mockResolvedValue(runningJob);
+    const eventSpy = vi
+      .spyOn(JobEventRepository, 'create')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+    vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(false);
+
+    await expect(
+      service.reportProgress('job-1', {
+        worker_id: 'worker-1',
+        percent: 10,
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+
+    expect(transitionSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'job-1',
+      JobStatus.PENDING,
+      JobStatus.RUNNING,
+      expect.objectContaining({
+        locked_by: 'worker-1',
+      }),
+    );
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
+
   it('transitions a running job to succeeded, releases the lock, and writes an event', async () => {
     const service = createService();
     const runningJob = createJobRow({
@@ -244,8 +279,27 @@ describe('InternalJobsService', () => {
     expect(result).toEqual({
       ack: true,
       cancel_requested: ['job-1', 'job-2'],
+      lost_locks: [],
     });
     expect(redis.values.get('worker:heartbeat:worker-1')).toContain('"seen_at"');
+    expect(renewSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns lost_locks when heartbeat renewals fail', async () => {
+    const db = new SelectableDb([{ job_id: 'job-1' }, { job_id: 'job-2' }]);
+    const service = new InternalJobsService(db.asDb() as never, createRedisMock().asClient() as never);
+    const renewSpy = vi.spyOn(RedisJobLock, 'renew').mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const result = await service.recordHeartbeat({
+      worker_id: 'worker-1',
+      active_jobs: ['job-1', 'job-2', 'job-2'],
+    });
+
+    expect(result).toEqual({
+      ack: true,
+      cancel_requested: ['job-1', 'job-2'],
+      lost_locks: ['job-2'],
+    });
     expect(renewSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
+++ b/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
@@ -11,12 +11,21 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { InternalJobsService } from '../internal-jobs.service.js';
 
 describe('InternalJobsService', () => {
+  const originalDefaultTenantId = process.env.DEFAULT_TENANT_ID;
+
   afterEach(() => {
+    if (originalDefaultTenantId === undefined) {
+      delete process.env.DEFAULT_TENANT_ID;
+    } else {
+      process.env.DEFAULT_TENANT_ID = originalDefaultTenantId;
+    }
+
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
   it('polls pending jobs by type and returns an empty array when none exist', async () => {
+    delete process.env.DEFAULT_TENANT_ID;
     const service = createService();
     const findPendingByTypeSpy = vi.spyOn(JobRepository, 'findPendingByType').mockResolvedValueOnce([createJobRow()]);
 
@@ -27,7 +36,7 @@ describe('InternalJobsService', () => {
         status: JobStatus.PENDING,
       }),
     ]);
-    expect(findPendingByTypeSpy).toHaveBeenCalledWith(expect.anything(), '', 'graphify', 2);
+    expect(findPendingByTypeSpy).toHaveBeenCalledWith(expect.anything(), 'default', 'graphify', 2);
 
     findPendingByTypeSpy.mockResolvedValueOnce([]);
     await expect(service.pollPendingJobs('graphify', 1)).resolves.toEqual([]);
@@ -265,7 +274,7 @@ describe('InternalJobsService', () => {
   });
 
   it('returns cancel_requested jobs on heartbeat', async () => {
-    const db = new SelectableDb([{ job_id: 'job-1' }, { job_id: 'job-2' }]);
+    const db = createDb([{ job_id: 'job-1' }, { job_id: 'job-2' }]);
     const redis = createRedisMock();
     const service = new InternalJobsService(db.asDb() as never, redis.asClient() as never);
     const renewSpy = vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(true);
@@ -286,7 +295,7 @@ describe('InternalJobsService', () => {
   });
 
   it('returns lost_locks when heartbeat renewals fail', async () => {
-    const db = new SelectableDb([{ job_id: 'job-1' }, { job_id: 'job-2' }]);
+    const db = createDb([{ job_id: 'job-1' }, { job_id: 'job-2' }]);
     const service = new InternalJobsService(db.asDb() as never, createRedisMock().asClient() as never);
     const renewSpy = vi.spyOn(RedisJobLock, 'renew').mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
@@ -302,22 +311,188 @@ describe('InternalJobsService', () => {
     });
     expect(renewSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('scanDeadWorkers finds stale workers and fails their jobs in a transaction', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T12:00:00.000Z'));
+
+    const db = createDb([
+      createJobRow({
+        status: JobStatus.RUNNING,
+        locked_by: 'worker-1',
+        locked_at: new Date('2026-04-30T11:55:00.000Z'),
+        started_at: new Date('2026-04-30T11:55:00.000Z'),
+        max_attempts: 1,
+      }),
+    ]);
+    const transactionSpy = vi.spyOn(db, 'transaction');
+    const redis = createRedisMock();
+    redis.values.set('worker:heartbeat:worker-1', JSON.stringify({ seen_at: '2026-04-30T11:58:00.000Z' }));
+    const service = new InternalJobsService(db.asDb() as never, redis.asClient() as never);
+    const transitionSpy = vi
+      .spyOn(JobStateMachine, 'transition')
+      .mockResolvedValue(createJobRow({ status: JobStatus.FAILED, attempt_count: 1 }));
+    const eventSpy = vi
+      .spyOn(JobEventRepository, 'create')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+    const releaseSpy = vi.spyOn(RedisJobLock, 'release').mockResolvedValue(true);
+
+    await expect(service.scanDeadWorkers()).resolves.toBe(1);
+
+    expect(transactionSpy).toHaveBeenCalledTimes(1);
+    expect(transitionSpy).toHaveBeenCalledTimes(1);
+    expect(transitionSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'job-1',
+      JobStatus.RUNNING,
+      JobStatus.FAILED,
+      expect.objectContaining({
+        attempt_count: 1,
+        locked_by: null,
+        locked_at: null,
+      }),
+    );
+    expect(eventSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        job_id: 'job-1',
+        event_type: 'timeout_detected',
+        detail_json: {
+          worker_id: 'worker-1',
+          locked_at: '2026-04-30T11:55:00.000Z',
+          last_heartbeat_at: '2026-04-30T11:58:00.000Z',
+          reason: 'worker_missed_heartbeat',
+        },
+      }),
+    );
+    expect(releaseSpy).toHaveBeenCalledWith(expect.anything(), 'job-1', 'worker-1');
+  });
+
+  it('scanDeadWorkers skips workers with recent heartbeats', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T12:00:00.000Z'));
+
+    const db = createDb([
+      createJobRow({
+        status: JobStatus.RUNNING,
+        locked_by: 'worker-1',
+        locked_at: new Date('2026-04-30T11:50:00.000Z'),
+        started_at: new Date('2026-04-30T11:50:00.000Z'),
+      }),
+    ]);
+    const transactionSpy = vi.spyOn(db, 'transaction');
+    const redis = createRedisMock();
+    redis.values.set('worker:heartbeat:worker-1', JSON.stringify({ seen_at: '2026-04-30T11:59:30.000Z' }));
+    const service = new InternalJobsService(db.asDb() as never, redis.asClient() as never);
+    const transitionSpy = vi.spyOn(JobStateMachine, 'transition').mockResolvedValue(createJobRow());
+
+    await expect(service.scanDeadWorkers()).resolves.toBe(0);
+
+    expect(transactionSpy).not.toHaveBeenCalled();
+    expect(transitionSpy).not.toHaveBeenCalled();
+  });
+
+  it('scanDeadWorkers retries eligible jobs for dead workers', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T12:00:00.000Z'));
+
+    const db = createDb([
+      createJobRow({
+        status: JobStatus.RUNNING,
+        locked_by: 'worker-1',
+        locked_at: new Date('2026-04-30T11:55:00.000Z'),
+        started_at: new Date('2026-04-30T11:55:00.000Z'),
+        attempt_count: 0,
+        max_attempts: 3,
+      }),
+    ]);
+    const transactionSpy = vi.spyOn(db, 'transaction');
+    const redis = createRedisMock();
+    redis.values.set('worker:heartbeat:worker-1', JSON.stringify({ seen_at: '2026-04-30T11:58:00.000Z' }));
+    const service = new InternalJobsService(db.asDb() as never, redis.asClient() as never);
+    const failedJob = createJobRow({
+      status: JobStatus.FAILED,
+      attempt_count: 1,
+      locked_by: null,
+      locked_at: null,
+      error_json: { code: 'WORKER_TIMEOUT', message: 'Worker heartbeat timed out' },
+      completed_at: new Date('2026-04-30T12:00:00.000Z'),
+      started_at: new Date('2026-04-30T11:55:00.000Z'),
+    });
+    const retriedJob = createJobRow({
+      status: JobStatus.PENDING,
+      attempt_count: 1,
+      locked_by: null,
+      locked_at: null,
+      next_run_at: new Date('2026-04-30T12:01:00.000Z'),
+      error_json: { code: 'WORKER_TIMEOUT', message: 'Worker heartbeat timed out' },
+      completed_at: null,
+      started_at: null,
+    });
+    const transitionSpy = vi
+      .spyOn(JobStateMachine, 'transition')
+      .mockResolvedValueOnce(failedJob)
+      .mockResolvedValueOnce(retriedJob);
+    const eventSpy = vi
+      .spyOn(JobEventRepository, 'create')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+    vi.spyOn(RedisJobLock, 'release').mockResolvedValue(true);
+
+    await expect(service.scanDeadWorkers()).resolves.toBe(1);
+
+    expect(transactionSpy).toHaveBeenCalledTimes(1);
+    expect(transitionSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      'job-1',
+      JobStatus.RUNNING,
+      JobStatus.FAILED,
+      expect.objectContaining({
+        attempt_count: 1,
+      }),
+    );
+    expect(transitionSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      'job-1',
+      JobStatus.FAILED,
+      JobStatus.PENDING,
+      expect.objectContaining({
+        next_run_at: new Date('2026-04-30T12:01:00.000Z'),
+      }),
+    );
+    expect(eventSpy).toHaveBeenCalledTimes(3);
+    expect(eventSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        job_id: 'job-1',
+        event_type: 'status_changed',
+        detail_json: {
+          from: JobStatus.FAILED,
+          to: JobStatus.PENDING,
+          worker_id: 'worker-1',
+          reason: 'worker_timeout_retry',
+          next_run_at: '2026-04-30T12:01:00.000Z',
+        },
+      }),
+    );
+  });
 });
 
 function createService(): InternalJobsService {
-  return new InternalJobsService(createTransactionalDb() as never, createRedisMock().asClient() as never);
+  return new InternalJobsService(createDb().asDb() as never, createRedisMock().asClient() as never);
 }
 
-function createTransactionalDb(): {
-  transaction: <T>(callback: (tx: unknown) => Promise<T>) => Promise<T>;
-} {
-  return {
-    transaction: async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => callback({}),
-  };
+function createDb<Row = unknown>(rows: Row[] = []): TestDb<Row> {
+  return new TestDb(rows);
 }
 
-class SelectableDb {
-  constructor(private readonly rows: Array<{ job_id: string }>) {}
+class TestDb<Row = unknown> {
+  constructor(private readonly rows: Row[]) {}
+
+  async transaction<T>(callback: (tx: unknown) => Promise<T>): Promise<T> {
+    return callback(this);
+  }
 
   select(): this {
     return this;
@@ -327,7 +502,7 @@ class SelectableDb {
     return this;
   }
 
-  where(): Promise<Array<{ job_id: string }>> {
+  where(): Promise<Row[]> {
     return Promise.resolve(this.rows);
   }
 

--- a/apps/api/src/internal/__tests__/internal.dto.test.ts
+++ b/apps/api/src/internal/__tests__/internal.dto.test.ts
@@ -1,0 +1,53 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { describe, expect, it } from 'vitest';
+
+import { WorkerHeartbeatDto } from '../internal.dto.js';
+
+describe('WorkerHeartbeatDto', () => {
+  it('accepts bounded active_jobs and system_info payloads', async () => {
+    const dto = plainToInstance(WorkerHeartbeatDto, {
+      worker_id: 'worker-1',
+      active_jobs: Array.from({ length: 50 }, (_, index) => `job-${index + 1}`),
+      system_info: {
+        hostname: 'worker-host-1',
+        stats: {
+          cpu_percent: 12,
+          memory_percent: 34,
+        },
+      },
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('rejects heartbeats with too many active jobs', async () => {
+    const dto = plainToInstance(WorkerHeartbeatDto, {
+      worker_id: 'worker-1',
+      active_jobs: Array.from({ length: 51 }, (_, index) => `job-${index + 1}`),
+    });
+
+    await expect(validate(dto)).resolves.not.toHaveLength(0);
+  });
+
+  it('rejects overly deep system_info payloads', async () => {
+    const dto = plainToInstance(WorkerHeartbeatDto, {
+      worker_id: 'worker-1',
+      system_info: {
+        level1: {
+          level2: {
+            level3: {
+              level4: {
+                cpu_percent: 10,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await expect(validate(dto)).resolves.not.toHaveLength(0);
+  });
+});

--- a/apps/api/src/internal/__tests__/worker-api-key.guard.test.ts
+++ b/apps/api/src/internal/__tests__/worker-api-key.guard.test.ts
@@ -1,6 +1,6 @@
 import { HttpException } from '@nestjs/common';
 import type { ExecutionContext } from '@nestjs/common';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { WorkerApiKeyGuard } from '../worker-api-key.guard.js';
 
@@ -13,6 +13,8 @@ describe('WorkerApiKeyGuard', () => {
     } else {
       process.env.WORKER_API_KEY = originalWorkerApiKey;
     }
+
+    vi.restoreAllMocks();
   });
 
   it('allows requests with the configured worker key', () => {

--- a/apps/api/src/internal/__tests__/worker-api-key.guard.test.ts
+++ b/apps/api/src/internal/__tests__/worker-api-key.guard.test.ts
@@ -1,0 +1,48 @@
+import { HttpException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { WorkerApiKeyGuard } from '../worker-api-key.guard.js';
+
+describe('WorkerApiKeyGuard', () => {
+  const originalWorkerApiKey = process.env.WORKER_API_KEY;
+
+  afterEach(() => {
+    if (originalWorkerApiKey === undefined) {
+      delete process.env.WORKER_API_KEY;
+    } else {
+      process.env.WORKER_API_KEY = originalWorkerApiKey;
+    }
+  });
+
+  it('allows requests with the configured worker key', () => {
+    process.env.WORKER_API_KEY = 'secret-worker-key';
+    const guard = new WorkerApiKeyGuard();
+
+    expect(guard.canActivate(createContext('secret-worker-key'))).toBe(true);
+  });
+
+  it.each([undefined, 'wrong-key'])('rejects requests with missing or invalid keys', (workerKey) => {
+    process.env.WORKER_API_KEY = 'secret-worker-key';
+    const guard = new WorkerApiKeyGuard();
+
+    expect(() => guard.canActivate(createContext(workerKey))).toThrowError(HttpException);
+
+    try {
+      guard.canActivate(createContext(workerKey));
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpException);
+      expect((error as HttpException).getStatus()).toBe(401);
+    }
+  });
+});
+
+function createContext(workerKey?: string): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        headers: workerKey === undefined ? {} : { 'x-worker-key': workerKey },
+      }),
+    }),
+  } as unknown as ExecutionContext;
+}

--- a/apps/api/src/internal/__tests__/worker-api-key.guard.test.ts
+++ b/apps/api/src/internal/__tests__/worker-api-key.guard.test.ts
@@ -2,6 +2,7 @@ import { HttpException } from '@nestjs/common';
 import type { ExecutionContext } from '@nestjs/common';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { getApiLogger } from '../../common/logger/logger.module.js';
 import { WorkerApiKeyGuard } from '../worker-api-key.guard.js';
 
 describe('WorkerApiKeyGuard', () => {
@@ -36,6 +37,18 @@ describe('WorkerApiKeyGuard', () => {
       expect(error).toBeInstanceOf(HttpException);
       expect((error as HttpException).getStatus()).toBe(401);
     }
+  });
+
+  it('warns when WORKER_API_KEY is not configured', () => {
+    delete process.env.WORKER_API_KEY;
+    const warnSpy = vi.spyOn(getApiLogger(), 'warn').mockImplementation(() => undefined);
+
+    new WorkerApiKeyGuard();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      { worker_api_key_present: false },
+      'WORKER_API_KEY is not configured; internal worker endpoints will reject all requests',
+    );
   });
 });
 

--- a/apps/api/src/internal/internal-jobs.controller.ts
+++ b/apps/api/src/internal/internal-jobs.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Get, Param, Patch, Query, UseGuards } from '@nestjs/common';
+import { Public } from '@cherrygraph/auth-core';
+
+import type { JobDto } from '../jobs/jobs.dto.js';
+import { InternalJobsService } from './internal-jobs.service.js';
+import { type JobFailureResponseDto, JobCompletionDto, JobFailureDto, JobProgressUpdateDto, PendingJobsQueryDto } from './internal.dto.js';
+import { WorkerApiKeyGuard } from './worker-api-key.guard.js';
+
+@Public()
+@UseGuards(WorkerApiKeyGuard)
+@Controller('internal/jobs')
+export class InternalJobsController {
+  constructor(private readonly internalJobsService: InternalJobsService) {}
+
+  @Get('pending')
+  async getPendingJobs(@Query() query: PendingJobsQueryDto): Promise<JobDto[]> {
+    return this.internalJobsService.pollPendingJobs(query.type, query.limit);
+  }
+
+  @Patch(':job_id/progress')
+  async reportProgress(
+    @Param('job_id') jobId: string,
+    @Body() body: JobProgressUpdateDto,
+  ): Promise<JobDto> {
+    return this.internalJobsService.reportProgress(jobId, body);
+  }
+
+  @Patch(':job_id/complete')
+  async reportComplete(
+    @Param('job_id') jobId: string,
+    @Body() body: JobCompletionDto,
+  ): Promise<JobDto> {
+    return this.internalJobsService.reportComplete(jobId, body);
+  }
+
+  @Patch(':job_id/fail')
+  async reportFailure(
+    @Param('job_id') jobId: string,
+    @Body() body: JobFailureDto,
+  ): Promise<JobFailureResponseDto> {
+    return this.internalJobsService.reportFailure(jobId, body);
+  }
+}

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -38,7 +38,7 @@ type StoredWorkerHeartbeat = {
   system_info?: Record<string, unknown>;
 };
 
-const DEAD_WORKER_SCAN_INTERVAL_MS = 60_000;
+const DEAD_WORKER_SCAN_INTERVAL_MS = 30_000;
 const DEAD_WORKER_THRESHOLD_MS = 90_000;
 const DEFAULT_LOCK_TTL_SECONDS = 600;
 const HEARTBEAT_TTL_SECONDS = 180;
@@ -61,7 +61,6 @@ export class InternalJobsService {
     const progress = toProgressDto(input.percent, input.stage);
 
     if (isJobStatus(job.status, JobStatus.PENDING)) {
-      await this.assertPendingJobOwner(job.id, input.worker_id);
       await this.touchWorkerHeartbeat(input.worker_id);
 
       try {
@@ -76,6 +75,8 @@ export class InternalJobsService {
             error_json: null,
             result_json: null,
           });
+
+          await this.renewOwnedJobLock(job.id, input.worker_id);
 
           await JobEventRepository.create(txDb, {
             job_id: job.id,
@@ -222,17 +223,12 @@ export class InternalJobsService {
 
   async recordHeartbeat(input: WorkerHeartbeatDto): Promise<WorkerHeartbeatResponseDto> {
     await this.touchWorkerHeartbeat(input.worker_id, input.system_info);
+    const lostLocks: string[] = [];
 
     if (input.active_jobs !== undefined && input.active_jobs.length > 0) {
       for (const jobId of new Set(input.active_jobs)) {
-        try {
-          await this.renewOwnedJobLock(jobId, input.worker_id);
-        } catch (error) {
-          if (isConflictHttpException(error)) {
-            continue;
-          }
-
-          throw error;
+        if (!(await this.tryRenewOwnedJobLock(jobId, input.worker_id))) {
+          lostLocks.push(jobId);
         }
       }
     }
@@ -240,6 +236,7 @@ export class InternalJobsService {
     return {
       ack: true,
       cancel_requested: await this.getCancelRequestedJobIds(input.worker_id, input.active_jobs),
+      lost_locks: lostLocks,
     };
   }
 
@@ -304,20 +301,13 @@ export class InternalJobsService {
     }
   }
 
-  private async assertPendingJobOwner(jobId: string, workerId: string): Promise<void> {
+  private async tryRenewOwnedJobLock(jobId: string, workerId: string): Promise<boolean> {
     const redis = this.getRequiredRedis();
-    const owner = await redis.get(RedisJobLock.key(jobId));
-
-    if (owner !== workerId) {
-      throwApiError(ErrorCode.CONFLICT, 'Job not owned by this worker', HttpStatus.CONFLICT);
-    }
+    return RedisJobLock.renew(redis, jobId, workerId, DEFAULT_LOCK_TTL_SECONDS);
   }
 
   private async renewOwnedJobLock(jobId: string, workerId: string): Promise<void> {
-    const redis = this.getRequiredRedis();
-    const renewed = await RedisJobLock.renew(redis, jobId, workerId, DEFAULT_LOCK_TTL_SECONDS);
-
-    if (!renewed) {
+    if (!(await this.tryRenewOwnedJobLock(jobId, workerId))) {
       throwApiError(ErrorCode.CONFLICT, 'Job not owned by this worker', HttpStatus.CONFLICT);
     }
   }
@@ -536,10 +526,6 @@ function isDeadWorker(jobsForWorker: JobRow[], lastHeartbeatAt: Date | null, now
   }, 0);
 
   return mostRecentActivityAt > 0 && now - mostRecentActivityAt > DEAD_WORKER_THRESHOLD_MS;
-}
-
-function isConflictHttpException(error: unknown): boolean {
-  return error instanceof HttpException && error.getStatus() === 409;
 }
 
 function isJobStatus(status: string, expected: JobStatus): boolean {

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -52,7 +52,12 @@ export class InternalJobsService {
   ) {}
 
   async pollPendingJobs(type: string, limit: number): Promise<JobDto[]> {
-    const pendingJobs = await JobRepository.findPendingByType(this.db, '', type, limit);
+    const pendingJobs = await JobRepository.findPendingByType(
+      this.db,
+      process.env.DEFAULT_TENANT_ID ?? 'default',
+      type,
+      limit,
+    );
     return pendingJobs.map((job) => toJobDto(job));
   }
 
@@ -371,61 +376,64 @@ export class InternalJobsService {
     const willRetry = nextAttemptCount < job.max_attempts;
 
     try {
-      const failedAt = new Date();
-      await JobStateMachine.transition(this.db, job.id, JobStatus.RUNNING, JobStatus.FAILED, {
-        attempt_count: nextAttemptCount,
-        error_json: {
-          code: 'WORKER_TIMEOUT',
-          message: 'Worker heartbeat timed out',
-        },
-        locked_by: null,
-        locked_at: null,
-        completed_at: failedAt,
-      });
-
-      await JobEventRepository.create(this.db, {
-        job_id: job.id,
-        event_type: 'status_changed',
-        detail_json: {
-          from: JobStatus.RUNNING,
-          to: JobStatus.FAILED,
-          worker_id: workerId,
-          retryable: willRetry,
-          reason: 'worker_timeout',
-        },
-      });
-
-      if (willRetry) {
-        const nextRunAt = new Date(Date.now() + getRetryDelaySeconds(nextAttemptCount) * 1_000);
-
-        await JobStateMachine.transition(this.db, job.id, JobStatus.FAILED, JobStatus.PENDING, {
-          next_run_at: nextRunAt,
-          started_at: null,
-          completed_at: null,
+      await this.db.transaction(async (tx) => {
+        const txDb = tx as JobsDatabase;
+        const failedAt = new Date();
+        await JobStateMachine.transition(txDb, job.id, JobStatus.RUNNING, JobStatus.FAILED, {
+          attempt_count: nextAttemptCount,
+          error_json: {
+            code: 'WORKER_TIMEOUT',
+            message: 'Worker heartbeat timed out',
+          },
+          locked_by: null,
+          locked_at: null,
+          completed_at: failedAt,
         });
 
-        await JobEventRepository.create(this.db, {
+        await JobEventRepository.create(txDb, {
           job_id: job.id,
           event_type: 'status_changed',
           detail_json: {
-            from: JobStatus.FAILED,
-            to: JobStatus.PENDING,
+            from: JobStatus.RUNNING,
+            to: JobStatus.FAILED,
             worker_id: workerId,
-            reason: 'worker_timeout_retry',
-            next_run_at: nextRunAt.toISOString(),
+            retryable: willRetry,
+            reason: 'worker_timeout',
           },
         });
-      }
 
-      await JobEventRepository.create(this.db, {
-        job_id: job.id,
-        event_type: 'timeout_detected',
-        detail_json: {
-          worker_id: workerId,
-          locked_at: job.locked_at?.toISOString() ?? null,
-          last_heartbeat_at: lastHeartbeatAt?.toISOString() ?? null,
-          reason: 'worker_missed_heartbeat',
-        },
+        if (willRetry) {
+          const nextRunAt = new Date(failedAt.getTime() + getRetryDelaySeconds(nextAttemptCount) * 1_000);
+
+          await JobStateMachine.transition(txDb, job.id, JobStatus.FAILED, JobStatus.PENDING, {
+            next_run_at: nextRunAt,
+            started_at: null,
+            completed_at: null,
+          });
+
+          await JobEventRepository.create(txDb, {
+            job_id: job.id,
+            event_type: 'status_changed',
+            detail_json: {
+              from: JobStatus.FAILED,
+              to: JobStatus.PENDING,
+              worker_id: workerId,
+              reason: 'worker_timeout_retry',
+              next_run_at: nextRunAt.toISOString(),
+            },
+          });
+        }
+
+        await JobEventRepository.create(txDb, {
+          job_id: job.id,
+          event_type: 'timeout_detected',
+          detail_json: {
+            worker_id: workerId,
+            locked_at: job.locked_at?.toISOString() ?? null,
+            last_heartbeat_at: lastHeartbeatAt?.toISOString() ?? null,
+            reason: 'worker_missed_heartbeat',
+          },
+        });
       });
 
       await this.releaseJobLock(job.id, workerId);

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -1,0 +1,547 @@
+import { HttpException, HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import {
+  JobConflictError,
+  JobEventRepository,
+  JobRepository,
+  JobStateMachine,
+  JobStatus,
+  RedisJobLock,
+  jobs,
+  type JobRow,
+} from '@cherrygraph/job-core';
+import { ErrorCode } from '@cherrygraph/shared';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { getApiLogger } from '../common/logger/logger.module.js';
+import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
+import { DRIZZLE } from '../database/drizzle.constants.js';
+import type {
+  JobCompletionDto,
+  JobFailureDto,
+  JobFailureResponseDto,
+  JobProgressUpdateDto,
+  WorkerHeartbeatDto,
+  WorkerHeartbeatResponseDto,
+} from './internal.dto.js';
+import type { JobDto, JobProgressDto } from '../jobs/jobs.dto.js';
+
+type JobsDatabase = NodePgDatabase;
+type InternalRedisClient = {
+  get: (key: string) => Promise<string | null>;
+  set: (key: string, value: string, ...args: Array<string | number>) => Promise<string | null>;
+  eval: (script: string, numKeys: number, ...args: Array<string | number>) => Promise<number | string | null>;
+};
+type StoredWorkerHeartbeat = {
+  seen_at: string;
+  system_info?: Record<string, unknown>;
+};
+
+const DEAD_WORKER_SCAN_INTERVAL_MS = 60_000;
+const DEAD_WORKER_THRESHOLD_MS = 90_000;
+const DEFAULT_LOCK_TTL_SECONDS = 600;
+const HEARTBEAT_TTL_SECONDS = 180;
+const MAX_RETRY_DELAY_SECONDS = 1_800;
+
+@Injectable()
+export class InternalJobsService {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: JobsDatabase,
+    @Optional() @Inject(REDIS_CLIENT) private readonly redis?: OptionalRedisClient,
+  ) {}
+
+  async pollPendingJobs(type: string, limit: number): Promise<JobDto[]> {
+    const pendingJobs = await JobRepository.findPendingByType(this.db, '', type, limit);
+    return pendingJobs.map((job) => toJobDto(job));
+  }
+
+  async reportProgress(jobId: string, input: JobProgressUpdateDto): Promise<JobDto> {
+    const job = await this.getJob(jobId);
+    const progress = toProgressDto(input.percent, input.stage);
+
+    if (isJobStatus(job.status, JobStatus.PENDING)) {
+      await this.assertPendingJobOwner(job.id, input.worker_id);
+      await this.touchWorkerHeartbeat(input.worker_id);
+
+      try {
+        const runningJob = await this.db.transaction(async (tx) => {
+          const txDb = tx as JobsDatabase;
+          const startedAt = new Date();
+          const nextJob = await JobStateMachine.transition(txDb, job.id, JobStatus.PENDING, JobStatus.RUNNING, {
+            locked_by: input.worker_id,
+            locked_at: startedAt,
+            started_at: startedAt,
+            completed_at: null,
+            error_json: null,
+            result_json: null,
+          });
+
+          await JobEventRepository.create(txDb, {
+            job_id: job.id,
+            event_type: 'status_changed',
+            detail_json: {
+              from: JobStatus.PENDING,
+              to: JobStatus.RUNNING,
+              worker_id: input.worker_id,
+            },
+          });
+
+          await JobEventRepository.create(txDb, {
+            job_id: job.id,
+            event_type: 'progress_updated',
+            detail_json: progress,
+          });
+
+          return nextJob;
+        });
+
+        return toJobDto(runningJob, progress);
+      } catch (error) {
+        handleJobConflict(error);
+        throw error;
+      }
+    }
+
+    this.assertRunningJobOwner(job, input.worker_id);
+    await this.renewOwnedJobLock(job.id, input.worker_id);
+    await this.touchWorkerHeartbeat(input.worker_id);
+    await JobEventRepository.create(this.db, {
+      job_id: job.id,
+      event_type: 'progress_updated',
+      detail_json: progress,
+    });
+
+    return toJobDto(job, progress);
+  }
+
+  async reportComplete(jobId: string, input: JobCompletionDto): Promise<JobDto> {
+    const job = await this.getJob(jobId);
+    this.assertRunningJobOwner(job, input.worker_id);
+    await this.renewOwnedJobLock(job.id, input.worker_id);
+
+    try {
+      const completedJob = await this.db.transaction(async (tx) => {
+        const txDb = tx as JobsDatabase;
+        const completedAt = new Date();
+        const nextJob = await JobStateMachine.transition(txDb, job.id, JobStatus.RUNNING, JobStatus.SUCCEEDED, {
+          result_json: input.result_json ?? null,
+          error_json: null,
+          locked_by: null,
+          locked_at: null,
+          completed_at: completedAt,
+        });
+
+        await JobEventRepository.create(txDb, {
+          job_id: job.id,
+          event_type: 'status_changed',
+          detail_json: {
+            from: JobStatus.RUNNING,
+            to: JobStatus.SUCCEEDED,
+            worker_id: input.worker_id,
+          },
+        });
+
+        return nextJob;
+      });
+
+      await this.releaseJobLock(job.id, input.worker_id);
+      return toJobDto(completedJob);
+    } catch (error) {
+      handleJobConflict(error);
+      throw error;
+    }
+  }
+
+  async reportFailure(jobId: string, input: JobFailureDto): Promise<JobFailureResponseDto> {
+    const job = await this.getJob(jobId);
+    this.assertRunningJobOwner(job, input.worker_id);
+    await this.renewOwnedJobLock(job.id, input.worker_id);
+
+    const nextAttemptCount = job.attempt_count + 1;
+    const willRetry = input.retryable !== false && nextAttemptCount < job.max_attempts;
+
+    try {
+      const nextJob = await this.db.transaction(async (tx) => {
+        const txDb = tx as JobsDatabase;
+        const failedAt = new Date();
+        const failedJob = await JobStateMachine.transition(txDb, job.id, JobStatus.RUNNING, JobStatus.FAILED, {
+          attempt_count: nextAttemptCount,
+          error_json: input.error_json,
+          locked_by: null,
+          locked_at: null,
+          completed_at: failedAt,
+        });
+
+        await JobEventRepository.create(txDb, {
+          job_id: job.id,
+          event_type: 'status_changed',
+          detail_json: {
+            from: JobStatus.RUNNING,
+            to: JobStatus.FAILED,
+            worker_id: input.worker_id,
+            retryable: willRetry,
+          },
+        });
+
+        if (!willRetry) {
+          return failedJob;
+        }
+
+        const nextRunAt = new Date(Date.now() + getRetryDelaySeconds(nextAttemptCount) * 1_000);
+        const retriedJob = await JobStateMachine.transition(txDb, job.id, JobStatus.FAILED, JobStatus.PENDING, {
+          next_run_at: nextRunAt,
+          started_at: null,
+          completed_at: null,
+        });
+
+        await JobEventRepository.create(txDb, {
+          job_id: job.id,
+          event_type: 'status_changed',
+          detail_json: {
+            from: JobStatus.FAILED,
+            to: JobStatus.PENDING,
+            worker_id: input.worker_id,
+            next_run_at: nextRunAt.toISOString(),
+          },
+        });
+
+        return retriedJob;
+      });
+
+      await this.releaseJobLock(job.id, input.worker_id);
+      return {
+        job: toJobDto(nextJob),
+        will_retry: willRetry,
+      };
+    } catch (error) {
+      handleJobConflict(error);
+      throw error;
+    }
+  }
+
+  async recordHeartbeat(input: WorkerHeartbeatDto): Promise<WorkerHeartbeatResponseDto> {
+    await this.touchWorkerHeartbeat(input.worker_id, input.system_info);
+
+    if (input.active_jobs !== undefined && input.active_jobs.length > 0) {
+      for (const jobId of new Set(input.active_jobs)) {
+        try {
+          await this.renewOwnedJobLock(jobId, input.worker_id);
+        } catch (error) {
+          if (isConflictHttpException(error)) {
+            continue;
+          }
+
+          throw error;
+        }
+      }
+    }
+
+    return {
+      ack: true,
+      cancel_requested: await this.getCancelRequestedJobIds(input.worker_id, input.active_jobs),
+    };
+  }
+
+  @Interval(DEAD_WORKER_SCAN_INTERVAL_MS)
+  async scanDeadWorkers(): Promise<number> {
+    if (this.redis === undefined) {
+      return 0;
+    }
+
+    try {
+      const runningJobs = (await this.db
+        .select()
+        .from(jobs)
+        .where(and(eq(jobs.status, JobStatus.RUNNING), isNotNull(jobs.locked_by)))) as JobRow[];
+      const jobsByWorker = new Map<string, JobRow[]>();
+
+      for (const job of runningJobs) {
+        if (job.locked_by === null) {
+          continue;
+        }
+
+        const workerJobs = jobsByWorker.get(job.locked_by) ?? [];
+        workerJobs.push(job);
+        jobsByWorker.set(job.locked_by, workerJobs);
+      }
+
+      let handled = 0;
+      for (const [workerId, workerJobs] of jobsByWorker) {
+        const heartbeat = await this.getWorkerHeartbeat(workerId);
+        if (!isDeadWorker(workerJobs, heartbeat, Date.now())) {
+          continue;
+        }
+
+        for (const job of workerJobs) {
+          handled += await this.failDeadWorkerJob(job, heartbeat);
+        }
+      }
+
+      return handled;
+    } catch (error) {
+      getApiLogger().error({ err: error }, 'Dead worker scan failed');
+      return 0;
+    }
+  }
+
+  private async getJob(jobId: string): Promise<JobRow> {
+    const job = await JobRepository.findById(this.db, jobId);
+    if (job === undefined) {
+      throwApiError(ErrorCode.NOT_FOUND, 'Job not found', HttpStatus.NOT_FOUND);
+    }
+
+    return job;
+  }
+
+  private assertRunningJobOwner(job: JobRow, workerId: string): void {
+    if (!isJobStatus(job.status, JobStatus.RUNNING)) {
+      throwApiError(ErrorCode.CONFLICT, 'Job is not running', HttpStatus.CONFLICT);
+    }
+
+    if (job.locked_by !== workerId) {
+      throwApiError(ErrorCode.CONFLICT, 'Job not owned by this worker', HttpStatus.CONFLICT);
+    }
+  }
+
+  private async assertPendingJobOwner(jobId: string, workerId: string): Promise<void> {
+    const redis = this.getRequiredRedis();
+    const owner = await redis.get(RedisJobLock.key(jobId));
+
+    if (owner !== workerId) {
+      throwApiError(ErrorCode.CONFLICT, 'Job not owned by this worker', HttpStatus.CONFLICT);
+    }
+  }
+
+  private async renewOwnedJobLock(jobId: string, workerId: string): Promise<void> {
+    const redis = this.getRequiredRedis();
+    const renewed = await RedisJobLock.renew(redis, jobId, workerId, DEFAULT_LOCK_TTL_SECONDS);
+
+    if (!renewed) {
+      throwApiError(ErrorCode.CONFLICT, 'Job not owned by this worker', HttpStatus.CONFLICT);
+    }
+  }
+
+  private async releaseJobLock(jobId: string, workerId: string): Promise<void> {
+    const redis = this.getRequiredRedis();
+    const released = await RedisJobLock.release(redis, jobId, workerId);
+
+    if (!released) {
+      getApiLogger().warn({ job_id: jobId, worker_id: workerId }, 'Worker lock was not released because ownership changed');
+    }
+  }
+
+  private async touchWorkerHeartbeat(workerId: string, systemInfo?: Record<string, unknown>): Promise<void> {
+    const redis = this.getRequiredRedis();
+    const seenAt = new Date().toISOString();
+    const payload: StoredWorkerHeartbeat = {
+      seen_at: seenAt,
+      ...(systemInfo !== undefined ? { system_info: systemInfo } : {}),
+    };
+
+    await redis.set(workerHeartbeatKey(workerId), JSON.stringify(payload), 'EX', HEARTBEAT_TTL_SECONDS);
+  }
+
+  private async getWorkerHeartbeat(workerId: string): Promise<Date | null> {
+    const redis = this.getRequiredRedis();
+    const stored = await redis.get(workerHeartbeatKey(workerId));
+    return parseWorkerHeartbeat(stored);
+  }
+
+  private async getCancelRequestedJobIds(workerId: string, activeJobs?: string[]): Promise<string[]> {
+    if (activeJobs !== undefined && activeJobs.length === 0) {
+      return [];
+    }
+
+    const conditions = [
+      eq(jobs.status, JobStatus.RUNNING),
+      eq(jobs.locked_by, workerId),
+      isNotNull(jobs.cancel_requested_at),
+    ];
+
+    if (activeJobs !== undefined && activeJobs.length > 0) {
+      conditions.push(inArray(jobs.id, [...new Set(activeJobs)]));
+    }
+
+    const rows = await this.db
+      .select({ job_id: jobs.id })
+      .from(jobs)
+      .where(and(...conditions));
+
+    return rows.map((row) => row.job_id);
+  }
+
+  private async failDeadWorkerJob(job: JobRow, lastHeartbeatAt: Date | null): Promise<number> {
+    if (job.locked_by === null) {
+      return 0;
+    }
+
+    const workerId = job.locked_by;
+    const nextAttemptCount = job.attempt_count + 1;
+    const willRetry = nextAttemptCount < job.max_attempts;
+
+    try {
+      const failedAt = new Date();
+      await JobStateMachine.transition(this.db, job.id, JobStatus.RUNNING, JobStatus.FAILED, {
+        attempt_count: nextAttemptCount,
+        error_json: {
+          code: 'WORKER_TIMEOUT',
+          message: 'Worker heartbeat timed out',
+        },
+        locked_by: null,
+        locked_at: null,
+        completed_at: failedAt,
+      });
+
+      await JobEventRepository.create(this.db, {
+        job_id: job.id,
+        event_type: 'status_changed',
+        detail_json: {
+          from: JobStatus.RUNNING,
+          to: JobStatus.FAILED,
+          worker_id: workerId,
+          retryable: willRetry,
+          reason: 'worker_timeout',
+        },
+      });
+
+      if (willRetry) {
+        const nextRunAt = new Date(Date.now() + getRetryDelaySeconds(nextAttemptCount) * 1_000);
+
+        await JobStateMachine.transition(this.db, job.id, JobStatus.FAILED, JobStatus.PENDING, {
+          next_run_at: nextRunAt,
+          started_at: null,
+          completed_at: null,
+        });
+
+        await JobEventRepository.create(this.db, {
+          job_id: job.id,
+          event_type: 'status_changed',
+          detail_json: {
+            from: JobStatus.FAILED,
+            to: JobStatus.PENDING,
+            worker_id: workerId,
+            reason: 'worker_timeout_retry',
+            next_run_at: nextRunAt.toISOString(),
+          },
+        });
+      }
+
+      await JobEventRepository.create(this.db, {
+        job_id: job.id,
+        event_type: 'timeout_detected',
+        detail_json: {
+          worker_id: workerId,
+          locked_at: job.locked_at?.toISOString() ?? null,
+          last_heartbeat_at: lastHeartbeatAt?.toISOString() ?? null,
+          reason: 'worker_missed_heartbeat',
+        },
+      });
+
+      await this.releaseJobLock(job.id, workerId);
+      return 1;
+    } catch (error) {
+      if (error instanceof JobConflictError) {
+        return 0;
+      }
+
+      throw error;
+    }
+  }
+
+  private getRequiredRedis(): InternalRedisClient {
+    if (this.redis === undefined) {
+      throwApiError(ErrorCode.INTERNAL_ERROR, 'Redis is not configured', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    return this.redis as unknown as InternalRedisClient;
+  }
+}
+
+function toJobDto(job: JobRow, progress: JobProgressDto | null = null): JobDto {
+  return {
+    job_id: job.id,
+    type: job.type,
+    status: job.status,
+    space_id: job.space_id,
+    progress,
+    created_by: job.created_by,
+    payload_json: job.payload_json,
+    result_json: job.result_json,
+    error_json: job.error_json,
+    cancel_requested_at: job.cancel_requested_at,
+    attempt_count: job.attempt_count,
+    max_attempts: job.max_attempts,
+    created_at: job.created_at,
+    started_at: job.started_at,
+    completed_at: job.completed_at,
+  };
+}
+
+function toProgressDto(percent: number, stage: string | undefined): JobProgressDto {
+  return {
+    percent,
+    ...(typeof stage === 'string' && stage.trim().length > 0 ? { stage } : {}),
+  };
+}
+
+function handleJobConflict(error: unknown): void {
+  if (error instanceof JobConflictError) {
+    throwApiError(ErrorCode.CONFLICT, error.message, HttpStatus.CONFLICT);
+  }
+}
+
+function throwApiError(code: ErrorCode, message: string, status: HttpStatus): never {
+  throw new HttpException({ code, message }, status);
+}
+
+function getRetryDelaySeconds(nextAttemptCount: number): number {
+  return Math.min(60 * 2 ** Math.max(0, nextAttemptCount - 1), MAX_RETRY_DELAY_SECONDS);
+}
+
+function workerHeartbeatKey(workerId: string): string {
+  return `worker:heartbeat:${workerId}`;
+}
+
+function parseWorkerHeartbeat(value: string | null): Date | null {
+  if (value === null || value.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<StoredWorkerHeartbeat>;
+    if (typeof parsed.seen_at === 'string') {
+      return parseDate(parsed.seen_at);
+    }
+  } catch {
+    return parseDate(value);
+  }
+
+  return null;
+}
+
+function parseDate(value: string): Date | null {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isDeadWorker(jobsForWorker: JobRow[], lastHeartbeatAt: Date | null, now: number): boolean {
+  if (lastHeartbeatAt !== null) {
+    return now - lastHeartbeatAt.getTime() > DEAD_WORKER_THRESHOLD_MS;
+  }
+
+  const mostRecentActivityAt = jobsForWorker.reduce<number>((latest, job) => {
+    const candidate = job.locked_at ?? job.started_at ?? job.created_at;
+    return Math.max(latest, candidate.getTime());
+  }, 0);
+
+  return mostRecentActivityAt > 0 && now - mostRecentActivityAt > DEAD_WORKER_THRESHOLD_MS;
+}
+
+function isConflictHttpException(error: unknown): boolean {
+  return error instanceof HttpException && error.getStatus() === 409;
+}
+
+function isJobStatus(status: string, expected: JobStatus): boolean {
+  return status === String(expected);
+}

--- a/apps/api/src/internal/internal-workers.controller.ts
+++ b/apps/api/src/internal/internal-workers.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { Public } from '@cherrygraph/auth-core';
+
+import { InternalJobsService } from './internal-jobs.service.js';
+import { type WorkerHeartbeatResponseDto, WorkerHeartbeatDto } from './internal.dto.js';
+import { WorkerApiKeyGuard } from './worker-api-key.guard.js';
+
+@Public()
+@UseGuards(WorkerApiKeyGuard)
+@Controller('internal/workers')
+export class InternalWorkersController {
+  constructor(private readonly internalJobsService: InternalJobsService) {}
+
+  @HttpCode(HttpStatus.OK)
+  @Post('heartbeat')
+  async recordHeartbeat(@Body() body: WorkerHeartbeatDto): Promise<WorkerHeartbeatResponseDto> {
+    return this.internalJobsService.recordHeartbeat(body);
+  }
+}

--- a/apps/api/src/internal/internal.dto.ts
+++ b/apps/api/src/internal/internal.dto.ts
@@ -1,8 +1,30 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsIn, IsInt, IsNotEmpty, IsObject, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  type ValidationOptions,
+  ValidateBy,
+} from 'class-validator';
 
 import { type JobDto } from '../jobs/jobs.dto.js';
 import { JOB_TYPES, type JobType } from '../jobs/jobs.dto.js';
+
+const MAX_HEARTBEAT_ACTIVE_JOBS = 50;
+const MAX_SYSTEM_INFO_DEPTH = 3;
+const MAX_SYSTEM_INFO_JSON_LENGTH = 4_096;
+const MAX_SYSTEM_INFO_KEYS_PER_LEVEL = 25;
+const MAX_SYSTEM_INFO_KEY_LENGTH = 100;
+const MAX_SYSTEM_INFO_STRING_LENGTH = 500;
 
 export class PendingJobsQueryDto {
   @IsIn(JOB_TYPES)
@@ -68,11 +90,14 @@ export class WorkerHeartbeatDto {
 
   @IsOptional()
   @IsArray()
+  @ArrayMaxSize(MAX_HEARTBEAT_ACTIVE_JOBS)
   @IsString({ each: true })
+  @MaxLength(200, { each: true })
   active_jobs?: string[];
 
   @IsOptional()
   @IsObject()
+  @IsBoundedSystemInfo()
   system_info?: Record<string, unknown>;
 }
 
@@ -84,4 +109,70 @@ export class JobFailureResponseDto {
 export class WorkerHeartbeatResponseDto {
   ack!: boolean;
   cancel_requested!: string[];
+  lost_locks!: string[];
+}
+
+function IsBoundedSystemInfo(validationOptions?: ValidationOptions): PropertyDecorator {
+  return ValidateBy(
+    {
+      name: 'isBoundedSystemInfo',
+      validator: {
+        validate: (value: unknown): boolean => isBoundedSystemInfo(value),
+        defaultMessage: (): string =>
+          `system_info must be JSON-serializable, at most ${MAX_SYSTEM_INFO_JSON_LENGTH} characters, and no deeper than ${MAX_SYSTEM_INFO_DEPTH} objects`,
+      },
+    },
+    validationOptions,
+  );
+}
+
+function isBoundedSystemInfo(value: unknown): boolean {
+  if (!isPlainRecord(value)) {
+    return false;
+  }
+
+  try {
+    if (JSON.stringify(value).length > MAX_SYSTEM_INFO_JSON_LENGTH) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
+  return validateSystemInfoNode(value, 0);
+}
+
+function validateSystemInfoNode(value: unknown, depth: number): boolean {
+  if (value === null) {
+    return true;
+  }
+
+  if (typeof value === 'string') {
+    return value.length <= MAX_SYSTEM_INFO_STRING_LENGTH;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return true;
+  }
+
+  if (!isPlainRecord(value) || depth > MAX_SYSTEM_INFO_DEPTH) {
+    return false;
+  }
+
+  const entries = Object.entries(value);
+  if (entries.length > MAX_SYSTEM_INFO_KEYS_PER_LEVEL) {
+    return false;
+  }
+
+  return entries.every(
+    ([key, nestedValue]) => key.length <= MAX_SYSTEM_INFO_KEY_LENGTH && validateSystemInfoNode(nestedValue, depth + 1),
+  );
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/apps/api/src/internal/internal.dto.ts
+++ b/apps/api/src/internal/internal.dto.ts
@@ -1,0 +1,87 @@
+import { Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsIn, IsInt, IsNotEmpty, IsObject, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+
+import { type JobDto } from '../jobs/jobs.dto.js';
+import { JOB_TYPES, type JobType } from '../jobs/jobs.dto.js';
+
+export class PendingJobsQueryDto {
+  @IsIn(JOB_TYPES)
+  type!: JobType;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  limit = 1;
+}
+
+export class JobProgressUpdateDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  worker_id!: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  percent!: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  stage?: string;
+}
+
+export class JobCompletionDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  worker_id!: string;
+
+  @IsOptional()
+  @IsObject()
+  result_json?: Record<string, unknown>;
+}
+
+export class JobFailureDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  worker_id!: string;
+
+  @IsObject()
+  error_json!: Record<string, unknown>;
+
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  retryable = true;
+}
+
+export class WorkerHeartbeatDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  worker_id!: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  active_jobs?: string[];
+
+  @IsOptional()
+  @IsObject()
+  system_info?: Record<string, unknown>;
+}
+
+export class JobFailureResponseDto {
+  job!: JobDto;
+  will_retry!: boolean;
+}
+
+export class WorkerHeartbeatResponseDto {
+  ack!: boolean;
+  cancel_requested!: string[];
+}

--- a/apps/api/src/internal/internal.module.ts
+++ b/apps/api/src/internal/internal.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+
+import { InternalJobsController } from './internal-jobs.controller.js';
+import { InternalJobsService } from './internal-jobs.service.js';
+import { InternalWorkersController } from './internal-workers.controller.js';
+import { WorkerApiKeyGuard } from './worker-api-key.guard.js';
+
+@Module({
+  imports: [ScheduleModule.forRoot()],
+  controllers: [InternalJobsController, InternalWorkersController],
+  providers: [InternalJobsService, WorkerApiKeyGuard],
+})
+export class InternalModule {}

--- a/apps/api/src/internal/worker-api-key.guard.ts
+++ b/apps/api/src/internal/worker-api-key.guard.ts
@@ -3,6 +3,8 @@ import { ErrorCode } from '@cherrygraph/shared';
 import * as crypto from 'node:crypto';
 import type { IncomingHttpHeaders } from 'node:http';
 
+import { getApiLogger } from '../common/logger/logger.module.js';
+
 type RequestLike = {
   headers?: IncomingHttpHeaders | Record<string, string | string[] | undefined>;
   raw?: {
@@ -12,6 +14,15 @@ type RequestLike = {
 
 @Injectable()
 export class WorkerApiKeyGuard implements CanActivate {
+  constructor() {
+    if (typeof process.env.WORKER_API_KEY !== 'string' || process.env.WORKER_API_KEY.length === 0) {
+      getApiLogger().warn(
+        { worker_api_key_present: false },
+        'WORKER_API_KEY is not configured; internal worker endpoints will reject all requests',
+      );
+    }
+  }
+
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest<RequestLike>();
     const expectedKey = process.env.WORKER_API_KEY;

--- a/apps/api/src/internal/worker-api-key.guard.ts
+++ b/apps/api/src/internal/worker-api-key.guard.ts
@@ -1,5 +1,6 @@
 import { CanActivate, ExecutionContext, HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { ErrorCode } from '@cherrygraph/shared';
+import * as crypto from 'node:crypto';
 import type { IncomingHttpHeaders } from 'node:http';
 
 type RequestLike = {
@@ -16,7 +17,7 @@ export class WorkerApiKeyGuard implements CanActivate {
     const expectedKey = process.env.WORKER_API_KEY;
     const providedKey = getHeaderValue(request, 'x-worker-key');
 
-    if (typeof expectedKey !== 'string' || expectedKey.length === 0 || providedKey !== expectedKey) {
+    if (typeof expectedKey !== 'string' || expectedKey.length === 0 || !hasMatchingWorkerApiKey(expectedKey, providedKey)) {
       throw new HttpException(
         {
           code: ErrorCode.UNAUTHENTICATED,
@@ -51,4 +52,14 @@ function normalizeHeaderValue(value: string | string[] | undefined): string | un
   }
 
   return undefined;
+}
+
+function hasMatchingWorkerApiKey(expectedKey: string, providedKey: string | undefined): boolean {
+  const expectedBuffer = Buffer.from(expectedKey);
+  const providedBuffer = Buffer.from(providedKey ?? '');
+  const normalizedProvidedBuffer =
+    providedBuffer.length === expectedBuffer.length ? providedBuffer : Buffer.alloc(expectedBuffer.length);
+  const keysMatch = crypto.timingSafeEqual(expectedBuffer, normalizedProvidedBuffer);
+
+  return providedBuffer.length === expectedBuffer.length && keysMatch;
 }

--- a/apps/api/src/internal/worker-api-key.guard.ts
+++ b/apps/api/src/internal/worker-api-key.guard.ts
@@ -1,0 +1,54 @@
+import { CanActivate, ExecutionContext, HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { ErrorCode } from '@cherrygraph/shared';
+import type { IncomingHttpHeaders } from 'node:http';
+
+type RequestLike = {
+  headers?: IncomingHttpHeaders | Record<string, string | string[] | undefined>;
+  raw?: {
+    headers?: IncomingHttpHeaders | Record<string, string | string[] | undefined>;
+  };
+};
+
+@Injectable()
+export class WorkerApiKeyGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<RequestLike>();
+    const expectedKey = process.env.WORKER_API_KEY;
+    const providedKey = getHeaderValue(request, 'x-worker-key');
+
+    if (typeof expectedKey !== 'string' || expectedKey.length === 0 || providedKey !== expectedKey) {
+      throw new HttpException(
+        {
+          code: ErrorCode.UNAUTHENTICATED,
+          message: 'Invalid worker API key',
+        },
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    return true;
+  }
+}
+
+function getHeaderValue(request: RequestLike, name: string): string | undefined {
+  const directValue = normalizeHeaderValue(request.headers?.[name]);
+  if (directValue !== undefined) {
+    return directValue;
+  }
+
+  return normalizeHeaderValue(request.raw?.headers?.[name]);
+}
+
+function normalizeHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const first = value.find((entry) => typeof entry === 'string' && entry.trim().length > 0);
+    return first?.trim();
+  }
+
+  return undefined;
+}

--- a/packages/job-core/src/repository.ts
+++ b/packages/job-core/src/repository.ts
@@ -163,23 +163,25 @@ export class JobRepository {
 
   static async findPendingByType(
     db: JobDatabase,
-    tenantId: string,
+    tenantId: string | undefined,
     type: string,
     limit: number,
   ): Promise<JobRow[]> {
     const normalizedLimit = Math.min(10, Math.max(1, Math.trunc(limit)));
+    const conditions = [
+      eq(jobs.type, type),
+      eq(jobs.status, JobStatus.PENDING),
+      sql`(${jobs.next_run_at} IS NULL OR ${jobs.next_run_at} <= now())`,
+    ] as SQL[];
+
+    if (tenantId !== undefined && tenantId.trim().length > 0) {
+      conditions.unshift(eq(jobs.tenant_id, tenantId.trim()));
+    }
 
     return db
       .select()
       .from(jobs)
-      .where(
-        and(
-          eq(jobs.tenant_id, tenantId),
-          eq(jobs.type, type),
-          eq(jobs.status, JobStatus.PENDING),
-          sql`(${jobs.next_run_at} IS NULL OR ${jobs.next_run_at} <= now())`,
-        ),
-      )
+      .where(and(...conditions))
       .orderBy(asc(jobs.priority), asc(jobs.created_at))
       .limit(normalizedLimit);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@nestjs/platform-fastify':
         specifier: ^11.1.19
         version: 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/schedule':
+        specifier: ^6.1.3
+        version: 6.1.3(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -1394,6 +1397,12 @@ packages:
       '@fastify/view':
         optional: true
 
+  '@nestjs/schedule@6.1.3':
+    resolution: {integrity: sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@11.1.0':
     resolution: {integrity: sha512-lVxGZ46tcdItFMoXr6vyKWlnOsm1SZm/GUqAEDvy2RL4Q4O+3bkziAhrO7Y8JLssFUUvNFEGqAizI52WAxhjDw==}
     peerDependencies:
@@ -1945,6 +1954,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/luxon@3.7.1':
+    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
+
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
@@ -2463,6 +2475,10 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+
+  cron@4.4.0:
+    resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
+    engines: {node: '>=18.x'}
 
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
@@ -5579,6 +5595,12 @@ snapshots:
       reusify: 1.1.0
       tslib: 2.8.1
 
+  '@nestjs/schedule@6.1.3(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+    dependencies:
+      '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 4.4.0
+
   '@nestjs/schematics@11.1.0(chokidar@4.0.3)(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 19.2.24(chokidar@4.0.3)
@@ -6282,6 +6304,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/luxon@3.7.1': {}
+
   '@types/methods@1.1.4': {}
 
   '@types/node@20.19.39':
@@ -6854,6 +6878,11 @@ snapshots:
 
   cron-parser@4.9.0:
     dependencies:
+      luxon: 3.7.2
+
+  cron@4.4.0:
+    dependencies:
+      '@types/luxon': 3.7.1
       luxon: 3.7.2
 
   cross-env@10.1.0:


### PR DESCRIPTION
## Summary
- Implement 5 internal Worker endpoints: poll, progress, complete, fail, heartbeat
- WorkerApiKeyGuard with crypto.timingSafeEqual
- Dead worker detection (30s scan interval, transaction-safe recovery)
- Lock ownership validation + heartbeat lost_locks signaling
- Claim atomicity: Redis lock verified after DB transition

## Test plan
- [x] Build + Lint pass
- [x] 302 tests pass (51 test files)

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `467e1ea7645278ac715115eba6401afed990aad7`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/60#issuecomment-4351044836) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/60#issuecomment-4351045073)
- Key findings addressed: Heartbeat lost_locks, claim atomicity, dead worker transaction, timing-safe key comparison, active_jobs cap, tenant scoping

Closes #52