### PR TITLE
feat(graphify-worker): implement Graphify CLI runner pipeline (#86)

### DIFF
--- a/apps/graphify-worker/pyproject.toml
+++ b/apps/graphify-worker/pyproject.toml
@@ -5,7 +5,8 @@ requires-python = ">=3.11"
 dependencies = [
   "redis",
   "httpx",
-  "aiohttp"
+  "aiohttp",
+  "requests"
 ]
 
 [project.optional-dependencies]

--- a/apps/graphify-worker/requirements.txt
+++ b/apps/graphify-worker/requirements.txt
@@ -1,3 +1,4 @@
 redis
 httpx
 aiohttp
+requests

--- a/apps/graphify-worker/src/manifest.py
+++ b/apps/graphify-worker/src/manifest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def generate_manifest(
+    space_id: str,
+    run_id: str,
+    mode: str,
+    input_files: list[Path],
+    graphify_ref: str | None,
+) -> dict[str, object]:
+    return {
+        "space_id": space_id,
+        "run_id": run_id,
+        "mode": mode,
+        "input_files": [str(path) for path in input_files],
+        "graphify_ref": graphify_ref,
+    }

--- a/apps/graphify-worker/src/runner.py
+++ b/apps/graphify-worker/src/runner.py
@@ -4,7 +4,9 @@ import datetime as dt
 import json
 import logging
 import os
+import re
 import shutil
+import stat
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -21,20 +23,40 @@ GRAPHIFY_REF = os.environ.get("GRAPHIFY_PINNED_REF")
 MAX_FILE_SIZE = 100 * 1024 * 1024
 MAX_TOTAL_SIZE = 1024 * 1024 * 1024
 OUTPUT_BUCKET = os.environ.get("GRAPHIFY_OUTPUT_BUCKET", "cherrywiki-graphify-out")
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_SCRUB_KEYS = {
+    "MINIO_ENDPOINT",
+    "MINIO_ACCESS_KEY",
+    "MINIO_SECRET_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "S3_ENDPOINT",
+    "WORKER_API_KEY",
+    "DATABASE_URL",
+    "REDIS_URL",
+}
 
 
 async def run(job_data: dict[str, Any]) -> dict[str, Any]:
     job_id = job_data.get("id") or job_data.get("job_id")
     payload = _payload(job_data)
-    tenant_id = str(payload.get("tenant_id") or job_data.get("tenant_id") or "default")
-    space_id = str(payload.get("space_id") or job_data.get("space_id") or "")
-    run_id = str(payload.get("run_id") or job_id)
+    tenant_id = _safe_id(
+        str(payload.get("tenant_id") or job_data.get("tenant_id") or "default")
+    )
+    space_id = _safe_id(str(payload.get("space_id") or job_data.get("space_id") or ""))
+    run_id = _safe_id(str(payload.get("run_id") or job_id))
     mode = str(payload.get("mode") or GRAPHIFY_MODE)
     input_uris = _input_uris(payload)
 
-    workdir = Path(GRAPHIFY_WORKDIR) / run_id
+    base = Path(GRAPHIFY_WORKDIR).resolve()
+    workdir = (base / run_id).resolve()
+    if not workdir.is_relative_to(base):
+        raise ValueError(f"workdir escapes base: {workdir}")
+
     input_dir = workdir / "input"
     output_dir = workdir / "output"
+    key_prefix = f"graphify-out/{tenant_id}/{space_id}/{run_id}"
 
     logger.info(
         "starting graphify job",
@@ -71,6 +93,7 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
                 text=True,
                 timeout=GRAPHIFY_TIMEOUT,
                 cwd=str(workdir),
+                env=_subprocess_env(),
             )
         except subprocess.TimeoutExpired as exc:
             raise RuntimeError(
@@ -83,7 +106,7 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
                     {
                         "reason": "cli_error",
                         "exit_code": result.returncode,
-                        "stderr": result.stderr[:2000],
+                        "stderr": _redacted_stderr(result.stderr or ""),
                     }
                 )
             )
@@ -92,27 +115,29 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
             output_dir, run_id=run_id, graphify_ref=GRAPHIFY_REF
         )
         report_path = output_dir / "validation_report.json"
-        report_path.write_text(json.dumps(validation, indent=2), encoding="utf-8")
+        _write_validation_report(report_path, validation)
         if not validation["validation_passed"]:
-            failed_checks = [
-                check for check in validation["checks"] if check["status"] == "failed"
-            ]
-            reason = failed_checks[0]["name"] if failed_checks else "validation_failed"
-            raise RuntimeError(
-                json.dumps({"reason": reason, "validation_report": validation})
-            )
+            try:
+                storage.upload_file(
+                    report_path, OUTPUT_BUCKET, f"{key_prefix}/validation_report.json"
+                )
+            except Exception:
+                logger.warning("Failed to upload validation report", exc_info=True)
+            raise RuntimeError(json.dumps(_validation_error(validation)))
 
-        key_prefix = f"graphify-out/{tenant_id}/{space_id}/{run_id}"
         storage.upload_directory(output_dir, OUTPUT_BUCKET, key_prefix)
 
         base_uri = f"s3://{OUTPUT_BUCKET}/{key_prefix}"
         graph_html_path = output_dir / "graph.html"
+        report_md_path = output_dir / "GRAPH_REPORT.md"
 
         return {
             "status": "success",
             "graph_json_uri": f"{base_uri}/graph.json",
             "wiki_output_uri": f"{base_uri}/wiki",
-            "report_uri": f"{base_uri}/GRAPH_REPORT.md",
+            "report_uri": f"{base_uri}/GRAPH_REPORT.md"
+            if report_md_path.exists()
+            else None,
             "graph_html_uri": f"{base_uri}/graph.html"
             if graph_html_path.exists()
             else None,
@@ -127,6 +152,66 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
     finally:
         if workdir.exists():
             shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _safe_id(value: str) -> str:
+    if not _SAFE_ID_RE.match(value):
+        raise ValueError(f"Invalid id for path use: {value!r}")
+    return value
+
+
+def _subprocess_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if key not in _SCRUB_KEYS}
+
+
+def _redacted_stderr(stderr: str) -> str:
+    scrubbed = stderr[:2000]
+    for key in _SCRUB_KEYS:
+        value = os.environ.get(key)
+        if value and value in scrubbed:
+            scrubbed = scrubbed.replace(value, "***REDACTED***")
+    return scrubbed[:2000]
+
+
+def _write_validation_report(report_path: Path, validation: dict[str, Any]) -> None:
+    if report_path.exists() or report_path.is_symlink():
+        if report_path.is_dir() and not report_path.is_symlink():
+            shutil.rmtree(report_path)
+        else:
+            report_path.unlink()
+    report_path.write_text(json.dumps(validation, indent=2), encoding="utf-8")
+
+
+def _validation_error(validation: dict[str, Any]) -> dict[str, Any]:
+    failed_checks = [
+        check for check in validation["checks"] if check["status"] == "failed"
+    ]
+    failed_check = failed_checks[0] if failed_checks else {}
+    reason = failed_check.get("name", "validation_failed")
+    details = failed_check.get("details", "")
+
+    if reason in {"file_size", "total_size"}:
+        return {
+            "reason": "quarantined",
+            "quarantine_type": reason,
+            "details": details,
+            "validation_report": validation,
+        }
+
+    if reason == "path_traversal":
+        return {
+            "reason": "path_traversal",
+            "file": _failed_path_from_details(details),
+            "validation_report": validation,
+        }
+
+    return {"reason": reason, "validation_report": validation}
+
+
+def _failed_path_from_details(details: str) -> str:
+    if ": " in details:
+        return details.split(": ", 1)[1]
+    return details
 
 
 def _payload(job_data: dict[str, Any]) -> dict[str, Any]:
@@ -196,6 +281,120 @@ def _validate_output(
     node_count = 0
     edge_count = 0
     wiki_page_count = 0
+
+    output_root = output_dir.resolve()
+    for path in output_dir.rglob("*"):
+        rel = path.relative_to(output_dir)
+        rel_str = rel.as_posix()
+        path_stat = path.lstat()
+
+        if ".." in rel.parts:
+            checks.append(
+                {
+                    "name": "path_traversal",
+                    "status": "failed",
+                    "details": f"path traversal: {rel_str}",
+                }
+            )
+            return _report(
+                checks,
+                False,
+                node_count,
+                edge_count,
+                wiki_page_count,
+                total_size,
+                run_id,
+                graphify_ref,
+            )
+
+        if stat.S_ISLNK(path_stat.st_mode):
+            checks.append(
+                {
+                    "name": "path_traversal",
+                    "status": "failed",
+                    "details": f"symlink: {rel_str}",
+                }
+            )
+            return _report(
+                checks,
+                False,
+                node_count,
+                edge_count,
+                wiki_page_count,
+                total_size,
+                run_id,
+                graphify_ref,
+            )
+
+        if not path.resolve().is_relative_to(output_root):
+            checks.append(
+                {
+                    "name": "path_traversal",
+                    "status": "failed",
+                    "details": f"path escapes output directory: {rel_str}",
+                }
+            )
+            return _report(
+                checks,
+                False,
+                node_count,
+                edge_count,
+                wiki_page_count,
+                total_size,
+                run_id,
+                graphify_ref,
+            )
+
+        if not stat.S_ISREG(path_stat.st_mode):
+            continue
+
+        size = path_stat.st_size
+        total_size += size
+        if size > MAX_FILE_SIZE:
+            checks.append(
+                {
+                    "name": "file_size",
+                    "status": "failed",
+                    "details": f"{rel_str}: {size} bytes > {MAX_FILE_SIZE}",
+                }
+            )
+            return _report(
+                checks,
+                False,
+                node_count,
+                edge_count,
+                wiki_page_count,
+                total_size,
+                run_id,
+                graphify_ref,
+            )
+
+    if total_size > MAX_TOTAL_SIZE:
+        checks.append(
+            {
+                "name": "total_size",
+                "status": "failed",
+                "details": f"total {total_size} bytes > {MAX_TOTAL_SIZE}",
+            }
+        )
+        return _report(
+            checks,
+            False,
+            node_count,
+            edge_count,
+            wiki_page_count,
+            total_size,
+            run_id,
+            graphify_ref,
+        )
+
+    checks.append(
+        {
+            "name": "size_limits",
+            "status": "passed",
+            "details": f"total {total_size} bytes",
+        }
+    )
 
     graph_json = output_dir / "graph.json"
     if graph_json.exists():
@@ -269,121 +468,6 @@ def _validate_output(
                 "details": "GRAPH_REPORT.md missing (non-fatal warning)",
             }
         )
-
-    output_root = output_dir.resolve()
-    for path in output_dir.rglob("*"):
-        rel = path.relative_to(output_dir)
-        rel_str = rel.as_posix()
-
-        if ".." in rel.parts:
-            checks.append(
-                {
-                    "name": "path_traversal",
-                    "status": "failed",
-                    "details": f"path traversal: {rel_str}",
-                }
-            )
-            return _report(
-                checks,
-                False,
-                node_count,
-                edge_count,
-                wiki_page_count,
-                total_size,
-                run_id,
-                graphify_ref,
-            )
-
-        if path.is_symlink():
-            checks.append(
-                {
-                    "name": "path_traversal",
-                    "status": "failed",
-                    "details": f"symlink: {rel_str}",
-                }
-            )
-            return _report(
-                checks,
-                False,
-                node_count,
-                edge_count,
-                wiki_page_count,
-                total_size,
-                run_id,
-                graphify_ref,
-            )
-
-        try:
-            path.resolve().relative_to(output_root)
-        except ValueError:
-            checks.append(
-                {
-                    "name": "path_traversal",
-                    "status": "failed",
-                    "details": f"path escapes output directory: {rel_str}",
-                }
-            )
-            return _report(
-                checks,
-                False,
-                node_count,
-                edge_count,
-                wiki_page_count,
-                total_size,
-                run_id,
-                graphify_ref,
-            )
-
-        if not path.is_file():
-            continue
-
-        size = path.stat().st_size
-        total_size += size
-        if size > MAX_FILE_SIZE:
-            checks.append(
-                {
-                    "name": "file_size",
-                    "status": "failed",
-                    "details": f"{rel_str}: {size} bytes > {MAX_FILE_SIZE}",
-                }
-            )
-            return _report(
-                checks,
-                False,
-                node_count,
-                edge_count,
-                wiki_page_count,
-                total_size,
-                run_id,
-                graphify_ref,
-            )
-
-    if total_size > MAX_TOTAL_SIZE:
-        checks.append(
-            {
-                "name": "total_size",
-                "status": "failed",
-                "details": f"total {total_size} bytes > {MAX_TOTAL_SIZE}",
-            }
-        )
-        return _report(
-            checks,
-            False,
-            node_count,
-            edge_count,
-            wiki_page_count,
-            total_size,
-            run_id,
-            graphify_ref,
-        )
-
-    checks.append(
-        {
-            "name": "size_limits",
-            "status": "passed",
-            "details": f"total {total_size} bytes",
-        }
-    )
 
     has_failures = any(check["status"] == "failed" for check in checks)
     return _report(

--- a/apps/graphify-worker/src/runner.py
+++ b/apps/graphify-worker/src/runner.py
@@ -266,9 +266,7 @@ def _download_inputs(
             input_files.append(local_path)
         except Exception as exc:
             raise RuntimeError(
-                json.dumps(
-                    {"reason": "download_failed", "uri": uri, "error": str(exc)}
-                )
+                json.dumps({"reason": "download_failed", "uri": uri, "error": str(exc)})
             ) from exc
     return input_files
 

--- a/apps/graphify-worker/src/runner.py
+++ b/apps/graphify-worker/src/runner.py
@@ -1,14 +1,421 @@
 from __future__ import annotations
 
+import datetime as dt
+import json
 import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
 from typing import Any
+
+from .manifest import generate_manifest
+from .storage_client import MinioStorageClient, parse_storage_uri
 
 logger = logging.getLogger(__name__)
 
+GRAPHIFY_WORKDIR = os.environ.get("GRAPHIFY_WORKDIR", "/tmp/graphify-workdir")
+GRAPHIFY_TIMEOUT = int(os.environ.get("GRAPHIFY_TIMEOUT_SECONDS", "3600"))
+GRAPHIFY_MODE = os.environ.get("GRAPHIFY_DEFAULT_MODE", "full")
+GRAPHIFY_REF = os.environ.get("GRAPHIFY_PINNED_REF")
+MAX_FILE_SIZE = 100 * 1024 * 1024
+MAX_TOTAL_SIZE = 1024 * 1024 * 1024
+OUTPUT_BUCKET = os.environ.get("GRAPHIFY_OUTPUT_BUCKET", "cherrywiki-graphify-out")
 
-async def run(job_data: dict[str, Any]) -> dict[str, str]:
+
+async def run(job_data: dict[str, Any]) -> dict[str, Any]:
+    job_id = job_data.get("id") or job_data.get("job_id")
+    payload = _payload(job_data)
+    tenant_id = str(payload.get("tenant_id") or job_data.get("tenant_id") or "default")
+    space_id = str(payload.get("space_id") or job_data.get("space_id") or "")
+    run_id = str(payload.get("run_id") or job_id)
+    mode = str(payload.get("mode") or GRAPHIFY_MODE)
+    input_uris = _input_uris(payload)
+
+    workdir = Path(GRAPHIFY_WORKDIR) / run_id
+    input_dir = workdir / "input"
+    output_dir = workdir / "output"
+
     logger.info(
-        "job received, no-op",
-        extra={"job_id": job_data.get("id") or job_data.get("job_id")},
+        "starting graphify job",
+        extra={"job_id": job_id, "run_id": run_id, "input_count": len(input_uris)},
     )
-    return {"status": "success"}
+
+    try:
+        input_dir.mkdir(parents=True, exist_ok=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        storage = MinioStorageClient.from_env()
+        input_files = _download_inputs(storage, input_uris, input_dir)
+
+        manifest = generate_manifest(space_id, run_id, mode, input_files, GRAPHIFY_REF)
+        manifest_path = workdir / "graphify_input_manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+        cmd = [
+            "graphify",
+            "--wiki",
+            "--mode",
+            mode,
+            "--output",
+            str(output_dir),
+            str(input_dir),
+        ]
+        if GRAPHIFY_REF:
+            cmd.extend(["--ref", GRAPHIFY_REF])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GRAPHIFY_TIMEOUT,
+                cwd=str(workdir),
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                json.dumps({"reason": "timeout", "timeout_seconds": GRAPHIFY_TIMEOUT})
+            ) from exc
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                json.dumps(
+                    {
+                        "reason": "cli_error",
+                        "exit_code": result.returncode,
+                        "stderr": result.stderr[:2000],
+                    }
+                )
+            )
+
+        validation = _validate_output(
+            output_dir, run_id=run_id, graphify_ref=GRAPHIFY_REF
+        )
+        report_path = output_dir / "validation_report.json"
+        report_path.write_text(json.dumps(validation, indent=2), encoding="utf-8")
+        if not validation["validation_passed"]:
+            failed_checks = [
+                check for check in validation["checks"] if check["status"] == "failed"
+            ]
+            reason = failed_checks[0]["name"] if failed_checks else "validation_failed"
+            raise RuntimeError(
+                json.dumps({"reason": reason, "validation_report": validation})
+            )
+
+        key_prefix = f"graphify-out/{tenant_id}/{space_id}/{run_id}"
+        storage.upload_directory(output_dir, OUTPUT_BUCKET, key_prefix)
+
+        base_uri = f"s3://{OUTPUT_BUCKET}/{key_prefix}"
+        graph_html_path = output_dir / "graph.html"
+
+        return {
+            "status": "success",
+            "graph_json_uri": f"{base_uri}/graph.json",
+            "wiki_output_uri": f"{base_uri}/wiki",
+            "report_uri": f"{base_uri}/GRAPH_REPORT.md",
+            "graph_html_uri": f"{base_uri}/graph.html"
+            if graph_html_path.exists()
+            else None,
+            "validation_report_uri": f"{base_uri}/validation_report.json",
+            "stats_json": {
+                "node_count": validation.get("node_count", 0),
+                "edge_count": validation.get("edge_count", 0),
+                "wiki_page_count": validation.get("wiki_page_count", 0),
+                "total_output_bytes": validation.get("total_output_bytes", 0),
+            },
+        }
+    finally:
+        if workdir.exists():
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _payload(job_data: dict[str, Any]) -> dict[str, Any]:
+    payload = job_data.get("payload_json", job_data)
+    if isinstance(payload, str):
+        parsed = json.loads(payload)
+        return parsed if isinstance(parsed, dict) else {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _input_uris(payload: dict[str, Any]) -> list[str]:
+    direct = payload.get("input_uris") or payload.get("source_document_uris")
+    if isinstance(direct, list):
+        return [str(uri) for uri in direct if uri]
+
+    source_documents = payload.get("source_documents")
+    if isinstance(source_documents, list):
+        uris: list[str] = []
+        for source_document in source_documents:
+            if not isinstance(source_document, dict):
+                continue
+            uri = (
+                source_document.get("parsed_md_uri")
+                or source_document.get("parsed_markdown_uri")
+                or source_document.get("parsed_uri")
+                or source_document.get("storage_uri")
+                or source_document.get("uri")
+            )
+            if uri:
+                uris.append(str(uri))
+        return uris
+
+    return []
+
+
+def _download_inputs(
+    storage: MinioStorageClient, input_uris: list[str], input_dir: Path
+) -> list[Path]:
+    input_files: list[Path] = []
+    used_names: set[str] = set()
+    for index, uri in enumerate(input_uris, start=1):
+        try:
+            ref = parse_storage_uri(uri)
+            filename = Path(ref.key).name or f"input-{index}.md"
+            if filename in used_names:
+                local_name = f"{index:04d}-{filename}"
+            else:
+                local_name = filename
+            used_names.add(local_name)
+            local_path = input_dir / local_name
+            storage.download_file(uri, local_path)
+            input_files.append(local_path)
+        except Exception as exc:
+            raise RuntimeError(
+                json.dumps(
+                    {"reason": "download_failed", "uri": uri, "error": str(exc)}
+                )
+            ) from exc
+    return input_files
+
+
+def _validate_output(
+    output_dir: Path, *, run_id: str | None = None, graphify_ref: str | None = None
+) -> dict[str, Any]:
+    checks: list[dict[str, str]] = []
+    total_size = 0
+    node_count = 0
+    edge_count = 0
+    wiki_page_count = 0
+
+    graph_json = output_dir / "graph.json"
+    if graph_json.exists():
+        try:
+            data = json.loads(graph_json.read_text(encoding="utf-8"))
+            nodes = data.get("nodes", []) if isinstance(data, dict) else []
+            edges = data.get("edges", []) if isinstance(data, dict) else []
+            node_count = len(nodes) if isinstance(nodes, list) else 0
+            edge_count = len(edges) if isinstance(edges, list) else 0
+            checks.append(
+                {
+                    "name": "graph_json_exists",
+                    "status": "passed",
+                    "details": f"{node_count} nodes, {edge_count} edges",
+                }
+            )
+        except (json.JSONDecodeError, OSError) as exc:
+            checks.append(
+                {
+                    "name": "graph_json_exists",
+                    "status": "failed",
+                    "details": f"Invalid JSON: {exc}",
+                }
+            )
+    else:
+        checks.append(
+            {
+                "name": "missing_graph_json",
+                "status": "failed",
+                "details": "graph.json not found",
+            }
+        )
+
+    wiki_dir = output_dir / "wiki"
+    if wiki_dir.is_dir():
+        md_files = [path for path in wiki_dir.glob("*.md") if path.is_file()]
+        wiki_page_count = len(md_files)
+        if wiki_page_count > 0:
+            checks.append(
+                {
+                    "name": "wiki_dir_exists",
+                    "status": "passed",
+                    "details": f"{wiki_page_count} pages",
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "name": "missing_wiki_dir",
+                    "status": "failed",
+                    "details": "wiki/ exists but contains no .md files",
+                }
+            )
+    else:
+        checks.append(
+            {
+                "name": "missing_wiki_dir",
+                "status": "failed",
+                "details": "wiki/ not found",
+            }
+        )
+
+    report = output_dir / "GRAPH_REPORT.md"
+    if report.exists():
+        checks.append({"name": "report_exists", "status": "passed", "details": ""})
+    else:
+        checks.append(
+            {
+                "name": "report_exists",
+                "status": "passed",
+                "details": "GRAPH_REPORT.md missing (non-fatal warning)",
+            }
+        )
+
+    output_root = output_dir.resolve()
+    for path in output_dir.rglob("*"):
+        rel = path.relative_to(output_dir)
+        rel_str = rel.as_posix()
+
+        if ".." in rel.parts:
+            checks.append(
+                {
+                    "name": "path_traversal",
+                    "status": "failed",
+                    "details": f"path traversal: {rel_str}",
+                }
+            )
+            return _report(
+                checks,
+                False,
+                node_count,
+                edge_count,
+                wiki_page_count,
+                total_size,
+                run_id,
+                graphify_ref,
+            )
+
+        if path.is_symlink():
+            checks.append(
+                {
+                    "name": "path_traversal",
+                    "status": "failed",
+                    "details": f"symlink: {rel_str}",
+                }
+            )
+            return _report(
+                checks,
+                False,
+                node_count,
+                edge_count,
+                wiki_page_count,
+                total_size,
+                run_id,
+                graphify_ref,
+            )
+
+        try:
+            path.resolve().relative_to(output_root)
+        except ValueError:
+            checks.append(
+                {
+                    "name": "path_traversal",
+                    "status": "failed",
+                    "details": f"path escapes output directory: {rel_str}",
+                }
+            )
+            return _report(
+                checks,
+                False,
+                node_count,
+                edge_count,
+                wiki_page_count,
+                total_size,
+                run_id,
+                graphify_ref,
+            )
+
+        if not path.is_file():
+            continue
+
+        size = path.stat().st_size
+        total_size += size
+        if size > MAX_FILE_SIZE:
+            checks.append(
+                {
+                    "name": "file_size",
+                    "status": "failed",
+                    "details": f"{rel_str}: {size} bytes > {MAX_FILE_SIZE}",
+                }
+            )
+            return _report(
+                checks,
+                False,
+                node_count,
+                edge_count,
+                wiki_page_count,
+                total_size,
+                run_id,
+                graphify_ref,
+            )
+
+    if total_size > MAX_TOTAL_SIZE:
+        checks.append(
+            {
+                "name": "total_size",
+                "status": "failed",
+                "details": f"total {total_size} bytes > {MAX_TOTAL_SIZE}",
+            }
+        )
+        return _report(
+            checks,
+            False,
+            node_count,
+            edge_count,
+            wiki_page_count,
+            total_size,
+            run_id,
+            graphify_ref,
+        )
+
+    checks.append(
+        {
+            "name": "size_limits",
+            "status": "passed",
+            "details": f"total {total_size} bytes",
+        }
+    )
+
+    has_failures = any(check["status"] == "failed" for check in checks)
+    return _report(
+        checks,
+        not has_failures,
+        node_count,
+        edge_count,
+        wiki_page_count,
+        total_size,
+        run_id,
+        graphify_ref,
+    )
+
+
+def _report(
+    checks: list[dict[str, str]],
+    passed: bool,
+    node_count: int,
+    edge_count: int,
+    wiki_page_count: int,
+    total_size: int,
+    run_id: str | None,
+    graphify_ref: str | None,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "graphify_ref": graphify_ref,
+        "validation_passed": passed,
+        "checks": checks,
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "wiki_page_count": wiki_page_count,
+        "total_output_bytes": total_size,
+        "generated_at": dt.datetime.now(dt.UTC).isoformat().replace("+00:00", "Z"),
+    }

--- a/apps/graphify-worker/src/storage_client.py
+++ b/apps/graphify-worker/src/storage_client.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import hmac
+import mimetypes
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import quote, urlsplit
+
+import requests
+
+
+@dataclass(frozen=True, slots=True)
+class StorageObjectRef:
+    bucket: str
+    key: str
+
+    @property
+    def uri(self) -> str:
+        return f"s3://{self.bucket}/{self.key}"
+
+
+def parse_storage_uri(uri: str) -> StorageObjectRef:
+    parsed = urlsplit(uri)
+    if parsed.scheme in {"s3", "minio"}:
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+    else:
+        parts = uri.split("/", 1)
+        bucket = parts[0]
+        key = parts[1] if len(parts) == 2 else ""
+
+    if not bucket or not key:
+        raise ValueError(f"Invalid storage URI: {uri}")
+    if key.startswith("/") or ".." in key.split("/"):
+        raise ValueError(f"Invalid storage key in URI: {uri}")
+    return StorageObjectRef(bucket=bucket, key=key)
+
+
+class MinioStorageClient:
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        access_key: str,
+        secret_key: str,
+        region: str = "us-east-1",
+        session: requests.Session | None = None,
+    ) -> None:
+        self.endpoint = endpoint.rstrip("/")
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.region = region
+        self.session = session or requests.Session()
+
+    @classmethod
+    def from_env(cls) -> "MinioStorageClient":
+        endpoint = os.environ.get("MINIO_ENDPOINT") or os.environ.get("S3_ENDPOINT")
+        access_key = os.environ.get("MINIO_ACCESS_KEY") or os.environ.get(
+            "AWS_ACCESS_KEY_ID"
+        )
+        secret_key = os.environ.get("MINIO_SECRET_KEY") or os.environ.get(
+            "AWS_SECRET_ACCESS_KEY"
+        )
+        if not endpoint or not access_key or not secret_key:
+            raise RuntimeError(
+                "MINIO_ENDPOINT, MINIO_ACCESS_KEY, and MINIO_SECRET_KEY are required"
+            )
+        return cls(
+            endpoint=endpoint,
+            access_key=access_key,
+            secret_key=secret_key,
+            region=os.environ.get("S3_REGION", "us-east-1"),
+        )
+
+    def download_file(self, uri: str, local_path: Path) -> None:
+        ref = parse_storage_uri(uri)
+        response = self._request("GET", ref)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(response.content)
+
+    def upload_file(self, local_path: Path, bucket: str, key: str) -> StorageObjectRef:
+        ref = StorageObjectRef(bucket=bucket, key=key.lstrip("/"))
+        content_type = (
+            mimetypes.guess_type(local_path.name)[0] or "application/octet-stream"
+        )
+        self._request(
+            "PUT",
+            ref,
+            body=local_path.read_bytes(),
+            content_type=content_type,
+        )
+        return ref
+
+    def upload_directory(
+        self, local_dir: Path, bucket: str, key_prefix: str
+    ) -> list[StorageObjectRef]:
+        uploaded: list[StorageObjectRef] = []
+        prefix = key_prefix.strip("/")
+        for path in sorted(local_dir.rglob("*")):
+            if not path.is_file():
+                continue
+
+            rel = path.relative_to(local_dir).as_posix()
+            key = f"{prefix}/{rel}" if prefix else rel
+            uploaded.append(self.upload_file(path, bucket, key))
+        return uploaded
+
+    def _request(
+        self,
+        method: str,
+        ref: StorageObjectRef,
+        *,
+        body: bytes | None = None,
+        content_type: str | None = None,
+    ) -> requests.Response:
+        payload = body or b""
+        payload_hash = hashlib.sha256(payload).hexdigest()
+        now = dt.datetime.now(dt.UTC)
+        amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+        date_stamp = now.strftime("%Y%m%d")
+        parsed_endpoint = urlsplit(self.endpoint)
+        canonical_uri = (
+            "/" + quote(ref.bucket, safe="") + "/" + quote(ref.key, safe="/~")
+        )
+        url = self.endpoint + canonical_uri
+        host = parsed_endpoint.netloc
+        headers = {
+            "host": host,
+            "x-amz-content-sha256": payload_hash,
+            "x-amz-date": amz_date,
+        }
+        if content_type is not None:
+            headers["content-type"] = content_type
+
+        signed_headers = "host;x-amz-content-sha256;x-amz-date"
+        canonical_headers = (
+            f"host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
+        )
+        credential_scope = f"{date_stamp}/{self.region}/s3/aws4_request"
+        canonical_request = "\n".join(
+            [
+                method,
+                canonical_uri,
+                "",
+                canonical_headers,
+                signed_headers,
+                payload_hash,
+            ]
+        )
+        string_to_sign = "\n".join(
+            [
+                "AWS4-HMAC-SHA256",
+                amz_date,
+                credential_scope,
+                hashlib.sha256(canonical_request.encode("utf-8")).hexdigest(),
+            ]
+        )
+        signature = hmac.new(
+            self._signing_key(date_stamp),
+            string_to_sign.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        headers["authorization"] = (
+            "AWS4-HMAC-SHA256 "
+            f"Credential={self.access_key}/{credential_scope}, "
+            f"SignedHeaders={signed_headers}, "
+            f"Signature={signature}"
+        )
+
+        response = self.session.request(
+            method, url, data=body, headers=headers, timeout=60
+        )
+        response.raise_for_status()
+        return response
+
+    def _signing_key(self, date_stamp: str) -> bytes:
+        date_key = _hmac(("AWS4" + self.secret_key).encode("utf-8"), date_stamp)
+        region_key = _hmac(date_key, self.region)
+        service_key = _hmac(region_key, "s3")
+        return _hmac(service_key, "aws4_request")
+
+
+def _hmac(key: bytes, message: str) -> bytes:
+    return hmac.new(key, message.encode("utf-8"), hashlib.sha256).digest()

--- a/apps/graphify-worker/tests/test_manifest.py
+++ b/apps/graphify-worker/tests/test_manifest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.manifest import generate_manifest
+
+
+def test_generate_manifest_uses_stringified_input_paths() -> None:
+    manifest = generate_manifest(
+        "space-1",
+        "run-1",
+        "full",
+        [Path("/work/input/a.md"), Path("/work/input/b.md")],
+        "graphify-v1",
+    )
+
+    assert manifest == {
+        "space_id": "space-1",
+        "run_id": "run-1",
+        "mode": "full",
+        "input_files": ["/work/input/a.md", "/work/input/b.md"],
+        "graphify_ref": "graphify-v1",
+    }

--- a/apps/graphify-worker/tests/test_runner.py
+++ b/apps/graphify-worker/tests/test_runner.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src import runner
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_OUTPUT = REPO_ROOT / "tests" / "fixtures" / "test-graphify-output"
+
+
+def test_run_success_uploads_outputs_and_cleans_workdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    captured_manifest: dict[str, Any] = {}
+
+    def fake_subprocess_run(cmd: list[str], **kwargs: Any) -> SimpleNamespace:
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        captured_manifest.update(
+            json.loads(
+                (Path(kwargs["cwd"]) / "graphify_input_manifest.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+        )
+        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    result = asyncio.run(runner.run(job_data()))
+
+    assert result["status"] == "success"
+    assert result["graph_json_uri"] == (
+        "s3://out-bucket/graphify-out/tenant-1/space-1/run-1/graph.json"
+    )
+    assert result["wiki_output_uri"] == (
+        "s3://out-bucket/graphify-out/tenant-1/space-1/run-1/wiki"
+    )
+    assert result["graph_html_uri"] is None
+    assert result["stats_json"]["node_count"] == fixture_count("nodes")
+    assert result["stats_json"]["edge_count"] == fixture_count("edges")
+    assert result["stats_json"]["wiki_page_count"] == 5
+    assert captured_manifest["space_id"] == "space-1"
+    assert captured_manifest["run_id"] == "run-1"
+    assert captured_manifest["mode"] == "full"
+    assert captured_manifest["graphify_ref"] == "graphify-ref"
+    assert len(captured_manifest["input_files"]) == 2
+    assert storage.downloads == [
+        "s3://input-bucket/doc-a/parsed.md",
+        "s3://input-bucket/doc-b/parsed.md",
+    ]
+    assert "graphify-out/tenant-1/space-1/run-1/graph.json" in storage.uploaded_keys
+    assert "graphify-out/tenant-1/space-1/run-1/validation_report.json" in (
+        storage.uploaded_keys
+    )
+    assert "graphify-out/tenant-1/space-1/run-1/wiki/index.md" in storage.uploaded_keys
+    assert storage.uploaded_validation_report["validation_passed"] is True
+    assert not (tmp_path / "run-1").exists()
+
+
+def test_run_timeout_reports_structured_error_and_cleans_workdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> None:
+        raise subprocess.TimeoutExpired(cmd, timeout=runner.GRAPHIFY_TIMEOUT)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    assert json.loads(str(exc_info.value))["reason"] == "timeout"
+    assert not (tmp_path / "run-1").exists()
+
+
+def test_run_cli_failure_includes_stderr_and_cleans_workdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    monkeypatch.setattr(
+        runner.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1, stderr="graphify exploded", stdout=""
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    error = json.loads(str(exc_info.value))
+    assert error["reason"] == "cli_error"
+    assert error["stderr"] == "graphify exploded"
+    assert not (tmp_path / "run-1").exists()
+
+
+def test_run_missing_graph_json_fails_validation_and_cleans_workdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        (output_dir / "wiki").mkdir(parents=True)
+        (output_dir / "wiki" / "index.md").write_text("# Index", encoding="utf-8")
+        (output_dir / "GRAPH_REPORT.md").write_text("report", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    error = json.loads(str(exc_info.value))
+    assert error["reason"] == "missing_graph_json"
+    assert storage.uploaded_keys == []
+    assert not (tmp_path / "run-1").exists()
+
+
+def test_run_missing_wiki_dir_fails_validation_and_cleans_workdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        (output_dir / "graph.json").write_text(
+            '{"nodes":[],"edges":[]}', encoding="utf-8"
+        )
+        (output_dir / "GRAPH_REPORT.md").write_text("report", encoding="utf-8")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    assert json.loads(str(exc_info.value))["reason"] == "missing_wiki_dir"
+    assert not (tmp_path / "run-1").exists()
+
+
+def test_run_path_traversal_detection_fails_on_symlink_and_cleans_workdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside", encoding="utf-8")
+
+    def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
+        try:
+            (output_dir / "wiki" / "escape.md").symlink_to(outside)
+        except OSError as exc:
+            pytest.skip(f"symlink not available: {exc}")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    assert json.loads(str(exc_info.value))["reason"] == "path_traversal"
+    assert not (tmp_path / "run-1").exists()
+
+
+def test_run_file_size_check_fails_validation_and_cleans_workdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(runner, "MAX_FILE_SIZE", 10)
+
+    def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    error = json.loads(str(exc_info.value))
+    assert error["reason"] == "file_size"
+    report = error["validation_report"]
+    assert report["validation_passed"] is False
+    assert any(check["name"] == "file_size" for check in report["checks"])
+    assert not (tmp_path / "run-1").exists()
+
+
+def test_validate_output_reports_pass_stats() -> None:
+    validation = runner._validate_output(
+        FIXTURE_OUTPUT, run_id="run-1", graphify_ref="graphify-ref"
+    )
+
+    assert validation["validation_passed"] is True
+    assert validation["run_id"] == "run-1"
+    assert validation["graphify_ref"] == "graphify-ref"
+    assert validation["node_count"] == fixture_count("nodes")
+    assert validation["edge_count"] == fixture_count("edges")
+    assert validation["wiki_page_count"] == 5
+    assert validation["generated_at"].endswith("Z")
+
+
+def install_runner_config(
+    monkeypatch: pytest.MonkeyPatch, workdir: Path, *, output_bucket: str = "out-bucket"
+) -> None:
+    monkeypatch.setattr(runner, "GRAPHIFY_WORKDIR", str(workdir))
+    monkeypatch.setattr(runner, "GRAPHIFY_TIMEOUT", 5)
+    monkeypatch.setattr(runner, "GRAPHIFY_MODE", "full")
+    monkeypatch.setattr(runner, "GRAPHIFY_REF", "graphify-ref")
+    monkeypatch.setattr(runner, "OUTPUT_BUCKET", output_bucket)
+    monkeypatch.setattr(runner, "MAX_FILE_SIZE", 100 * 1024 * 1024)
+    monkeypatch.setattr(runner, "MAX_TOTAL_SIZE", 1024 * 1024 * 1024)
+
+
+def install_fake_storage(monkeypatch: pytest.MonkeyPatch) -> "FakeStorage":
+    storage = FakeStorage()
+
+    class FakeStorageFactory:
+        @classmethod
+        def from_env(cls) -> FakeStorage:
+            return storage
+
+    monkeypatch.setattr(runner, "MinioStorageClient", FakeStorageFactory)
+    return storage
+
+
+def job_data() -> dict[str, Any]:
+    return {
+        "id": "job-1",
+        "payload_json": {
+            "tenant_id": "tenant-1",
+            "space_id": "space-1",
+            "run_id": "run-1",
+            "mode": "full",
+            "input_uris": [
+                "s3://input-bucket/doc-a/parsed.md",
+                "s3://input-bucket/doc-b/parsed.md",
+            ],
+        },
+    }
+
+
+def fixture_count(key: str) -> int:
+    graph = json.loads((FIXTURE_OUTPUT / "graph.json").read_text(encoding="utf-8"))
+    return len(graph[key])
+
+
+class FakeStorage:
+    def __init__(self) -> None:
+        self.downloads: list[str] = []
+        self.uploaded_keys: list[str] = []
+        self.uploaded_validation_report: dict[str, Any] = {}
+
+    def download_file(self, uri: str, local_path: Path) -> None:
+        self.downloads.append(uri)
+        local_path.write_text(f"# {uri}", encoding="utf-8")
+
+    def upload_directory(self, local_dir: Path, bucket: str, key_prefix: str) -> None:
+        assert bucket == "out-bucket"
+        for path in sorted(local_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(local_dir).as_posix()
+            key = f"{key_prefix}/{rel}"
+            self.uploaded_keys.append(key)
+            if rel == "validation_report.json":
+                self.uploaded_validation_report = json.loads(
+                    path.read_text(encoding="utf-8")
+                )

--- a/apps/graphify-worker/tests/test_runner.py
+++ b/apps/graphify-worker/tests/test_runner.py
@@ -46,6 +46,9 @@ def test_run_success_uploads_outputs_and_cleans_workdir(
     assert result["wiki_output_uri"] == (
         "s3://out-bucket/graphify-out/tenant-1/space-1/run-1/wiki"
     )
+    assert result["report_uri"] == (
+        "s3://out-bucket/graphify-out/tenant-1/space-1/run-1/GRAPH_REPORT.md"
+    )
     assert result["graph_html_uri"] is None
     assert result["stats_json"]["node_count"] == fixture_count("nodes")
     assert result["stats_json"]["edge_count"] == fixture_count("edges")
@@ -66,6 +69,40 @@ def test_run_success_uploads_outputs_and_cleans_workdir(
     assert "graphify-out/tenant-1/space-1/run-1/wiki/index.md" in storage.uploaded_keys
     assert storage.uploaded_validation_report["validation_passed"] is True
     assert not (tmp_path / "run-1").exists()
+
+
+def test_run_success_omits_report_uri_when_report_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
+        (output_dir / "GRAPH_REPORT.md").unlink()
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    result = asyncio.run(runner.run(job_data()))
+
+    assert result["status"] == "success"
+    assert result["report_uri"] is None
+
+
+@pytest.mark.parametrize("run_id", ["../../etc", "/tmp/evil", "../escape"])
+def test_run_rejects_unsafe_run_id(
+    run_id: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_runner_config(monkeypatch, tmp_path)
+    data = job_data()
+    data["payload_json"]["run_id"] = run_id
+
+    with pytest.raises(ValueError, match="Invalid id for path use"):
+        asyncio.run(runner.run(data))
+
+    assert not any(tmp_path.iterdir())
 
 
 def test_run_timeout_reports_structured_error_and_cleans_workdir(
@@ -109,6 +146,38 @@ def test_run_cli_failure_includes_stderr_and_cleans_workdir(
     assert not (tmp_path / "run-1").exists()
 
 
+def test_run_cli_failure_scrubs_env_and_redacts_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    monkeypatch.setenv("MINIO_SECRET_KEY", "super-secret")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "session-secret")
+    captured_env: dict[str, str] = {}
+
+    def fake_subprocess_run(_cmd: list[str], **kwargs: Any) -> SimpleNamespace:
+        captured_env.update(kwargs["env"])
+        return SimpleNamespace(
+            returncode=1,
+            stderr=f"failed with super-secret and session-secret {'x' * 3000}",
+            stdout="",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    error = json.loads(str(exc_info.value))
+    assert "MINIO_SECRET_KEY" not in captured_env
+    assert "AWS_SESSION_TOKEN" not in captured_env
+    assert "super-secret" not in error["stderr"]
+    assert "session-secret" not in error["stderr"]
+    assert "***REDACTED***" in error["stderr"]
+    assert len(error["stderr"]) <= 2000
+    assert not (tmp_path / "run-1").exists()
+
+
 def test_run_missing_graph_json_fails_validation_and_cleans_workdir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -129,14 +198,17 @@ def test_run_missing_graph_json_fails_validation_and_cleans_workdir(
 
     error = json.loads(str(exc_info.value))
     assert error["reason"] == "missing_graph_json"
-    assert storage.uploaded_keys == []
+    assert storage.uploaded_keys == [
+        "graphify-out/tenant-1/space-1/run-1/validation_report.json"
+    ]
+    assert storage.uploaded_validation_report["validation_passed"] is False
     assert not (tmp_path / "run-1").exists()
 
 
 def test_run_missing_wiki_dir_fails_validation_and_cleans_workdir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    install_fake_storage(monkeypatch)
+    storage = install_fake_storage(monkeypatch)
     install_runner_config(monkeypatch, tmp_path)
 
     def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
@@ -153,13 +225,17 @@ def test_run_missing_wiki_dir_fails_validation_and_cleans_workdir(
         asyncio.run(runner.run(job_data()))
 
     assert json.loads(str(exc_info.value))["reason"] == "missing_wiki_dir"
+    assert storage.uploaded_keys == [
+        "graphify-out/tenant-1/space-1/run-1/validation_report.json"
+    ]
+    assert storage.uploaded_validation_report["validation_passed"] is False
     assert not (tmp_path / "run-1").exists()
 
 
 def test_run_path_traversal_detection_fails_on_symlink_and_cleans_workdir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    install_fake_storage(monkeypatch)
+    storage = install_fake_storage(monkeypatch)
     install_runner_config(monkeypatch, tmp_path)
 
     outside = tmp_path / "outside.md"
@@ -179,14 +255,20 @@ def test_run_path_traversal_detection_fails_on_symlink_and_cleans_workdir(
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(runner.run(job_data()))
 
-    assert json.loads(str(exc_info.value))["reason"] == "path_traversal"
+    error = json.loads(str(exc_info.value))
+    assert error["reason"] == "path_traversal"
+    assert error["file"] == "wiki/escape.md"
+    assert storage.uploaded_keys == [
+        "graphify-out/tenant-1/space-1/run-1/validation_report.json"
+    ]
+    assert storage.uploaded_validation_report["validation_passed"] is False
     assert not (tmp_path / "run-1").exists()
 
 
 def test_run_file_size_check_fails_validation_and_cleans_workdir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    install_fake_storage(monkeypatch)
+    storage = install_fake_storage(monkeypatch)
     install_runner_config(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "MAX_FILE_SIZE", 10)
 
@@ -201,11 +283,64 @@ def test_run_file_size_check_fails_validation_and_cleans_workdir(
         asyncio.run(runner.run(job_data()))
 
     error = json.loads(str(exc_info.value))
-    assert error["reason"] == "file_size"
+    assert error["reason"] == "quarantined"
+    assert error["quarantine_type"] == "file_size"
+    assert error["details"]
     report = error["validation_report"]
     assert report["validation_passed"] is False
     assert any(check["name"] == "file_size" for check in report["checks"])
+    assert storage.uploaded_keys == [
+        "graphify-out/tenant-1/space-1/run-1/validation_report.json"
+    ]
+    assert storage.uploaded_validation_report["validation_passed"] is False
     assert not (tmp_path / "run-1").exists()
+
+
+def test_run_total_size_check_uses_quarantine_error_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(runner, "MAX_TOTAL_SIZE", 10)
+
+    def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    error = json.loads(str(exc_info.value))
+    assert error["reason"] == "quarantined"
+    assert error["quarantine_type"] == "total_size"
+    assert error["details"]
+    assert error["validation_report"]["validation_passed"] is False
+    assert storage.uploaded_keys == [
+        "graphify-out/tenant-1/space-1/run-1/validation_report.json"
+    ]
+    assert storage.uploaded_validation_report["validation_passed"] is False
+    assert not (tmp_path / "run-1").exists()
+
+
+def test_validate_output_checks_size_before_parsing_graph_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(runner, "MAX_FILE_SIZE", 10)
+    (tmp_path / "graph.json").write_text(
+        "not valid json and too large", encoding="utf-8"
+    )
+
+    validation = runner._validate_output(tmp_path, run_id="run-1")
+
+    assert validation["validation_passed"] is False
+    failed_checks = [
+        check for check in validation["checks"] if check["status"] == "failed"
+    ]
+    assert failed_checks[0]["name"] == "file_size"
+    assert all(check["name"] != "graph_json_exists" for check in validation["checks"])
 
 
 def test_validate_output_reports_pass_stats() -> None:
@@ -277,15 +412,18 @@ class FakeStorage:
         self.downloads.append(uri)
         local_path.write_text(f"# {uri}", encoding="utf-8")
 
-    def upload_directory(self, local_dir: Path, bucket: str, key_prefix: str) -> None:
+    def upload_file(self, local_path: Path, bucket: str, key: str) -> None:
         assert bucket == "out-bucket"
+        self.uploaded_keys.append(key)
+        if key.endswith("/validation_report.json"):
+            self.uploaded_validation_report = json.loads(
+                local_path.read_text(encoding="utf-8")
+            )
+
+    def upload_directory(self, local_dir: Path, bucket: str, key_prefix: str) -> None:
         for path in sorted(local_dir.rglob("*")):
             if not path.is_file():
                 continue
             rel = path.relative_to(local_dir).as_posix()
             key = f"{key_prefix}/{rel}"
-            self.uploaded_keys.append(key)
-            if rel == "validation_report.json":
-                self.uploaded_validation_report = json.loads(
-                    path.read_text(encoding="utf-8")
-                )
+            self.upload_file(path, bucket, key)

--- a/apps/graphify-worker/tests/test_runner_integration.py
+++ b/apps/graphify-worker/tests/test_runner_integration.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src import runner
+from tests.test_runner import FIXTURE_OUTPUT, fixture_count, install_runner_config
+
+
+def test_runner_integration_with_prepared_graphify_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = IntegrationStorage()
+
+    class StorageFactory:
+        @classmethod
+        def from_env(cls) -> IntegrationStorage:
+            return storage
+
+    install_runner_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(runner, "MinioStorageClient", StorageFactory)
+
+    def fake_subprocess_run(cmd: list[str], **_kwargs: Any) -> SimpleNamespace:
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_subprocess_run)
+
+    result = asyncio.run(
+        runner.run(
+            {
+                "id": "job-integration",
+                "payload_json": {
+                    "tenant_id": "tenant-1",
+                    "space_id": "space-1",
+                    "run_id": "run-integration",
+                    "input_uris": ["s3://input-bucket/doc/parsed.md"],
+                },
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["stats_json"]["node_count"] == fixture_count("nodes")
+    assert result["stats_json"]["edge_count"] == fixture_count("edges")
+    assert result["stats_json"]["wiki_page_count"] == 5
+    assert storage.validation_report["validation_passed"] is True
+    assert storage.validation_report["node_count"] == fixture_count("nodes")
+    assert "graphify-out/tenant-1/space-1/run-integration/graph.json" in (
+        storage.uploaded_keys
+    )
+    assert "graphify-out/tenant-1/space-1/run-integration/wiki/index.md" in (
+        storage.uploaded_keys
+    )
+    assert not (tmp_path / "run-integration").exists()
+
+
+class IntegrationStorage:
+    def __init__(self) -> None:
+        self.uploaded_keys: list[str] = []
+        self.validation_report: dict[str, Any] = {}
+
+    def download_file(self, _uri: str, local_path: Path) -> None:
+        local_path.write_text("# parsed", encoding="utf-8")
+
+    def upload_directory(self, local_dir: Path, _bucket: str, key_prefix: str) -> None:
+        for path in sorted(local_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(local_dir).as_posix()
+            self.uploaded_keys.append(f"{key_prefix}/{rel}")
+            if rel == "validation_report.json":
+                self.validation_report = json.loads(path.read_text(encoding="utf-8"))

--- a/apps/graphify-worker/tests/test_storage_client.py
+++ b/apps/graphify-worker/tests/test_storage_client.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.storage_client import MinioStorageClient, parse_storage_uri
+
+
+def test_parse_storage_uri_rejects_path_traversal() -> None:
+    assert parse_storage_uri("s3://bucket/path/file.md").bucket == "bucket"
+    assert parse_storage_uri("s3://bucket/path/file.md").key == "path/file.md"
+
+    with pytest.raises(ValueError):
+        parse_storage_uri("s3://bucket/path/../file.md")
+
+
+def test_download_file_uses_signed_get_and_writes_destination(tmp_path: Path) -> None:
+    session = FakeSession([FakeResponse(b"parsed markdown")])
+    client = MinioStorageClient(
+        endpoint="http://minio:9000",
+        access_key="access",
+        secret_key="secret",
+        session=session,
+    )
+
+    destination = tmp_path / "nested" / "parsed.md"
+    client.download_file("s3://source-bucket/path/parsed.md", destination)
+
+    assert destination.read_bytes() == b"parsed markdown"
+    request = session.requests[0]
+    assert request["method"] == "GET"
+    assert request["url"] == "http://minio:9000/source-bucket/path/parsed.md"
+    assert request["headers"]["authorization"].startswith("AWS4-HMAC-SHA256")
+
+
+def test_upload_file_uses_signed_put(tmp_path: Path) -> None:
+    session = FakeSession([FakeResponse(b"")])
+    client = MinioStorageClient(
+        endpoint="http://minio:9000",
+        access_key="access",
+        secret_key="secret",
+        session=session,
+    )
+    source = tmp_path / "graph.json"
+    source.write_text('{"nodes":[],"edges":[]}', encoding="utf-8")
+
+    uploaded = client.upload_file(source, "out-bucket", "prefix/graph.json")
+
+    assert uploaded.uri == "s3://out-bucket/prefix/graph.json"
+    request = session.requests[0]
+    assert request["method"] == "PUT"
+    assert request["url"] == "http://minio:9000/out-bucket/prefix/graph.json"
+    assert request["data"] == b'{"nodes":[],"edges":[]}'
+    assert "content-type" in request["headers"]
+
+
+def test_upload_directory_uploads_nested_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_dir = tmp_path / "output"
+    (local_dir / "wiki").mkdir(parents=True)
+    (local_dir / "graph.json").write_text("{}", encoding="utf-8")
+    (local_dir / "wiki" / "index.md").write_text("# Index", encoding="utf-8")
+    client = MinioStorageClient(
+        endpoint="http://minio:9000", access_key="access", secret_key="secret"
+    )
+    calls: list[tuple[Path, str, str]] = []
+
+    def fake_upload_file(local_path: Path, bucket: str, key: str) -> object:
+        calls.append((local_path, bucket, key))
+        return object()
+
+    monkeypatch.setattr(client, "upload_file", fake_upload_file)
+
+    client.upload_directory(local_dir, "out-bucket", "graphify-out/tenant/space/run")
+
+    assert calls == [
+        (
+            local_dir / "graph.json",
+            "out-bucket",
+            "graphify-out/tenant/space/run/graph.json",
+        ),
+        (
+            local_dir / "wiki" / "index.md",
+            "out-bucket",
+            "graphify-out/tenant/space/run/wiki/index.md",
+        ),
+    ]
+
+
+class FakeResponse:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class FakeSession:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self.responses = responses
+        self.requests: list[dict[str, Any]] = []
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        data: bytes | None,
+        headers: dict[str, str],
+        timeout: int,
+    ) -> FakeResponse:
+        self.requests.append(
+            {
+                "method": method,
+                "url": url,
+                "data": data,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return self.responses.pop(0)


### PR DESCRIPTION
## Summary

- Replace no-op runner with full Graphify CLI execution pipeline (download → manifest → CLI → validate → upload → cleanup)
- Add MinIO storage client with AWS4 signing
- Implement output validation per Doc 12 §6.1 (path safety, symlinks, file size ≤100MB, total ≤1GB)
- Security hardening: safe ID validation, workdir containment, subprocess env scrubbing, stderr redaction
- Generate and upload validation_report.json (even on failure for diagnostics)
- Quarantine error format matches spec (reason=quarantined + quarantine_type)

## Test plan

- [x] Python tests: 26 passed (storage, manifest, runner, path traversal, quarantine, env scrub, integration)
- [x] `npm run build` + `npm test` — 555 Node tests passing
- [x] `ruff format` check passes

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `354e8fa93cc6b0b6be7c0c17d14176da254a970d`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/94#issuecomment-4362633126) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/94#issuecomment-4362633179) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/94#issuecomment-4362633249) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/94#issuecomment-4362633305)
- Key findings addressed: run_id path traversal (critical), graph.json parsed before size check, subprocess credential exposure, quarantine error format, validation report upload on failure

Closes #86