### PR TITLE
test: add Stage 2 integration tests (#55)

### DIFF
--- a/apps/web/src/__tests__/jobs-page.test.tsx
+++ b/apps/web/src/__tests__/jobs-page.test.tsx
@@ -48,8 +48,8 @@ describe('JobDetailPage', () => {
     renderJobsRoute('/admin/jobs/job-1');
 
     expect(await screen.findByRole('heading', { name: 'Job Detail' })).toBeInTheDocument();
+    expect(await screen.findByText('space-main')).toBeInTheDocument();
     expect(screen.getAllByText('Graphify').length).toBeGreaterThan(0);
-    expect(screen.getByText('space-main')).toBeInTheDocument();
     expect(screen.getByText('Progress Updated')).toBeInTheDocument();
     expect(screen.getByRole('progressbar', { name: 'chunking progress' })).toHaveAttribute('aria-valuenow', '65');
   });
@@ -59,6 +59,7 @@ describe('JobDetailPage', () => {
 
     renderJobsRoute('/admin/jobs/job-1');
 
+    await screen.findByText('space-main');
     fireEvent.click(await screen.findByRole('button', { name: 'Cancel Job' }));
 
     await waitFor(() =>

--- a/tests/integration/job-cancel.test.ts
+++ b/tests/integration/job-cancel.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { JobEventRepository, JobRepository, JobStatus } from '@cherrygraph/job-core';
+
+import { JobsService, type JobContext } from '../../apps/api/src/jobs/jobs.service.js';
+import { InMemoryJobDb, TEST_TENANT_ID, TEST_USER_ID } from './stage2-integration-test-utils.js';
+
+describe('Stage 2 job cancel integration', () => {
+  it('cancels a pending job directly and records status_changed', async () => {
+    const db = new InMemoryJobDb();
+    const service = new JobsService(db.asDb() as never);
+
+    await JobRepository.create(db.asDb(), {
+      id: 'job-pending',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      status: JobStatus.PENDING,
+      created_by: TEST_USER_ID,
+    });
+
+    const result = await service.cancelJob('job-pending', createCreatorContext());
+
+    expect(result).toEqual({
+      job_id: 'job-pending',
+      status: JobStatus.CANCELLED,
+      cancel_requested_at: null,
+    });
+    expect(db.getJob('job-pending')).toMatchObject({
+      status: JobStatus.CANCELLED,
+    });
+
+    const events = await JobEventRepository.queryByJobId(db.asDb(), 'job-pending');
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event_type).toBe('status_changed');
+    expect(events[0]?.detail_json).toMatchObject({
+      from: JobStatus.PENDING,
+      to: JobStatus.CANCELLED,
+      requested_by: TEST_USER_ID,
+    });
+  });
+
+  it('sets cancel_requested_at for a running job and records cancel_requested', async () => {
+    const db = new InMemoryJobDb();
+    const service = new JobsService(db.asDb() as never);
+
+    await JobRepository.create(db.asDb(), {
+      id: 'job-running',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      status: JobStatus.RUNNING,
+      locked_by: 'worker-1',
+      locked_at: new Date('2026-04-30T12:00:00.000Z'),
+      started_at: new Date('2026-04-30T12:00:00.000Z'),
+      created_by: TEST_USER_ID,
+    });
+
+    const result = await service.cancelJob('job-running', createCreatorContext());
+
+    expect(result.job_id).toBe('job-running');
+    expect(result.status).toBe(JobStatus.RUNNING);
+    expect(result.cancel_requested_at).toBeInstanceOf(Date);
+    expect(db.getJob('job-running')?.cancel_requested_at).toBeInstanceOf(Date);
+
+    const events = await JobEventRepository.queryByJobId(db.asDb(), 'job-running');
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event_type).toBe('cancel_requested');
+    expect(events[0]?.detail_json).toMatchObject({
+      requested_by: TEST_USER_ID,
+    });
+  });
+
+  it('treats repeated cancel on an already requested running job as idempotent', async () => {
+    const db = new InMemoryJobDb();
+    const service = new JobsService(db.asDb() as never);
+    const cancelRequestedAt = new Date('2026-04-30T12:05:00.000Z');
+
+    await JobRepository.create(db.asDb(), {
+      id: 'job-running',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      status: JobStatus.RUNNING,
+      locked_by: 'worker-1',
+      locked_at: new Date('2026-04-30T12:00:00.000Z'),
+      started_at: new Date('2026-04-30T12:00:00.000Z'),
+      cancel_requested_at: cancelRequestedAt,
+      created_by: TEST_USER_ID,
+    });
+
+    const result = await service.cancelJob('job-running', createCreatorContext());
+
+    expect(result).toEqual({
+      job_id: 'job-running',
+      status: JobStatus.RUNNING,
+      cancel_requested_at: cancelRequestedAt,
+    });
+    expect(await JobEventRepository.queryByJobId(db.asDb(), 'job-running')).toEqual([]);
+  });
+});
+
+function createCreatorContext(): JobContext {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: TEST_USER_ID,
+    userId: TEST_USER_ID,
+    actorRole: 'viewer',
+  };
+}

--- a/tests/integration/job-idempotency.test.ts
+++ b/tests/integration/job-idempotency.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { JobRepository } from '@cherrygraph/job-core';
+
+import { InMemoryJobDb, TEST_TENANT_ID, TEST_USER_ID } from './stage2-integration-test-utils.js';
+
+describe('Stage 2 job idempotency integration', () => {
+  it('deduplicates by tenant and idempotency key while allowing the same key in another tenant', async () => {
+    const db = new InMemoryJobDb();
+
+    const first = await JobRepository.create(db.asDb(), {
+      id: 'job-1',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      idempotency_key: 'idem-1',
+      created_by: TEST_USER_ID,
+      payload_json: { source_id: 'source-1' },
+    });
+    const duplicate = await JobRepository.create(db.asDb(), {
+      id: 'job-2',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      idempotency_key: 'idem-1',
+      created_by: TEST_USER_ID,
+      payload_json: { source_id: 'source-2' },
+    });
+    const otherTenant = await JobRepository.create(db.asDb(), {
+      id: 'job-3',
+      tenant_id: 'tenant-2',
+      type: 'graphify',
+      idempotency_key: 'idem-1',
+      created_by: TEST_USER_ID,
+    });
+
+    expect(duplicate).toEqual(first);
+    expect(otherTenant.id).toBe('job-3');
+    expect(db.getJobs().map((job) => ({ id: job.id, tenant_id: job.tenant_id }))).toEqual([
+      { id: 'job-1', tenant_id: TEST_TENANT_ID },
+      { id: 'job-3', tenant_id: 'tenant-2' },
+    ]);
+  });
+});

--- a/tests/integration/lua-lock-atomicity.test.ts
+++ b/tests/integration/lua-lock-atomicity.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { RedisJobLock } from '@cherrygraph/job-core';
+
+import { ExpiringRedisMock } from './stage2-integration-test-utils.js';
+
+describe('Stage 2 Lua lock atomicity integration', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows only the owner to release a Redis lock', async () => {
+    const redis = new ExpiringRedisMock();
+    redis.seed(RedisJobLock.key('job-1'), 'worker-1', 600);
+
+    await expect(RedisJobLock.release(redis, 'job-1', 'worker-1')).resolves.toBe(true);
+    expect(redis.has(RedisJobLock.key('job-1'))).toBe(false);
+
+    redis.seed(RedisJobLock.key('job-1'), 'worker-2', 600);
+    await expect(RedisJobLock.release(redis, 'job-1', 'worker-1')).resolves.toBe(false);
+    await expect(redis.get(RedisJobLock.key('job-1'))).resolves.toBe('worker-2');
+  });
+
+  it('allows only the owner to renew a Redis lock and resets TTL atomically', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T12:00:00.000Z'));
+
+    const redis = new ExpiringRedisMock();
+    redis.seed(RedisJobLock.key('job-1'), 'worker-1', 1);
+
+    await expect(RedisJobLock.renew(redis, 'job-1', 'worker-1', 5)).resolves.toBe(true);
+    vi.advanceTimersByTime(1_500);
+    expect(redis.has(RedisJobLock.key('job-1'))).toBe(true);
+
+    redis.seed(RedisJobLock.key('job-2'), 'worker-2', 600);
+    await expect(RedisJobLock.renew(redis, 'job-2', 'worker-1', 5)).resolves.toBe(false);
+    await expect(redis.get(RedisJobLock.key('job-2'))).resolves.toBe('worker-2');
+  });
+});

--- a/tests/integration/minio-connectivity.test.ts
+++ b/tests/integration/minio-connectivity.test.ts
@@ -1,0 +1,198 @@
+import { Readable } from 'node:stream';
+
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadBucketCommand,
+  PutObjectCommand,
+  S3Client,
+} from '../../apps/api/node_modules/@aws-sdk/client-s3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PRIMARY_STORAGE_BUCKET, REQUIRED_STORAGE_BUCKETS, getBucketName } from '../../apps/api/src/storage/storage.constants.js';
+
+describe('Stage 2 MinIO connectivity integration', () => {
+  const originalEnv = {
+    MINIO_ENDPOINT: process.env.MINIO_ENDPOINT,
+    MINIO_ACCESS_KEY: process.env.MINIO_ACCESS_KEY,
+    MINIO_SECRET_KEY: process.env.MINIO_SECRET_KEY,
+    S3_REGION: process.env.S3_REGION,
+    S3_ENDPOINT: process.env.S3_ENDPOINT,
+    AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+    STORAGE_BUCKET_PREFIX: process.env.STORAGE_BUCKET_PREFIX,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MINIO_ENDPOINT = 'http://localhost:9000';
+    process.env.MINIO_ACCESS_KEY = 'minio-access';
+    process.env.MINIO_SECRET_KEY = 'minio-secret';
+    delete process.env.S3_REGION;
+    delete process.env.S3_ENDPOINT;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.STORAGE_BUCKET_PREFIX;
+  });
+
+  afterEach(() => {
+    restoreStorageEnv(originalEnv);
+  });
+
+  it('creates buckets, transfers objects, presigns URLs, and reports healthy storage', async () => {
+    const { StorageService } = await import('../../apps/api/src/storage/storage.service.js');
+    const client = new MemoryS3Client();
+    const service = new StorageService(client.asClient());
+
+    await service.ensureBuckets();
+
+    expect([...client.bucketNames].sort()).toEqual(REQUIRED_STORAGE_BUCKETS.map((bucket) => getBucketName(bucket)).sort());
+
+    const bucket = getBucketName(PRIMARY_STORAGE_BUCKET);
+    await service.upload(bucket, 'docs/file.txt', Buffer.from('hello world'), 'text/plain');
+
+    const downloaded = await service.download(bucket, 'docs/file.txt');
+    expect(await readableToString(downloaded)).toBe('hello world');
+
+    const downloadUrl = await service.getPresignedDownloadUrl(bucket, 'docs/file.txt', 120);
+    const uploadUrl = await service.getPresignedUploadUrl(bucket, 'docs/file.txt', 'text/plain', 240);
+
+    expect(downloadUrl).toContain(`/${bucket}/docs/file.txt`);
+    expect(downloadUrl).toContain('X-Amz-Expires=120');
+    expect(uploadUrl).toContain(`/${bucket}/docs/file.txt`);
+    expect(uploadUrl).toContain('X-Amz-Expires=240');
+
+    await expect(service.healthCheck()).resolves.toEqual(
+      expect.objectContaining({
+        status: 'healthy',
+      }),
+    );
+  });
+});
+
+class MemoryS3Client {
+  readonly bucketNames = new Set<string>();
+  private readonly objects = new Map<string, { body: Buffer; contentType?: string }>();
+
+  asClient(): S3Client {
+    const client = new S3Client({
+      region: 'us-east-1',
+      endpoint: 'http://localhost:9000',
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: 'minio-access',
+        secretAccessKey: 'minio-secret',
+      },
+    });
+    client.send = this.send.bind(this) as typeof client.send;
+    return client;
+  }
+
+  async send(command: object): Promise<unknown> {
+    if (isCommand(command, HeadBucketCommand, 'HeadBucketCommand')) {
+      const bucket = command.input.Bucket;
+      if (bucket === undefined || !this.bucketNames.has(bucket)) {
+        throw Object.assign(new Error('missing bucket'), { name: 'NotFound' });
+      }
+
+      return {};
+    }
+
+    if (isCommand(command, CreateBucketCommand, 'CreateBucketCommand')) {
+      const bucket = command.input.Bucket;
+      if (bucket === undefined) {
+        throw new Error('Bucket is required');
+      }
+
+      this.bucketNames.add(bucket);
+      return {};
+    }
+
+    if (isCommand(command, PutObjectCommand, 'PutObjectCommand')) {
+      const bucket = command.input.Bucket;
+      const key = command.input.Key;
+      if (bucket === undefined || key === undefined || !this.bucketNames.has(bucket)) {
+        throw new Error('Bucket must exist before upload');
+      }
+
+      this.objects.set(this.objectKey(bucket, key), {
+        body: normalizeBody(command.input.Body),
+        contentType: command.input.ContentType,
+      });
+      return {};
+    }
+
+    if (isCommand(command, GetObjectCommand, 'GetObjectCommand')) {
+      const bucket = command.input.Bucket;
+      const key = command.input.Key;
+      if (bucket === undefined || key === undefined) {
+        throw new Error('Bucket and key are required');
+      }
+
+      const object = this.objects.get(this.objectKey(bucket, key));
+      if (object === undefined) {
+        throw Object.assign(new Error('missing object'), { name: 'NoSuchKey' });
+      }
+
+      return {
+        Body: Readable.from([object.body]),
+      };
+    }
+
+    if (isCommand(command, DeleteObjectCommand, 'DeleteObjectCommand')) {
+      const bucket = command.input.Bucket;
+      const key = command.input.Key;
+      if (bucket !== undefined && key !== undefined) {
+        this.objects.delete(this.objectKey(bucket, key));
+      }
+
+      return {};
+    }
+
+    throw new Error('Unsupported S3 command in integration test');
+  }
+
+  private objectKey(bucket: string, key: string): string {
+    return `${bucket}/${key}`;
+  }
+}
+
+async function readableToString(stream: Readable): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function normalizeBody(body: unknown): Buffer {
+  if (Buffer.isBuffer(body)) {
+    return body;
+  }
+
+  if (typeof body === 'string') {
+    return Buffer.from(body);
+  }
+
+  throw new Error('MemoryS3Client only supports Buffer or string bodies');
+}
+
+function isCommand<Input extends object>(
+  value: object,
+  commandClass: new (...args: any[]) => { input: Input },
+  expectedName: string,
+): value is { input: Input } {
+  return value instanceof commandClass || value.constructor.name === expectedName;
+}
+
+function restoreStorageEnv(originalEnv: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}

--- a/tests/integration/stage2-integration-test-utils.ts
+++ b/tests/integration/stage2-integration-test-utils.ts
@@ -1,0 +1,727 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  JobStatus,
+  job_events,
+  jobs,
+  type JobDatabase,
+  type JobEventRow,
+  type JobRow,
+  type RedisJobLockClient,
+} from '@cherrygraph/job-core';
+
+export const TEST_TENANT_ID = 'tenant-1';
+export const TEST_SPACE_ID = 'space-1';
+export const TEST_USER_ID = 'user-1';
+
+type SupportedTable = typeof jobs | typeof job_events;
+type SortDirection = 'asc' | 'desc';
+type PredicateNode =
+  | { type: 'and'; nodes: PredicateNode[] }
+  | { type: 'eq'; column: string; value: unknown }
+  | { type: 'in'; column: string; values: unknown[] }
+  | { type: 'is-null'; column: string }
+  | { type: 'is-not-null'; column: string }
+  | { type: 'next-run-ready'; column: string }
+  | { type: 'timeout-expired'; lockedAtColumn: string; timeoutColumn: string; defaultSeconds: number };
+type SortNode = {
+  column: string;
+  direction: SortDirection;
+};
+type RedisEntry = {
+  value: string;
+  expiresAt: number | null;
+};
+
+export class InMemoryJobDb {
+  private readonly jobRows: JobRow[];
+  private readonly eventRows: JobEventRow[];
+
+  constructor(seed: { jobs?: JobRow[]; events?: JobEventRow[] } = {}) {
+    this.jobRows = clone(seed.jobs ?? []);
+    this.eventRows = clone(seed.events ?? []);
+  }
+
+  asDb(): JobDatabase {
+    return this as unknown as JobDatabase;
+  }
+
+  async transaction<T>(callback: (tx: JobDatabase) => Promise<T>): Promise<T> {
+    return callback(this.asDb());
+  }
+
+  select(fields?: unknown): InMemorySelectBuilder {
+    return new InMemorySelectBuilder(this, fields);
+  }
+
+  insert(table?: unknown): { values: (value: unknown) => InMemoryInsertBuilder } {
+    return {
+      values: (value: unknown) => new InMemoryInsertBuilder(this, table, value),
+    };
+  }
+
+  update(table?: unknown): { set: (value: unknown) => InMemoryUpdateBuilder } {
+    return {
+      set: (value: unknown) => new InMemoryUpdateBuilder(this, table, value),
+    };
+  }
+
+  getJob(jobId: string): JobRow | undefined {
+    return clone(this.jobRows.find((row) => row.id === jobId));
+  }
+
+  getJobs(): JobRow[] {
+    return clone(this.jobRows);
+  }
+
+  getEvents(): JobEventRow[] {
+    return clone(this.eventRows);
+  }
+
+  selectRows(
+    table: unknown,
+    fields: unknown,
+    condition: unknown,
+    orderByClauses: unknown[],
+    limitValue: number | undefined,
+    offsetValue: number | undefined,
+  ): unknown[] {
+    const rows = this.getTable(table);
+    const filtered = rows.filter((row) => matchesCondition(row, condition));
+    const ordered = applyOrderBy(filtered, orderByClauses);
+    const offset = offsetValue ?? 0;
+    const limited = limitValue === undefined ? ordered.slice(offset) : ordered.slice(offset, offset + limitValue);
+    return projectRows(limited, fields);
+  }
+
+  insertRows(table: unknown, value: unknown, conflictTarget: unknown): unknown[] {
+    const values = Array.isArray(value) ? value : [value];
+    const inserted: unknown[] = [];
+
+    for (const entry of values) {
+      if (!isRecord(entry)) {
+        continue;
+      }
+
+      if (table === jobs) {
+        const row = normalizeJobRow(entry as Partial<JobRow>);
+        if (hasIdempotencyConflict(this.jobRows, row, conflictTarget)) {
+          continue;
+        }
+
+        this.jobRows.push(row);
+        inserted.push(clone(row));
+        continue;
+      }
+
+      if (table === job_events) {
+        const row = normalizeEventRow(entry as Partial<JobEventRow>);
+        this.eventRows.push(row);
+        inserted.push(clone(row));
+        continue;
+      }
+
+      throw new Error('Unsupported table insert in Stage 2 integration harness');
+    }
+
+    return inserted;
+  }
+
+  updateRows(table: unknown, value: unknown, condition: unknown): unknown[] {
+    if (!isRecord(value)) {
+      throw new Error('Stage 2 integration harness updates require record values');
+    }
+
+    const rows = this.getTable(table);
+    const updated: unknown[] = [];
+
+    for (const row of rows) {
+      if (!matchesCondition(row, condition)) {
+        continue;
+      }
+
+      Object.assign(row, clone(value));
+      updated.push(clone(row));
+    }
+
+    return updated;
+  }
+
+  private getTable(table: unknown): Array<JobRow | JobEventRow> {
+    if (table === jobs) {
+      return this.jobRows;
+    }
+
+    if (table === job_events) {
+      return this.eventRows;
+    }
+
+    throw new Error('Unsupported table access in Stage 2 integration harness');
+  }
+}
+
+class InMemorySelectBuilder implements PromiseLike<unknown[]> {
+  private table?: unknown;
+  private condition?: unknown;
+  private readonly orderByClauses: unknown[] = [];
+  private limitValue?: number;
+  private offsetValue?: number;
+
+  constructor(
+    private readonly db: InMemoryJobDb,
+    private readonly fields?: unknown,
+  ) {}
+
+  from(table?: unknown): this {
+    this.table = table;
+    return this;
+  }
+
+  $dynamic(): this {
+    return this;
+  }
+
+  innerJoin(): this {
+    return this;
+  }
+
+  where(condition: unknown): this {
+    this.condition = condition;
+    return this;
+  }
+
+  orderBy(...clauses: unknown[]): this {
+    this.orderByClauses.push(...clauses);
+    return this;
+  }
+
+  limit(value: number): this {
+    this.limitValue = value;
+    return this;
+  }
+
+  offset(value: number): this {
+    this.offsetValue = value;
+    return this;
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(
+      this.db.selectRows(
+        this.table,
+        this.fields,
+        this.condition,
+        this.orderByClauses,
+        this.limitValue,
+        this.offsetValue,
+      ),
+    ).then(onfulfilled ?? undefined, onrejected ?? undefined);
+  }
+}
+
+class InMemoryInsertBuilder {
+  private conflictTarget?: unknown;
+
+  constructor(
+    private readonly db: InMemoryJobDb,
+    private readonly table: unknown,
+    private readonly value: unknown,
+  ) {}
+
+  onConflictDoNothing(config: { target: unknown }): this {
+    this.conflictTarget = config.target;
+    return this;
+  }
+
+  async returning(): Promise<unknown[]> {
+    return this.db.insertRows(this.table, this.value, this.conflictTarget);
+  }
+}
+
+class InMemoryUpdateBuilder {
+  private condition?: unknown;
+
+  constructor(
+    private readonly db: InMemoryJobDb,
+    private readonly table: unknown,
+    private readonly value: unknown,
+  ) {}
+
+  where(condition: unknown): this {
+    this.condition = condition;
+    return this;
+  }
+
+  async returning(): Promise<unknown[]> {
+    return this.db.updateRows(this.table, this.value, this.condition);
+  }
+}
+
+export class ExpiringRedisMock implements RedisJobLockClient {
+  private readonly store = new Map<string, RedisEntry>();
+
+  async get(key: string): Promise<string | null> {
+    this.purgeExpired(key);
+    return this.store.get(key)?.value ?? null;
+  }
+
+  async set(key: string, value: string, ...args: Array<string | number>): Promise<string | null> {
+    this.purgeExpired(key);
+
+    const ttlSeconds = parseTtlSeconds(args);
+    const mode = parseMode(args);
+
+    if (mode === 'NX' && this.store.has(key)) {
+      return null;
+    }
+
+    if (mode === 'XX' && !this.store.has(key)) {
+      return null;
+    }
+
+    this.store.set(key, {
+      value,
+      expiresAt: ttlSeconds === undefined ? null : Date.now() + ttlSeconds * 1_000,
+    });
+
+    return 'OK';
+  }
+
+  async eval(script: string, _numKeys: number, ...args: Array<string | number>): Promise<number | string | null> {
+    const [key, workerId, ttlSeconds] = args;
+    if (typeof key !== 'string' || typeof workerId !== 'string') {
+      throw new Error('ExpiringRedisMock requires string key and worker id');
+    }
+
+    this.purgeExpired(key);
+
+    if (
+      script ===
+      "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
+    ) {
+      if (this.store.get(key)?.value === workerId) {
+        this.store.delete(key);
+        return 1;
+      }
+
+      return 0;
+    }
+
+    if (
+      script ===
+      "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2]) else return nil end"
+    ) {
+      if (typeof ttlSeconds !== 'number') {
+        throw new Error('ExpiringRedisMock renew requires a numeric TTL');
+      }
+
+      if (this.store.get(key)?.value !== workerId) {
+        return null;
+      }
+
+      this.store.set(key, {
+        value: workerId,
+        expiresAt: Date.now() + ttlSeconds * 1_000,
+      });
+      return 'OK';
+    }
+
+    throw new Error(`Unsupported Redis Lua script: ${script}`);
+  }
+
+  seed(key: string, value: string, ttlSeconds = 600): void {
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + ttlSeconds * 1_000,
+    });
+  }
+
+  has(key: string): boolean {
+    this.purgeExpired(key);
+    return this.store.has(key);
+  }
+
+  private purgeExpired(key: string): void {
+    const entry = this.store.get(key);
+    if (entry?.expiresAt !== null && entry !== undefined && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+    }
+  }
+}
+
+export function createJobRecord(overrides: Partial<JobRow> = {}): JobRow {
+  return normalizeJobRow(overrides);
+}
+
+export function createJobEventRecord(overrides: Partial<JobEventRow> = {}): JobEventRow {
+  return normalizeEventRow(overrides);
+}
+
+function normalizeJobRow(overrides: Partial<JobRow>): JobRow {
+  return {
+    id: overrides.id ?? randomUUID(),
+    tenant_id: overrides.tenant_id ?? TEST_TENANT_ID,
+    space_id: overrides.space_id === undefined ? TEST_SPACE_ID : overrides.space_id,
+    queue_name: overrides.queue_name ?? 'default',
+    type: overrides.type ?? 'graphify',
+    priority: overrides.priority ?? 100,
+    status: overrides.status ?? JobStatus.PENDING,
+    attempt_count: overrides.attempt_count ?? 0,
+    max_attempts: overrides.max_attempts ?? 3,
+    timeout_seconds: overrides.timeout_seconds === undefined ? 600 : overrides.timeout_seconds,
+    locked_by: overrides.locked_by === undefined ? null : overrides.locked_by,
+    locked_at: overrides.locked_at === undefined ? null : overrides.locked_at,
+    next_run_at: overrides.next_run_at === undefined ? null : overrides.next_run_at,
+    cancel_requested_at: overrides.cancel_requested_at === undefined ? null : overrides.cancel_requested_at,
+    payload_json: overrides.payload_json ?? {},
+    result_json: overrides.result_json === undefined ? null : overrides.result_json,
+    error_json: overrides.error_json === undefined ? null : overrides.error_json,
+    idempotency_key: overrides.idempotency_key === undefined ? null : overrides.idempotency_key,
+    created_by: overrides.created_by === undefined ? TEST_USER_ID : overrides.created_by,
+    created_at: overrides.created_at ?? new Date(),
+    started_at: overrides.started_at === undefined ? null : overrides.started_at,
+    completed_at: overrides.completed_at === undefined ? null : overrides.completed_at,
+  };
+}
+
+function normalizeEventRow(overrides: Partial<JobEventRow>): JobEventRow {
+  return {
+    id: overrides.id ?? randomUUID(),
+    job_id: overrides.job_id ?? 'job-1',
+    event_type: overrides.event_type ?? 'status_changed',
+    detail_json: overrides.detail_json ?? {},
+    created_at: overrides.created_at ?? new Date(),
+  };
+}
+
+function hasIdempotencyConflict(existingRows: JobRow[], nextRow: JobRow, conflictTarget: unknown): boolean {
+  if (!Array.isArray(conflictTarget)) {
+    return false;
+  }
+
+  const targetColumns = conflictTarget
+    .map((entry) => (isRecord(entry) && typeof entry.name === 'string' ? entry.name : undefined))
+    .filter((value): value is string => value !== undefined);
+
+  if (!targetColumns.includes('tenant_id') || !targetColumns.includes('idempotency_key')) {
+    return false;
+  }
+
+  if (nextRow.idempotency_key === null) {
+    return false;
+  }
+
+  return existingRows.some(
+    (row) => row.tenant_id === nextRow.tenant_id && row.idempotency_key === nextRow.idempotency_key,
+  );
+}
+
+function projectRows(rows: Array<JobRow | JobEventRow>, fields: unknown): unknown[] {
+  if (fields === undefined) {
+    return clone(rows);
+  }
+
+  if (isRecord(fields) && Object.keys(fields).length === 1 && 'total' in fields) {
+    return [{ total: rows.length }];
+  }
+
+  if (!isRecord(fields)) {
+    return clone(rows);
+  }
+
+  return rows.map((row) => {
+    const projected: Record<string, unknown> = {};
+    for (const [alias, field] of Object.entries(fields)) {
+      const columnName = resolveColumnName(field);
+      projected[alias] = columnName === undefined ? undefined : (row as Record<string, unknown>)[columnName];
+    }
+
+    return projected;
+  });
+}
+
+function applyOrderBy(rows: Array<JobRow | JobEventRow>, clauses: unknown[]): Array<JobRow | JobEventRow> {
+  if (clauses.length === 0) {
+    return rows.slice();
+  }
+
+  const sortNodes = clauses.map(parseSortClause);
+  return rows.slice().sort((left, right) => {
+    for (const sortNode of sortNodes) {
+      const comparison = compareValues(
+        (left as Record<string, unknown>)[sortNode.column],
+        (right as Record<string, unknown>)[sortNode.column],
+      );
+
+      if (comparison !== 0) {
+        return sortNode.direction === 'asc' ? comparison : -comparison;
+      }
+    }
+
+    return 0;
+  });
+}
+
+function compareValues(left: unknown, right: unknown): number {
+  if (left === right) {
+    return 0;
+  }
+
+  if (left === null || left === undefined) {
+    return 1;
+  }
+
+  if (right === null || right === undefined) {
+    return -1;
+  }
+
+  if (left instanceof Date && right instanceof Date) {
+    return left.getTime() - right.getTime();
+  }
+
+  if (typeof left === 'number' && typeof right === 'number') {
+    return left - right;
+  }
+
+  return String(left).localeCompare(String(right));
+}
+
+function parseSortClause(clause: unknown): SortNode {
+  const chunks = getQueryChunks(clause);
+  if (
+    chunks.length === 3 &&
+    chunkText(chunks[0]) === '' &&
+    resolveColumnName(chunks[1]) !== undefined &&
+    (chunkText(chunks[2]) === ' asc' || chunkText(chunks[2]) === ' desc')
+  ) {
+    return {
+      column: resolveColumnName(chunks[1]) ?? '',
+      direction: chunkText(chunks[2]).trim() as SortDirection,
+    };
+  }
+
+  throw new Error('Unsupported sort clause in Stage 2 integration harness');
+}
+
+function matchesCondition(row: JobRow | JobEventRow, condition: unknown): boolean {
+  if (condition === undefined) {
+    return true;
+  }
+
+  return evaluatePredicate(parsePredicate(condition), row as Record<string, unknown>);
+}
+
+function parsePredicate(condition: unknown): PredicateNode {
+  const chunks = getQueryChunks(condition);
+
+  if (
+    chunks.length === 3 &&
+    chunkText(chunks[0]) === '(' &&
+    hasQueryChunks(chunks[1]) &&
+    chunkText(chunks[2]) === ')'
+  ) {
+    const nodes = splitAndClauses(getQueryChunks(chunks[1])).map(parsePredicate);
+    return {
+      type: 'and',
+      nodes,
+    };
+  }
+
+  if (
+    chunks.length === 5 &&
+    chunkText(chunks[0]) === '' &&
+    resolveColumnName(chunks[1]) !== undefined &&
+    chunkText(chunks[2]) === ' = ' &&
+    isParam(chunks[3]) &&
+    chunkText(chunks[4]) === ''
+  ) {
+    return {
+      type: 'eq',
+      column: resolveColumnName(chunks[1]) ?? '',
+      value: chunks[3].value,
+    };
+  }
+
+  if (
+    chunks.length === 5 &&
+    chunkText(chunks[0]) === '' &&
+    resolveColumnName(chunks[1]) !== undefined &&
+    chunkText(chunks[2]) === ' in ' &&
+    Array.isArray(chunks[3]) &&
+    chunkText(chunks[4]) === ''
+  ) {
+    return {
+      type: 'in',
+      column: resolveColumnName(chunks[1]) ?? '',
+      values: chunks[3].filter(isParam).map((entry) => entry.value),
+    };
+  }
+
+  if (
+    chunks.length === 3 &&
+    chunkText(chunks[0]) === '' &&
+    resolveColumnName(chunks[1]) !== undefined &&
+    chunkText(chunks[2]) === ' is null'
+  ) {
+    return {
+      type: 'is-null',
+      column: resolveColumnName(chunks[1]) ?? '',
+    };
+  }
+
+  if (
+    chunks.length === 3 &&
+    chunkText(chunks[0]) === '' &&
+    resolveColumnName(chunks[1]) !== undefined &&
+    chunkText(chunks[2]) === ' is not null'
+  ) {
+    return {
+      type: 'is-not-null',
+      column: resolveColumnName(chunks[1]) ?? '',
+    };
+  }
+
+  if (
+    chunks.length === 5 &&
+    chunkText(chunks[0]) === '(' &&
+    resolveColumnName(chunks[1]) !== undefined &&
+    chunkText(chunks[2]) === ' IS NULL OR ' &&
+    resolveColumnName(chunks[3]) === resolveColumnName(chunks[1]) &&
+    chunkText(chunks[4]) === ' <= now())'
+  ) {
+    return {
+      type: 'next-run-ready',
+      column: resolveColumnName(chunks[1]) ?? '',
+    };
+  }
+
+  if (
+    (chunks.length === 5 || chunks.length === 7) &&
+    chunkText(chunks[0]) === '' &&
+    resolveColumnName(chunks[1]) !== undefined &&
+    chunkText(chunks[2]) === ' + coalesce(' &&
+    resolveColumnName(chunks[3]) !== undefined
+  ) {
+    const defaultSeconds =
+      chunks.length === 7
+        ? normalizeNumericChunk(chunks[5]) ?? 1800
+        : Number.parseInt(chunkText(chunks[4]).match(/^,\s*(\d+)\)/)?.[1] ?? '1800', 10);
+    const tail = chunks.length === 7 ? chunkText(chunks[6]) : chunkText(chunks[4]);
+
+    if (tail === ") * interval '1 second' < now()" || tail.endsWith("* interval '1 second' < now()")) {
+      return {
+        type: 'timeout-expired',
+        lockedAtColumn: resolveColumnName(chunks[1]) ?? '',
+        timeoutColumn: resolveColumnName(chunks[3]) ?? '',
+        defaultSeconds,
+      };
+    }
+  }
+
+  throw new Error('Unsupported SQL predicate in Stage 2 integration harness');
+}
+
+function evaluatePredicate(node: PredicateNode, row: Record<string, unknown>): boolean {
+  if (node.type === 'and') {
+    return node.nodes.every((child) => evaluatePredicate(child, row));
+  }
+
+  if (node.type === 'eq') {
+    return row[node.column] === node.value;
+  }
+
+  if (node.type === 'in') {
+    return node.values.includes(row[node.column]);
+  }
+
+  if (node.type === 'is-null') {
+    return row[node.column] === null || row[node.column] === undefined;
+  }
+
+  if (node.type === 'is-not-null') {
+    return row[node.column] !== null && row[node.column] !== undefined;
+  }
+
+  if (node.type === 'next-run-ready') {
+    const value = row[node.column];
+    return !(value instanceof Date) || value.getTime() <= Date.now();
+  }
+
+  const lockedAt = row[node.lockedAtColumn];
+  if (!(lockedAt instanceof Date)) {
+    return false;
+  }
+
+  const timeoutSeconds =
+    typeof row[node.timeoutColumn] === 'number' ? (row[node.timeoutColumn] as number) : node.defaultSeconds;
+  return lockedAt.getTime() + timeoutSeconds * 1_000 < Date.now();
+}
+
+function splitAndClauses(chunks: unknown[]): unknown[] {
+  const clauses: unknown[] = [];
+
+  for (let index = 0; index < chunks.length; index += 2) {
+    clauses.push(chunks[index]);
+    if (index < chunks.length - 1 && chunkText(chunks[index + 1]) !== ' and ') {
+      throw new Error('Unsupported boolean expression in Stage 2 integration harness');
+    }
+  }
+
+  return clauses;
+}
+
+function parseTtlSeconds(args: Array<string | number>): number | undefined {
+  const ttlIndex = args.findIndex((entry) => entry === 'EX');
+  return ttlIndex === -1 || typeof args[ttlIndex + 1] !== 'number' ? undefined : args[ttlIndex + 1];
+}
+
+function parseMode(args: Array<string | number>): 'NX' | 'XX' | undefined {
+  return args.find((entry): entry is 'NX' | 'XX' => entry === 'NX' || entry === 'XX');
+}
+
+function getQueryChunks(value: unknown): unknown[] {
+  if (!hasQueryChunks(value)) {
+    return [];
+  }
+
+  return value.queryChunks;
+}
+
+function hasQueryChunks(value: unknown): value is { queryChunks: unknown[] } {
+  return isRecord(value) && Array.isArray(value.queryChunks);
+}
+
+function chunkText(value: unknown): string {
+  return isRecord(value) && Array.isArray(value.value) ? value.value.join('') : '';
+}
+
+function resolveColumnName(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.name === 'string' ? value.name : undefined;
+}
+
+function isParam(value: unknown): value is { value: unknown; encoder: unknown } {
+  return isRecord(value) && 'encoder' in value && !Array.isArray(value.value);
+}
+
+function normalizeNumericChunk(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (isParam(value) && typeof value.value === 'number' && Number.isFinite(value.value)) {
+    return value.value;
+  }
+
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null;
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/tests/integration/worker-crash-recovery.test.ts
+++ b/tests/integration/worker-crash-recovery.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { JobEventRepository, JobRepository, JobStatus, RedisJobLock, TimeoutScanner } from '@cherrygraph/job-core';
+
+import { InternalJobsService } from '../../apps/api/src/internal/internal-jobs.service.js';
+import { ExpiringRedisMock, InMemoryJobDb, TEST_TENANT_ID, TEST_USER_ID } from './stage2-integration-test-utils.js';
+
+describe('Stage 2 worker crash recovery integration', () => {
+  const originalDefaultTenantId = process.env.DEFAULT_TENANT_ID;
+
+  beforeEach(() => {
+    process.env.DEFAULT_TENANT_ID = TEST_TENANT_ID;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalDefaultTenantId === undefined) {
+      delete process.env.DEFAULT_TENANT_ID;
+    } else {
+      process.env.DEFAULT_TENANT_ID = originalDefaultTenantId;
+    }
+  });
+
+  it('requeues a crashed job after timeout and lets another worker claim it', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T12:00:00.000Z'));
+
+    const db = new InMemoryJobDb();
+    const redis = new ExpiringRedisMock();
+    const service = new InternalJobsService(db.asDb() as never, redis as never);
+
+    await JobRepository.create(db.asDb(), {
+      id: 'job-1',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      timeout_seconds: 30,
+      max_attempts: 3,
+      created_by: TEST_USER_ID,
+      payload_json: { source_id: 'source-1' },
+    });
+
+    await expect(RedisJobLock.acquire(redis, 'job-1', 'worker-1', 600)).resolves.toBe(true);
+    await service.reportProgress('job-1', {
+      worker_id: 'worker-1',
+      percent: 10,
+      stage: 'fetching',
+    });
+
+    vi.advanceTimersByTime(31_000);
+
+    await expect(TimeoutScanner.scan(db.asDb(), redis)).resolves.toBe(1);
+    expect(db.getJob('job-1')).toMatchObject({
+      status: JobStatus.PENDING,
+      attempt_count: 1,
+      locked_by: null,
+      locked_at: null,
+    });
+    expect(redis.has(RedisJobLock.key('job-1'))).toBe(false);
+
+    const recoveryEvents = await JobEventRepository.queryByJobId(db.asDb(), 'job-1');
+    expect(recoveryEvents.map((event) => event.event_type)).toEqual([
+      'status_changed',
+      'progress_updated',
+      'status_changed',
+      'status_changed',
+      'timeout_detected',
+    ]);
+    expect(recoveryEvents[2]?.detail_json).toMatchObject({
+      from: JobStatus.RUNNING,
+      to: JobStatus.FAILED,
+      reason: 'timeout',
+    });
+    expect(recoveryEvents[3]?.detail_json).toMatchObject({
+      from: JobStatus.FAILED,
+      to: JobStatus.PENDING,
+      reason: 'timeout_retry',
+    });
+
+    vi.advanceTimersByTime(60_000);
+
+    const polled = await service.pollPendingJobs('graphify', 1);
+    expect(polled).toMatchObject([
+      {
+        job_id: 'job-1',
+        status: JobStatus.PENDING,
+      },
+    ]);
+
+    await expect(RedisJobLock.acquire(redis, 'job-1', 'worker-2', 600)).resolves.toBe(true);
+    const reactivated = await service.reportProgress('job-1', {
+      worker_id: 'worker-2',
+      percent: 5,
+      stage: 'retrying',
+    });
+
+    expect(reactivated).toMatchObject({
+      job_id: 'job-1',
+      status: JobStatus.RUNNING,
+      progress: {
+        percent: 5,
+        stage: 'retrying',
+      },
+    });
+    expect(db.getJob('job-1')).toMatchObject({
+      status: JobStatus.RUNNING,
+      locked_by: 'worker-2',
+      attempt_count: 1,
+    });
+  });
+});

--- a/tests/integration/worker-heartbeat.test.ts
+++ b/tests/integration/worker-heartbeat.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { JobEventRepository, JobRepository, JobStateMachine, JobStatus, RedisJobLock } from '@cherrygraph/job-core';
+
+import { InternalJobsService } from '../../apps/api/src/internal/internal-jobs.service.js';
+import { ExpiringRedisMock, InMemoryJobDb, TEST_TENANT_ID, TEST_USER_ID } from './stage2-integration-test-utils.js';
+
+describe('Stage 2 worker heartbeat integration', () => {
+  const originalDefaultTenantId = process.env.DEFAULT_TENANT_ID;
+
+  beforeEach(() => {
+    process.env.DEFAULT_TENANT_ID = TEST_TENANT_ID;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalDefaultTenantId === undefined) {
+      delete process.env.DEFAULT_TENANT_ID;
+    } else {
+      process.env.DEFAULT_TENANT_ID = originalDefaultTenantId;
+    }
+  });
+
+  it('marks a worker dead after 3 missed intervals and releases its locks', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T12:00:00.000Z'));
+
+    const db = new InMemoryJobDb();
+    const redis = new ExpiringRedisMock();
+    const service = new InternalJobsService(db.asDb() as never, redis as never);
+
+    await JobRepository.create(db.asDb(), {
+      id: 'job-1',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      max_attempts: 3,
+      created_by: TEST_USER_ID,
+    });
+    await expect(RedisJobLock.acquire(redis, 'job-1', 'worker-1', 600)).resolves.toBe(true);
+    await JobStateMachine.transition(db.asDb(), 'job-1', JobStatus.PENDING, JobStatus.RUNNING, {
+      locked_by: 'worker-1',
+      locked_at: new Date(),
+      started_at: new Date(),
+    });
+
+    await expect(
+      service.recordHeartbeat({
+        worker_id: 'worker-1',
+        active_jobs: ['job-1'],
+        system_info: { cpu_percent: 12 },
+      }),
+    ).resolves.toEqual({
+      ack: true,
+      cancel_requested: [],
+      lost_locks: [],
+    });
+
+    vi.advanceTimersByTime(30_000);
+    await expect(
+      service.recordHeartbeat({
+        worker_id: 'worker-1',
+        active_jobs: ['job-1'],
+        system_info: { cpu_percent: 15 },
+      }),
+    ).resolves.toEqual({
+      ack: true,
+      cancel_requested: [],
+      lost_locks: [],
+    });
+
+    vi.advanceTimersByTime(91_000);
+
+    await expect(service.scanDeadWorkers()).resolves.toBe(1);
+    expect(db.getJob('job-1')).toMatchObject({
+      status: JobStatus.PENDING,
+      attempt_count: 1,
+      locked_by: null,
+      locked_at: null,
+    });
+    expect(redis.has(RedisJobLock.key('job-1'))).toBe(false);
+
+    const events = await JobEventRepository.queryByJobId(db.asDb(), 'job-1');
+    expect(events.map((event) => event.event_type)).toEqual([
+      'status_changed',
+      'status_changed',
+      'timeout_detected',
+    ]);
+    expect(events[0]?.detail_json).toMatchObject({
+      from: JobStatus.RUNNING,
+      to: JobStatus.FAILED,
+      worker_id: 'worker-1',
+      reason: 'worker_timeout',
+    });
+    expect(events[1]?.detail_json).toMatchObject({
+      from: JobStatus.FAILED,
+      to: JobStatus.PENDING,
+      worker_id: 'worker-1',
+      reason: 'worker_timeout_retry',
+    });
+    expect(events[2]?.detail_json).toMatchObject({
+      worker_id: 'worker-1',
+      reason: 'worker_missed_heartbeat',
+    });
+  });
+});

--- a/tests/integration/worker-job-lifecycle.test.ts
+++ b/tests/integration/worker-job-lifecycle.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { JobEventRepository, JobRepository, JobStatus, RedisJobLock } from '@cherrygraph/job-core';
+
+import { InternalJobsService } from '../../apps/api/src/internal/internal-jobs.service.js';
+import { ExpiringRedisMock, InMemoryJobDb, TEST_TENANT_ID, TEST_USER_ID } from './stage2-integration-test-utils.js';
+
+describe('Stage 2 worker lifecycle integration', () => {
+  const originalDefaultTenantId = process.env.DEFAULT_TENANT_ID;
+
+  beforeEach(() => {
+    process.env.DEFAULT_TENANT_ID = TEST_TENANT_ID;
+  });
+
+  afterEach(() => {
+    if (originalDefaultTenantId === undefined) {
+      delete process.env.DEFAULT_TENANT_ID;
+    } else {
+      process.env.DEFAULT_TENANT_ID = originalDefaultTenantId;
+    }
+  });
+
+  it('runs poll -> lock -> progress -> complete and exposes the next pending job', async () => {
+    const db = new InMemoryJobDb();
+    const redis = new ExpiringRedisMock();
+    const service = new InternalJobsService(db.asDb() as never, redis as never);
+
+    const firstJob = await JobRepository.create(db.asDb(), {
+      id: 'job-1',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      priority: 10,
+      created_by: TEST_USER_ID,
+      payload_json: { source_id: 'source-1' },
+      created_at: new Date('2026-04-30T12:00:00.000Z'),
+    });
+    const secondJob = await JobRepository.create(db.asDb(), {
+      id: 'job-2',
+      tenant_id: TEST_TENANT_ID,
+      type: 'graphify',
+      priority: 20,
+      created_by: TEST_USER_ID,
+      payload_json: { source_id: 'source-2' },
+      created_at: new Date('2026-04-30T12:01:00.000Z'),
+    });
+
+    const polled = await service.pollPendingJobs('graphify', 1);
+    expect(polled).toMatchObject([
+      {
+        job_id: firstJob.id,
+        status: JobStatus.PENDING,
+      },
+    ]);
+
+    await expect(RedisJobLock.acquire(redis, firstJob.id, 'worker-1', 600)).resolves.toBe(true);
+
+    const running = await service.reportProgress(firstJob.id, {
+      worker_id: 'worker-1',
+      percent: 45,
+      stage: 'chunking',
+    });
+    expect(running).toMatchObject({
+      job_id: firstJob.id,
+      status: JobStatus.RUNNING,
+      progress: {
+        percent: 45,
+        stage: 'chunking',
+      },
+    });
+
+    const completed = await service.reportComplete(firstJob.id, {
+      worker_id: 'worker-1',
+      result_json: { output: 'done' },
+    });
+    expect(completed).toMatchObject({
+      job_id: firstJob.id,
+      status: JobStatus.SUCCEEDED,
+      result_json: { output: 'done' },
+    });
+
+    const events = await JobEventRepository.queryByJobId(db.asDb(), firstJob.id);
+    expect(events.map((event) => event.event_type)).toEqual([
+      'status_changed',
+      'progress_updated',
+      'status_changed',
+    ]);
+    expect(events[0]?.detail_json).toMatchObject({
+      from: JobStatus.PENDING,
+      to: JobStatus.RUNNING,
+      worker_id: 'worker-1',
+    });
+    expect(events[1]?.detail_json).toEqual({
+      percent: 45,
+      stage: 'chunking',
+    });
+    expect(events[2]?.detail_json).toMatchObject({
+      from: JobStatus.RUNNING,
+      to: JobStatus.SUCCEEDED,
+      worker_id: 'worker-1',
+    });
+
+    expect(db.getJob(firstJob.id)).toMatchObject({
+      status: JobStatus.SUCCEEDED,
+      locked_by: null,
+      result_json: { output: 'done' },
+    });
+    expect(redis.has(RedisJobLock.key(firstJob.id))).toBe(false);
+
+    const subsequentPoll = await service.pollPendingJobs('graphify', 1);
+    expect(subsequentPoll).toMatchObject([
+      {
+        job_id: secondJob.id,
+        status: JobStatus.PENDING,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- 7 integration test files covering all Stage 2 acceptance criteria (tasks.md 7.1-7.7)
- Worker lifecycle, crash recovery, heartbeat, MinIO, idempotency, cancel, Lua lock
- Shared in-memory test harness

## Test plan
- [x] 312 tests pass across all packages
- [x] CI Node job passes

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `15b797d43b632f6a84a7c10abf618079b96787f0`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/62#issuecomment-4351528754) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/62#issuecomment-4351528974)
- Key findings addressed: Mock-based integration by design; CI async test timing fixed

Closes #55