### PR TITLE
chore: Stage 2 CI & deploy verification (#56)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,8 @@ services:
       MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin_dev_secret}
+      STORAGE_BUCKET_PREFIX: ${STORAGE_BUCKET_PREFIX:-cherrywiki}
+      WORKER_API_KEY: ${WORKER_API_KEY:-dev-worker-api-key}
       MODEL_API_BASE_URL: ${MODEL_API_BASE_URL:-http://localhost:11434}
       MODEL_API_KEY: ${MODEL_API_KEY:-dev-model-key}
       DEFAULT_CHAT_MODEL: ${DEFAULT_CHAT_MODEL:-gpt-4.1}

--- a/docs/ops/env.example
+++ b/docs/ops/env.example
@@ -29,6 +29,7 @@ COMPOSE_REDIS_URL=redis://redis:6379
 MINIO_ENDPOINT=http://minio:9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=replace-with-strong-password
+STORAGE_BUCKET_PREFIX=cherrywiki
 
 # --- Model API ---
 MODEL_API_BASE_URL=https://api.openai.com/v1
@@ -46,6 +47,7 @@ GRAPHIFY_MAX_NODES=50000
 GRAPHIFY_MAX_EDGES=200000
 
 # --- Worker ---
+WORKER_API_KEY=replace-with-strong-random-key
 WORKER_HEALTH_PORT=9090
 
 # --- Upload ---

--- a/ops/nginx/nginx.conf
+++ b/ops/nginx/nginx.conf
@@ -35,6 +35,12 @@ http {
       proxy_set_header Connection $connection_upgrade;
     }
 
+    # --- Stage 2: Block external access to Internal Worker API ---
+    location /internal/ {
+      return 403 '{"error": "Internal API is not accessible externally."}';
+      add_header Content-Type application/json always;
+    }
+
     # --- Phase 1: Cherry API ---
     location /api/ {
       proxy_pass http://cherry-api:8080;


### PR DESCRIPTION
## Summary
- Block /internal/ routes in Nginx (403 for external access)
- Add WORKER_API_KEY and STORAGE_BUCKET_PREFIX to env.example + docker-compose.yml
- CI Redis service verified working (in #50 pipeline)
- Docker Compose healthchecks verified for Redis/MinIO/API

## Test plan
- [x] Build + Lint pass
- [x] Nginx config blocks /internal/ with 403
- [x] env.example has all new Stage 2 vars

## Agent Review

- Reviewer agents used: Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `925dd998a3ee027f301e52da6e067e5e4b744cf2`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/63#issuecomment-4351545279) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/63#issuecomment-4351545477)
- Key findings addressed: None needed — config-only change

Closes #56