### PR TITLE
feat(shared/wiki-core): Drizzle Schema + wiki-core Package + Canonical Wiki Repo Init

### DIFF
--- a/packages/shared/src/schema/__tests__/validation.test.ts
+++ b/packages/shared/src/schema/__tests__/validation.test.ts
@@ -24,6 +24,24 @@ const validModelConfigInput = {
   model_type: 'chat',
 };
 
+const validWikiPageInput = {
+  tenant_id: 'tenant-1',
+  space_id: 'space-1',
+  page_id: 'rd-platform.community.community_1',
+  title: 'Community 1',
+  slug: 'Community_1',
+};
+
+const validWikiPageVersionInput = {
+  tenant_id: 'tenant-1',
+  space_id: 'space-1',
+  wiki_page_pk: 'wiki-page-pk-1',
+  page_id: 'rd-platform.community.community_1',
+  version_no: 1,
+  content_markdown: '# Community 1',
+  source: 'graphify',
+};
+
 describe('Zod schema validation', () => {
   it('validates insertUserSchema inputs', () => {
     expect(schema.insertUserSchema.safeParse(validUserInput).success).toBe(true);
@@ -151,6 +169,38 @@ describe('Zod schema validation', () => {
   });
 });
 
+describe('Wiki Zod validation', () => {
+  it('validates insertWikiPageSchema inputs', () => {
+    const parsed = schema.insertWikiPageSchema.parse({ ...validWikiPageInput, extra: 'ignored' });
+    expect(parsed.status).toBe('draft');
+    expect(Object.hasOwn(parsed, 'extra')).toBe(false);
+
+    const missingTitle: Record<string, unknown> = { ...validWikiPageInput };
+    delete missingTitle.title;
+    expect(schema.insertWikiPageSchema.safeParse(missingTitle).success).toBe(false);
+  });
+
+  it('validates insertWikiPageVersionSchema inputs', () => {
+    const parsed = schema.insertWikiPageVersionSchema.parse(validWikiPageVersionInput);
+    expect(parsed.frontmatter_json).toEqual({});
+    expect(parsed.status).toBe('draft');
+
+    expect(schema.insertWikiPageVersionSchema.safeParse({ ...validWikiPageVersionInput, source: 'crawler' }).success).toBe(false);
+  });
+
+  it('validates publishRequestSchema inputs', () => {
+    expect(schema.publishRequestSchema.safeParse({ version_id: 'version-1' }).success).toBe(true);
+    expect(schema.publishRequestSchema.safeParse({ version_id: 'version-1', publish_note: 'Ready' }).success).toBe(true);
+    expect(schema.publishRequestSchema.safeParse({ version_id: '' }).success).toBe(false);
+  });
+
+  it('validates rollbackRequestSchema inputs', () => {
+    expect(schema.rollbackRequestSchema.safeParse({ target_version_id: 'version-1' }).success).toBe(true);
+    expect(schema.rollbackRequestSchema.safeParse({ target_version_id: 'version-1', reason: 'Restore prior content' }).success).toBe(true);
+    expect(schema.rollbackRequestSchema.safeParse({ target_version_id: '' }).success).toBe(false);
+  });
+});
+
 const tenantScopedTables = [
   schema.users,
   schema.groups,
@@ -164,4 +214,8 @@ const tenantScopedTables = [
   schema.system_settings,
   schema.file_blobs,
   schema.source_documents,
+  schema.wikiPages,
+  schema.wikiPageVersions,
+  schema.wikiSections,
+  schema.sourceLinks,
 ] as const satisfies readonly { tenant_id: { notNull: boolean } }[];

--- a/packages/shared/src/schema/core.ts
+++ b/packages/shared/src/schema/core.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
-import { bigint, boolean, index, integer, jsonb, pgTable, primaryKey, text, timestamp, unique } from 'drizzle-orm/pg-core';
+import { bigint, boolean, foreignKey, index, integer, jsonb, pgTable, primaryKey, text, timestamp, unique } from 'drizzle-orm/pg-core';
+import type { PgTableExtraConfigValue } from 'drizzle-orm/pg-core';
 
 export const tenants = pgTable('tenants', {
   id: text('id').primaryKey(),
@@ -320,4 +321,134 @@ export const job_events = pgTable(
     created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [index('idx_job_events_job').on(table.job_id, table.created_at)],
+);
+
+export const wikiPages = pgTable(
+  'wiki_pages',
+  {
+    id: text('id').primaryKey(),
+    tenant_id: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    space_id: text('space_id')
+      .notNull()
+      .references(() => spaces.id),
+    page_id: text('page_id').notNull(),
+    title: text('title').notNull(),
+    slug: text('slug').notNull(),
+    status: text('status').notNull().default('draft'),
+    current_version_id: text('current_version_id'),
+    indexed_version_id: text('indexed_version_id'),
+    sync_status: text('sync_status').notNull().default('synced'),
+    docmost_page_id: text('docmost_page_id'),
+    created_by: text('created_by').references(() => users.id),
+    created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table): PgTableExtraConfigValue[] => [
+    unique('wiki_pages_tenant_id_space_id_page_id_unique').on(table.tenant_id, table.space_id, table.page_id),
+    index('idx_wiki_pages_indexed_version').on(table.indexed_version_id),
+    index('idx_wiki_pages_current_indexed').on(table.current_version_id, table.indexed_version_id),
+    foreignKey({
+      name: 'fk_wiki_pages_current_version',
+      columns: [table.current_version_id],
+      foreignColumns: [wikiPageVersions.id],
+    }),
+    foreignKey({
+      name: 'fk_wiki_pages_indexed_version',
+      columns: [table.indexed_version_id],
+      foreignColumns: [wikiPageVersions.id],
+    }),
+  ],
+);
+
+export const wikiPageVersions = pgTable(
+  'wiki_page_versions',
+  {
+    id: text('id').primaryKey(),
+    tenant_id: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    space_id: text('space_id')
+      .notNull()
+      .references(() => spaces.id),
+    wiki_page_pk: text('wiki_page_pk')
+      .notNull()
+      .references(() => wikiPages.id),
+    page_id: text('page_id').notNull(),
+    version_no: integer('version_no').notNull(),
+    content_markdown: text('content_markdown').notNull(),
+    frontmatter_json: jsonb('frontmatter_json').notNull().default(sql`'{}'::jsonb`),
+    source: text('source').notNull(),
+    graphify_run_id: text('graphify_run_id'),
+    commit_hash: text('commit_hash'),
+    status: text('status').notNull().default('draft'),
+    created_by: text('created_by').references(() => users.id),
+    created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table): PgTableExtraConfigValue[] => [
+    unique('wiki_page_versions_wiki_page_pk_version_no_unique').on(table.wiki_page_pk, table.version_no),
+    index('idx_wiki_versions_status').on(table.tenant_id, table.space_id, table.status, table.created_at.desc()),
+  ],
+);
+
+export const wikiSections = pgTable(
+  'wiki_sections',
+  {
+    id: text('id').primaryKey(),
+    tenant_id: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    space_id: text('space_id')
+      .notNull()
+      .references(() => spaces.id),
+    wiki_page_pk: text('wiki_page_pk')
+      .notNull()
+      .references(() => wikiPages.id),
+    page_version_id: text('page_version_id')
+      .notNull()
+      .references(() => wikiPageVersions.id),
+    section_id: text('section_id').notNull(),
+    heading: text('heading').notNull(),
+    level: integer('level').notNull().default(2),
+    section_index: integer('section_index').notNull(),
+    start_offset: integer('start_offset'),
+    end_offset: integer('end_offset'),
+    content_hash: text('content_hash'),
+    acl_json: jsonb('acl_json').notNull().default(sql`'{}'::jsonb`),
+    created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique('wiki_sections_page_version_id_section_id_unique').on(table.page_version_id, table.section_id),
+    index('idx_wiki_sections_page_version').on(table.page_version_id),
+  ],
+);
+
+export const sourceLinks = pgTable(
+  'source_links',
+  {
+    id: text('id').primaryKey(),
+    tenant_id: text('tenant_id')
+      .notNull()
+      .references(() => tenants.id),
+    space_id: text('space_id')
+      .notNull()
+      .references(() => spaces.id),
+    wiki_page_pk: text('wiki_page_pk')
+      .notNull()
+      .references(() => wikiPages.id),
+    page_version_id: text('page_version_id')
+      .notNull()
+      .references(() => wikiPageVersions.id),
+    section_id: text('section_id').references(() => wikiSections.id),
+    source_document_id: text('source_document_id').references(() => source_documents.id),
+    source_uri: text('source_uri'),
+    quote_hash: text('quote_hash'),
+    evidence_type: text('evidence_type').notNull().default('reference'),
+    created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('idx_source_links_page_version').on(table.page_version_id),
+    index('idx_source_links_source_doc').on(table.source_document_id),
+  ],
 );

--- a/packages/shared/src/schema/validation.ts
+++ b/packages/shared/src/schema/validation.ts
@@ -230,6 +230,46 @@ export const updateSourceDocumentSchema = z
   })
   .partial();
 
+export const wikiPageStatusSchema = z.enum(['draft', 'published', 'archived']);
+export const wikiVersionSourceSchema = z.enum(['graphify', 'human', 'import', 'rollback']);
+
+export const insertWikiPageSchema = z.object({
+  id: optionalIdSchema.optional(),
+  tenant_id: idSchema,
+  space_id: idSchema,
+  page_id: nonEmptyString.max(500),
+  title: nonEmptyString.max(500),
+  slug: nonEmptyString.max(500),
+  status: wikiPageStatusSchema.default('draft'),
+  created_by: optionalIdSchema.nullable().optional(),
+});
+
+export const insertWikiPageVersionSchema = z.object({
+  id: optionalIdSchema.optional(),
+  tenant_id: idSchema,
+  space_id: idSchema,
+  wiki_page_pk: idSchema,
+  page_id: nonEmptyString.max(500),
+  version_no: z.number().int().positive(),
+  content_markdown: z.string(),
+  frontmatter_json: unstructuredJsonRecordSchema.default({}),
+  source: wikiVersionSourceSchema,
+  graphify_run_id: optionalIdSchema.nullable().optional(),
+  commit_hash: z.string().max(200).nullable().optional(),
+  status: wikiPageStatusSchema.default('draft'),
+  created_by: optionalIdSchema.nullable().optional(),
+});
+
+export const publishRequestSchema = z.object({
+  version_id: nonEmptyString.max(200),
+  publish_note: z.string().max(1000).optional(),
+});
+
+export const rollbackRequestSchema = z.object({
+  target_version_id: nonEmptyString.max(200),
+  reason: z.string().max(1000).optional(),
+});
+
 export type InsertUserInput = z.infer<typeof insertUserSchema>;
 export type UpdateUserInput = z.infer<typeof updateUserSchema>;
 export type InsertSpaceInput = z.infer<typeof insertSpaceSchema>;
@@ -248,3 +288,9 @@ export type SourceDocumentMetadata = z.infer<typeof sourceDocumentMetadataSchema
 export type InsertFileBlobInput = z.infer<typeof insertFileBlobSchema>;
 export type InsertSourceDocumentInput = z.infer<typeof insertSourceDocumentSchema>;
 export type UpdateSourceDocumentInput = z.infer<typeof updateSourceDocumentSchema>;
+export type WikiPageStatus = z.infer<typeof wikiPageStatusSchema>;
+export type WikiVersionSource = z.infer<typeof wikiVersionSourceSchema>;
+export type InsertWikiPageInput = z.infer<typeof insertWikiPageSchema>;
+export type InsertWikiPageVersionInput = z.infer<typeof insertWikiPageVersionSchema>;
+export type PublishRequestInput = z.infer<typeof publishRequestSchema>;
+export type RollbackRequestInput = z.infer<typeof rollbackRequestSchema>;

--- a/packages/wiki-core/package.json
+++ b/packages/wiki-core/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsc -b",
     "lint": "eslint src --max-warnings=0",
+    "test": "vitest run --config ../../vitest.config.ts",
     "typecheck": "tsc -b"
   },
   "dependencies": {

--- a/packages/wiki-core/package.json
+++ b/packages/wiki-core/package.json
@@ -15,5 +15,11 @@
     "build": "tsc -b",
     "lint": "eslint src --max-warnings=0",
     "typecheck": "tsc -b"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.1"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9"
   }
 }

--- a/packages/wiki-core/src/__tests__/frontmatter.test.ts
+++ b/packages/wiki-core/src/__tests__/frontmatter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateFrontmatter, parseFrontmatter } from '../frontmatter.js';
+import type { WikiFrontmatter } from '../types.js';
+
+const fullFrontmatter: WikiFrontmatter = {
+  page_id: 'rd-platform.community.community_1',
+  title: 'Community: Auth / Token Service',
+  space_id: 'rd-platform',
+  page_type: 'community',
+  status: 'draft',
+  curation_status: 'auto_generated',
+  source: 'graphify',
+  graphify_run_id: 'run-1',
+  graphify_schema_version: '0.5.3',
+  managed_by: 'graphify',
+  source_document_ids: ['doc-1', 'doc-2'],
+  graph_node_ids: ['node-1', 'node-2'],
+  version: 1,
+  acl_hash: '',
+  created_by: 'user-1',
+  created_at: '2026-05-01T00:00:00.000Z',
+  updated_at: '2026-05-01T00:00:00.000Z',
+};
+
+describe('frontmatter', () => {
+  it('parses valid frontmatter with all Doc 21 fields', () => {
+    const markdown = generateFrontmatter(fullFrontmatter, '# Content');
+    const parsed = parseFrontmatter(markdown);
+
+    expect(parsed.frontmatter).toEqual(fullFrontmatter);
+    expect(parsed.content).toBe('# Content');
+  });
+
+  it('returns empty frontmatter for markdown without frontmatter', () => {
+    expect(parseFrontmatter('# Just content')).toEqual({
+      frontmatter: {},
+      content: '# Just content',
+    });
+  });
+
+  it('returns empty frontmatter for empty frontmatter', () => {
+    expect(parseFrontmatter('---\n---\n# Content')).toEqual({
+      frontmatter: {},
+      content: '# Content',
+    });
+  });
+
+  it('preserves all fields through generate and parse', () => {
+    const markdown = generateFrontmatter(fullFrontmatter, 'Body');
+
+    expect(parseFrontmatter(markdown)).toEqual({
+      frontmatter: fullFrontmatter,
+      content: 'Body',
+    });
+  });
+
+  it('handles special characters in title', () => {
+    const frontmatter = {
+      ...fullFrontmatter,
+      title: 'Auth: token/service & 数据库设计',
+    };
+    const parsed = parseFrontmatter(generateFrontmatter(frontmatter, 'Content'));
+
+    expect(parsed.frontmatter.title).toBe('Auth: token/service & 数据库设计');
+  });
+});

--- a/packages/wiki-core/src/__tests__/frontmatter.test.ts
+++ b/packages/wiki-core/src/__tests__/frontmatter.test.ts
@@ -39,6 +39,15 @@ describe('frontmatter', () => {
     });
   });
 
+  it('does not parse body horizontal rules as frontmatter', () => {
+    const markdown = '# Just content\n\n---\ntitle: Not frontmatter\n---\n\nBody';
+
+    expect(parseFrontmatter(markdown)).toEqual({
+      frontmatter: {},
+      content: markdown,
+    });
+  });
+
   it('returns empty frontmatter for empty frontmatter', () => {
     expect(parseFrontmatter('---\n---\n# Content')).toEqual({
       frontmatter: {},

--- a/packages/wiki-core/src/__tests__/page-id.test.ts
+++ b/packages/wiki-core/src/__tests__/page-id.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { generatePageId } from '../page-id.js';
+
+describe('generatePageId', () => {
+  it('generates community page ids', () => {
+    expect(generatePageId('rd-platform', 'community', 'community_1')).toBe('rd-platform.community.community_1');
+  });
+
+  it('generates index page ids', () => {
+    expect(generatePageId('rd-platform', 'index', 'root')).toBe('rd-platform.index.root');
+  });
+
+  it('generates god node page ids', () => {
+    expect(generatePageId('rd-platform', 'god_node', 'a1b2c3d4e5f6')).toBe('rd-platform.god-node.a1b2c3d4e5f6');
+  });
+
+  it('generates article page ids', () => {
+    expect(generatePageId('rd-platform', 'generated_article', 'abc123def456')).toBe('rd-platform.page.abc123def456');
+  });
+});

--- a/packages/wiki-core/src/__tests__/repo-init.test.ts
+++ b/packages/wiki-core/src/__tests__/repo-init.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { initWikiRepo } from '../repo-init.js';
+
+describe('initWikiRepo', () => {
+  let basePath: string;
+
+  beforeEach(() => {
+    basePath = fs.mkdtempSync(path.join(os.tmpdir(), 'wiki-core-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(basePath, { force: true, recursive: true });
+  });
+
+  it('creates the expected directory structure', () => {
+    const spacePath = initWikiRepo(basePath, 'rd-platform');
+
+    for (const dir of ['pages', 'communities', 'god-nodes', '_attachments', '_metadata']) {
+      expect(fs.statSync(path.join(spacePath, dir)).isDirectory()).toBe(true);
+    }
+  });
+
+  it('is idempotent on an existing repo', () => {
+    const firstPath = initWikiRepo(basePath, 'rd-platform');
+    fs.writeFileSync(path.join(firstPath, '_metadata', 'pages.jsonl'), 'existing\n', 'utf-8');
+    const secondPath = initWikiRepo(basePath, 'rd-platform');
+
+    expect(secondPath).toBe(firstPath);
+    expect(fs.readFileSync(path.join(secondPath, '_metadata', 'pages.jsonl'), 'utf-8')).toBe('existing\n');
+  });
+
+  it('returns the space path', () => {
+    expect(initWikiRepo(basePath, 'rd-platform')).toBe(path.join(basePath, 'spaces', 'rd-platform'));
+  });
+
+  it('creates an empty pages.jsonl file', () => {
+    const spacePath = initWikiRepo(basePath, 'rd-platform');
+
+    expect(fs.readFileSync(path.join(spacePath, '_metadata', 'pages.jsonl'), 'utf-8')).toBe('');
+  });
+});

--- a/packages/wiki-core/src/__tests__/repo-init.test.ts
+++ b/packages/wiki-core/src/__tests__/repo-init.test.ts
@@ -43,4 +43,8 @@ describe('initWikiRepo', () => {
 
     expect(fs.readFileSync(path.join(spacePath, '_metadata', 'pages.jsonl'), 'utf-8')).toBe('');
   });
+
+  it('rejects path traversal space ids', () => {
+    expect(() => initWikiRepo(basePath, '../../etc')).toThrow();
+  });
 });

--- a/packages/wiki-core/src/__tests__/sections.test.ts
+++ b/packages/wiki-core/src/__tests__/sections.test.ts
@@ -24,6 +24,27 @@ describe('extractSections', () => {
     expect(section?.section_id).toBe('page-1#heading-section-a');
   });
 
+  it('preserves Chinese heading text in section ids', () => {
+    const [section] = extractSections('## 数据库设计', 'page-1');
+
+    expect(section?.section_id).toBe('page-1#heading-数据库设计');
+  });
+
+  it('deduplicates repeated heading section ids', () => {
+    const sections = extractSections('## Foo\n\n## Foo', 'page-1');
+
+    expect(sections.map((section) => section.section_id)).toEqual([
+      'page-1#heading-foo',
+      'page-1#heading-foo-2',
+    ]);
+  });
+
+  it('uses a fallback section id for punctuation-only headings', () => {
+    const [section] = extractSections('## !!!', 'page-1');
+
+    expect(section?.section_id).toBe('page-1#heading-section-0');
+  });
+
   it('returns correct heading levels', () => {
     const sections = extractSections('## Section A\n\n### Sub', 'page-1');
 

--- a/packages/wiki-core/src/__tests__/sections.test.ts
+++ b/packages/wiki-core/src/__tests__/sections.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractSections } from '../sections.js';
+
+describe('extractSections', () => {
+  it('extracts h2 and h3 headings', () => {
+    const sections = extractSections('# Title\n\n## Section A\n\nText\n\n### Sub\n\n## Section B', 'page-1');
+
+    expect(sections).toHaveLength(3);
+    expect(sections.map((section) => section.heading)).toEqual(['Section A', 'Sub', 'Section B']);
+  });
+
+  it('excludes h1 headings', () => {
+    expect(extractSections('# Title', 'page-1')).toEqual([]);
+  });
+
+  it('handles empty markdown', () => {
+    expect(extractSections('', 'page-1')).toEqual([]);
+  });
+
+  it('generates section ids from page id and heading slug', () => {
+    const [section] = extractSections('## Section A', 'page-1');
+
+    expect(section?.section_id).toBe('page-1#heading-section-a');
+  });
+
+  it('returns correct heading levels', () => {
+    const sections = extractSections('## Section A\n\n### Sub', 'page-1');
+
+    expect(sections.map((section) => section.level)).toEqual([2, 3]);
+  });
+
+  it('uses sequential section indexes starting from zero', () => {
+    const sections = extractSections('## A\n\n### B\n\n## C', 'page-1');
+
+    expect(sections.map((section) => section.section_index)).toEqual([0, 1, 2]);
+  });
+});

--- a/packages/wiki-core/src/__tests__/slug.test.ts
+++ b/packages/wiki-core/src/__tests__/slug.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateSlug } from '../slug.js';
+
+describe('generateSlug', () => {
+  it('replaces spaces with underscores', () => {
+    expect(generateSlug('Hello World')).toBe('Hello_World');
+  });
+
+  it('replaces slash and colon with hyphens', () => {
+    expect(generateSlug('auth/token:service')).toBe('auth-token-service');
+  });
+
+  it('deduplicates once', () => {
+    expect(generateSlug('Hello World', ['Hello_World'])).toBe('Hello_World_2');
+  });
+
+  it('deduplicates repeatedly', () => {
+    expect(generateSlug('Hello World', ['Hello_World', 'Hello_World_2'])).toBe('Hello_World_3');
+  });
+
+  it('preserves Chinese characters', () => {
+    expect(generateSlug('数据库设计')).toBe('数据库设计');
+  });
+
+  it('handles empty strings', () => {
+    expect(generateSlug('')).toBe('');
+  });
+});

--- a/packages/wiki-core/src/__tests__/source-links.test.ts
+++ b/packages/wiki-core/src/__tests__/source-links.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { batchCreateSourceLinks, createSourceLink } from '../source-links.js';
+
+describe('source link helpers', () => {
+  it('creates a source link with all fields', () => {
+    const link = {
+      wiki_page_pk: 'page-pk-1',
+      page_version_id: 'version-1',
+      section_id: 'section-1',
+      source_document_id: 'doc-1',
+      source_uri: 's3://bucket/doc.md',
+      quote_hash: 'hash-1',
+      evidence_type: 'quote',
+    };
+
+    expect(createSourceLink(link)).toEqual(link);
+  });
+
+  it('defaults evidence_type to reference', () => {
+    expect(
+      createSourceLink({
+        wiki_page_pk: 'page-pk-1',
+        page_version_id: 'version-1',
+        evidence_type: '',
+      }).evidence_type,
+    ).toBe('reference');
+  });
+
+  it('processes batches', () => {
+    expect(
+      batchCreateSourceLinks([
+        { wiki_page_pk: 'page-pk-1', page_version_id: 'version-1', evidence_type: 'quote' },
+        { wiki_page_pk: 'page-pk-2', page_version_id: 'version-2', evidence_type: '' },
+      ]),
+    ).toEqual([
+      { wiki_page_pk: 'page-pk-1', page_version_id: 'version-1', evidence_type: 'quote' },
+      { wiki_page_pk: 'page-pk-2', page_version_id: 'version-2', evidence_type: 'reference' },
+    ]);
+  });
+});

--- a/packages/wiki-core/src/__tests__/state-machine.test.ts
+++ b/packages/wiki-core/src/__tests__/state-machine.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { PublishStateMachine } from '../state-machine.js';
+
+describe('PublishStateMachine', () => {
+  const machine = new PublishStateMachine();
+
+  it('publishes drafts', () => {
+    expect(machine.canPublish('draft')).toBe(true);
+    expect(machine.publish('draft')).toBe('published');
+  });
+
+  it('rejects publishing already published versions', () => {
+    expect(() => machine.publish('published')).toThrow('VERSION_ALREADY_PUBLISHED');
+  });
+
+  it('rejects publishing archived versions', () => {
+    expect(() => machine.publish('archived')).toThrow();
+  });
+
+  it('archives published pages', () => {
+    expect(machine.canArchive('published')).toBe(true);
+    expect(machine.archive('published')).toBe('archived');
+  });
+
+  it('rejects archiving drafts', () => {
+    expect(() => machine.archive('draft')).toThrow();
+  });
+
+  it('creates rollback version data', () => {
+    expect(machine.rollback('# Prior content', 3)).toEqual({
+      content: '# Prior content',
+      versionNo: 4,
+      source: 'rollback',
+      status: 'published',
+    });
+  });
+});

--- a/packages/wiki-core/src/__tests__/version.test.ts
+++ b/packages/wiki-core/src/__tests__/version.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getNextVersionNo } from '../version.js';
+
+describe('getNextVersionNo', () => {
+  it('starts at 1 for empty version lists', () => {
+    expect(getNextVersionNo([])).toBe(1);
+  });
+
+  it('increments consecutive versions', () => {
+    expect(getNextVersionNo([1, 2])).toBe(3);
+  });
+
+  it('uses max plus one for unordered versions', () => {
+    expect(getNextVersionNo([1, 3, 2])).toBe(4);
+  });
+});

--- a/packages/wiki-core/src/frontmatter.ts
+++ b/packages/wiki-core/src/frontmatter.ts
@@ -2,7 +2,7 @@ import { JSON_SCHEMA, dump, load } from 'js-yaml';
 
 import type { WikiFrontmatter } from './types.js';
 
-const frontmatterPattern = /^---[ \t]*\r?\n([\s\S]*?)^---[ \t]*(?:\r?\n|$)/m;
+const frontmatterPattern = /^---[ \t]*\r?\n(?:(.*?)\r?\n)?---[ \t]*(?:\r?\n|$)/s;
 
 export function parseFrontmatter(markdown: string): { frontmatter: Partial<WikiFrontmatter>; content: string } {
   const match = frontmatterPattern.exec(markdown);

--- a/packages/wiki-core/src/frontmatter.ts
+++ b/packages/wiki-core/src/frontmatter.ts
@@ -1,0 +1,32 @@
+import { JSON_SCHEMA, dump, load } from 'js-yaml';
+
+import type { WikiFrontmatter } from './types.js';
+
+const frontmatterPattern = /^---[ \t]*\r?\n([\s\S]*?)^---[ \t]*(?:\r?\n|$)/m;
+
+export function parseFrontmatter(markdown: string): { frontmatter: Partial<WikiFrontmatter>; content: string } {
+  const match = frontmatterPattern.exec(markdown);
+
+  if (!match) {
+    return { frontmatter: {}, content: markdown };
+  }
+
+  const rawFrontmatter = match[1] ?? '';
+  const parsed = rawFrontmatter.trim() ? load(rawFrontmatter, { schema: JSON_SCHEMA }) : {};
+  const frontmatter =
+    parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Partial<WikiFrontmatter>) : {};
+
+  const content = markdown.slice(match[0].length).replace(/^\r?\n/, '');
+  return { frontmatter, content };
+}
+
+export function generateFrontmatter(frontmatter: WikiFrontmatter, content: string): string {
+  const yaml = dump(frontmatter, {
+    lineWidth: -1,
+    noRefs: true,
+    schema: JSON_SCHEMA,
+    sortKeys: false,
+  }).trimEnd();
+
+  return `---\n${yaml}\n---\n\n${content}`;
+}

--- a/packages/wiki-core/src/index.ts
+++ b/packages/wiki-core/src/index.ts
@@ -1,1 +1,9 @@
-export {};
+export * from './types.js';
+export * from './frontmatter.js';
+export * from './slug.js';
+export * from './page-id.js';
+export * from './state-machine.js';
+export * from './sections.js';
+export * from './version.js';
+export * from './repo-init.js';
+export * from './source-links.js';

--- a/packages/wiki-core/src/page-id.ts
+++ b/packages/wiki-core/src/page-id.ts
@@ -1,0 +1,12 @@
+export type WikiPageType = 'community' | 'god_node' | 'generated_article' | 'index';
+
+const typePrefixes: Record<WikiPageType, string> = {
+  index: 'index',
+  community: 'community',
+  god_node: 'god-node',
+  generated_article: 'page',
+};
+
+export function generatePageId(spaceId: string, pageType: WikiPageType, stableKey: string): string {
+  return `${spaceId}.${typePrefixes[pageType]}.${stableKey}`;
+}

--- a/packages/wiki-core/src/repo-init.ts
+++ b/packages/wiki-core/src/repo-init.ts
@@ -3,6 +3,18 @@ import path from 'node:path';
 
 export function initWikiRepo(basePath: string, spaceId: string): string {
   const spacePath = path.join(basePath, 'spaces', spaceId);
+  const resolvedBasePath = path.resolve(basePath);
+  const resolvedSpacesPath = path.join(resolvedBasePath, 'spaces');
+  const resolvedSpacePath = path.resolve(spacePath);
+
+  if (spaceId.split(/[\\/]/).includes('..') || /[\\/]/.test(spaceId)) {
+    throw new Error('Invalid spaceId: path traversal is not allowed');
+  }
+
+  if (!resolvedSpacePath.startsWith(`${resolvedSpacesPath}${path.sep}`)) {
+    throw new Error('Invalid spaceId: path must stay within the spaces directory');
+  }
+
   const dirs = ['pages', 'communities', 'god-nodes', '_attachments', '_metadata'];
 
   for (const dir of dirs) {

--- a/packages/wiki-core/src/repo-init.ts
+++ b/packages/wiki-core/src/repo-init.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function initWikiRepo(basePath: string, spaceId: string): string {
+  const spacePath = path.join(basePath, 'spaces', spaceId);
+  const dirs = ['pages', 'communities', 'god-nodes', '_attachments', '_metadata'];
+
+  for (const dir of dirs) {
+    fs.mkdirSync(path.join(spacePath, dir), { recursive: true });
+  }
+
+  const jsonlPath = path.join(spacePath, '_metadata', 'pages.jsonl');
+  if (!fs.existsSync(jsonlPath)) {
+    fs.writeFileSync(jsonlPath, '', 'utf-8');
+  }
+
+  return spacePath;
+}

--- a/packages/wiki-core/src/sections.ts
+++ b/packages/wiki-core/src/sections.ts
@@ -6,23 +6,33 @@ function slugifyHeading(heading: string): string {
   return heading
     .toLowerCase()
     .trim()
+    .replace(/\p{P}+/gu, '')
     .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
 }
 
 export function extractSections(markdown: string, pageId: string): WikiSection[] {
   const matches = Array.from(markdown.matchAll(headingPattern));
+  const seenSlugs = new Set<string>();
 
   return matches.map((match, index) => {
     const heading = (match[2] ?? '').trim().replace(/\s+#*$/, '');
     const nextMatch = matches[index + 1];
     const level = match[1]?.length ?? 2;
     const startOffset = match.index ?? 0;
+    const baseSlug = slugifyHeading(heading) || `section-${index}`;
+    let slug = baseSlug;
+    let suffix = 2;
+
+    while (seenSlugs.has(slug)) {
+      slug = `${baseSlug}-${suffix}`;
+      suffix += 1;
+    }
+    seenSlugs.add(slug);
 
     return {
-      section_id: `${pageId}#heading-${slugifyHeading(heading)}`,
+      section_id: `${pageId}#heading-${slug}`,
       heading,
       level,
       section_index: index,

--- a/packages/wiki-core/src/sections.ts
+++ b/packages/wiki-core/src/sections.ts
@@ -1,0 +1,34 @@
+import type { WikiSection } from './types.js';
+
+const headingPattern = /^(#{2,3})(?!#)[ \t]+(.+?)\s*#*\s*$/gm;
+
+function slugifyHeading(heading: string): string {
+  return heading
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function extractSections(markdown: string, pageId: string): WikiSection[] {
+  const matches = Array.from(markdown.matchAll(headingPattern));
+
+  return matches.map((match, index) => {
+    const heading = (match[2] ?? '').trim().replace(/\s+#*$/, '');
+    const nextMatch = matches[index + 1];
+    const level = match[1]?.length ?? 2;
+    const startOffset = match.index ?? 0;
+
+    return {
+      section_id: `${pageId}#heading-${slugifyHeading(heading)}`,
+      heading,
+      level,
+      section_index: index,
+      start_offset: startOffset,
+      end_offset: nextMatch?.index ?? markdown.length,
+      content_hash: null,
+    };
+  });
+}

--- a/packages/wiki-core/src/slug.ts
+++ b/packages/wiki-core/src/slug.ts
@@ -1,0 +1,17 @@
+export function generateSlug(label: string, existingSlugs: readonly string[] = []): string {
+  const baseSlug = label.replace(/\//g, '-').replace(/ /g, '_').replace(/:/g, '-');
+  const taken = new Set(existingSlugs);
+
+  if (!taken.has(baseSlug)) {
+    return baseSlug;
+  }
+
+  let index = 2;
+  let slug = `${baseSlug}_${index}`;
+  while (taken.has(slug)) {
+    index += 1;
+    slug = `${baseSlug}_${index}`;
+  }
+
+  return slug;
+}

--- a/packages/wiki-core/src/source-links.ts
+++ b/packages/wiki-core/src/source-links.ts
@@ -1,0 +1,17 @@
+export interface SourceLink {
+  wiki_page_pk: string;
+  page_version_id: string;
+  section_id?: string | null;
+  source_document_id?: string | null;
+  source_uri?: string | null;
+  quote_hash?: string | null;
+  evidence_type: string;
+}
+
+export function createSourceLink(link: SourceLink): SourceLink {
+  return { ...link, evidence_type: link.evidence_type || 'reference' };
+}
+
+export function batchCreateSourceLinks(links: SourceLink[]): SourceLink[] {
+  return links.map(createSourceLink);
+}

--- a/packages/wiki-core/src/state-machine.ts
+++ b/packages/wiki-core/src/state-machine.ts
@@ -1,0 +1,43 @@
+export type WikiPageStatus = 'draft' | 'published' | 'archived';
+
+export class PublishStateMachine {
+  canPublish(currentStatus: string): boolean {
+    return currentStatus === 'draft';
+  }
+
+  publish(currentStatus: string): WikiPageStatus {
+    if (this.canPublish(currentStatus)) {
+      return 'published';
+    }
+
+    if (currentStatus === 'published') {
+      throw new Error('VERSION_ALREADY_PUBLISHED');
+    }
+
+    throw new Error('INVALID_PUBLISH_TRANSITION');
+  }
+
+  canArchive(currentStatus: string): boolean {
+    return currentStatus === 'published';
+  }
+
+  archive(currentStatus: string): WikiPageStatus {
+    if (this.canArchive(currentStatus)) {
+      return 'archived';
+    }
+
+    throw new Error('INVALID_ARCHIVE_TRANSITION');
+  }
+
+  rollback(
+    targetVersionContent: string,
+    currentMaxVersionNo: number,
+  ): { content: string; versionNo: number; source: 'rollback'; status: 'published' } {
+    return {
+      content: targetVersionContent,
+      versionNo: currentMaxVersionNo + 1,
+      source: 'rollback',
+      status: 'published',
+    };
+  }
+}

--- a/packages/wiki-core/src/types.ts
+++ b/packages/wiki-core/src/types.ts
@@ -1,0 +1,29 @@
+export interface WikiFrontmatter {
+  page_id: string;
+  title: string;
+  space_id: string;
+  page_type: 'community' | 'god_node' | 'generated_article' | 'index';
+  status: 'draft' | 'published' | 'archived';
+  curation_status: 'auto_generated' | 'human_curated' | 'mixed';
+  source: 'graphify' | 'human' | 'import' | 'rollback';
+  graphify_run_id?: string;
+  graphify_schema_version?: string;
+  managed_by: 'graphify' | 'human_curated';
+  source_document_ids: string[];
+  graph_node_ids: string[];
+  version: number;
+  acl_hash: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WikiSection {
+  section_id: string;
+  heading: string;
+  level: number;
+  section_index: number;
+  start_offset: number | null;
+  end_offset: number | null;
+  content_hash: string | null;
+}

--- a/packages/wiki-core/src/version.ts
+++ b/packages/wiki-core/src/version.ts
@@ -1,0 +1,7 @@
+export function getNextVersionNo(existingVersionNos: readonly number[]): number {
+  if (existingVersionNos.length === 0) {
+    return 1;
+  }
+
+  return Math.max(...existingVersionNos) + 1;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,7 +277,15 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
 
-  packages/wiki-core: {}
+  packages/wiki-core:
+    dependencies:
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
+    devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
 
 packages:
 
@@ -1965,6 +1973,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -6549,6 +6560,8 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/schemas/migrations/0005_small_vance_astro.sql
+++ b/schemas/migrations/0005_small_vance_astro.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "source_links" (
+CREATE TABLE IF NOT EXISTS "source_links" (
 	"id" text PRIMARY KEY NOT NULL,
 	"tenant_id" text NOT NULL,
 	"space_id" text NOT NULL,
@@ -12,7 +12,7 @@ CREATE TABLE "source_links" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE "wiki_page_versions" (
+CREATE TABLE IF NOT EXISTS "wiki_page_versions" (
 	"id" text PRIMARY KEY NOT NULL,
 	"tenant_id" text NOT NULL,
 	"space_id" text NOT NULL,
@@ -30,7 +30,7 @@ CREATE TABLE "wiki_page_versions" (
 	CONSTRAINT "wiki_page_versions_wiki_page_pk_version_no_unique" UNIQUE("wiki_page_pk","version_no")
 );
 --> statement-breakpoint
-CREATE TABLE "wiki_pages" (
+CREATE TABLE IF NOT EXISTS "wiki_pages" (
 	"id" text PRIMARY KEY NOT NULL,
 	"tenant_id" text NOT NULL,
 	"space_id" text NOT NULL,
@@ -48,7 +48,7 @@ CREATE TABLE "wiki_pages" (
 	CONSTRAINT "wiki_pages_tenant_id_space_id_page_id_unique" UNIQUE("tenant_id","space_id","page_id")
 );
 --> statement-breakpoint
-CREATE TABLE "wiki_sections" (
+CREATE TABLE IF NOT EXISTS "wiki_sections" (
 	"id" text PRIMARY KEY NOT NULL,
 	"tenant_id" text NOT NULL,
 	"space_id" text NOT NULL,
@@ -66,28 +66,199 @@ CREATE TABLE "wiki_sections" (
 	CONSTRAINT "wiki_sections_page_version_id_section_id_unique" UNIQUE("page_version_id","section_id")
 );
 --> statement-breakpoint
-ALTER TABLE "source_links" ADD CONSTRAINT "source_links_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "source_links" ADD CONSTRAINT "source_links_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "source_links" ADD CONSTRAINT "source_links_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "source_links" ADD CONSTRAINT "source_links_page_version_id_wiki_page_versions_id_fk" FOREIGN KEY ("page_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "source_links" ADD CONSTRAINT "source_links_section_id_wiki_sections_id_fk" FOREIGN KEY ("section_id") REFERENCES "public"."wiki_sections"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "source_links" ADD CONSTRAINT "source_links_source_document_id_source_documents_id_fk" FOREIGN KEY ("source_document_id") REFERENCES "public"."source_documents"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_pages" ADD CONSTRAINT "fk_wiki_pages_current_version" FOREIGN KEY ("current_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_pages" ADD CONSTRAINT "fk_wiki_pages_indexed_version" FOREIGN KEY ("indexed_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_page_version_id_wiki_page_versions_id_fk" FOREIGN KEY ("page_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "idx_source_links_page_version" ON "source_links" USING btree ("page_version_id");--> statement-breakpoint
-CREATE INDEX "idx_source_links_source_doc" ON "source_links" USING btree ("source_document_id");--> statement-breakpoint
-CREATE INDEX "idx_wiki_versions_status" ON "wiki_page_versions" USING btree ("tenant_id","space_id","status","created_at" DESC NULLS LAST);--> statement-breakpoint
-CREATE INDEX "idx_wiki_pages_indexed_version" ON "wiki_pages" USING btree ("indexed_version_id");--> statement-breakpoint
-CREATE INDEX "idx_wiki_pages_current_indexed" ON "wiki_pages" USING btree ("current_version_id","indexed_version_id");--> statement-breakpoint
-CREATE INDEX "idx_wiki_sections_page_version" ON "wiki_sections" USING btree ("page_version_id");
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'source_links'
+      AND constraint_name = 'source_links_tenant_id_tenants_id_fk'
+  ) THEN
+    ALTER TABLE "source_links" ADD CONSTRAINT "source_links_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'source_links'
+      AND constraint_name = 'source_links_space_id_spaces_id_fk'
+  ) THEN
+    ALTER TABLE "source_links" ADD CONSTRAINT "source_links_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'source_links'
+      AND constraint_name = 'source_links_wiki_page_pk_wiki_pages_id_fk'
+  ) THEN
+    ALTER TABLE "source_links" ADD CONSTRAINT "source_links_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'source_links'
+      AND constraint_name = 'source_links_page_version_id_wiki_page_versions_id_fk'
+  ) THEN
+    ALTER TABLE "source_links" ADD CONSTRAINT "source_links_page_version_id_wiki_page_versions_id_fk" FOREIGN KEY ("page_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'source_links'
+      AND constraint_name = 'source_links_section_id_wiki_sections_id_fk'
+  ) THEN
+    ALTER TABLE "source_links" ADD CONSTRAINT "source_links_section_id_wiki_sections_id_fk" FOREIGN KEY ("section_id") REFERENCES "public"."wiki_sections"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'source_links'
+      AND constraint_name = 'source_links_source_document_id_source_documents_id_fk'
+  ) THEN
+    ALTER TABLE "source_links" ADD CONSTRAINT "source_links_source_document_id_source_documents_id_fk" FOREIGN KEY ("source_document_id") REFERENCES "public"."source_documents"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_page_versions'
+      AND constraint_name = 'wiki_page_versions_tenant_id_tenants_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_page_versions'
+      AND constraint_name = 'wiki_page_versions_space_id_spaces_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_page_versions'
+      AND constraint_name = 'wiki_page_versions_wiki_page_pk_wiki_pages_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_page_versions'
+      AND constraint_name = 'wiki_page_versions_created_by_users_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_pages'
+      AND constraint_name = 'wiki_pages_tenant_id_tenants_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_pages'
+      AND constraint_name = 'wiki_pages_space_id_spaces_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_pages'
+      AND constraint_name = 'wiki_pages_created_by_users_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_pages'
+      AND constraint_name = 'fk_wiki_pages_current_version'
+  ) THEN
+    ALTER TABLE "wiki_pages" ADD CONSTRAINT "fk_wiki_pages_current_version" FOREIGN KEY ("current_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_pages'
+      AND constraint_name = 'fk_wiki_pages_indexed_version'
+  ) THEN
+    ALTER TABLE "wiki_pages" ADD CONSTRAINT "fk_wiki_pages_indexed_version" FOREIGN KEY ("indexed_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_sections'
+      AND constraint_name = 'wiki_sections_tenant_id_tenants_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_sections'
+      AND constraint_name = 'wiki_sections_space_id_spaces_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_sections'
+      AND constraint_name = 'wiki_sections_wiki_page_pk_wiki_pages_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'wiki_sections'
+      AND constraint_name = 'wiki_sections_page_version_id_wiki_page_versions_id_fk'
+  ) THEN
+    ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_page_version_id_wiki_page_versions_id_fk" FOREIGN KEY ("page_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;
+  END IF;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_source_links_page_version" ON "source_links" USING btree ("page_version_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_source_links_source_doc" ON "source_links" USING btree ("source_document_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_wiki_versions_status" ON "wiki_page_versions" USING btree ("tenant_id","space_id","status","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_wiki_pages_indexed_version" ON "wiki_pages" USING btree ("indexed_version_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_wiki_pages_current_indexed" ON "wiki_pages" USING btree ("current_version_id","indexed_version_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_wiki_sections_page_version" ON "wiki_sections" USING btree ("page_version_id");

--- a/schemas/migrations/0005_small_vance_astro.sql
+++ b/schemas/migrations/0005_small_vance_astro.sql
@@ -1,0 +1,93 @@
+CREATE TABLE "source_links" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"space_id" text NOT NULL,
+	"wiki_page_pk" text NOT NULL,
+	"page_version_id" text NOT NULL,
+	"section_id" text,
+	"source_document_id" text,
+	"source_uri" text,
+	"quote_hash" text,
+	"evidence_type" text DEFAULT 'reference' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "wiki_page_versions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"space_id" text NOT NULL,
+	"wiki_page_pk" text NOT NULL,
+	"page_id" text NOT NULL,
+	"version_no" integer NOT NULL,
+	"content_markdown" text NOT NULL,
+	"frontmatter_json" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"source" text NOT NULL,
+	"graphify_run_id" text,
+	"commit_hash" text,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"created_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "wiki_page_versions_wiki_page_pk_version_no_unique" UNIQUE("wiki_page_pk","version_no")
+);
+--> statement-breakpoint
+CREATE TABLE "wiki_pages" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"space_id" text NOT NULL,
+	"page_id" text NOT NULL,
+	"title" text NOT NULL,
+	"slug" text NOT NULL,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"current_version_id" text,
+	"indexed_version_id" text,
+	"sync_status" text DEFAULT 'synced' NOT NULL,
+	"docmost_page_id" text,
+	"created_by" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "wiki_pages_tenant_id_space_id_page_id_unique" UNIQUE("tenant_id","space_id","page_id")
+);
+--> statement-breakpoint
+CREATE TABLE "wiki_sections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"tenant_id" text NOT NULL,
+	"space_id" text NOT NULL,
+	"wiki_page_pk" text NOT NULL,
+	"page_version_id" text NOT NULL,
+	"section_id" text NOT NULL,
+	"heading" text NOT NULL,
+	"level" integer DEFAULT 2 NOT NULL,
+	"section_index" integer NOT NULL,
+	"start_offset" integer,
+	"end_offset" integer,
+	"content_hash" text,
+	"acl_json" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "wiki_sections_page_version_id_section_id_unique" UNIQUE("page_version_id","section_id")
+);
+--> statement-breakpoint
+ALTER TABLE "source_links" ADD CONSTRAINT "source_links_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "source_links" ADD CONSTRAINT "source_links_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "source_links" ADD CONSTRAINT "source_links_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "source_links" ADD CONSTRAINT "source_links_page_version_id_wiki_page_versions_id_fk" FOREIGN KEY ("page_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "source_links" ADD CONSTRAINT "source_links_section_id_wiki_sections_id_fk" FOREIGN KEY ("section_id") REFERENCES "public"."wiki_sections"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "source_links" ADD CONSTRAINT "source_links_source_document_id_source_documents_id_fk" FOREIGN KEY ("source_document_id") REFERENCES "public"."source_documents"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_page_versions" ADD CONSTRAINT "wiki_page_versions_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_pages" ADD CONSTRAINT "wiki_pages_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_pages" ADD CONSTRAINT "fk_wiki_pages_current_version" FOREIGN KEY ("current_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_pages" ADD CONSTRAINT "fk_wiki_pages_indexed_version" FOREIGN KEY ("indexed_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_wiki_page_pk_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_pk") REFERENCES "public"."wiki_pages"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_sections" ADD CONSTRAINT "wiki_sections_page_version_id_wiki_page_versions_id_fk" FOREIGN KEY ("page_version_id") REFERENCES "public"."wiki_page_versions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_source_links_page_version" ON "source_links" USING btree ("page_version_id");--> statement-breakpoint
+CREATE INDEX "idx_source_links_source_doc" ON "source_links" USING btree ("source_document_id");--> statement-breakpoint
+CREATE INDEX "idx_wiki_versions_status" ON "wiki_page_versions" USING btree ("tenant_id","space_id","status","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "idx_wiki_pages_indexed_version" ON "wiki_pages" USING btree ("indexed_version_id");--> statement-breakpoint
+CREATE INDEX "idx_wiki_pages_current_indexed" ON "wiki_pages" USING btree ("current_version_id","indexed_version_id");--> statement-breakpoint
+CREATE INDEX "idx_wiki_sections_page_version" ON "wiki_sections" USING btree ("page_version_id");

--- a/schemas/migrations/meta/0005_snapshot.json
+++ b/schemas/migrations/meta/0005_snapshot.json
@@ -1,0 +1,2756 @@
+{
+  "id": "8bc63ce6-d443-4428-8ebe-c89afb06a341",
+  "prevId": "95a499e3-bd65-4d3c-9ff1-5021a518e7b9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_tenant_time": {
+          "name": "idx_audit_logs_tenant_time",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_tenant_id_tenants_id_fk": {
+          "name": "audit_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_actor_user_id_users_id_fk": {
+          "name": "audit_logs_actor_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_blobs": {
+      "name": "file_blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_uri": {
+          "name": "storage_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_blobs_tenant_id_tenants_id_fk": {
+          "name": "file_blobs_tenant_id_tenants_id_fk",
+          "tableFrom": "file_blobs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_blobs_tenant_id_sha256_unique": {
+          "name": "file_blobs_tenant_id_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_members_tenant_id_tenants_id_fk": {
+          "name": "group_members_tenant_id_tenants_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_members_group_id_user_id_pk": {
+          "name": "group_members_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_permission_version": {
+          "name": "idx_groups_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_tenant_id_tenants_id_fk": {
+          "name": "groups_tenant_id_tenants_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_tenant_id_name_unique": {
+          "name": "groups_tenant_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_events": {
+      "name": "job_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail_json": {
+          "name": "detail_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_job_events_job": {
+          "name": "idx_job_events_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_events_job_id_jobs_id_fk": {
+          "name": "job_events_job_id_jobs_id_fk",
+          "tableFrom": "job_events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_poll": {
+          "name": "idx_jobs_poll",
+          "columns": [
+            {
+              "expression": "queue_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_locked": {
+          "name": "idx_jobs_locked",
+          "columns": [
+            {
+              "expression": "locked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"locked_by\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_space": {
+          "name": "idx_jobs_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_tenant_id_tenants_id_fk": {
+          "name": "jobs_tenant_id_tenants_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "jobs_space_id_spaces_id_fk": {
+          "name": "jobs_space_id_spaces_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "jobs_created_by_users_id_fk": {
+          "name": "jobs_created_by_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jobs_tenant_id_idempotency_key_unique": {
+          "name": "jobs_tenant_id_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_configs": {
+      "name": "model_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key_ref": {
+          "name": "encrypted_api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_rpm": {
+          "name": "rate_limit_rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visible_group_ids": {
+          "name": "visible_group_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_configs_tenant_type": {
+          "name": "idx_model_configs_tenant_type",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_configs_tenant_id_tenants_id_fk": {
+          "name": "model_configs_tenant_id_tenants_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_configs_tenant_id_provider_model_id_unique": {
+          "name": "model_configs_tenant_id_provider_model_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "provider",
+            "model_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_versions": {
+      "name": "permission_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_permissions_json": {
+          "name": "old_permissions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_permissions_json": {
+          "name": "new_permissions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_permission_versions_space": {
+          "name": "idx_permission_versions_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_permission_versions_subject": {
+          "name": "idx_permission_versions_subject",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_versions_tenant_id_tenants_id_fk": {
+          "name": "permission_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_versions_space_id_spaces_id_fk": {
+          "name": "permission_versions_space_id_spaces_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_versions_actor_user_id_users_id_fk": {
+          "name": "permission_versions_actor_user_id_users_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user": {
+          "name": "idx_sessions_user",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_refresh": {
+          "name": "idx_sessions_refresh",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_tenant_id_tenants_id_fk": {
+          "name": "sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_refresh_token_hash_unique": {
+          "name": "sessions_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_uri": {
+          "name": "source_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_hash": {
+          "name": "quote_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reference'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_source_links_page_version": {
+          "name": "idx_source_links_page_version",
+          "columns": [
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_source_links_source_doc": {
+          "name": "idx_source_links_source_doc",
+          "columns": [
+            {
+              "expression": "source_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_tenant_id_tenants_id_fk": {
+          "name": "source_links_tenant_id_tenants_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_space_id_spaces_id_fk": {
+          "name": "source_links_space_id_spaces_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "source_links_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_page_version_id_wiki_page_versions_id_fk": {
+          "name": "source_links_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_section_id_wiki_sections_id_fk": {
+          "name": "source_links_section_id_wiki_sections_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_source_document_id_source_documents_id_fk": {
+          "name": "source_links_source_document_id_source_documents_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_documents": {
+      "name": "source_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_blob_id": {
+          "name": "file_blob_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploaded'"
+        },
+        "parsed_uri": {
+          "name": "parsed_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_documents_tenant_id_tenants_id_fk": {
+          "name": "source_documents_tenant_id_tenants_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_space_id_spaces_id_fk": {
+          "name": "source_documents_space_id_spaces_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_file_blob_id_file_blobs_id_fk": {
+          "name": "source_documents_file_blob_id_file_blobs_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "file_blobs",
+          "columnsFrom": [
+            "file_blob_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_uploader_id_users_id_fk": {
+          "name": "source_documents_uploader_id_users_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_documents_space_id_file_blob_id_unique": {
+          "name": "source_documents_space_id_file_blob_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "space_id",
+            "file_blob_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_permissions": {
+      "name": "space_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_permissions_tenant_id_tenants_id_fk": {
+          "name": "space_permissions_tenant_id_tenants_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "space_permissions_space_id_spaces_id_fk": {
+          "name": "space_permissions_space_id_spaces_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "space_permissions_group_id_groups_id_fk": {
+          "name": "space_permissions_group_id_groups_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "space_permissions_space_id_group_id_permission_unique": {
+          "name": "space_permissions_space_id_group_id_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "space_id",
+            "group_id",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "docmost_space_id": {
+          "name": "docmost_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_repo_path": {
+          "name": "wiki_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_graphify_run_id": {
+          "name": "active_graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_index_snapshot_id": {
+          "name": "active_index_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_consistency_status": {
+          "name": "index_consistency_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "strict_knowledge_only": {
+          "name": "strict_knowledge_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "graphify_config": {
+          "name": "graphify_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "default_publish_policy": {
+          "name": "default_publish_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor_publish'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_spaces_consistency": {
+          "name": "idx_spaces_consistency",
+          "columns": [
+            {
+              "expression": "index_consistency_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_spaces_permission_version": {
+          "name": "idx_spaces_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_tenant_id_tenants_id_fk": {
+          "name": "spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "spaces_tenant_id_slug_unique": {
+          "name": "spaces_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_tenant_id_tenants_id_fk": {
+          "name": "system_settings_tenant_id_tenants_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_settings_tenant_id_category_key_unique": {
+          "name": "system_settings_tenant_id_category_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "category",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_permission_version": {
+          "name": "idx_users_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_tenant_id_email_unique": {
+          "name": "users_tenant_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_page_versions": {
+      "name": "wiki_page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontmatter_json": {
+          "name": "frontmatter_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_versions_status": {
+          "name": "idx_wiki_versions_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_page_versions_tenant_id_tenants_id_fk": {
+          "name": "wiki_page_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_space_id_spaces_id_fk": {
+          "name": "wiki_page_versions_space_id_spaces_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_created_by_users_id_fk": {
+          "name": "wiki_page_versions_created_by_users_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_page_versions_wiki_page_pk_version_no_unique": {
+          "name": "wiki_page_versions_wiki_page_pk_version_no_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wiki_page_pk",
+            "version_no"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_pages": {
+      "name": "wiki_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_version_id": {
+          "name": "indexed_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "docmost_page_id": {
+          "name": "docmost_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_pages_indexed_version": {
+          "name": "idx_wiki_pages_indexed_version",
+          "columns": [
+            {
+              "expression": "indexed_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wiki_pages_current_indexed": {
+          "name": "idx_wiki_pages_current_indexed",
+          "columns": [
+            {
+              "expression": "current_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "indexed_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_pages_tenant_id_tenants_id_fk": {
+          "name": "wiki_pages_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_pages_space_id_spaces_id_fk": {
+          "name": "wiki_pages_space_id_spaces_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_pages_created_by_users_id_fk": {
+          "name": "wiki_pages_created_by_users_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_wiki_pages_current_version": {
+          "name": "fk_wiki_pages_current_version",
+          "tableFrom": "wiki_pages",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_wiki_pages_indexed_version": {
+          "name": "fk_wiki_pages_indexed_version",
+          "tableFrom": "wiki_pages",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "indexed_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_pages_tenant_id_space_id_page_id_unique": {
+          "name": "wiki_pages_tenant_id_space_id_page_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "page_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_sections": {
+      "name": "wiki_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "section_index": {
+          "name": "section_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_offset": {
+          "name": "end_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_sections_page_version": {
+          "name": "idx_wiki_sections_page_version",
+          "columns": [
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_sections_tenant_id_tenants_id_fk": {
+          "name": "wiki_sections_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_space_id_spaces_id_fk": {
+          "name": "wiki_sections_space_id_spaces_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_sections_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_page_version_id_wiki_page_versions_id_fk": {
+          "name": "wiki_sections_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_sections_page_version_id_section_id_unique": {
+          "name": "wiki_sections_page_version_id_section_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_version_id",
+            "section_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/schemas/migrations/meta/_journal.json
+++ b/schemas/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777617354603,
       "tag": "0004_shocking_kronos",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777640673096,
+      "tag": "0005_small_vance_astro",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #77
Part of #76

## Summary
- Add 4 Drizzle ORM tables (wikiPages, wikiPageVersions, wikiSections, sourceLinks) with 6 indexes and circular FK constraints
- Add Zod validation schemas for wiki entities (insertWikiPage, insertWikiPageVersion, publishRequest, rollbackRequest)
- Implement wiki-core package: frontmatter parser/generator, slug generator, pageId generator, PublishStateMachine, section extractor, version helpers, repo init, source-links foundation
- Generate Drizzle migration 0005

## Test plan
- [x] 63 unit tests passing across 10 test files
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Typecheck passes
- [x] Schema validation passes

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `2ec99542335851650af2bac457388b91bd234117`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/80#issuecomment-4359526804) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/80#issuecomment-4359526935) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/80#issuecomment-4359527133) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/80#issuecomment-4359527333)
- Key findings addressed: frontmatter regex anchored to document start, section ID dedup with Unicode preservation, repo-init path traversal validation, wiki-core test script for CI, migration idempotency with IF NOT EXISTS guards