### PR TITLE
feat(web): implement Task Center UI (#54)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,8 @@ import { AuthProvider } from './lib/auth';
 import AuditPage from './pages/admin/AuditPage';
 import GroupsPage from './pages/admin/GroupsPage';
 import HealthPage from './pages/admin/HealthPage';
+import JobDetailPage from './pages/admin/JobDetailPage';
+import JobsPage from './pages/admin/JobsPage';
 import ModelsPage from './pages/admin/ModelsPage';
 import SpacesPage from './pages/admin/SpacesPage';
 import UsersPage from './pages/admin/UsersPage';
@@ -38,7 +40,8 @@ export function AppRoutes() {
         <Route path="models" element={<ModelsPage />} />
         <Route path="audit" element={<AuditPage />} />
         <Route path="health" element={<HealthPage />} />
-        <Route path="jobs" element={<Navigate to="/admin/health" replace />} />
+        <Route path="jobs" element={<JobsPage />} />
+        <Route path="jobs/:jobId" element={<JobDetailPage />} />
       </Route>
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/apps/web/src/__tests__/jobs-page.test.tsx
+++ b/apps/web/src/__tests__/jobs-page.test.tsx
@@ -1,0 +1,221 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ProgressBar from '../components/ProgressBar';
+import JobDetailPage from '../pages/admin/JobDetailPage';
+import JobsPage from '../pages/admin/JobsPage';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('JobsPage', () => {
+  it('renders the jobs table and filters', async () => {
+    const fetchMock = stubJobApi();
+
+    renderJobsRoute('/admin/jobs');
+
+    expect(await screen.findByRole('heading', { name: 'Task Center' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Type')).toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+    expect(screen.getByLabelText('Page')).toBeInTheDocument();
+    expect(screen.getByLabelText('Per page')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Progress' })).toBeInTheDocument();
+    expect(await screen.findByText('job-1')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('fetches the jobs list from /api/admin/jobs', async () => {
+    const fetchMock = stubJobApi();
+
+    renderJobsRoute('/admin/jobs');
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+      expect(getRequestUrl(fetchMock.mock.calls[0]?.[0] ?? '')).toContain(
+        '/api/admin/jobs?page=1&per_page=20&sort=-created_at',
+      );
+    });
+  });
+});
+
+describe('JobDetailPage', () => {
+  it('renders job details and the event timeline', async () => {
+    stubJobApi();
+
+    renderJobsRoute('/admin/jobs/job-1');
+
+    expect(await screen.findByRole('heading', { name: 'Job Detail' })).toBeInTheDocument();
+    expect(screen.getAllByText('Graphify').length).toBeGreaterThan(0);
+    expect(screen.getByText('space-main')).toBeInTheDocument();
+    expect(screen.getByText('Progress Updated')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'chunking progress' })).toHaveAttribute('aria-valuenow', '65');
+  });
+
+  it('calls POST /api/jobs/:id/cancel when the cancel button is pressed', async () => {
+    const fetchMock = stubJobApi();
+
+    renderJobsRoute('/admin/jobs/job-1');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel Job' }));
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(
+          ([input, init]) => getRequestPath(input) === '/api/jobs/job-1/cancel' && init?.method === 'POST',
+        ),
+      ).toBe(true),
+    );
+  });
+});
+
+describe('ProgressBar', () => {
+  it('renders progress text, stage, and aria state', () => {
+    render(<ProgressBar percent={65} stage="chunking" size="md" />);
+
+    expect(screen.getByText('65%')).toBeInTheDocument();
+    expect(screen.getByText('chunking')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'chunking progress' })).toHaveAttribute('aria-valuenow', '65');
+  });
+});
+
+function renderJobsRoute(path: string): void {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/admin/jobs" element={<JobsPage />} />
+        <Route path="/admin/jobs/:jobId" element={<JobDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function stubJobApi() {
+  let cancelRequestedAt: string | null = null;
+
+  const fetchMock = vi.fn<typeof fetch>((input, init) => {
+    const path = getRequestPath(input);
+
+    if (path === '/api/admin/jobs') {
+      return Promise.resolve(
+        jsonResponse({
+          data: [buildJob(cancelRequestedAt)],
+          meta: {
+            request_id: 'req-admin-jobs',
+            pagination: {
+              page: 1,
+              per_page: 20,
+              total: 1,
+              has_next: false,
+            },
+          },
+        }),
+      );
+    }
+
+    if (path === '/api/jobs/job-1' && init?.method !== 'POST') {
+      return Promise.resolve(
+        jsonResponse({
+          data: buildJob(cancelRequestedAt),
+          meta: { request_id: 'req-job-detail' },
+        }),
+      );
+    }
+
+    if (path === '/api/jobs/job-1/events') {
+      return Promise.resolve(
+        jsonResponse({
+          data: [
+            {
+              event: 'status_changed',
+              timestamp: '2026-04-29T10:00:00.000Z',
+              detail: {
+                from: 'pending',
+                to: 'running',
+              },
+            },
+            {
+              event: 'progress_updated',
+              timestamp: '2026-04-29T10:02:00.000Z',
+              detail: {
+                percent: 65,
+                stage: 'chunking',
+              },
+            },
+          ],
+          meta: { request_id: 'req-job-events' },
+        }),
+      );
+    }
+
+    if (path === '/api/jobs/job-1/cancel' && init?.method === 'POST') {
+      cancelRequestedAt = '2026-04-29T10:03:00.000Z';
+
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            job_id: 'job-1',
+            status: 'running',
+            cancel_requested_at: cancelRequestedAt,
+          },
+          meta: { request_id: 'req-job-cancel' },
+        }),
+      );
+    }
+
+    return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function buildJob(cancelRequestedAt: string | null = null) {
+  return {
+    job_id: 'job-1',
+    type: 'graphify',
+    status: 'running',
+    space_id: 'space-main',
+    progress: {
+      percent: 65,
+      stage: 'chunking',
+    },
+    created_by: 'user-admin',
+    payload_json: {
+      source_id: 'source-1',
+    },
+    result_json: null,
+    error_json: null,
+    cancel_requested_at: cancelRequestedAt,
+    attempt_count: 1,
+    max_attempts: 3,
+    created_at: '2026-04-29T10:00:00.000Z',
+    started_at: '2026-04-29T10:01:00.000Z',
+    completed_at: null,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function getRequestPath(input: RequestInfo | URL): string {
+  return getRequestUrl(input).split('?')[0] ?? '';
+}
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}

--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -8,6 +8,7 @@ const NAV_ITEMS = [
   { label: 'Spaces', to: '/admin/spaces' },
   { label: 'Models', to: '/admin/models' },
   { label: 'Audit Logs', to: '/admin/audit' },
+  { label: 'Task Center', to: '/admin/jobs' },
   { label: 'System Health', to: '/admin/health' },
 ];
 

--- a/apps/web/src/components/ProgressBar.tsx
+++ b/apps/web/src/components/ProgressBar.tsx
@@ -1,0 +1,36 @@
+type ProgressBarProps = {
+  percent: number;
+  stage: string;
+  size?: 'sm' | 'md';
+};
+
+export default function ProgressBar({ percent, stage, size = 'md' }: ProgressBarProps) {
+  const clampedPercent = clampPercent(percent);
+
+  return (
+    <div className="progress-bar" data-size={size}>
+      <div className="progress-bar-header">
+        <span className="progress-bar-stage">{stage}</span>
+        <span className="progress-bar-percent">{clampedPercent}%</span>
+      </div>
+      <div
+        className="progress-bar-track"
+        role="progressbar"
+        aria-label={stage.length > 0 ? `${stage} progress` : 'Progress'}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={clampedPercent}
+      >
+        <div className="progress-bar-fill" style={{ width: `${clampedPercent}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function clampPercent(percent: number): number {
+  if (!Number.isFinite(percent)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, Math.round(percent)));
+}

--- a/apps/web/src/components/adminUi.tsx
+++ b/apps/web/src/components/adminUi.tsx
@@ -109,15 +109,19 @@ export function parseIdList(value: string): string[] {
 }
 
 function normalizeStatusClass(status: string): string {
-  if (status === 'healthy' || status === 'active' || status === 'enabled') {
+  if (status === 'healthy' || status === 'active' || status === 'enabled' || status === 'succeeded') {
     return 'healthy';
+  }
+
+  if (status === 'running') {
+    return 'info';
   }
 
   if (status === 'degraded') {
     return 'degraded';
   }
 
-  if (status === 'not_configured') {
+  if (status === 'not_configured' || status === 'pending' || status === 'cancelled') {
     return 'neutral';
   }
 

--- a/apps/web/src/lib/adminTypes.ts
+++ b/apps/web/src/lib/adminTypes.ts
@@ -115,7 +115,7 @@ export type SystemHealth = {
   uptime: number;
 };
 
-export const ADMIN_JOB_TYPE_FILTER_OPTIONS = ['ingestion', 'graphify', 'reindex', 'rebuild'] as const;
+export const ADMIN_JOB_TYPE_FILTER_OPTIONS = ['ingestion', 'graphify', 'reindex', 'rebuild', 'wiki_sync'] as const;
 
 export const ADMIN_JOB_STATUS_OPTIONS = ['pending', 'running', 'succeeded', 'failed', 'cancelled'] as const;
 
@@ -141,6 +141,13 @@ export type AdminJob = {
   started_at: string | null;
   completed_at: string | null;
 };
+
+export function getDisplayStatus(job: AdminJob): string {
+  if (job.status === 'running' && job.cancel_requested_at !== null) {
+    return 'cancelling';
+  }
+  return job.status;
+}
 
 export type JobEvent = {
   event: string;

--- a/apps/web/src/lib/adminTypes.ts
+++ b/apps/web/src/lib/adminTypes.ts
@@ -114,3 +114,42 @@ export type SystemHealth = {
   components: Record<string, HealthComponent>;
   uptime: number;
 };
+
+export const ADMIN_JOB_TYPE_FILTER_OPTIONS = ['ingestion', 'graphify', 'reindex', 'rebuild'] as const;
+
+export const ADMIN_JOB_STATUS_OPTIONS = ['pending', 'running', 'succeeded', 'failed', 'cancelled'] as const;
+
+export type JobProgress = {
+  percent?: number;
+  stage?: string;
+};
+
+export type AdminJob = {
+  job_id: string;
+  type: string;
+  status: string;
+  space_id: string | null;
+  progress: JobProgress | null;
+  created_by: string | null;
+  payload_json: unknown;
+  result_json: unknown;
+  error_json: unknown;
+  cancel_requested_at: string | null;
+  attempt_count: number;
+  max_attempts: number;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+};
+
+export type JobEvent = {
+  event: string;
+  timestamp: string;
+  detail: unknown;
+};
+
+export type CancelJobResponse = {
+  job_id: string;
+  status: string;
+  cancel_requested_at: string | null;
+};

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -59,23 +59,31 @@ export function configureApiClient(config: ApiClientConfig): void {
 
 export const api = {
   get<T>(path: string, query?: QueryParams): Promise<T> {
-    return request<T>('GET', path, { query });
+    return requestData<T>('GET', path, { query });
+  },
+  getWrapped<T>(path: string, query?: QueryParams): Promise<ApiWrappedResponse<T>> {
+    return requestWrapped<T>('GET', path, { query });
   },
   post<T>(path: string, body?: unknown): Promise<T> {
-    return request<T>('POST', path, { body });
+    return requestData<T>('POST', path, { body });
   },
   put<T>(path: string, body?: unknown): Promise<T> {
-    return request<T>('PUT', path, { body });
+    return requestData<T>('PUT', path, { body });
   },
   patch<T>(path: string, body?: unknown): Promise<T> {
-    return request<T>('PATCH', path, { body });
+    return requestData<T>('PATCH', path, { body });
   },
   delete<T>(path: string): Promise<T> {
-    return request<T>('DELETE', path);
+    return requestData<T>('DELETE', path);
   },
 };
 
-async function request<T>(method: string, path: string, options: RequestOptions = {}): Promise<T> {
+async function requestData<T>(method: string, path: string, options: RequestOptions = {}): Promise<T> {
+  const response = await requestWrapped<T>(method, path, options);
+  return response.data;
+}
+
+async function requestWrapped<T>(method: string, path: string, options: RequestOptions = {}): Promise<ApiWrappedResponse<T>> {
   const headers = new Headers(options.headers);
   headers.set('Accept', 'application/json');
 
@@ -106,7 +114,7 @@ async function request<T>(method: string, path: string, options: RequestOptions 
     throw error;
   }
 
-  return unwrapResponse<T>(body);
+  return wrapResponse<T>(body);
 }
 
 function buildApiUrl(path: string, query?: QueryParams): string {
@@ -140,12 +148,17 @@ async function readJson(response: Response): Promise<unknown> {
   }
 }
 
-function unwrapResponse<T>(body: unknown): T {
+function wrapResponse<T>(body: unknown): ApiWrappedResponse<T> {
   if (isRecord(body) && 'data' in body) {
-    return body.data as T;
+    return {
+      data: body.data as T,
+      ...(isRecord(body.meta) ? { meta: normalizeMeta(body.meta) } : {}),
+    };
   }
 
-  return body as T;
+  return {
+    data: body as T,
+  };
 }
 
 function createApiError(status: number, body: unknown): ApiError {
@@ -177,4 +190,21 @@ function normalizeErrorBody(body: unknown): { code: string; message: string; det
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function normalizeMeta(meta: Record<string, unknown>): ApiMeta {
+  return {
+    ...(typeof meta.request_id === 'string' ? { request_id: meta.request_id } : {}),
+    ...(isPaginationMeta(meta.pagination) ? { pagination: meta.pagination } : {}),
+  };
+}
+
+function isPaginationMeta(value: unknown): value is NonNullable<ApiMeta['pagination']> {
+  return (
+    isRecord(value) &&
+    typeof value.page === 'number' &&
+    typeof value.per_page === 'number' &&
+    typeof value.total === 'number' &&
+    typeof value.has_next === 'boolean'
+  );
 }

--- a/apps/web/src/pages/admin/JobDetailPage.tsx
+++ b/apps/web/src/pages/admin/JobDetailPage.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import ProgressBar from '../../components/ProgressBar';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  StatusBadge,
+  formatDate,
+  formatLabel,
+  getErrorMessage,
+} from '../../components/adminUi';
+import { api } from '../../lib/api';
+import { type AdminJob, type CancelJobResponse, type JobEvent } from '../../lib/adminTypes';
+
+const JOB_REFRESH_INTERVAL_MS = 5_000;
+
+export default function JobDetailPage() {
+  const navigate = useNavigate();
+  const { jobId = '' } = useParams();
+  const [job, setJob] = useState<AdminJob | null>(null);
+  const [events, setEvents] = useState<JobEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadJobDetail = useCallback(
+    async (background = false) => {
+      if (jobId.length === 0) {
+        setJob(null);
+        setEvents([]);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!background) {
+        setIsLoading(true);
+      }
+      setError(null);
+
+      try {
+        const [jobResponse, eventResponse] = await Promise.all([
+          api.get<AdminJob>(`/jobs/${jobId}`),
+          api.get<JobEvent[]>(`/jobs/${jobId}/events`, {
+            limit: 100,
+            offset: 0,
+          }),
+        ]);
+        setJob(jobResponse);
+        setEvents(eventResponse);
+      } catch (err) {
+        setError(getErrorMessage(err));
+      } finally {
+        if (!background) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [jobId],
+  );
+
+  useEffect(() => {
+    void loadJobDetail();
+  }, [loadJobDetail]);
+
+  useEffect(() => {
+    if (job?.status !== 'running') {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void loadJobDetail(true);
+    }, JOB_REFRESH_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [job?.status, loadJobDetail]);
+
+  async function cancelJob(): Promise<void> {
+    if (job === null) {
+      return;
+    }
+
+    setIsCancelling(true);
+    setError(null);
+
+    try {
+      const response = await api.post<CancelJobResponse>(`/jobs/${job.job_id}/cancel`);
+      setJob((current) =>
+        current === null
+          ? current
+          : {
+              ...current,
+              status: response.status,
+              cancel_requested_at: response.cancel_requested_at,
+            },
+      );
+      await loadJobDetail(true);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsCancelling(false);
+    }
+  }
+
+  const showCancelButton = job !== null && (job.status === 'pending' || job.status === 'running');
+  const isCancellationPending = job !== null && job.status === 'running' && job.cancel_requested_at !== null;
+  const cancelButtonLabel = isCancellationPending || isCancelling ? 'Cancelling...' : 'Cancel Job';
+
+  return (
+    <>
+      <PageHeader
+        title="Job Detail"
+        description="Inspect payloads, progress, and lifecycle events for a background task."
+        actions={
+          <>
+            <button
+              className="button button-secondary"
+              type="button"
+              onClick={() => {
+                void navigate('/admin/jobs');
+              }}
+            >
+              Back to Jobs
+            </button>
+            {showCancelButton ? (
+              <button
+                className="button button-danger"
+                type="button"
+                disabled={isCancelling || isCancellationPending}
+                onClick={() => {
+                  void cancelJob();
+                }}
+              >
+                {cancelButtonLabel}
+              </button>
+            ) : null}
+          </>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      {isLoading ? (
+        <LoadingState label="Loading job details..." />
+      ) : job === null ? (
+        <EmptyState label="Job details are unavailable." />
+      ) : (
+        <>
+          <section className="detail-panel" aria-label="Job overview">
+            <div className="detail-panel-header">
+              <div>
+                <h2>{formatLabel(job.type)}</h2>
+                <p>{job.job_id}</p>
+              </div>
+              <StatusBadge status={job.status} />
+            </div>
+
+            {job.status === 'running' ? (
+              <ProgressBar percent={job.progress?.percent ?? 0} stage={job.progress?.stage ?? 'Running'} size="md" />
+            ) : null}
+
+            <div className="settings-grid">
+              <div>
+                <span className="eyebrow">Job ID</span>
+                <code>{job.job_id}</code>
+              </div>
+              <div>
+                <span className="eyebrow">Type</span>
+                <span className="job-meta-value">{formatLabel(job.type)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Status</span>
+                <StatusBadge status={job.status} />
+              </div>
+              <div>
+                <span className="eyebrow">Space</span>
+                <span className="job-meta-value">{job.space_id ?? 'Global'}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Created by</span>
+                <span className="job-meta-value">{job.created_by ?? 'System'}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Created at</span>
+                <span className="job-meta-value">{formatDate(job.created_at)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Started at</span>
+                <span className="job-meta-value">{formatDate(job.started_at)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Completed at</span>
+                <span className="job-meta-value">{formatDate(job.completed_at)}</span>
+              </div>
+              {job.cancel_requested_at !== null ? (
+                <div>
+                  <span className="eyebrow">Cancellation requested</span>
+                  <span className="job-meta-value">{formatDate(job.cancel_requested_at)}</span>
+                </div>
+              ) : null}
+            </div>
+          </section>
+
+          <section className="detail-panel" aria-label="Job data">
+            <div className="detail-panel-header">
+              <div>
+                <h2>Job Data</h2>
+                <p>Payload, result, and error snapshots captured during execution.</p>
+              </div>
+            </div>
+
+            <details className="job-json-disclosure" open>
+              <summary>Payload JSON</summary>
+              <pre>{formatJson(job.payload_json)}</pre>
+            </details>
+            <details className="job-json-disclosure">
+              <summary>Result JSON</summary>
+              <pre>{formatJson(job.result_json)}</pre>
+            </details>
+            <details className="job-json-disclosure">
+              <summary>Error JSON</summary>
+              <pre>{formatJson(job.error_json)}</pre>
+            </details>
+          </section>
+
+          <section className="detail-panel" aria-label="Job events">
+            <div className="detail-panel-header">
+              <div>
+                <h2>Event Timeline</h2>
+                <p>Chronological state transitions and progress updates from the job lifecycle.</p>
+              </div>
+            </div>
+
+            {events.length === 0 ? (
+              <EmptyState label="No job events have been recorded yet." />
+            ) : (
+              <ol className="job-timeline">
+                {events.map((event, index) => (
+                  <li key={`${event.timestamp}-${event.event}-${index}`} className="job-timeline-item">
+                    <span className="job-timeline-marker" aria-hidden="true" />
+                    <article className="job-timeline-card">
+                      <div className="job-timeline-header">
+                        <strong>{formatLabel(event.event)}</strong>
+                        <span>{formatDate(event.timestamp)}</span>
+                      </div>
+                      <pre className="timeline-event-detail">{formatJson(event.detail)}</pre>
+                    </article>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </section>
+        </>
+      )}
+    </>
+  );
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value ?? null, null, 2);
+}

--- a/apps/web/src/pages/admin/JobDetailPage.tsx
+++ b/apps/web/src/pages/admin/JobDetailPage.tsx
@@ -12,7 +12,7 @@ import {
   getErrorMessage,
 } from '../../components/adminUi';
 import { api } from '../../lib/api';
-import { type AdminJob, type CancelJobResponse, type JobEvent } from '../../lib/adminTypes';
+import { type AdminJob, type CancelJobResponse, type JobEvent, getDisplayStatus } from '../../lib/adminTypes';
 
 const JOB_REFRESH_INTERVAL_MS = 5_000;
 
@@ -155,11 +155,11 @@ export default function JobDetailPage() {
                 <h2>{formatLabel(job.type)}</h2>
                 <p>{job.job_id}</p>
               </div>
-              <StatusBadge status={job.status} />
+              <StatusBadge status={getDisplayStatus(job)} />
             </div>
 
-            {job.status === 'running' ? (
-              <ProgressBar percent={job.progress?.percent ?? 0} stage={job.progress?.stage ?? 'Running'} size="md" />
+            {job.progress?.percent !== undefined ? (
+              <ProgressBar percent={job.progress.percent} stage={job.progress?.stage ?? (job.status === 'running' ? 'Running' : 'Complete')} size="md" />
             ) : null}
 
             <div className="settings-grid">
@@ -173,7 +173,7 @@ export default function JobDetailPage() {
               </div>
               <div>
                 <span className="eyebrow">Status</span>
-                <StatusBadge status={job.status} />
+                <StatusBadge status={getDisplayStatus(job)} />
               </div>
               <div>
                 <span className="eyebrow">Space</span>

--- a/apps/web/src/pages/admin/JobsPage.tsx
+++ b/apps/web/src/pages/admin/JobsPage.tsx
@@ -1,0 +1,352 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import ProgressBar from '../../components/ProgressBar';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  StatusBadge,
+  formatDate,
+  formatLabel,
+  getErrorMessage,
+} from '../../components/adminUi';
+import { type ApiMeta, api } from '../../lib/api';
+import {
+  ADMIN_JOB_STATUS_OPTIONS,
+  ADMIN_JOB_TYPE_FILTER_OPTIONS,
+  type AdminJob,
+} from '../../lib/adminTypes';
+
+const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
+  page: 1,
+  per_page: 20,
+  total: 0,
+  has_next: false,
+};
+
+const JOB_POLL_INTERVAL_MS = 5_000;
+const PER_PAGE_OPTIONS = [10, 20, 50, 100];
+
+export default function JobsPage() {
+  const navigate = useNavigate();
+  const [jobs, setJobs] = useState<AdminJob[]>([]);
+  const [type, setType] = useState('');
+  const [status, setStatus] = useState('');
+  const [spaceId, setSpaceId] = useState('');
+  const deferredSpaceId = useDeferredValue(spaceId);
+  const [page, setPage] = useState(DEFAULT_PAGINATION.page);
+  const [perPage, setPerPage] = useState(DEFAULT_PAGINATION.per_page);
+  const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadJobs = useCallback(
+    async (background = false) => {
+      if (!background) {
+        setIsLoading(true);
+      }
+      setError(null);
+
+      try {
+        const response = await api.getWrapped<AdminJob[]>('/admin/jobs', {
+          type,
+          status,
+          space_id: deferredSpaceId,
+          page,
+          per_page: perPage,
+          sort: '-created_at',
+        });
+        setJobs(response.data);
+        setPagination(
+          response.meta?.pagination ?? {
+            page,
+            per_page: perPage,
+            total: response.data.length,
+            has_next: false,
+          },
+        );
+      } catch (err) {
+        setError(getErrorMessage(err));
+      } finally {
+        if (!background) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [deferredSpaceId, page, perPage, status, type],
+  );
+
+  useEffect(() => {
+    void loadJobs();
+  }, [loadJobs]);
+
+  const shouldPoll = status === 'running' || jobs.some((job) => job.status === 'running');
+
+  useEffect(() => {
+    if (!shouldPoll) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void loadJobs(true);
+    }, JOB_POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [loadJobs, shouldPoll]);
+
+  const totalPages = useMemo(() => {
+    const computedPages = Math.ceil(pagination.total / Math.max(1, pagination.per_page));
+    return Math.max(page, computedPages, 1);
+  }, [page, pagination.per_page, pagination.total]);
+
+  return (
+    <>
+      <PageHeader
+        title="Task Center"
+        description="Track ingestion, graph, and maintenance jobs across spaces."
+        actions={
+          <button
+            className="button button-secondary"
+            type="button"
+            onClick={() => {
+              void loadJobs();
+            }}
+          >
+            Refresh
+          </button>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      <section className="toolbar" aria-label="Job filters">
+        <label>
+          Type
+          <select
+            value={type}
+            onChange={(event) => {
+              setType(event.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="">All types</option>
+            {ADMIN_JOB_TYPE_FILTER_OPTIONS.map((jobType) => (
+              <option key={jobType} value={jobType}>
+                {formatLabel(jobType)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Status
+          <select
+            value={status}
+            onChange={(event) => {
+              setStatus(event.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="">All statuses</option>
+            {ADMIN_JOB_STATUS_OPTIONS.map((jobStatus) => (
+              <option key={jobStatus} value={jobStatus}>
+                {formatLabel(jobStatus)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Space
+          <input
+            type="search"
+            value={spaceId}
+            onChange={(event) => {
+              setSpaceId(event.target.value);
+              setPage(1);
+            }}
+            placeholder="Space ID"
+          />
+        </label>
+        <label>
+          Page
+          <select value={page} onChange={(event) => setPage(Number(event.target.value))}>
+            {Array.from({ length: totalPages }, (_, index) => index + 1).map((pageValue) => (
+              <option key={pageValue} value={pageValue}>
+                Page {pageValue}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Per page
+          <select
+            value={perPage}
+            onChange={(event) => {
+              setPerPage(Number(event.target.value));
+              setPage(1);
+            }}
+          >
+            {PER_PAGE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      {isLoading ? (
+        <LoadingState label="Loading jobs..." />
+      ) : jobs.length === 0 ? (
+        <EmptyState label="No jobs match the current filters." />
+      ) : (
+        <>
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Type</th>
+                  <th>Status</th>
+                  <th>Space</th>
+                  <th>Progress</th>
+                  <th>Created</th>
+                  <th>Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                {jobs.map((job) => (
+                  <tr
+                    key={job.job_id}
+                    className="interactive-row"
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => {
+                      void navigate(`/admin/jobs/${job.job_id}`);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        void navigate(`/admin/jobs/${job.job_id}`);
+                      }
+                    }}
+                  >
+                    <td>
+                      <strong>{formatLabel(job.type)}</strong>
+                      <span className="subtle-id">{job.job_id}</span>
+                    </td>
+                    <td>
+                      <StatusBadge status={job.status} />
+                    </td>
+                    <td>{job.space_id ?? 'Global'}</td>
+                    <td className="progress-cell">{renderProgressCell(job)}</td>
+                    <td>{formatDate(job.created_at)}</td>
+                    <td>{formatJobDuration(job)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="pagination-bar">
+            <span className="pagination-summary">
+              Showing {getFirstItemIndex(pagination)}-{getLastItemIndex(pagination, jobs.length)} of {pagination.total}
+            </span>
+            <span className="pagination-summary">
+              Page {pagination.page} of {totalPages}
+            </span>
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+function renderProgressCell(job: AdminJob) {
+  if (job.progress !== null || job.status === 'running' || job.status === 'succeeded') {
+    return (
+      <ProgressBar
+        percent={job.progress?.percent ?? (job.status === 'succeeded' ? 100 : 0)}
+        stage={job.progress?.stage ?? getFallbackProgressStage(job.status)}
+        size="sm"
+      />
+    );
+  }
+
+  return <span className="muted-copy">{formatLabel(job.status)}</span>;
+}
+
+function getFallbackProgressStage(status: string): string {
+  if (status === 'running') {
+    return 'Running';
+  }
+
+  if (status === 'succeeded') {
+    return 'Completed';
+  }
+
+  return formatLabel(status);
+}
+
+function formatJobDuration(job: AdminJob): string {
+  if (job.started_at === null) {
+    return job.status === 'pending' ? 'Queued' : 'Not started';
+  }
+
+  const startedAt = parseTimestamp(job.started_at);
+  if (startedAt === null) {
+    return 'Unavailable';
+  }
+
+  const completedAt =
+    job.completed_at !== null ? parseTimestamp(job.completed_at) : job.status === 'running' ? Date.now() : null;
+
+  if (completedAt === null) {
+    return 'In progress';
+  }
+
+  return formatElapsedTime(completedAt - startedAt);
+}
+
+function parseTimestamp(value: string): number | null {
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function formatElapsedTime(durationMs: number): string {
+  if (durationMs < 1_000) {
+    return '<1s';
+  }
+
+  const totalSeconds = Math.floor(durationMs / 1_000);
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${seconds}s`;
+}
+
+function getFirstItemIndex(pagination: NonNullable<ApiMeta['pagination']>): number {
+  if (pagination.total === 0) {
+    return 0;
+  }
+
+  return (pagination.page - 1) * pagination.per_page + 1;
+}
+
+function getLastItemIndex(pagination: NonNullable<ApiMeta['pagination']>, itemCount: number): number {
+  if (pagination.total === 0) {
+    return 0;
+  }
+
+  return getFirstItemIndex(pagination) + itemCount - 1;
+}

--- a/apps/web/src/pages/admin/JobsPage.tsx
+++ b/apps/web/src/pages/admin/JobsPage.tsx
@@ -16,6 +16,7 @@ import {
   ADMIN_JOB_STATUS_OPTIONS,
   ADMIN_JOB_TYPE_FILTER_OPTIONS,
   type AdminJob,
+  getDisplayStatus,
 } from '../../lib/adminTypes';
 
 const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
@@ -237,7 +238,7 @@ export default function JobsPage() {
                       <span className="subtle-id">{job.job_id}</span>
                     </td>
                     <td>
-                      <StatusBadge status={job.status} />
+                      <StatusBadge status={getDisplayStatus(job)} />
                     </td>
                     <td>{job.space_id ?? 'Global'}</td>
                     <td className="progress-cell">{renderProgressCell(job)}</td>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -376,6 +376,15 @@ tbody tr:last-child td {
   border-bottom: 0;
 }
 
+.interactive-row {
+  cursor: pointer;
+}
+
+.interactive-row:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
 .row-actions {
   display: flex;
   flex-wrap: wrap;
@@ -401,6 +410,11 @@ tbody tr:last-child td {
 .status-degraded {
   background: var(--color-status-degraded-bg);
   color: var(--color-status-degraded-text);
+}
+
+.status-info {
+  background: var(--color-status-info-bg);
+  color: var(--color-status-info-text);
 }
 
 .status-neutral {
@@ -429,6 +443,179 @@ tbody tr:last-child td {
   color: var(--color-text-3);
   font-size: 0.8rem;
   line-height: 1.45;
+}
+
+.pagination-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.pagination-summary {
+  color: var(--color-text-2);
+  font-size: 0.9rem;
+}
+
+.progress-cell {
+  min-width: 220px;
+}
+
+.progress-bar {
+  display: grid;
+  gap: 8px;
+}
+
+.progress-bar[data-size='sm'] {
+  gap: 6px;
+}
+
+.progress-bar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.84rem;
+}
+
+.progress-bar[data-size='sm'] .progress-bar-header {
+  font-size: 0.78rem;
+}
+
+.progress-bar-stage {
+  overflow: hidden;
+  color: var(--color-text-2);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.progress-bar-percent {
+  flex-shrink: 0;
+  color: var(--color-text-1);
+  font-weight: 800;
+}
+
+.progress-bar-track {
+  overflow: hidden;
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: var(--color-background-mute);
+}
+
+.progress-bar[data-size='sm'] .progress-bar-track {
+  height: 8px;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--color-primary), var(--color-info));
+  transition: width var(--transition-normal);
+}
+
+.job-meta-value {
+  display: block;
+  overflow-wrap: anywhere;
+  color: var(--color-text-1);
+  font-weight: 700;
+}
+
+.job-json-disclosure {
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+}
+
+.job-json-disclosure summary {
+  cursor: pointer;
+  padding: 14px 16px;
+  color: var(--color-text-1);
+  font-weight: 800;
+  list-style: none;
+}
+
+.job-json-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
+.job-json-disclosure[open] summary {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.job-json-disclosure pre,
+.timeline-event-detail {
+  margin: 0;
+  overflow-x: auto;
+  padding: 16px;
+  color: var(--color-text-1);
+  font-family: var(--font-family-mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.job-timeline {
+  display: grid;
+  gap: 14px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.job-timeline-item {
+  position: relative;
+  padding-left: 22px;
+}
+
+.job-timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 8px;
+  bottom: -18px;
+  width: 2px;
+  background: var(--color-border);
+}
+
+.job-timeline-item:last-child::before {
+  bottom: 8px;
+}
+
+.job-timeline-marker {
+  position: absolute;
+  left: 0;
+  top: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-full);
+  background: var(--color-primary);
+  box-shadow: 0 0 0 4px var(--color-primary-mute);
+}
+
+.job-timeline-card {
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+}
+
+.job-timeline-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+}
+
+.job-timeline-header strong {
+  color: var(--color-text-1);
+}
+
+.job-timeline-header span {
+  color: var(--color-text-3);
+  font-size: 0.85rem;
+  text-align: right;
 }
 
 .modal-backdrop {
@@ -724,6 +911,10 @@ dd {
 
   .row-actions,
   .form-actions {
+    flex-direction: column;
+  }
+
+  .job-timeline-header {
     flex-direction: column;
   }
 

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -41,6 +41,8 @@
   --color-status-healthy-text: #166534;
   --color-status-degraded-bg: #fef3c7;
   --color-status-degraded-text: #92400e;
+  --color-status-info-bg: #dbeafe;
+  --color-status-info-text: #1d4ed8;
   --color-status-unhealthy-bg: #fee2e2;
   --color-status-unhealthy-text: #991b1b;
   --color-status-neutral-bg: #e2e8f0;
@@ -115,6 +117,8 @@
   --color-status-healthy-text: #7ce2ad;
   --color-status-degraded-bg: rgba(250, 173, 20, 0.18);
   --color-status-degraded-text: #ffd666;
+  --color-status-info-bg: rgba(51, 140, 255, 0.18);
+  --color-status-info-text: #93c5fd;
   --color-status-unhealthy-bg: rgba(255, 77, 79, 0.18);
   --color-status-unhealthy-text: #ffaaa5;
   --color-status-neutral-bg: rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Summary
- Add Task Center admin page with job list, type/status filters, pagination
- Add job detail page with event timeline, cancel action, progress bar
- Show 'Cancelling...' status when cancel_requested_at is set
- 5s auto-refresh for running jobs

## Test plan
- [x] Build + Lint pass
- [x] 18 tests pass (2 test files)

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `435979946bbb660cfc129d4248e44bae5a12c53e`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/61#issuecomment-4351221977) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/61#issuecomment-4351222235)
- Key findings addressed: Cancelling status display, wiki_sync filter, terminal progress bar

Closes #54