### PR TITLE
feat(web): Cherry Web 只读 Wiki UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,10 +12,13 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "rehype-highlight": "^7.0.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-dropzone": "^15.0.0",
-    "react-router": "^7.14.2"
+    "react-markdown": "^10.1.0",
+    "react-router": "^7.14.2",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,8 +24,9 @@ export function AppRoutes() {
       <Route path="/login" element={<Login />} />
       <Route path="/chat" element={<Chat />} />
       <Route path="/chat/:id" element={<Chat />} />
-      <Route path="/wiki/:spaceId" element={<Wiki />} />
-      <Route path="/wiki/:spaceId/:pageId" element={<Wiki />} />
+      <Route path="/spaces/:spaceId/wiki" element={<Wiki />} />
+      <Route path="/spaces/:spaceId/wiki/:pageId" element={<Wiki />} />
+      <Route path="/spaces/:spaceId/wiki/:pageId/history" element={<Wiki />} />
       <Route path="/spaces/:spaceId/uploads" element={<UploadCenter />} />
       <Route
         path="/admin"

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
@@ -58,10 +59,11 @@ describe('App routing', () => {
     expect(screen.getByRole('heading', { name: 'Chat' })).toBeInTheDocument();
   });
 
-  it('renders Wiki for /wiki/test-space', () => {
-    renderRoute('/wiki/test-space');
+  it('renders Wiki for /spaces/:spaceId/wiki', async () => {
+    mockWikiListApi();
+    renderRoute('/spaces/test-space/wiki');
 
-    expect(screen.getByRole('heading', { name: 'Wiki' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Wiki' })).toBeInTheDocument();
   });
 
   it('renders Upload Center for /spaces/:spaceId/uploads when authenticated', async () => {
@@ -124,10 +126,12 @@ describe('App routing', () => {
     expect(screen.queryAllByRole('heading', { name: 'Chat' }).length).toBeGreaterThan(0);
   });
 
-  it('renders Wiki for /wiki/:spaceId/:pageId', () => {
-    renderRoute('/wiki/test-space/page-456');
+  it('renders Wiki for /spaces/:spaceId/wiki/:pageId', async () => {
+    mockWikiDetailApi();
+    renderRoute('/spaces/test-space/wiki/page-456');
 
-    expect(screen.queryAllByRole('heading', { name: 'Wiki' }).length).toBeGreaterThan(0);
+    expect(await screen.findByLabelText('Wiki page content')).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { name: 'Test Wiki Page' }).length).toBeGreaterThan(0);
   });
 
   it('renders NotFound for /nonexistent', () => {
@@ -343,6 +347,72 @@ function mockUploadApi(): void {
               total: 0,
               has_next: false,
             },
+          },
+        }));
+      }
+
+      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+    }),
+  );
+}
+
+function mockWikiListApi(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path.startsWith('/api/spaces/test-space/wiki/pages')) {
+        return Promise.resolve(jsonResponse({
+          data: [],
+          meta: {
+            request_id: 'req-wiki-pages',
+            pagination: {
+              page: 1,
+              per_page: 20,
+              total: 0,
+              has_next: false,
+            },
+          },
+        }));
+      }
+
+      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+    }),
+  );
+}
+
+function mockWikiDetailApi(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/spaces/test-space/wiki/pages/page-456/content') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            page_id: 'page-456',
+            version_id: 'version-1',
+            title: 'Test Wiki Page',
+            content_markdown: '# Test Wiki Page',
+          },
+        }));
+      }
+
+      if (path === '/api/spaces/test-space/wiki/pages/page-456') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            id: 'row-page-456',
+            page_id: 'page-456',
+            space_id: 'test-space',
+            title: 'Test Wiki Page',
+            slug: 'test-wiki-page',
+            status: 'published',
+            current_version_id: 'version-1',
+            indexed_version_id: 'version-1',
+            sync_status: 'synced',
+            created_by: 'user-admin',
+            updated_at: '2026-05-01T10:00:00.000Z',
           },
         }));
       }

--- a/apps/web/src/__tests__/jobs-page.test.tsx
+++ b/apps/web/src/__tests__/jobs-page.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/apps/web/src/__tests__/wiki.test.tsx
+++ b/apps/web/src/__tests__/wiki.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WikiPage, WikiPageContent, WikiPageVersion } from '../lib/wikiApi.js';
+import WikiPageDetail from '../pages/wiki/WikiPageDetail.js';
+import WikiPageList from '../pages/wiki/WikiPageList.js';
+import WikiVersionHistory from '../pages/wiki/WikiVersionHistory.js';
+import { WikiStatusBadge } from '../pages/wiki/wikiUi.js';
+
+type GetWrappedMock = (path: string, query?: Record<string, unknown>) => Promise<unknown>;
+type PostMock = (path: string, body?: unknown) => Promise<unknown>;
+
+const apiMocks = vi.hoisted(() => ({
+  getWrapped: vi.fn<GetWrappedMock>(),
+  post: vi.fn<PostMock>(),
+}));
+
+vi.mock('../lib/api.js', () => {
+  class ApiError extends Error {
+    readonly status: number;
+    readonly code: string;
+    readonly details: unknown;
+
+    constructor(input: { status: number; code: string; message: string; details?: unknown }) {
+      super(input.message);
+      this.name = 'ApiError';
+      this.status = input.status;
+      this.code = input.code;
+      this.details = input.details;
+    }
+  }
+
+  return {
+    ApiError,
+    api: {
+      getWrapped: apiMocks.getWrapped,
+      post: apiMocks.post,
+    },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('WikiPageList', () => {
+  it('renders loading state, then page list', async () => {
+    apiMocks.getWrapped.mockResolvedValueOnce({
+      data: [
+        buildPage({ id: 'row-1', page_id: 'space-1.community.main', title: 'Community Overview', status: 'published' }),
+      ],
+      meta: { pagination: { page: 1, per_page: 20, total: 1, has_next: false } },
+    });
+
+    renderWithRouter(<WikiPageList spaceId="space-1" />);
+
+    expect(screen.getByText('Loading wiki pages...')).toBeInTheDocument();
+    expect(await screen.findByText('Community Overview')).toBeInTheDocument();
+    expect(getStatusBadge('Published')).toHaveClass('status-healthy');
+    expect(screen.getByText('space-1.community.main')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no pages exist', async () => {
+    apiMocks.getWrapped.mockResolvedValueOnce({
+      data: [],
+      meta: { pagination: { page: 1, per_page: 20, total: 0, has_next: false } },
+    });
+
+    renderWithRouter(<WikiPageList spaceId="space-1" />);
+
+    expect(await screen.findByText('No wiki pages in this space yet.')).toBeInTheDocument();
+  });
+});
+
+describe('WikiPageDetail', () => {
+  it('renders markdown content', async () => {
+    apiMocks.getWrapped.mockImplementation((path: string) => {
+      if (path.endsWith('/content')) {
+        return Promise.resolve({
+          data: buildContent({
+            title: 'Cherry Knowledge',
+            content_markdown: [
+              '# Markdown Title',
+              '',
+              '- [x] Parsed source',
+              '',
+              '| Field | Value |',
+              '| --- | --- |',
+              '| Status | Ready |',
+              '',
+              '```ts',
+              'const wiki = true;',
+              '```',
+            ].join('\n'),
+          }),
+        });
+      }
+
+      return Promise.resolve({ data: buildPage({ title: 'Cherry Knowledge', status: 'published' }) });
+    });
+
+    renderWithRouter(<WikiPageDetail spaceId="space-1" pageId="page-1" />);
+
+    expect(await screen.findByRole('heading', { name: 'Markdown Title' })).toBeInTheDocument();
+    expect(screen.getByText('Parsed source')).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Ready' })).toBeInTheDocument();
+    expect(document.querySelector('code.hljs')).toHaveTextContent('const wiki = true;');
+  });
+});
+
+describe('WikiVersionHistory', () => {
+  it('renders version list', async () => {
+    apiMocks.getWrapped.mockImplementation((path: string) => {
+      if (path.endsWith('/versions')) {
+        return Promise.resolve({
+          data: [
+            buildVersion({ id: 'version-2', version_no: 2, source: 'graphify', status: 'published' }),
+            buildVersion({ id: 'version-1', version_no: 1, source: 'manual', status: 'archived' }),
+          ],
+          meta: { pagination: { page: 1, per_page: 20, total: 2, has_next: false } },
+        });
+      }
+
+      return Promise.resolve({ data: buildPage({ current_version_id: 'version-2', title: 'Versioned Page' }) });
+    });
+
+    renderWithRouter(<WikiVersionHistory spaceId="space-1" pageId="page-1" />);
+
+    expect(await screen.findByText('Version 2')).toBeInTheDocument();
+    expect(screen.getByText('Graphify')).toBeInTheDocument();
+    expect(screen.getByText('Version 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rollback' })).toBeInTheDocument();
+  });
+});
+
+describe('WikiStatusBadge', () => {
+  it('renders status badges with correct text and classes', () => {
+    render(
+      <>
+        <WikiStatusBadge status="draft" />
+        <WikiStatusBadge status="published" />
+        <WikiStatusBadge status="archived" />
+      </>,
+    );
+
+    expect(getStatusBadge('Draft')).toHaveClass('status-neutral');
+    expect(getStatusBadge('Published')).toHaveClass('status-healthy');
+    expect(getStatusBadge('Archived')).toHaveClass('status-degraded');
+  });
+});
+
+function renderWithRouter(element: ReactElement): void {
+  render(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+function buildPage(overrides: Partial<WikiPage> = {}): WikiPage {
+  return {
+    id: 'page-row-id',
+    page_id: 'page-1',
+    space_id: 'space-1',
+    title: 'Wiki Page',
+    slug: 'wiki-page',
+    status: 'draft',
+    current_version_id: 'version-2',
+    indexed_version_id: 'version-1',
+    sync_status: 'synced',
+    created_by: 'author-1',
+    updated_at: '2026-05-01T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildContent(overrides: Partial<WikiPageContent> = {}): WikiPageContent {
+  return {
+    page_id: 'page-1',
+    version_id: 'version-2',
+    title: 'Wiki Page',
+    content_markdown: '# Wiki Page',
+    ...overrides,
+  };
+}
+
+function buildVersion(overrides: Partial<WikiPageVersion> = {}): WikiPageVersion {
+  return {
+    id: 'version-1',
+    page_id: 'page-1',
+    version_no: 1,
+    source: 'manual',
+    status: 'draft',
+    created_by: 'author-1',
+    created_at: '2026-05-01T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function getStatusBadge(label: string): HTMLElement {
+  const badge = screen.getAllByText(label).find((element) => element.classList.contains('status-badge'));
+  if (badge === undefined) {
+    throw new Error(`Status badge not found: ${label}`);
+  }
+
+  return badge;
+}

--- a/apps/web/src/__tests__/wiki.test.tsx
+++ b/apps/web/src/__tests__/wiki.test.tsx
@@ -118,8 +118,8 @@ describe('WikiVersionHistory', () => {
       if (path.endsWith('/versions')) {
         return Promise.resolve({
           data: [
-            buildVersion({ id: 'version-2', version_no: 2, source: 'graphify', status: 'published' }),
-            buildVersion({ id: 'version-1', version_no: 1, source: 'manual', status: 'archived' }),
+            buildVersion({ version_id: 'version-2', source_run_id: 'graphify', status: 'current' }),
+            buildVersion({ version_id: 'version-1', source_run_id: null, status: 'archived' }),
           ],
           meta: { pagination: { page: 1, per_page: 20, total: 2, has_next: false } },
         });
@@ -130,9 +130,9 @@ describe('WikiVersionHistory', () => {
 
     renderWithRouter(<WikiVersionHistory spaceId="space-1" pageId="page-1" />);
 
-    expect(await screen.findByText('Version 2')).toBeInTheDocument();
+    expect(await screen.findByText('version-2')).toBeInTheDocument();
     expect(screen.getByText('Graphify')).toBeInTheDocument();
-    expect(screen.getByText('Version 1')).toBeInTheDocument();
+    expect(screen.getByText('version-1')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Rollback' })).toBeInTheDocument();
   });
 });
@@ -186,12 +186,11 @@ function buildContent(overrides: Partial<WikiPageContent> = {}): WikiPageContent
 
 function buildVersion(overrides: Partial<WikiPageVersion> = {}): WikiPageVersion {
   return {
-    id: 'version-1',
-    page_id: 'page-1',
-    version_no: 1,
-    source: 'manual',
-    status: 'draft',
-    created_by: 'author-1',
+    version_id: 'version-1',
+    content_hash: 'sha256:version-1',
+    author: 'author-1',
+    source_run_id: null,
+    status: 'archived',
     created_at: '2026-05-01T09:00:00.000Z',
     ...overrides,
   };

--- a/apps/web/src/lib/wikiApi.ts
+++ b/apps/web/src/lib/wikiApi.ts
@@ -15,12 +15,11 @@ export type WikiPage = {
 };
 
 export type WikiPageVersion = {
-  id: string;
-  page_id: string;
-  version_no: number;
-  source: string;
-  status: string;
-  created_by: string | null;
+  version_id: string;
+  content_hash: string;
+  author: string;
+  source_run_id: string | null;
+  status: 'current' | 'archived';
   created_at: string;
 };
 

--- a/apps/web/src/lib/wikiApi.ts
+++ b/apps/web/src/lib/wikiApi.ts
@@ -1,0 +1,76 @@
+import { api, type ApiWrappedResponse } from './api.js';
+
+export type WikiPage = {
+  id: string;
+  page_id: string;
+  space_id: string;
+  title: string;
+  slug: string;
+  status: string;
+  current_version_id: string | null;
+  indexed_version_id: string | null;
+  sync_status: string;
+  created_by: string | null;
+  updated_at: string;
+};
+
+export type WikiPageVersion = {
+  id: string;
+  page_id: string;
+  version_no: number;
+  source: string;
+  status: string;
+  created_by: string | null;
+  created_at: string;
+};
+
+export type WikiPageContent = {
+  page_id: string;
+  version_id: string;
+  title: string;
+  content_markdown: string;
+};
+
+export type WikiPageListResponse = ApiWrappedResponse<WikiPage[]>;
+export type WikiPageResponse = ApiWrappedResponse<WikiPage>;
+export type WikiPageContentResponse = ApiWrappedResponse<WikiPageContent>;
+export type WikiPageVersionListResponse = ApiWrappedResponse<WikiPageVersion[]>;
+
+export const wikiApi = {
+  listPages(spaceId: string, params: { page?: number; per_page?: number; status?: string; search?: string } = {}) {
+    return api.getWrapped<WikiPage[]>(`/spaces/${encodeURIComponent(spaceId)}/wiki/pages`, params);
+  },
+
+  getPage(spaceId: string, pageId: string) {
+    return api.getWrapped<WikiPage>(`/spaces/${encodeURIComponent(spaceId)}/wiki/pages/${encodeURIComponent(pageId)}`);
+  },
+
+  getContent(spaceId: string, pageId: string, versionId?: string) {
+    const query = versionId ? { version_id: versionId } : undefined;
+    return api.getWrapped<WikiPageContent>(
+      `/spaces/${encodeURIComponent(spaceId)}/wiki/pages/${encodeURIComponent(pageId)}/content`,
+      query,
+    );
+  },
+
+  listVersions(spaceId: string, pageId: string, params: { page?: number; per_page?: number } = {}) {
+    return api.getWrapped<WikiPageVersion[]>(
+      `/spaces/${encodeURIComponent(spaceId)}/wiki/pages/${encodeURIComponent(pageId)}/versions`,
+      params,
+    );
+  },
+
+  publish(spaceId: string, pageId: string, versionId: string, publishNote?: string) {
+    return api.post<{ page_id: string; version_id: string; status: string }>(
+      `/spaces/${encodeURIComponent(spaceId)}/wiki/pages/${encodeURIComponent(pageId)}/publish`,
+      { version_id: versionId, publish_note: publishNote },
+    );
+  },
+
+  rollback(spaceId: string, pageId: string, targetVersionId: string, reason?: string) {
+    return api.post<{ page_id: string; new_version_id: string; status: string }>(
+      `/spaces/${encodeURIComponent(spaceId)}/wiki/pages/${encodeURIComponent(pageId)}/rollback`,
+      { target_version_id: targetVersionId, reason },
+    );
+  },
+};

--- a/apps/web/src/pages/Wiki.tsx
+++ b/apps/web/src/pages/Wiki.tsx
@@ -1,3 +1,37 @@
+import { useLocation, useParams, useSearchParams } from 'react-router';
+import NotFound from './NotFound.js';
+import WikiPageDetail from './wiki/WikiPageDetail.js';
+import WikiPageList from './wiki/WikiPageList.js';
+import WikiVersionHistory from './wiki/WikiVersionHistory.js';
+
 export default function Wiki() {
-  return <h1>Wiki</h1>;
+  const { spaceId, pageId } = useParams();
+  const [searchParams] = useSearchParams();
+  const location = useLocation();
+
+  if (spaceId === undefined || spaceId.length === 0) {
+    return <NotFound />;
+  }
+
+  if (pageId === undefined || pageId.length === 0) {
+    return <WikiPageList spaceId={spaceId} />;
+  }
+
+  const encodedPageId = encodeURIComponent(pageId);
+  const isHistoryView =
+    searchParams.get('view') === 'history' || location.pathname.endsWith(`/wiki/${encodedPageId}/history`);
+
+  if (isHistoryView) {
+    return <WikiVersionHistory spaceId={spaceId} pageId={pageId} />;
+  }
+
+  const versionId = searchParams.get('version_id');
+
+  return (
+    <WikiPageDetail
+      spaceId={spaceId}
+      pageId={pageId}
+      {...(versionId !== null && versionId.length > 0 ? { versionId } : {})}
+    />
+  );
 }

--- a/apps/web/src/pages/wiki/WikiPageDetail.tsx
+++ b/apps/web/src/pages/wiki/WikiPageDetail.tsx
@@ -82,6 +82,7 @@ export default function WikiPageDetail({ spaceId, pageId, versionId }: WikiPageD
     );
   }
 
+  // Space-level wiki permissions are not exposed to the frontend yet; API authorization gates publish for now.
   const canPublish = page !== null && page.status === 'draft' && page.current_version_id !== null;
 
   return (
@@ -128,7 +129,13 @@ export default function WikiPageDetail({ spaceId, pageId, versionId }: WikiPageD
             <span>Updated {formatDate(page.updated_at)}</span>
             {versionId !== undefined && versionId.length > 0 ? <span>Version {content.version_id}</span> : null}
           </div>
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeHighlight]}
+            components={{
+              img: (props) => <img {...props} referrerPolicy="no-referrer" loading="lazy" />,
+            }}
+          >
             {content.content_markdown}
           </ReactMarkdown>
         </article>

--- a/apps/web/src/pages/wiki/WikiPageDetail.tsx
+++ b/apps/web/src/pages/wiki/WikiPageDetail.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Link } from 'react-router';
+import rehypeHighlight from 'rehype-highlight';
+import remarkGfm from 'remark-gfm';
+import {
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  formatDate,
+  getErrorMessage,
+} from '../../components/adminUi.js';
+import { ApiError } from '../../lib/api.js';
+import { wikiApi, type WikiPage, type WikiPageContent } from '../../lib/wikiApi.js';
+import NotFound from '../NotFound.js';
+import { WikiStatusBadge } from './wikiUi.js';
+
+type WikiPageDetailProps = {
+  spaceId: string;
+  pageId: string;
+  versionId?: string;
+};
+
+export default function WikiPageDetail({ spaceId, pageId, versionId }: WikiPageDetailProps) {
+  const [page, setPage] = useState<WikiPage | null>(null);
+  const [content, setContent] = useState<WikiPageContent | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPage = useCallback(async () => {
+    setIsLoading(true);
+    setNotFound(false);
+    setError(null);
+
+    try {
+      const [pageResponse, contentResponse] = await Promise.all([
+        wikiApi.getPage(spaceId, pageId),
+        wikiApi.getContent(spaceId, pageId, versionId),
+      ]);
+      setPage(pageResponse.data);
+      setContent(contentResponse.data);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setNotFound(true);
+      } else {
+        setError(getErrorMessage(err));
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [pageId, spaceId, versionId]);
+
+  useEffect(() => {
+    void loadPage();
+  }, [loadPage]);
+
+  async function publishCurrentVersion(): Promise<void> {
+    if (page?.current_version_id === null || page?.current_version_id === undefined) {
+      return;
+    }
+
+    setIsPublishing(true);
+    setError(null);
+
+    try {
+      await wikiApi.publish(spaceId, pageId, page.current_version_id);
+      await loadPage();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsPublishing(false);
+    }
+  }
+
+  if (notFound) {
+    return (
+      <main className="admin-content wiki-page">
+        <NotFound />
+      </main>
+    );
+  }
+
+  const canPublish = page !== null && page.status === 'draft' && page.current_version_id !== null;
+
+  return (
+    <main className="admin-content wiki-page">
+      <PageHeader
+        title={page?.title ?? 'Wiki Page'}
+        {...(page !== null
+          ? {
+              description: `${page.status === 'draft' ? 'Draft' : page.status === 'published' ? 'Published' : 'Archived'} page updated ${formatDate(page.updated_at)}`,
+            }
+          : {})}
+        actions={
+          <>
+            <Link className="button button-secondary" to={`/spaces/${encodeURIComponent(spaceId)}/wiki`}>
+              Back to Wiki
+            </Link>
+            <Link className="button button-secondary" to={`/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}/history`}>
+              History
+            </Link>
+            {canPublish ? (
+              <button
+                className="button button-primary"
+                type="button"
+                disabled={isPublishing}
+                onClick={() => {
+                  void publishCurrentVersion();
+                }}
+              >
+                {isPublishing ? 'Publishing...' : 'Publish'}
+              </button>
+            ) : null}
+          </>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      {isLoading ? (
+        <LoadingState label="Loading wiki page..." />
+      ) : page !== null && content !== null ? (
+        <article className="detail-panel wiki-detail" aria-label="Wiki page content">
+          <div className="wiki-detail-meta">
+            <WikiStatusBadge status={page.status} />
+            <span>Updated {formatDate(page.updated_at)}</span>
+            {versionId !== undefined && versionId.length > 0 ? <span>Version {content.version_id}</span> : null}
+          </div>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+            {content.content_markdown}
+          </ReactMarkdown>
+        </article>
+      ) : (
+        <div className="muted-state">Wiki page content is unavailable.</div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/pages/wiki/WikiPageList.tsx
+++ b/apps/web/src/pages/wiki/WikiPageList.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  formatDate,
+  getErrorMessage,
+} from '../../components/adminUi.js';
+import { type ApiMeta } from '../../lib/api.js';
+import { wikiApi, type WikiPage } from '../../lib/wikiApi.js';
+import { WIKI_PAGE_SIZE, WikiStatusBadge, getFirstItemIndex, getLastItemIndex } from './wikiUi.js';
+
+type WikiPageListProps = {
+  spaceId: string;
+};
+
+const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
+  page: 1,
+  per_page: WIKI_PAGE_SIZE,
+  total: 0,
+  has_next: false,
+};
+
+const STATUS_OPTIONS = ['draft', 'published', 'archived'] as const;
+
+export default function WikiPageList({ spaceId }: WikiPageListProps) {
+  const navigate = useNavigate();
+  const [pages, setPages] = useState<WikiPage[]>([]);
+  const [page, setPage] = useState(DEFAULT_PAGINATION.page);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPages = useCallback(async () => {
+    if (spaceId.length === 0) {
+      setPages([]);
+      setPagination(DEFAULT_PAGINATION);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await wikiApi.listPages(spaceId, {
+        page,
+        per_page: WIKI_PAGE_SIZE,
+        ...(statusFilter.length > 0 ? { status: statusFilter } : {}),
+        ...(debouncedSearch.length > 0 ? { search: debouncedSearch } : {}),
+      });
+      setPages(response.data);
+      setPagination(
+        response.meta?.pagination ?? {
+          page,
+          per_page: WIKI_PAGE_SIZE,
+          total: response.data.length,
+          has_next: false,
+        },
+      );
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [debouncedSearch, page, spaceId, statusFilter]);
+
+  useEffect(() => {
+    void loadPages();
+  }, [loadPages]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearch(searchInput.trim());
+    }, 300);
+
+    return () => window.clearTimeout(timeout);
+  }, [searchInput]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [spaceId]);
+
+  function openPage(wikiPage: WikiPage): void {
+    void navigate(`/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(wikiPage.page_id)}`);
+  }
+
+  return (
+    <main className="admin-content wiki-page">
+      <PageHeader title="Wiki" description="Read canonical pages generated for this knowledge space." />
+
+      <ErrorBanner error={error} />
+
+      <section className="detail-panel" aria-label="Wiki pages">
+        <div className="detail-panel-header">
+          <div>
+            <h2>Pages</h2>
+            <p>Browse the current wiki page catalog.</p>
+          </div>
+        </div>
+
+        <div className="toolbar">
+          <label>
+            Search
+            <input
+              type="search"
+              value={searchInput}
+              placeholder="Search titles"
+              onChange={(event) => {
+                setSearchInput(event.target.value);
+                setPage(1);
+              }}
+            />
+          </label>
+          <label>
+            Status
+            <select
+              value={statusFilter}
+              onChange={(event) => {
+                setStatusFilter(event.target.value);
+                setPage(1);
+              }}
+            >
+              <option value="">All statuses</option>
+              {STATUS_OPTIONS.map((status) => (
+                <option key={status} value={status}>
+                  {status[0]?.toUpperCase() ?? ''}
+                  {status.slice(1)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {isLoading ? (
+          <LoadingState label="Loading wiki pages..." />
+        ) : pages.length === 0 ? (
+          <EmptyState label="No wiki pages in this space yet." />
+        ) : (
+          <>
+            <div className="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Title</th>
+                    <th>Status</th>
+                    <th>Updated</th>
+                    <th>Created By</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pages.map((wikiPage) => (
+                    <tr
+                      key={wikiPage.id}
+                      className="interactive-row"
+                      tabIndex={0}
+                      onClick={() => openPage(wikiPage)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          openPage(wikiPage);
+                        }
+                      }}
+                    >
+                      <td>
+                        <strong>{wikiPage.title}</strong>
+                        <span className="subtle-id">{wikiPage.page_id}</span>
+                      </td>
+                      <td>
+                        <WikiStatusBadge status={wikiPage.status} />
+                      </td>
+                      <td>{formatDate(wikiPage.updated_at)}</td>
+                      <td>{wikiPage.created_by ?? 'Unknown'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="pagination-bar">
+              <span className="pagination-summary">
+                Showing {getFirstItemIndex(pagination.page, pagination.total)}-
+                {getLastItemIndex(pagination.page, pages.length, pagination.total)} of {pagination.total}
+              </span>
+              <div className="upload-pagination-actions">
+                <button
+                  className="button button-secondary"
+                  type="button"
+                  disabled={pagination.page <= 1}
+                  onClick={() => setPage(pagination.page - 1)}
+                >
+                  Previous
+                </button>
+                <span className="pagination-summary">
+                  Page {pagination.page} of {Math.max(1, Math.ceil(pagination.total / WIKI_PAGE_SIZE), pagination.page)}
+                </span>
+                <button
+                  className="button button-secondary"
+                  type="button"
+                  disabled={!pagination.has_next}
+                  onClick={() => setPage(pagination.page + 1)}
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/pages/wiki/WikiVersionHistory.tsx
+++ b/apps/web/src/pages/wiki/WikiVersionHistory.tsx
@@ -73,11 +73,11 @@ export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHisto
   }, [loadVersions]);
 
   async function rollbackVersion(version: WikiPageVersion): Promise<void> {
-    setRollingBackVersionId(version.id);
+    setRollingBackVersionId(version.version_id);
     setError(null);
 
     try {
-      await wikiApi.rollback(spaceId, pageId, version.id);
+      await wikiApi.rollback(spaceId, pageId, version.version_id);
       void navigate(`/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}`);
     } catch (err) {
       setError(getErrorMessage(err));
@@ -88,7 +88,7 @@ export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHisto
 
   function openVersion(version: WikiPageVersion): void {
     void navigate(
-      `/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}?version_id=${encodeURIComponent(version.id)}`,
+      `/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}?version_id=${encodeURIComponent(version.version_id)}`,
     );
   }
 
@@ -135,10 +135,10 @@ export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHisto
                 </thead>
                 <tbody>
                   {versions.map((version) => {
-                    const isCurrent = page?.current_version_id === version.id;
+                    const isCurrent = version.status === 'current';
                     return (
                       <tr
-                        key={version.id}
+                        key={version.version_id}
                         className="interactive-row"
                         tabIndex={0}
                         onClick={() => openVersion(version)}
@@ -150,27 +150,27 @@ export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHisto
                         }}
                       >
                         <td>
-                          <strong>Version {version.version_no}</strong>
-                          <span className="subtle-id">{version.id}</span>
+                          <strong>{version.version_id}</strong>
                         </td>
-                        <td>{formatLabel(version.source)}</td>
+                        <td>{formatLabel(version.source_run_id ?? 'manual')}</td>
                         <td>
                           <WikiStatusBadge status={version.status} />
                         </td>
-                        <td>{version.created_by ?? 'Unknown'}</td>
+                        <td>{version.author}</td>
                         <td>{formatDate(version.created_at)}</td>
                         <td>
+                          {/* Space-level wiki permissions are not exposed to the frontend yet; API authorization gates rollback for now. */}
                           {!isCurrent ? (
                             <button
                               className="button button-secondary"
                               type="button"
-                              disabled={rollingBackVersionId === version.id}
+                              disabled={rollingBackVersionId === version.version_id}
                               onClick={(event) => {
                                 event.stopPropagation();
                                 void rollbackVersion(version);
                               }}
                             >
-                              {rollingBackVersionId === version.id ? 'Rolling back...' : 'Rollback'}
+                              {rollingBackVersionId === version.version_id ? 'Rolling back...' : 'Rollback'}
                             </button>
                           ) : (
                             <span className="pagination-summary">Current</span>

--- a/apps/web/src/pages/wiki/WikiVersionHistory.tsx
+++ b/apps/web/src/pages/wiki/WikiVersionHistory.tsx
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  formatDate,
+  formatLabel,
+  getErrorMessage,
+} from '../../components/adminUi.js';
+import { ApiError, type ApiMeta } from '../../lib/api.js';
+import { wikiApi, type WikiPage, type WikiPageVersion } from '../../lib/wikiApi.js';
+import NotFound from '../NotFound.js';
+import { WIKI_PAGE_SIZE, WikiStatusBadge, getFirstItemIndex, getLastItemIndex } from './wikiUi.js';
+
+type WikiVersionHistoryProps = {
+  spaceId: string;
+  pageId: string;
+};
+
+const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
+  page: 1,
+  per_page: WIKI_PAGE_SIZE,
+  total: 0,
+  has_next: false,
+};
+
+export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHistoryProps) {
+  const navigate = useNavigate();
+  const [page, setPage] = useState<WikiPage | null>(null);
+  const [versions, setVersions] = useState<WikiPageVersion[]>([]);
+  const [pageNumber, setPageNumber] = useState(DEFAULT_PAGINATION.page);
+  const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
+  const [isLoading, setIsLoading] = useState(true);
+  const [rollingBackVersionId, setRollingBackVersionId] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadVersions = useCallback(async () => {
+    setIsLoading(true);
+    setNotFound(false);
+    setError(null);
+
+    try {
+      const [pageResponse, versionsResponse] = await Promise.all([
+        wikiApi.getPage(spaceId, pageId),
+        wikiApi.listVersions(spaceId, pageId, { page: pageNumber, per_page: WIKI_PAGE_SIZE }),
+      ]);
+      setPage(pageResponse.data);
+      setVersions(versionsResponse.data);
+      setPagination(
+        versionsResponse.meta?.pagination ?? {
+          page: pageNumber,
+          per_page: WIKI_PAGE_SIZE,
+          total: versionsResponse.data.length,
+          has_next: false,
+        },
+      );
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setNotFound(true);
+      } else {
+        setError(getErrorMessage(err));
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [pageId, pageNumber, spaceId]);
+
+  useEffect(() => {
+    void loadVersions();
+  }, [loadVersions]);
+
+  async function rollbackVersion(version: WikiPageVersion): Promise<void> {
+    setRollingBackVersionId(version.id);
+    setError(null);
+
+    try {
+      await wikiApi.rollback(spaceId, pageId, version.id);
+      void navigate(`/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}`);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setRollingBackVersionId(null);
+    }
+  }
+
+  function openVersion(version: WikiPageVersion): void {
+    void navigate(
+      `/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}?version_id=${encodeURIComponent(version.id)}`,
+    );
+  }
+
+  if (notFound) {
+    return (
+      <main className="admin-content wiki-page">
+        <NotFound />
+      </main>
+    );
+  }
+
+  return (
+    <main className="admin-content wiki-page">
+      <PageHeader
+        title="Version History"
+        {...(page !== null ? { description: page.title } : {})}
+        actions={
+          <Link className="button button-secondary" to={`/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}`}>
+            Back to Page
+          </Link>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      <section className="detail-panel" aria-label="Wiki version history">
+        {isLoading ? (
+          <LoadingState label="Loading wiki versions..." />
+        ) : versions.length === 0 ? (
+          <EmptyState label="No versions are available for this page." />
+        ) : (
+          <>
+            <div className="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Version</th>
+                    <th>Source</th>
+                    <th>Status</th>
+                    <th>Created By</th>
+                    <th>Created At</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {versions.map((version) => {
+                    const isCurrent = page?.current_version_id === version.id;
+                    return (
+                      <tr
+                        key={version.id}
+                        className="interactive-row"
+                        tabIndex={0}
+                        onClick={() => openVersion(version)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            openVersion(version);
+                          }
+                        }}
+                      >
+                        <td>
+                          <strong>Version {version.version_no}</strong>
+                          <span className="subtle-id">{version.id}</span>
+                        </td>
+                        <td>{formatLabel(version.source)}</td>
+                        <td>
+                          <WikiStatusBadge status={version.status} />
+                        </td>
+                        <td>{version.created_by ?? 'Unknown'}</td>
+                        <td>{formatDate(version.created_at)}</td>
+                        <td>
+                          {!isCurrent ? (
+                            <button
+                              className="button button-secondary"
+                              type="button"
+                              disabled={rollingBackVersionId === version.id}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                void rollbackVersion(version);
+                              }}
+                            >
+                              {rollingBackVersionId === version.id ? 'Rolling back...' : 'Rollback'}
+                            </button>
+                          ) : (
+                            <span className="pagination-summary">Current</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="pagination-bar">
+              <span className="pagination-summary">
+                Showing {getFirstItemIndex(pagination.page, pagination.total)}-
+                {getLastItemIndex(pagination.page, versions.length, pagination.total)} of {pagination.total}
+              </span>
+              <div className="upload-pagination-actions">
+                <button
+                  className="button button-secondary"
+                  type="button"
+                  disabled={pagination.page <= 1}
+                  onClick={() => setPageNumber(pagination.page - 1)}
+                >
+                  Previous
+                </button>
+                <span className="pagination-summary">
+                  Page {pagination.page} of {Math.max(1, Math.ceil(pagination.total / WIKI_PAGE_SIZE), pagination.page)}
+                </span>
+                <button
+                  className="button button-secondary"
+                  type="button"
+                  disabled={!pagination.has_next}
+                  onClick={() => setPageNumber(pagination.page + 1)}
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/pages/wiki/wikiUi.tsx
+++ b/apps/web/src/pages/wiki/wikiUi.tsx
@@ -1,0 +1,39 @@
+import { formatLabel } from '../../components/adminUi.js';
+
+export const WIKI_PAGE_SIZE = 20;
+
+export function WikiStatusBadge({ status }: { status: string }) {
+  return <span className={`status-badge status-${getWikiStatusClass(status)}`}>{formatLabel(status)}</span>;
+}
+
+export function getWikiStatusClass(status: string): string {
+  if (status === 'published') {
+    return 'healthy';
+  }
+
+  if (status === 'archived') {
+    return 'degraded';
+  }
+
+  if (status === 'draft') {
+    return 'neutral';
+  }
+
+  return 'info';
+}
+
+export function getFirstItemIndex(page: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return (page - 1) * WIKI_PAGE_SIZE + 1;
+}
+
+export function getLastItemIndex(page: number, itemCount: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return Math.min(total, getFirstItemIndex(page, total) + itemCount - 1);
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -630,6 +630,72 @@ tbody tr:last-child td {
   padding: 16px;
 }
 
+.wiki-page {
+  min-height: 100vh;
+}
+
+.wiki-detail {
+  max-width: 980px;
+}
+
+.wiki-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-text-3);
+  font-size: 0.9rem;
+}
+
+.wiki-detail h1,
+.wiki-detail h2,
+.wiki-detail h3 {
+  margin: 20px 0 10px;
+  color: var(--color-text-1);
+  letter-spacing: 0;
+  line-height: 1.25;
+}
+
+.wiki-detail p,
+.wiki-detail li {
+  color: var(--color-text-1);
+  line-height: 1.7;
+}
+
+.wiki-detail a {
+  color: var(--color-link);
+}
+
+.wiki-detail table {
+  min-width: 0;
+}
+
+.wiki-detail pre {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  padding: 14px;
+}
+
+.wiki-detail pre code {
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.wiki-detail :not(pre) > code {
+  border-radius: var(--radius-xs);
+  background: var(--color-background-soft);
+  padding: 2px 5px;
+}
+
+.wiki-detail blockquote {
+  margin: 16px 0;
+  border-left: 4px solid var(--color-border-strong);
+  color: var(--color-text-2);
+  padding-left: 14px;
+}
+
 .upload-metadata-json {
   margin: 0;
   overflow-x: auto;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,9 +177,18 @@ importers:
       react-dropzone:
         specifier: ^15.0.0
         version: 15.0.0(react@19.2.5)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       react-router:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -1965,6 +1974,9 @@ packages:
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1974,8 +1986,14 @@ packages:
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
@@ -1986,8 +2004,14 @@ packages:
   '@types/luxon@3.7.1':
     resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
@@ -2014,6 +2038,12 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -2079,6 +2109,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.1':
     resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -2308,6 +2341,9 @@ packages:
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2403,6 +2439,9 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2410,6 +2449,18 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -2478,6 +2529,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2599,6 +2653,9 @@ packages:
   decko@1.2.0:
     resolution: {integrity: sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2628,6 +2685,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -2817,6 +2877,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -2872,6 +2936,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -2897,6 +2964,9 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -3081,12 +3151,31 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3129,6 +3218,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
@@ -3141,8 +3233,17 @@ packages:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3156,9 +3257,16 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3384,9 +3492,15 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -3419,6 +3533,9 @@ packages:
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@4.3.0:
     resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
     engines: {node: '>= 12'}
@@ -3427,6 +3544,51 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -3453,6 +3615,90 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -3668,6 +3914,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -3829,6 +4078,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   protobufjs@7.5.6:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
@@ -3878,6 +4130,12 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-router@7.14.2:
     resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
@@ -3937,6 +4195,21 @@ packages:
 
   reftools@1.1.9:
     resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
+
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4114,6 +4387,9 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -4145,6 +4421,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -4167,6 +4446,12 @@ packages:
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-components@6.3.9:
     resolution: {integrity: sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==}
@@ -4282,6 +4567,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-algebra@1.2.2:
     resolution: {integrity: sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==}
 
@@ -4366,6 +4657,27 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -4408,6 +4720,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -4628,6 +4946,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -6550,6 +6871,10 @@ snapshots:
 
   '@types/cookiejar@2.1.5': {}
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
@@ -6562,7 +6887,15 @@ snapshots:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/js-yaml@4.0.9': {}
 
@@ -6570,7 +6903,13 @@ snapshots:
 
   '@types/luxon@3.7.1': {}
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/methods@1.1.4': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.39':
     dependencies:
@@ -6606,6 +6945,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/validator@13.15.10': {}
 
@@ -6703,6 +7046,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.1
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.21.0))':
     dependencies:
@@ -6961,6 +7306,8 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -7074,12 +7421,22 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
 
@@ -7138,6 +7495,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
 
@@ -7243,6 +7602,10 @@ snapshots:
 
   decko@1.2.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -7260,6 +7623,10 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dezalgo@1.0.4:
     dependencies:
@@ -7422,6 +7789,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -7497,6 +7866,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -7543,6 +7914,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -7776,6 +8149,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  highlight.js@11.11.1: {}
+
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
@@ -7783,6 +8193,8 @@ snapshots:
       - '@noble/hashes'
 
   html-escaper@2.0.2: {}
+
+  html-url-attributes@3.0.1: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -7822,6 +8234,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   ioredis@5.10.1:
     dependencies:
       '@ioredis/commands': 1.5.1
@@ -7840,7 +8254,16 @@ snapshots:
 
   ipaddr.js@2.3.0: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arrayish@0.2.1: {}
+
+  is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -7850,7 +8273,11 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@1.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -8050,9 +8477,17 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@11.3.5: {}
 
@@ -8082,9 +8517,164 @@ snapshots:
 
   mark.js@8.11.1: {}
 
+  markdown-table@3.0.4: {}
+
   marked@4.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
 
@@ -8101,6 +8691,197 @@ snapshots:
   merge-stream@2.0.0: {}
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -8310,6 +9091,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8464,6 +9255,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.1.0: {}
+
   protobufjs@7.5.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -8522,6 +9315,24 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.5
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-router@7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -8596,6 +9407,48 @@ snapshots:
   reflect-metadata@0.2.2: {}
 
   reftools@1.1.9: {}
+
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -8814,6 +9667,8 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  space-separated-tokens@2.0.2: {}
+
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
@@ -8838,6 +9693,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -8855,6 +9715,14 @@ snapshots:
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-components@6.3.9(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -8983,6 +9851,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-algebra@1.2.2: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
@@ -9060,6 +9932,44 @@ snapshots:
 
   undici@7.25.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -9089,6 +9999,16 @@ snapshots:
   validator@13.15.35: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.21.0):
     dependencies:
@@ -9267,3 +10187,5 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     ],
   },
   test: {
-    include: ['packages/**/src/**/*.test.ts', 'apps/**/src/**/*.test.ts', 'tests/**/*.test.ts'],
+    include: ['packages/**/src/**/*.test.ts', 'apps/**/src/**/*.test.ts', 'apps/**/src/**/*.test.tsx', 'tests/**/*.test.ts'],
     passWithNoTests: true,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Closes #79
Part of #76

## Summary
- Add Wiki API client (wikiApi.ts) for all 6 wiki endpoints
- Implement WikiPageList: paginated list, status filter, search, badges, empty state
- Implement WikiPageDetail: Markdown rendering (react-markdown + remark-gfm + rehype-highlight)
- Implement WikiVersionHistory: version list, rollback button, version content view
- Update routes to /spaces/:spaceId/wiki pattern
- Install react-markdown, remark-gfm, rehype-highlight

## Test plan
- [x] 5 frontend component tests passing
- [x] Build passes (pnpm build)
- [x] Lint passes (pnpm lint)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `ccaffac810b3d9eacbb3e01621952c86dfc4ed12`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/82#issuecomment-4359820165) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/82#issuecomment-4359820278) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/82#issuecomment-4359820384) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/82#issuecomment-4359820501)
- Key findings addressed: API contract mismatch (WikiPageVersion type aligned with backend), Markdown image referrer leak (referrerPolicy=no-referrer), permission gating deferred with comments