### PR TITLE
feat(web): Upload Center UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-dropzone": "^15.0.0",
     "react-router": "^7.14.2"
   },
   "devDependencies": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import Home from './pages/Home';
 import Login from './pages/Login';
 import NotFound from './pages/NotFound';
 import Wiki from './pages/Wiki';
+import UploadCenter from './pages/uploads/UploadCenter';
 
 export function AppRoutes() {
   return (
@@ -25,6 +26,7 @@ export function AppRoutes() {
       <Route path="/chat/:id" element={<Chat />} />
       <Route path="/wiki/:spaceId" element={<Wiki />} />
       <Route path="/wiki/:spaceId/:pageId" element={<Wiki />} />
+      <Route path="/spaces/:spaceId/uploads" element={<UploadCenter />} />
       <Route
         path="/admin"
         element={

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -64,6 +64,13 @@ describe('App routing', () => {
     expect(screen.getByRole('heading', { name: 'Wiki' })).toBeInTheDocument();
   });
 
+  it('renders Upload Center for /spaces/:spaceId/uploads when authenticated', async () => {
+    mockUploadApi();
+    renderRoute('/spaces/test-space/uploads', ADMIN_USER);
+
+    expect(await screen.findByRole('heading', { name: 'Upload Center' })).toBeInTheDocument();
+  });
+
   it('redirects unauthenticated admin users to /login', () => {
     renderRoute('/admin');
 
@@ -311,6 +318,32 @@ function mockAdminApi(): void {
             },
           },
           meta: { request_id: 'req-health' },
+        }));
+      }
+
+      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+    }),
+  );
+}
+
+function mockUploadApi(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path.startsWith('/api/spaces/test-space/uploads')) {
+        return Promise.resolve(jsonResponse({
+          data: [],
+          meta: {
+            request_id: 'req-uploads',
+            pagination: {
+              page: 1,
+              per_page: 20,
+              total: 0,
+              has_next: false,
+            },
+          },
         }));
       }
 

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -1,0 +1,402 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import FileUploadZone from '../pages/uploads/FileUploadZone';
+import UploadDetail from '../pages/uploads/UploadDetail';
+import UploadList from '../pages/uploads/UploadList';
+import UrlUploadForm from '../pages/uploads/UrlUploadForm';
+import type { UploadItem, UploadResponse, UploadStatus } from '../pages/uploads/types';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('FileUploadZone', () => {
+  it('uploads dropped files with progress and success feedback', async () => {
+    const requests = stubXmlHttpRequest();
+    const onUploaded = vi.fn<(response: UploadResponse, file: File) => void>();
+    const file = new File(['hello'], 'notes.md', { type: 'text/markdown' });
+
+    render(<FileUploadZone spaceId="space-1" accessToken="test-token" onUploaded={onUploaded} />);
+
+    const dropzone = getDropzone();
+    fireEvent.drop(dropzone, createDropEvent(file));
+
+    expect(await screen.findByText(/source_document_id: source-1/i)).toBeInTheDocument();
+    expect(onUploaded).toHaveBeenCalledWith(expect.objectContaining({ source_document_id: 'source-1' }), file);
+    expect(requests[0]?.method).toBe('POST');
+    expect(requests[0]?.url).toBe('/api/spaces/space-1/uploads');
+    expect(requests[0]?.headers.get('Authorization')).toBe('Bearer test-token');
+  });
+
+  it('supports click selection through the hidden file input', async () => {
+    stubXmlHttpRequest('source-click');
+    const onUploaded = vi.fn<(response: UploadResponse, file: File) => void>();
+    const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+
+    render(<FileUploadZone spaceId="space-1" accessToken={null} onUploaded={onUploaded} />);
+
+    const input = screen.getByLabelText('Choose files for upload');
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(await screen.findByText(/source_document_id: source-click/i)).toBeInTheDocument();
+    expect(onUploaded).toHaveBeenCalledWith(expect.objectContaining({ source_document_id: 'source-click' }), file);
+  });
+
+  it('rejects unsupported file types before sending a request', async () => {
+    const requests = stubXmlHttpRequest();
+    const file = new File(['bad'], 'script.exe', { type: 'application/octet-stream' });
+
+    render(<FileUploadZone spaceId="space-1" accessToken={null} onUploaded={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('Choose files for upload'), { target: { files: [file] } });
+
+    expect(await screen.findByText('UNSUPPORTED_FILE_TYPE')).toBeInTheDocument();
+    expect(screen.getByText(/Unsupported file type/i)).toBeInTheDocument();
+    expect(requests).toHaveLength(0);
+  });
+
+  it('rejects files larger than 200 MB before sending a request', async () => {
+    const requests = stubXmlHttpRequest();
+    const file = new File(['large'], 'large.pdf', { type: 'application/pdf' });
+    Object.defineProperty(file, 'size', { value: 201 * 1024 * 1024 });
+
+    render(<FileUploadZone spaceId="space-1" accessToken={null} onUploaded={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('Choose files for upload'), { target: { files: [file] } });
+
+    expect(await screen.findByText('FILE_TOO_LARGE')).toBeInTheDocument();
+    expect(screen.getByText(/200 MB upload limit/i)).toBeInTheDocument();
+    expect(requests).toHaveLength(0);
+  });
+});
+
+describe('UrlUploadForm', () => {
+  it('validates URLs before submitting', async () => {
+    const fetchMock = stubUrlUploadApi();
+
+    render(<UrlUploadForm spaceId="space-1" onUploaded={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'ftp://example.com/file' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add URL' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid http or https URL.');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('submits valid URL uploads', async () => {
+    const fetchMock = stubUrlUploadApi();
+    const onUploaded = vi.fn<(response: UploadResponse, url: string) => void>();
+
+    render(<UrlUploadForm spaceId="space-1" onUploaded={onUploaded} />);
+
+    fireEvent.change(screen.getByLabelText('URL'), { target: { value: 'https://example.com/doc' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add URL' }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent('source-url');
+    expect(onUploaded).toHaveBeenCalledWith(expect.objectContaining({ source_document_id: 'source-url' }), 'https://example.com/doc');
+    expect(getRequestPath(fetchMock.mock.calls[0]?.[0] ?? '')).toBe('/api/spaces/space-1/uploads');
+    expect(JSON.parse(getRequestBody(fetchMock.mock.calls[0]?.[1]))).toEqual({
+      source_type: 'url',
+      url: 'https://example.com/doc',
+    });
+  });
+});
+
+describe('UploadList', () => {
+  it('renders status badges, rows, and actions', () => {
+    render(
+      <UploadList
+        uploads={[
+          buildUpload({ id: 'source-1', filename: 'notes.md', status: 'parsing' }),
+          buildUpload({ id: 'source-2', filename: 'done.pdf', status: 'parsed' }),
+          buildUpload({ id: 'source-3', filename: 'bad.pdf', status: 'parse_failed' }),
+        ]}
+        page={1}
+        total={3}
+        statusFilter=""
+        onStatusFilterChange={vi.fn()}
+        onPageChange={vi.fn()}
+        onSelectUpload={vi.fn()}
+      />,
+    );
+
+    expect(getStatusBadge('Parsing')).toHaveClass('status-info');
+    expect(getStatusBadge('Parsed')).toHaveClass('status-healthy');
+    expect(getStatusBadge('Parse Failed')).toHaveClass('status-unhealthy');
+    expect(screen.getByRole('columnheader', { name: 'Filename' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Details' })).toHaveLength(3);
+  });
+
+  it('renders pagination controls', () => {
+    const onPageChange = vi.fn<(page: number) => void>();
+
+    render(
+      <UploadList
+        uploads={[buildUpload({ id: 'source-page' })]}
+        page={2}
+        total={41}
+        statusFilter=""
+        onStatusFilterChange={vi.fn()}
+        onPageChange={onPageChange}
+        onSelectUpload={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
+  it('renders an empty state', () => {
+    render(
+      <UploadList
+        uploads={[]}
+        page={1}
+        total={0}
+        statusFilter=""
+        onStatusFilterChange={vi.fn()}
+        onPageChange={vi.fn()}
+        onSelectUpload={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('No uploads match the current filters.')).toBeInTheDocument();
+  });
+});
+
+describe('UploadDetail', () => {
+  it('shows detail metadata, progress, failure details, and reprocess action', async () => {
+    const fetchMock = stubReprocessApi();
+    const onReprocessed = vi.fn<(response: UploadResponse) => void>();
+
+    render(
+      <UploadDetail
+        upload={buildUpload({ status: 'parse_failed' })}
+        status={buildStatus({ status: 'parse_failed', progress_percent: 65 })}
+        onClose={vi.fn()}
+        onReprocessed={onReprocessed}
+      />,
+    );
+
+    expect(screen.getByRole('dialog', { name: 'Upload detail' })).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Parse failed progress' })).toHaveAttribute('aria-valuenow', '65');
+    expect(screen.getByText('parser_error')).toBeInTheDocument();
+    expect(screen.getByText('Could not parse PDF')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reprocess' }));
+
+    await waitFor(() => expect(onReprocessed).toHaveBeenCalledWith(expect.objectContaining({ status: 'uploaded' })));
+    expect(getRequestPath(fetchMock.mock.calls[0]?.[0] ?? '')).toBe('/api/uploads/source-1/reprocess');
+    expect(fetchMock.mock.calls[0]?.[1]?.method).toBe('POST');
+  });
+
+  it('hides reprocess for completed uploads', () => {
+    render(
+      <UploadDetail
+        upload={buildUpload({ status: 'parsed' })}
+        status={buildStatus({ status: 'parsed', progress_percent: 100 })}
+        onClose={vi.fn()}
+        onReprocessed={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Reprocess' })).not.toBeInTheDocument();
+  });
+});
+
+type MockXhrRequest = {
+  method: string;
+  url: string;
+  headers: Headers;
+};
+
+function stubXmlHttpRequest(sourceDocumentId = 'source-1'): MockXhrRequest[] {
+  const requests: MockXhrRequest[] = [];
+
+  class MockXMLHttpRequest {
+    method = '';
+    url = '';
+    headers = new Headers();
+    status = 201;
+    responseText = JSON.stringify({
+      data: {
+        source_document_id: sourceDocumentId,
+        file_blob_id: 'blob-1',
+        job_id: 'job-1',
+        status: 'uploaded',
+        created: true,
+      },
+    });
+    withCredentials = false;
+    upload: { onprogress: ((event: ProgressEvent<XMLHttpRequestEventTarget>) => void) | null } = {
+      onprogress: null,
+    };
+    onload: ((event: ProgressEvent<XMLHttpRequestEventTarget>) => void) | null = null;
+    onerror: ((event: ProgressEvent<XMLHttpRequestEventTarget>) => void) | null = null;
+
+    open(method: string, url: string): void {
+      this.method = method;
+      this.url = url;
+    }
+
+    setRequestHeader(key: string, value: string): void {
+      this.headers.set(key, value);
+    }
+
+    send(): void {
+      requests.push({ method: this.method, url: this.url, headers: this.headers });
+      this.upload.onprogress?.(
+        new ProgressEvent('progress', {
+          lengthComputable: true,
+          loaded: 50,
+          total: 100,
+        }) as ProgressEvent<XMLHttpRequestEventTarget>,
+      );
+      this.onload?.(new ProgressEvent('load') as ProgressEvent<XMLHttpRequestEventTarget>);
+    }
+  }
+
+  vi.stubGlobal('XMLHttpRequest', MockXMLHttpRequest);
+  return requests;
+}
+
+function createDropEvent(file: File) {
+  return {
+    dataTransfer: {
+      files: [file],
+      items: [
+        {
+          kind: 'file',
+          type: file.type,
+          getAsFile: () => file,
+        },
+      ],
+      types: ['Files'],
+    },
+  };
+}
+
+function getDropzone(): Element {
+  const dropzone = screen.getByText('Drop files or click to select').closest('.upload-dropzone');
+  if (dropzone === null) {
+    throw new Error('Dropzone not found');
+  }
+
+  return dropzone;
+}
+
+function getStatusBadge(label: string): HTMLElement {
+  const badge = screen.getAllByText(label).find((element) => element.classList.contains('status-badge'));
+  if (badge === undefined) {
+    throw new Error(`Status badge not found: ${label}`);
+  }
+
+  return badge;
+}
+
+function stubUrlUploadApi() {
+  const fetchMock = vi.fn<typeof fetch>((input, init) => {
+    if (getRequestPath(input) === '/api/spaces/space-1/uploads' && init?.method === 'POST') {
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            source_document_id: 'source-url',
+            file_blob_id: null,
+            job_id: 'job-url',
+            status: 'uploaded',
+            created: true,
+          },
+        }),
+      );
+    }
+
+    return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function stubReprocessApi() {
+  const fetchMock = vi.fn<typeof fetch>((input, init) => {
+    if (getRequestPath(input) === '/api/uploads/source-1/reprocess' && init?.method === 'POST') {
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            source_document_id: 'source-1',
+            file_blob_id: 'blob-1',
+            job_id: 'job-reprocess',
+            status: 'uploaded',
+            created: true,
+          },
+        }),
+      );
+    }
+
+    return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function buildUpload(overrides: Partial<UploadItem> = {}): UploadItem {
+  return {
+    id: 'source-1',
+    filename: 'notes.md',
+    mime_type: 'text/markdown',
+    sha256: 'a'.repeat(64),
+    size_bytes: 1024,
+    source_type: 'upload',
+    classification: null,
+    status: 'uploaded',
+    uploader_id: 'user-1',
+    space_id: 'space-1',
+    metadata_json: { author: 'Docs' },
+    created_at: '2026-05-01T10:00:00.000Z',
+    updated_at: '2026-05-01T10:01:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildStatus(overrides: Partial<UploadStatus> = {}): UploadStatus {
+  return {
+    source_document_id: 'source-1',
+    status: 'uploaded',
+    job_id: 'job-1',
+    job_status: 'running',
+    progress_percent: 50,
+    error_json: {
+      error_type: 'parser_error',
+      error_message: 'Could not parse PDF',
+    },
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function getRequestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input.split('?')[0] ?? input;
+  }
+
+  if (input instanceof URL) {
+    return input.pathname;
+  }
+
+  return input.url.split('?')[0] ?? input.url;
+}
+
+function getRequestBody(init: RequestInit | undefined): string {
+  if (typeof init?.body !== 'string') {
+    throw new Error('Expected request body to be a JSON string');
+  }
+
+  return init.body;
+}

--- a/apps/web/src/hooks/useUploadPolling.ts
+++ b/apps/web/src/hooks/useUploadPolling.ts
@@ -1,0 +1,55 @@
+import { useEffect, useMemo } from 'react';
+import { api } from '../lib/api';
+import { isUploadProcessing, type UploadItem, type UploadStatus } from '../pages/uploads/types';
+
+const DEFAULT_UPLOAD_POLL_INTERVAL_MS = 5_000;
+
+export function useUploadPolling({
+  uploads,
+  onStatuses,
+  onError,
+  intervalMs = DEFAULT_UPLOAD_POLL_INTERVAL_MS,
+}: {
+  uploads: UploadItem[];
+  onStatuses: (statuses: UploadStatus[]) => void;
+  onError?: (error: unknown) => void;
+  intervalMs?: number;
+}) {
+  const processingIds = useMemo(
+    () => uploads.filter((upload) => isUploadProcessing(upload.status)).map((upload) => upload.id),
+    [uploads],
+  );
+  const processingKey = processingIds.join('|');
+
+  useEffect(() => {
+    if (processingIds.length === 0) {
+      return;
+    }
+
+    let isCancelled = false;
+
+    async function pollStatuses(): Promise<void> {
+      try {
+        const statuses = await Promise.all(
+          processingIds.map((id) => api.get<UploadStatus>(`/uploads/${encodeURIComponent(id)}/status`)),
+        );
+        if (!isCancelled) {
+          onStatuses(statuses);
+        }
+      } catch (err) {
+        if (!isCancelled) {
+          onError?.(err);
+        }
+      }
+    }
+
+    const intervalId = window.setInterval(() => {
+      void pollStatuses();
+    }, intervalMs);
+
+    return () => {
+      isCancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [intervalMs, onError, onStatuses, processingIds, processingKey]);
+}

--- a/apps/web/src/pages/uploads/FileUploadZone.tsx
+++ b/apps/web/src/pages/uploads/FileUploadZone.tsx
@@ -1,0 +1,272 @@
+import { useCallback, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+import ProgressBar from '../../components/ProgressBar';
+import {
+  MAX_UPLOAD_SIZE_BYTES,
+  SUPPORTED_UPLOAD_EXTENSIONS,
+  formatFileSize,
+  getUploadErrorCode,
+  getUploadErrorMessage,
+  isSupportedUploadFile,
+  readApiErrorBody,
+  unwrapApiBody,
+  type UploadResponse,
+} from './types';
+
+type UploadAttemptStatus = 'queued' | 'uploading' | 'success' | 'error';
+
+type UploadAttempt = {
+  id: string;
+  filename: string;
+  sizeBytes: number;
+  status: UploadAttemptStatus;
+  progress: number;
+  sourceDocumentId?: string;
+  errorCode?: string;
+  errorMessage?: string;
+};
+
+type FileUploadZoneProps = {
+  spaceId: string;
+  accessToken: string | null;
+  onUploaded: (response: UploadResponse, file: File) => void;
+};
+
+let uploadAttemptCounter = 0;
+
+export default function FileUploadZone({ spaceId, accessToken, onUploaded }: FileUploadZoneProps) {
+  const [attempts, setAttempts] = useState<UploadAttempt[]>([]);
+
+  const updateAttempt = useCallback((id: string, patch: Partial<UploadAttempt>) => {
+    setAttempts((current) => current.map((attempt) => (attempt.id === id ? { ...attempt, ...patch } : attempt)));
+  }, []);
+
+  const uploadFiles = useCallback(
+    (files: File[]) => {
+      const nextUploads = files.map((file) => ({
+        file,
+        attempt: validateFileAttempt(file, createFileAttemptKey(file)),
+      }));
+      setAttempts((current) => [...nextUploads.map((upload) => upload.attempt), ...current]);
+
+      for (const { attempt, file } of nextUploads) {
+        if (attempt.status === 'error') {
+          continue;
+        }
+
+        updateAttempt(attempt.id, { status: 'uploading', progress: 0 });
+        void uploadFile({
+          spaceId,
+          accessToken,
+          file,
+          onProgress: (progress) => updateAttempt(attempt.id, { progress }),
+        })
+          .then((response) => {
+            updateAttempt(attempt.id, {
+              status: 'success',
+              progress: 100,
+              sourceDocumentId: response.source_document_id,
+            });
+            onUploaded(response, file);
+          })
+          .catch((err: unknown) => {
+            updateAttempt(attempt.id, {
+              status: 'error',
+              errorCode: getUploadErrorCode(err),
+              errorMessage: getUploadErrorMessage(err),
+            });
+          });
+      }
+    },
+    [accessToken, onUploaded, spaceId, updateAttempt],
+  );
+
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      uploadFiles(acceptedFiles);
+    },
+    [uploadFiles],
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    multiple: true,
+    noKeyboard: false,
+    onDrop,
+  });
+
+  return (
+    <section className="detail-panel upload-panel" aria-label="File upload">
+      <div className="detail-panel-header">
+        <div>
+          <h2>Files</h2>
+          <p>Drop files here or choose them from disk.</p>
+        </div>
+      </div>
+
+      <div
+        {...getRootProps({
+          className: isDragActive ? 'upload-dropzone active' : 'upload-dropzone',
+        })}
+      >
+        <input {...getInputProps({ 'aria-label': 'Choose files for upload' })} />
+        <strong>{isDragActive ? 'Release to upload' : 'Drop files or click to select'}</strong>
+        <span>
+          Supported: {SUPPORTED_UPLOAD_EXTENSIONS.join(', ')}. Limit: {formatFileSize(MAX_UPLOAD_SIZE_BYTES)} per
+          file.
+        </span>
+      </div>
+
+      {attempts.length > 0 ? (
+        <div className="upload-attempt-list" aria-label="Upload results">
+          {attempts.map((attempt) => (
+            <article className="upload-attempt" key={attempt.id}>
+              <div className="upload-attempt-header">
+                <div>
+                  <strong>{attempt.filename}</strong>
+                  <span>{formatFileSize(attempt.sizeBytes)}</span>
+                </div>
+                {renderAttemptState(attempt)}
+              </div>
+              {attempt.status === 'uploading' ? (
+                <ProgressBar percent={attempt.progress} stage="Uploading" size="sm" />
+              ) : null}
+              {attempt.status === 'success' && attempt.sourceDocumentId !== undefined ? (
+                <p className="upload-result upload-result-success">✓ source_document_id: {attempt.sourceDocumentId}</p>
+              ) : null}
+              {attempt.status === 'error' ? (
+                <p className="upload-result upload-result-error" role="alert">
+                  <strong>{attempt.errorCode ?? 'UPLOAD_ERROR'}</strong>: {attempt.errorMessage ?? 'Upload failed'}
+                </p>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function validateFileAttempt(file: File, id: string): UploadAttempt {
+  if (!isSupportedUploadFile(file.name)) {
+    return {
+      id,
+      filename: file.name,
+      sizeBytes: file.size,
+      status: 'error',
+      progress: 0,
+      errorCode: 'UNSUPPORTED_FILE_TYPE',
+      errorMessage: 'Unsupported file type.',
+    };
+  }
+
+  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+    return {
+      id,
+      filename: file.name,
+      sizeBytes: file.size,
+      status: 'error',
+      progress: 0,
+      errorCode: 'FILE_TOO_LARGE',
+      errorMessage: 'File exceeds the 200 MB upload limit.',
+    };
+  }
+
+  return {
+    id,
+    filename: file.name,
+    sizeBytes: file.size,
+    status: 'queued',
+    progress: 0,
+  };
+}
+
+function createFileAttemptKey(file: File): string {
+  uploadAttemptCounter += 1;
+  return `${file.name}-${file.size}-${file.lastModified}-${uploadAttemptCounter}`;
+}
+
+function renderAttemptState(attempt: UploadAttempt) {
+  if (attempt.status === 'success') {
+    return <span className="upload-state upload-state-success">Uploaded</span>;
+  }
+
+  if (attempt.status === 'error') {
+    return <span className="upload-state upload-state-error">Failed</span>;
+  }
+
+  if (attempt.status === 'uploading') {
+    return <span className="upload-state upload-state-info">Uploading</span>;
+  }
+
+  return <span className="upload-state upload-state-info">Queued</span>;
+}
+
+function uploadFile({
+  spaceId,
+  accessToken,
+  file,
+  onProgress,
+}: {
+  spaceId: string;
+  accessToken: string | null;
+  file: File;
+  onProgress: (progress: number) => void;
+}): Promise<UploadResponse> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    const formData = new FormData();
+    formData.append('source_type', 'upload');
+    formData.append('file', file);
+
+    xhr.open('POST', `/api/spaces/${encodeURIComponent(spaceId)}/uploads`);
+    xhr.withCredentials = true;
+    xhr.setRequestHeader('Accept', 'application/json');
+    if (accessToken !== null && accessToken.length > 0) {
+      xhr.setRequestHeader('Authorization', `Bearer ${accessToken}`);
+    }
+
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable && event.total > 0) {
+        onProgress(Math.round((event.loaded / event.total) * 100));
+      }
+    };
+
+    xhr.onload = () => {
+      const body = parseResponseBody(xhr.responseText);
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(unwrapApiBody<UploadResponse>(body));
+        return;
+      }
+
+      reject(new UploadRequestError(readApiErrorBody(body)));
+    };
+
+    xhr.onerror = () => {
+      reject(new UploadRequestError({ code: 'NETWORK_ERROR', message: 'Network error while uploading file.' }));
+    };
+
+    xhr.send(formData);
+  });
+}
+
+function parseResponseBody(value: string): unknown {
+  if (value.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+class UploadRequestError extends Error {
+  readonly code: string;
+
+  constructor(input: { code: string; message: string }) {
+    super(input.message);
+    this.name = 'UploadRequestError';
+    this.code = input.code;
+  }
+}

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Navigate, useParams } from 'react-router';
+import { ErrorBanner, LoadingState, PageHeader, getErrorMessage } from '../../components/adminUi';
+import { useUploadPolling } from '../../hooks/useUploadPolling';
+import { type ApiMeta, api } from '../../lib/api';
+import { useAuth } from '../../lib/auth';
+import FileUploadZone from './FileUploadZone';
+import UploadDetail from './UploadDetail';
+import UploadList from './UploadList';
+import UrlUploadForm from './UrlUploadForm';
+import { UPLOAD_PAGE_SIZE, type UploadItem, type UploadResponse, type UploadStatus } from './types';
+
+const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
+  page: 1,
+  per_page: UPLOAD_PAGE_SIZE,
+  total: 0,
+  has_next: false,
+};
+
+export default function UploadCenter() {
+  const { spaceId = '' } = useParams();
+  const { accessToken, isAuthenticated } = useAuth();
+  const [uploads, setUploads] = useState<UploadItem[]>([]);
+  const [page, setPage] = useState(DEFAULT_PAGINATION.page);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedUploadId, setSelectedUploadId] = useState<string | null>(null);
+  const [selectedStatus, setSelectedStatus] = useState<UploadStatus | null>(null);
+
+  const loadUploads = useCallback(
+    async (background = false) => {
+      if (spaceId.length === 0) {
+        setUploads([]);
+        setPagination(DEFAULT_PAGINATION);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!background) {
+        setIsLoading(true);
+      }
+      setError(null);
+
+      try {
+        const response = await api.getWrapped<UploadItem[]>(`/spaces/${encodeURIComponent(spaceId)}/uploads`, {
+          page,
+          per_page: UPLOAD_PAGE_SIZE,
+          status: statusFilter,
+          sort: '-created_at',
+        });
+        setUploads(response.data);
+        setPagination(
+          response.meta?.pagination ?? {
+            page,
+            per_page: UPLOAD_PAGE_SIZE,
+            total: response.data.length,
+            has_next: false,
+          },
+        );
+      } catch (err) {
+        setError(getErrorMessage(err));
+      } finally {
+        if (!background) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [page, spaceId, statusFilter],
+  );
+
+  useEffect(() => {
+    void loadUploads();
+  }, [loadUploads]);
+
+  useEffect(() => {
+    setSelectedUploadId(null);
+    setSelectedStatus(null);
+    setPage(1);
+  }, [spaceId]);
+
+  const mergeStatuses = useCallback((statuses: UploadStatus[]) => {
+    setUploads((current) =>
+      current.map((upload) => {
+        const status = statuses.find((candidate) => candidate.source_document_id === upload.id);
+        return status === undefined
+          ? upload
+          : {
+              ...upload,
+              status: status.status,
+              progress_percent: status.progress_percent,
+              job_id: status.job_id,
+              job_status: status.job_status,
+              error_json: status.error_json,
+            };
+      }),
+    );
+    setSelectedStatus((current) => {
+      if (current === null) {
+        return current;
+      }
+
+      return statuses.find((status) => status.source_document_id === current.source_document_id) ?? current;
+    });
+  }, []);
+
+  useUploadPolling({
+    uploads,
+    onStatuses: mergeStatuses,
+    onError: (err) => setError(getErrorMessage(err)),
+  });
+
+  const selectedUpload = useMemo(
+    () => uploads.find((upload) => upload.id === selectedUploadId) ?? null,
+    [selectedUploadId, uploads],
+  );
+
+  const loadUploadStatus = useCallback(async (uploadId: string) => {
+    try {
+      const status = await api.get<UploadStatus>(`/uploads/${encodeURIComponent(uploadId)}/status`);
+      setSelectedStatus(status);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  }, []);
+
+  function addOptimisticUpload(response: UploadResponse, input: { filename: string; sourceType: string; sizeBytes: number | null }): void {
+    const now = new Date().toISOString();
+    const upload: UploadItem = {
+      id: response.source_document_id,
+      filename: input.filename,
+      mime_type: null,
+      sha256: null,
+      size_bytes: input.sizeBytes,
+      source_type: input.sourceType,
+      classification: null,
+      status: response.status,
+      uploader_id: null,
+      space_id: spaceId,
+      metadata_json: {},
+      created_at: now,
+      updated_at: now,
+      job_id: response.job_id,
+    };
+
+    setUploads((current) => {
+      if (statusFilter.length > 0 && statusFilter !== upload.status) {
+        return current;
+      }
+
+      const withoutDuplicate = current.filter((item) => item.id !== upload.id);
+      return [upload, ...withoutDuplicate].slice(0, UPLOAD_PAGE_SIZE);
+    });
+    setPagination((current) => ({ ...current, total: response.created ? current.total + 1 : current.total }));
+    void loadUploads(true);
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return (
+    <main className="admin-content upload-page">
+      <PageHeader
+        title="Upload Center"
+        description="Upload files and URLs, then track processing status for this space."
+        actions={
+          <button
+            className="button button-secondary"
+            type="button"
+            onClick={() => {
+              void loadUploads();
+            }}
+          >
+            Refresh
+          </button>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      <div className="upload-center-grid">
+        <FileUploadZone
+          spaceId={spaceId}
+          accessToken={accessToken}
+          onUploaded={(response, file) =>
+            addOptimisticUpload(response, {
+              filename: file.name,
+              sourceType: 'upload',
+              sizeBytes: file.size,
+            })
+          }
+        />
+        <UrlUploadForm
+          spaceId={spaceId}
+          onUploaded={(response, url) =>
+            addOptimisticUpload(response, {
+              filename: url,
+              sourceType: 'url',
+              sizeBytes: null,
+            })
+          }
+        />
+      </div>
+
+      {isLoading ? (
+        <LoadingState label="Loading uploads..." />
+      ) : (
+        <UploadList
+          uploads={uploads}
+          page={pagination.page}
+          total={pagination.total}
+          statusFilter={statusFilter}
+          onStatusFilterChange={(nextStatus) => {
+            setStatusFilter(nextStatus);
+            setPage(1);
+          }}
+          onPageChange={setPage}
+          onSelectUpload={(upload) => {
+            setSelectedUploadId(upload.id);
+            setSelectedStatus(null);
+            void loadUploadStatus(upload.id);
+          }}
+        />
+      )}
+
+      {selectedUpload !== null ? (
+        <UploadDetail
+          upload={selectedUpload}
+          status={selectedStatus}
+          onClose={() => {
+            setSelectedUploadId(null);
+            setSelectedStatus(null);
+          }}
+          onReprocessed={(response) => {
+            mergeStatuses([
+              {
+                source_document_id: response.source_document_id,
+                status: response.status,
+                job_id: response.job_id,
+                job_status: null,
+                progress_percent: null,
+                error_json: null,
+              },
+            ]);
+            void loadUploads(true);
+            void loadUploadStatus(response.source_document_id);
+          }}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/src/pages/uploads/UploadDetail.tsx
+++ b/apps/web/src/pages/uploads/UploadDetail.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import ProgressBar from '../../components/ProgressBar';
+import { ErrorBanner, formatDate, formatLabel, getErrorMessage } from '../../components/adminUi';
+import { api } from '../../lib/api';
+import {
+  formatFileSize,
+  getUploadProgressPercent,
+  getUploadStageLabel,
+  readUploadFailureDetails,
+  type UploadItem,
+  type UploadResponse,
+  type UploadStatus,
+} from './types';
+import { UploadStatusBadge } from './UploadList';
+
+type UploadDetailProps = {
+  upload: UploadItem;
+  status: UploadStatus | null;
+  onClose: () => void;
+  onReprocessed: (response: UploadResponse) => void;
+};
+
+export default function UploadDetail({ upload, status, onClose, onReprocessed }: UploadDetailProps) {
+  const [isReprocessing, setIsReprocessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const activeStatus = status?.status ?? upload.status;
+  const failureDetails = readUploadFailureDetails(status, upload);
+  const showFailureDetails =
+    activeStatus === 'parse_failed' || activeStatus === 'security_rejected' || failureDetails.errorMessage !== null;
+
+  async function reprocessUpload(): Promise<void> {
+    setIsReprocessing(true);
+    setError(null);
+
+    try {
+      const response = await api.post<UploadResponse>(`/uploads/${encodeURIComponent(upload.id)}/reprocess`);
+      onReprocessed(response);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsReprocessing(false);
+    }
+  }
+
+  return (
+    <div className="upload-drawer-backdrop" role="presentation">
+      <aside className="upload-drawer" role="dialog" aria-modal="true" aria-label="Upload detail">
+        <div className="modal-header">
+          <div>
+            <h2>Upload Detail</h2>
+            <p className="muted-copy">{upload.filename}</p>
+          </div>
+          <button className="icon-button" type="button" aria-label="Close dialog" onClick={onClose}>
+            x
+          </button>
+        </div>
+
+        <ErrorBanner error={error} />
+
+        <section className="detail-panel upload-detail-section" aria-label="Upload overview">
+          <div className="detail-panel-header">
+            <div>
+              <h2>{upload.filename}</h2>
+              <p>{upload.id}</p>
+            </div>
+            <UploadStatusBadge status={activeStatus} />
+          </div>
+
+          <ProgressBar
+            percent={getUploadProgressPercent(upload, status)}
+            stage={getUploadStageLabel(upload, status)}
+            size="md"
+          />
+
+          <div className="settings-grid">
+            <div>
+              <span className="eyebrow">Source Document ID</span>
+              <code>{upload.id}</code>
+            </div>
+            <div>
+              <span className="eyebrow">Type</span>
+              <span className="job-meta-value">{formatLabel(upload.source_type)}</span>
+            </div>
+            <div>
+              <span className="eyebrow">Size</span>
+              <span className="job-meta-value">{formatFileSize(upload.size_bytes)}</span>
+            </div>
+            <div>
+              <span className="eyebrow">Uploader</span>
+              <span className="job-meta-value">{upload.uploader_id ?? 'Unknown'}</span>
+            </div>
+            <div>
+              <span className="eyebrow">MIME</span>
+              <span className="job-meta-value">{upload.mime_type ?? 'Unknown'}</span>
+            </div>
+            <div>
+              <span className="eyebrow">SHA256</span>
+              <span className="job-meta-value">{upload.sha256 ?? 'Pending'}</span>
+            </div>
+            <div>
+              <span className="eyebrow">Created</span>
+              <span className="job-meta-value">{formatDate(upload.created_at)}</span>
+            </div>
+            <div>
+              <span className="eyebrow">Updated</span>
+              <span className="job-meta-value">{formatDate(upload.updated_at)}</span>
+            </div>
+            <div>
+              <span className="eyebrow">Job ID</span>
+              <span className="job-meta-value">{status?.job_id ?? upload.job_id ?? 'None'}</span>
+            </div>
+            <div>
+              <span className="eyebrow">Job Status</span>
+              <span className="job-meta-value">{status?.job_status ?? upload.job_status ?? 'None'}</span>
+            </div>
+          </div>
+        </section>
+
+        {showFailureDetails ? (
+          <section className="detail-panel upload-detail-section" aria-label="Failure details">
+            <div className="detail-panel-header">
+              <div>
+                <h2>Failure Details</h2>
+                <p>Parser or security validation details returned by the processing job.</p>
+              </div>
+            </div>
+            <div className="settings-grid">
+              <div>
+                <span className="eyebrow">Error Type</span>
+                <span className="job-meta-value">{failureDetails.errorType ?? 'Unknown'}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Error Message</span>
+                <span className="job-meta-value">{failureDetails.errorMessage ?? 'No error message recorded'}</span>
+              </div>
+            </div>
+          </section>
+        ) : null}
+
+        <section className="detail-panel upload-detail-section" aria-label="Metadata">
+          <div className="detail-panel-header">
+            <div>
+              <h2>Metadata</h2>
+              <p>Raw upload metadata captured by the API.</p>
+            </div>
+          </div>
+          <pre className="upload-metadata-json">{JSON.stringify(upload.metadata_json ?? {}, null, 2)}</pre>
+        </section>
+
+        {activeStatus === 'parse_failed' ? (
+          <div className="form-actions">
+            <button
+              className="button button-primary"
+              type="button"
+              disabled={isReprocessing}
+              onClick={() => {
+                void reprocessUpload();
+              }}
+            >
+              {isReprocessing ? 'Reprocessing...' : 'Reprocess'}
+            </button>
+          </div>
+        ) : null}
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/src/pages/uploads/UploadList.tsx
+++ b/apps/web/src/pages/uploads/UploadList.tsx
@@ -1,0 +1,148 @@
+import { EmptyState, formatDate, formatLabel } from '../../components/adminUi';
+import {
+  UPLOAD_PAGE_SIZE,
+  UPLOAD_STATUS_OPTIONS,
+  formatFileSize,
+  getUploadStatusClass,
+  type UploadItem,
+} from './types';
+
+type UploadListProps = {
+  uploads: UploadItem[];
+  page: number;
+  total: number;
+  statusFilter: string;
+  onStatusFilterChange: (status: string) => void;
+  onPageChange: (page: number) => void;
+  onSelectUpload: (upload: UploadItem) => void;
+};
+
+export default function UploadList({
+  uploads,
+  page,
+  total,
+  statusFilter,
+  onStatusFilterChange,
+  onPageChange,
+  onSelectUpload,
+}: UploadListProps) {
+  const totalPages = Math.max(1, Math.ceil(total / UPLOAD_PAGE_SIZE), page);
+
+  return (
+    <section className="detail-panel" aria-label="Upload list">
+      <div className="detail-panel-header">
+        <div>
+          <h2>Uploads</h2>
+          <p>Track processing state for files and URLs in this space.</p>
+        </div>
+        <label className="upload-status-filter">
+          Status
+          <select
+            value={statusFilter}
+            onChange={(event) => {
+              onStatusFilterChange(event.target.value);
+            }}
+          >
+            <option value="">All statuses</option>
+            {UPLOAD_STATUS_OPTIONS.map((status) => (
+              <option key={status} value={status}>
+                {formatLabel(status)}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {uploads.length === 0 ? (
+        <EmptyState label="No uploads match the current filters." />
+      ) : (
+        <>
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Filename</th>
+                  <th>Type</th>
+                  <th>Size</th>
+                  <th>Status</th>
+                  <th>Uploader</th>
+                  <th>Time</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {uploads.map((upload) => (
+                  <tr key={upload.id}>
+                    <td>
+                      <strong>{upload.filename}</strong>
+                      <span className="subtle-id">{upload.id}</span>
+                    </td>
+                    <td>{formatLabel(upload.source_type)}</td>
+                    <td>{formatFileSize(upload.size_bytes)}</td>
+                    <td>
+                      <UploadStatusBadge status={upload.status} />
+                    </td>
+                    <td>{upload.uploader_id ?? 'Unknown'}</td>
+                    <td>{formatDate(upload.created_at)}</td>
+                    <td>
+                      <button className="button button-secondary" type="button" onClick={() => onSelectUpload(upload)}>
+                        Details
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="pagination-bar">
+            <span className="pagination-summary">
+              Showing {getFirstItemIndex(page, total)}-{getLastItemIndex(page, uploads.length, total)} of {total}
+            </span>
+            <div className="upload-pagination-actions">
+              <button
+                className="button button-secondary"
+                type="button"
+                disabled={page <= 1}
+                onClick={() => onPageChange(page - 1)}
+              >
+                Previous
+              </button>
+              <span className="pagination-summary">
+                Page {page} of {totalPages}
+              </span>
+              <button
+                className="button button-secondary"
+                type="button"
+                disabled={page >= totalPages}
+                onClick={() => onPageChange(page + 1)}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+export function UploadStatusBadge({ status }: { status: string }) {
+  return <span className={`status-badge status-${getUploadStatusClass(status)}`}>{formatLabel(status)}</span>;
+}
+
+function getFirstItemIndex(page: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return (page - 1) * UPLOAD_PAGE_SIZE + 1;
+}
+
+function getLastItemIndex(page: number, itemCount: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return Math.min(total, getFirstItemIndex(page, total) + itemCount - 1);
+}

--- a/apps/web/src/pages/uploads/UrlUploadForm.tsx
+++ b/apps/web/src/pages/uploads/UrlUploadForm.tsx
@@ -1,0 +1,91 @@
+import { type FormEvent, useState } from 'react';
+import { ErrorBanner, getErrorMessage } from '../../components/adminUi';
+import { api } from '../../lib/api';
+import type { UploadResponse } from './types';
+
+type UrlUploadFormProps = {
+  spaceId: string;
+  onUploaded: (response: UploadResponse, url: string) => void;
+};
+
+export default function UrlUploadForm({ spaceId, onUploaded }: UrlUploadFormProps) {
+  const [url, setUrl] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  async function submitUrl(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+
+    const trimmedUrl = url.trim();
+    if (!isValidHttpUrl(trimmedUrl)) {
+      setError('Enter a valid http or https URL.');
+      setSuccessMessage(null);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    try {
+      const response = await api.post<UploadResponse>(`/spaces/${encodeURIComponent(spaceId)}/uploads`, {
+        source_type: 'url',
+        url: trimmedUrl,
+      });
+      onUploaded(response, trimmedUrl);
+      setUrl('');
+      setSuccessMessage(`Added source_document_id: ${response.source_document_id}`);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="detail-panel upload-panel" aria-label="URL upload">
+      <div className="detail-panel-header">
+        <div>
+          <h2>URL</h2>
+          <p>Add a web source to fetch and process for this space.</p>
+        </div>
+      </div>
+
+      <form className="url-upload-form" noValidate onSubmit={(event) => void submitUrl(event)}>
+        <label>
+          URL
+          <input
+            type="url"
+            value={url}
+            placeholder="https://example.com/article"
+            onChange={(event) => setUrl(event.target.value)}
+          />
+        </label>
+        <button className="button button-primary" type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Adding...' : 'Add URL'}
+        </button>
+      </form>
+
+      <ErrorBanner error={error} />
+      {successMessage !== null ? (
+        <p className="upload-result upload-result-success" role="status">
+          {successMessage}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function isValidHttpUrl(value: string): boolean {
+  if (value.length === 0) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/pages/uploads/types.ts
+++ b/apps/web/src/pages/uploads/types.ts
@@ -1,0 +1,287 @@
+import { ApiError } from '../../lib/api';
+
+export const UPLOAD_PAGE_SIZE = 20;
+export const MAX_UPLOAD_SIZE_BYTES = 200 * 1024 * 1024;
+
+export const SUPPORTED_UPLOAD_EXTENSIONS = [
+  '.md',
+  '.mdx',
+  '.txt',
+  '.rst',
+  '.pdf',
+  '.docx',
+  '.pptx',
+  '.xlsx',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.webp',
+  '.zip',
+] as const;
+
+export const UPLOAD_STATUS_OPTIONS = [
+  'uploaded',
+  'validating',
+  'archived',
+  'parsing',
+  'parsed',
+  'graphify_pending',
+  'graphify_running',
+  'parse_failed',
+  'security_rejected',
+] as const;
+
+export type UploadSourceType = 'upload' | 'url';
+
+export type UploadResponse = {
+  source_document_id: string;
+  file_blob_id: string | null;
+  job_id: string | null;
+  status: string;
+  created: boolean;
+  error_code?: string;
+};
+
+export type UploadItem = {
+  id: string;
+  filename: string;
+  mime_type: string | null;
+  sha256: string | null;
+  size_bytes: number | null;
+  source_type: string;
+  classification: string | null;
+  status: string;
+  uploader_id: string | null;
+  space_id: string;
+  metadata_json: unknown;
+  created_at: string;
+  updated_at: string;
+  progress_percent?: number | null;
+  job_id?: string | null;
+  job_status?: string | null;
+  error_json?: unknown;
+};
+
+export type UploadStatus = {
+  source_document_id: string;
+  status: string;
+  job_id: string | null;
+  job_status: string | null;
+  progress_percent: number | null;
+  error_json: unknown;
+};
+
+export type UploadFailureDetails = {
+  errorType: string | null;
+  errorMessage: string | null;
+};
+
+export function getUploadExtension(filename: string): string {
+  const dotIndex = filename.lastIndexOf('.');
+  return dotIndex >= 0 ? filename.slice(dotIndex).toLowerCase() : '';
+}
+
+export function isSupportedUploadFile(filename: string): boolean {
+  return SUPPORTED_UPLOAD_EXTENSIONS.includes(
+    getUploadExtension(filename) as (typeof SUPPORTED_UPLOAD_EXTENSIONS)[number],
+  );
+}
+
+export function formatFileSize(sizeBytes: number | null | undefined): string {
+  if (sizeBytes === null || sizeBytes === undefined) {
+    return 'Unknown';
+  }
+
+  if (sizeBytes < 1024) {
+    return `${sizeBytes} B`;
+  }
+
+  const units = ['KB', 'MB', 'GB'];
+  let size = sizeBytes / 1024;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${size.toFixed(size >= 10 ? 1 : 2)} ${units[unitIndex] ?? 'GB'}`;
+}
+
+export function isUploadProcessing(status: string): boolean {
+  return !isUploadTerminal(status);
+}
+
+export function isUploadTerminal(status: string): boolean {
+  return (
+    status === 'parsed' ||
+    status === 'completed' ||
+    status === 'published' ||
+    status === 'indexed' ||
+    status === 'wiki_proposed' ||
+    status === 'parse_failed' ||
+    status === 'security_rejected' ||
+    status === 'failed' ||
+    status === 'rejected'
+  );
+}
+
+export function getUploadStatusClass(status: string): string {
+  if (
+    status === 'parsed' ||
+    status === 'completed' ||
+    status === 'published' ||
+    status === 'indexed' ||
+    status === 'wiki_proposed'
+  ) {
+    return 'healthy';
+  }
+
+  if (status === 'parse_failed' || status === 'security_rejected' || status === 'failed' || status === 'rejected') {
+    return 'unhealthy';
+  }
+
+  return 'info';
+}
+
+export function getUploadProgressPercent(upload: UploadItem, status?: UploadStatus | null): number {
+  if (status?.progress_percent !== null && status?.progress_percent !== undefined) {
+    return status.progress_percent;
+  }
+
+  if (upload.progress_percent !== null && upload.progress_percent !== undefined) {
+    return upload.progress_percent;
+  }
+
+  switch (upload.status) {
+    case 'uploaded':
+      return 10;
+    case 'validating':
+      return 30;
+    case 'archived':
+      return 45;
+    case 'parsing':
+      return 70;
+    case 'graphify_pending':
+      return 90;
+    case 'graphify_running':
+      return 95;
+    case 'parsed':
+    case 'completed':
+    case 'published':
+    case 'indexed':
+    case 'wiki_proposed':
+      return 100;
+    default:
+      return 0;
+  }
+}
+
+export function getUploadStageLabel(upload: UploadItem, status?: UploadStatus | null): string {
+  const activeStatus = status?.status ?? upload.status;
+  const jobStatus = status?.job_status ?? upload.job_status;
+
+  switch (activeStatus) {
+    case 'uploaded':
+      return 'Uploaded';
+    case 'validating':
+      return 'Validating';
+    case 'archived':
+      return 'Queued for parsing';
+    case 'parsing':
+      return 'Parsing';
+    case 'graphify_pending':
+      return 'Waiting for graphify';
+    case 'graphify_running':
+      return 'Building graph';
+    case 'parsed':
+      return 'Parsed';
+    case 'parse_failed':
+      return 'Parse failed';
+    case 'security_rejected':
+      return 'Security rejected';
+    default:
+      return jobStatus !== null && jobStatus !== undefined ? jobStatus : activeStatus;
+  }
+}
+
+export function readUploadFailureDetails(status?: UploadStatus | null, upload?: UploadItem | null): UploadFailureDetails {
+  const source = status?.error_json ?? upload?.error_json ?? upload?.metadata_json;
+  if (!isRecord(source)) {
+    return { errorType: null, errorMessage: null };
+  }
+
+  const error = isRecord(source.error) ? source.error : source;
+  const errorType =
+    readString(error.error_type) ??
+    readString(error.type) ??
+    readString(error.code) ??
+    readString(source.rejection_reason) ??
+    null;
+  const errorMessage =
+    readString(error.error_message) ??
+    readString(error.message) ??
+    readString(source.rejection_message) ??
+    readString(source.rejection_reason) ??
+    null;
+
+  return { errorType, errorMessage };
+}
+
+export function getUploadErrorCode(error: unknown): string {
+  if (error instanceof ApiError) {
+    return error.code;
+  }
+
+  if (isRecord(error) && typeof error.code === 'string') {
+    return error.code;
+  }
+
+  return 'UPLOAD_ERROR';
+}
+
+export function getUploadErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (isRecord(error) && typeof error.message === 'string') {
+    return error.message;
+  }
+
+  return 'Upload failed';
+}
+
+export function unwrapApiBody<T>(body: unknown): T {
+  if (isRecord(body) && 'data' in body) {
+    return body.data as T;
+  }
+
+  return body as T;
+}
+
+export function readApiErrorBody(body: unknown): { code: string; message: string } {
+  if (isRecord(body)) {
+    if (isRecord(body.error)) {
+      return {
+        code: readString(body.error.code) ?? 'UPLOAD_ERROR',
+        message: readString(body.error.message) ?? 'Upload failed',
+      };
+    }
+
+    return {
+      code: readString(body.code) ?? 'UPLOAD_ERROR',
+      message: readString(body.message) ?? 'Upload failed',
+    };
+  }
+
+  return { code: 'UPLOAD_ERROR', message: 'Upload failed' };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -462,6 +462,187 @@ tbody tr:last-child td {
   min-width: 220px;
 }
 
+.upload-page {
+  min-height: 100vh;
+}
+
+.upload-center-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  gap: 20px;
+}
+
+.upload-panel {
+  align-content: start;
+}
+
+.upload-dropzone {
+  display: grid;
+  min-height: 180px;
+  place-items: center;
+  gap: 8px;
+  border: 2px dashed var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  color: var(--color-text-2);
+  padding: 28px;
+  text-align: center;
+  transition:
+    border-color var(--transition-fast),
+    background-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.upload-dropzone:hover,
+.upload-dropzone.active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-mute);
+  color: var(--color-text-1);
+}
+
+.upload-dropzone strong {
+  color: var(--color-text-1);
+  font-size: 1.05rem;
+}
+
+.upload-dropzone span {
+  max-width: 620px;
+  line-height: 1.5;
+}
+
+.upload-attempt-list {
+  display: grid;
+  gap: 10px;
+}
+
+.upload-attempt {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  padding: 12px;
+}
+
+.upload-attempt-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.upload-attempt-header strong,
+.upload-attempt-header span {
+  display: block;
+}
+
+.upload-attempt-header span {
+  margin-top: 4px;
+  color: var(--color-text-3);
+  font-size: 0.84rem;
+}
+
+.upload-state {
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  padding: 4px 9px;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.upload-state-success,
+.upload-result-success {
+  color: var(--color-status-healthy-text);
+}
+
+.upload-state-success {
+  background: var(--color-status-healthy-bg);
+}
+
+.upload-state-error,
+.upload-result-error {
+  color: var(--color-status-unhealthy-text);
+}
+
+.upload-state-error {
+  background: var(--color-status-unhealthy-bg);
+}
+
+.upload-state-info {
+  background: var(--color-status-info-bg);
+  color: var(--color-status-info-text);
+}
+
+.upload-result {
+  margin: 0;
+  overflow-wrap: anywhere;
+  line-height: 1.45;
+}
+
+.url-upload-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 12px;
+}
+
+.url-upload-form label,
+.upload-status-filter {
+  display: grid;
+  gap: 7px;
+  color: var(--color-text-2);
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+.upload-status-filter {
+  min-width: 210px;
+}
+
+.upload-pagination-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.upload-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  justify-content: flex-end;
+  background: var(--color-backdrop);
+}
+
+.upload-drawer {
+  display: grid;
+  width: min(100%, 720px);
+  max-height: 100vh;
+  align-content: start;
+  gap: 18px;
+  overflow-y: auto;
+  background: var(--color-surface);
+  padding: 22px;
+  box-shadow: var(--shadow-modal);
+}
+
+.upload-detail-section {
+  padding: 16px;
+}
+
+.upload-metadata-json {
+  margin: 0;
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  color: var(--color-text-1);
+  font-family: var(--font-family-mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  padding: 16px;
+}
+
 .progress-bar {
   display: grid;
   gap: 8px;
@@ -884,6 +1065,11 @@ dd {
     padding: 20px;
   }
 
+  .upload-center-grid,
+  .url-upload-form {
+    grid-template-columns: 1fr;
+  }
+
   .form-grid {
     grid-template-columns: 1fr;
   }
@@ -910,7 +1096,9 @@ dd {
   }
 
   .row-actions,
-  .form-actions {
+  .form-actions,
+  .upload-attempt-header,
+  .upload-pagination-actions {
     flex-direction: column;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,24 +163,6 @@ importers:
         specifier: ^5.76.3
         version: 5.76.3
 
-  apps/ingestion-worker:
-    dependencies:
-      '@cherrygraph/job-core':
-        specifier: workspace:*
-        version: link:../../packages/job-core
-      bullmq:
-        specifier: ^5.76.3
-        version: 5.76.3
-
-  apps/url-fetcher-worker:
-    dependencies:
-      '@cherrygraph/job-core':
-        specifier: workspace:*
-        version: link:../../packages/job-core
-      bullmq:
-        specifier: ^5.76.3
-        version: 5.76.3
-
   apps/web:
     dependencies:
       react:
@@ -189,6 +171,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-dropzone:
+        specifier: ^15.0.0
+        version: 15.0.0(react@19.2.5)
       react-router:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2302,6 +2287,10 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
@@ -2947,6 +2936,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
 
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
@@ -3859,6 +3852,12 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-dropzone@15.0.0:
+    resolution: {integrity: sha512-lGjYV/EoqEjEWPnmiSvH4v5IoIAwQM2W4Z1C0Q/Pw2xD0eVzKPS359BQTUMum+1fa0kH2nrKjuavmTPOGhpLPg==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -6939,6 +6938,8 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  attr-accept@2.2.5: {}
+
   avvio@9.2.0:
     dependencies:
       '@fastify/error': 4.2.0
@@ -7594,6 +7595,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
 
   file-type@21.3.4:
     dependencies:
@@ -8490,6 +8495,13 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-dropzone@15.0.0(react@19.2.5):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 19.2.5
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
## Summary

- Upload Center page at `/spaces/:spaceId/uploads`
- File upload: drag-drop zone (react-dropzone), multi-file, progress tracking, type/size validation
- URL upload: form with http/https validation
- Upload list: table with status badges (blue/green/red), pagination, status filter
- Upload detail: side drawer with metadata, progress, error details, reprocess button
- Auto-polling: 5s interval for processing files, stops at terminal state
- Frontend tests for all components

Closes #69

## Test plan

- [x] Build passes
- [x] 400 tests pass — zero regressions
- [x] Upload component tests pass