### PR TITLE
feat(wiki-core): implement wiki normalization module (#87)

### DIFF
--- a/packages/wiki-core/src/__tests__/normalization-block-markers.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-block-markers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { injectBlockMarkers, parseBlockMarkers } from '../normalization/block-markers.js';
+
+describe('block markers', () => {
+  it('injects markers at h2 boundaries', () => {
+    const marked = injectBlockMarkers('# Page\n\n## Overview\nText\n\n## Sources\n- doc', 'run-1');
+
+    expect(marked).toContain('<!-- graphify:managed:start id="overview" run="run-1" -->');
+    expect(marked).toContain('<!-- graphify:managed:start id="sources" run="run-1" -->');
+    expect(marked.match(/graphify:managed:end/g)).toHaveLength(2);
+  });
+
+  it('parses graphify and human start markers', () => {
+    const markers = parseBlockMarkers(
+      '<!-- graphify:managed:start id="overview" run="run-1" -->\n<!-- graphify:human:start id="notes" run="run-2" -->',
+    );
+
+    expect(markers).toEqual([
+      { blockId: 'overview', owner: 'graphify', runId: 'run-1' },
+      { blockId: 'notes', owner: 'human', runId: 'run-2' },
+    ]);
+  });
+
+  it('round-trips injected block IDs through parse', () => {
+    const markers = parseBlockMarkers(injectBlockMarkers('# Page\n\n## Overview\nText\n\n## Sources\n- doc', 'run-1'));
+
+    expect(markers.map(marker => marker.blockId)).toEqual(['overview', 'sources']);
+  });
+});

--- a/packages/wiki-core/src/__tests__/normalization-git-commit.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-git-commit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { importGraphifyWiki, type ExistingPageInfo } from '../normalization/import-graphify-wiki.js';
+
+describe('normalization git commit info', () => {
+  it('formats first import commit messages', () => {
+    const result = importGraphifyWiki({
+      tenantId: 'tenant-1',
+      spaceId: 'space-1',
+      spaceSlug: 'space',
+      runId: 'run_1',
+      communityLabels: ['Auth System'],
+      godNodeLabels: [],
+      stableKeys: new Map(),
+      wikiFiles: new Map([
+        ['auth-system.md', '# Auth System\n\n## Overview\nText'],
+        ['permission-system.md', '# Permission System\n\n## Overview\nText'],
+      ]),
+      reportMarkdown: '',
+      existingPages: new Map(),
+      existingBlockMetadata: new Map(),
+      sourceDocumentIds: [],
+      now: '2026-05-02T12:00:00.000Z',
+    });
+
+    expect(result.gitCommits[0]?.message).toBe(
+      '[space][graphify][run_1] add 2 pages: auth-system, permission-system',
+    );
+  });
+
+  it('formats mixed add and update commit messages', () => {
+    const existingPage: ExistingPageInfo = {
+      pageId: 'space-1.index.root',
+      slug: 'index',
+      currentVersionNo: 1,
+      status: 'draft',
+      pageType: 'index',
+    };
+    const result = importGraphifyWiki({
+      tenantId: 'tenant-1',
+      spaceId: 'space-1',
+      spaceSlug: 'space',
+      runId: 'run_2',
+      communityLabels: ['Auth System'],
+      godNodeLabels: [],
+      stableKeys: new Map(),
+      wikiFiles: new Map([
+        ['index.md', '# Wiki Index\n\n## Overview\nText'],
+        ['auth-system.md', '# Auth System\n\n## Overview\nText'],
+      ]),
+      reportMarkdown: '',
+      existingPages: new Map([[existingPage.pageId, existingPage]]),
+      existingBlockMetadata: new Map(),
+      sourceDocumentIds: [],
+      now: '2026-05-02T12:00:00.000Z',
+    });
+
+    expect(result.gitCommits[0]?.message).toBe('[space][graphify][run_2] add 1 page, update 1 page: auth-system, index');
+  });
+});

--- a/packages/wiki-core/src/__tests__/normalization-identify-page-type.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-identify-page-type.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { identifyPageType } from '../normalization/identify-page-type.js';
+
+describe('identifyPageType', () => {
+  it('identifies index.md as the index page', () => {
+    expect(identifyPageType('index.md', [], [])).toBe('index');
+  });
+
+  it('identifies community pages after safeFilename conversion', () => {
+    expect(identifyPageType('Auth_System.md', ['Auth System'], [])).toBe('community');
+  });
+
+  it('identifies god node pages after safeFilename conversion', () => {
+    expect(identifyPageType('JWT_Authentication.md', [], ['JWT Authentication'])).toBe('god_node');
+  });
+
+  it('also matches fixture-style lowercase hyphen filenames', () => {
+    expect(identifyPageType('jwt-authentication.md', [], ['JWT Authentication'])).toBe('god_node');
+  });
+
+  it('falls back to generated articles for unmatched pages', () => {
+    expect(identifyPageType('upload-pipeline.md', ['Auth System'], ['JWT Authentication'])).toBe('generated_article');
+  });
+});

--- a/packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts
@@ -44,6 +44,11 @@ describe('importGraphifyWiki', () => {
       'sources',
     ]);
     expect(authPage.sections.map(section => section.heading)).toContain('JWT Authentication');
+    const jwtSection = authPage.sections.find(section => section.heading === 'JWT Authentication');
+    if (typeof jwtSection?.start_offset !== 'number') {
+      throw new Error('JWT Authentication section should have a numeric start offset');
+    }
+    expect(authPage.contentMarkdown.slice(jwtSection.start_offset).startsWith('### JWT Authentication')).toBe(true);
 
     const parsed = parseFrontmatter(authPage.contentMarkdown);
     expect(parsed.frontmatter).toMatchObject({
@@ -82,6 +87,53 @@ describe('importGraphifyWiki', () => {
     expect(second.pagesUpdated).toHaveLength(5);
     expect(bySlug(second.pagesUpdated, 'auth-system').versionNo).toBe(2);
     expect(parseFrontmatter(bySlug(second.pagesUpdated, 'auth-system').contentMarkdown).frontmatter.version).toBe(2);
+  });
+
+  it('uses matched community labels rather than filename stems for community page IDs', () => {
+    const result = importGraphifyWiki({
+      ...baseParams(),
+      spaceId: 'space-1',
+      spaceSlug: 'space',
+      communityLabels: ['C++'],
+      godNodeLabels: [],
+      stableKeys: new Map(),
+      wikiFiles: new Map([['c++.md', '# C++\n\n## Overview\nText']]),
+      reportMarkdown: '',
+    });
+
+    expect(result.pagesCreated[0]?.pageType).toBe('community');
+    expect(result.pagesCreated[0]?.pageId).toBe('space-1.community.c__');
+  });
+
+  it('classifies existing pages with matching content hashes as unchanged', () => {
+    const content = '# Auth System\n\n## Overview\nText';
+    const existingPage: ExistingPageInfo = {
+      pageId: 'space-1.community.auth_system',
+      slug: 'auth-system',
+      currentVersionNo: 1,
+      status: 'draft',
+      pageType: 'community',
+      contentHash: hash(content),
+    };
+    const result = importGraphifyWiki({
+      ...baseParams(),
+      spaceId: 'space-1',
+      spaceSlug: 'space',
+      runId: 'gf_unchanged',
+      communityLabels: ['Auth System'],
+      godNodeLabels: [],
+      stableKeys: new Map(),
+      wikiFiles: new Map([['auth-system.md', content]]),
+      reportMarkdown: '',
+      existingPages: new Map([[existingPage.pageId, existingPage]]),
+      existingBlockMetadata: new Map(),
+    });
+
+    expect(result.pagesCreated).toHaveLength(0);
+    expect(result.pagesUpdated).toHaveLength(0);
+    expect(result.pagesUnchanged).toEqual([existingPage.pageId]);
+    expect(result.indexUpdateManifest.pagesUpdated).toEqual([]);
+    expect(result.gitCommits[0]?.message).toBe('[space][graphify][gf_unchanged] no changes');
   });
 
   it('preserves human-owned blocks and creates graphify suggestion proposals', () => {
@@ -159,6 +211,24 @@ describe('importGraphifyWiki', () => {
 
     expect(result.pagesCreated.some(page => page.slug === 'GRAPH_REPORT')).toBe(false);
     expect(result.graphReport?.reportMarkdown).toContain('# Graph Report');
+  });
+
+  it('rejects unsafe space IDs before constructing repo paths', () => {
+    expect(() => importGraphifyWiki({ ...baseParams(), spaceId: '../rd-platform' })).toThrow(
+      'Invalid spaceId for path',
+    );
+  });
+
+  it('rejects slugs containing path separators', () => {
+    expect(() =>
+      importGraphifyWiki({
+        ...baseParams(),
+        communityLabels: [],
+        godNodeLabels: [],
+        stableKeys: new Map(),
+        wikiFiles: new Map([['bad\\slug.md', '# Bad Slug\n\n## Overview\nText']]),
+      }),
+    ).toThrow('Invalid slug for path');
   });
 });
 

--- a/packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts
@@ -1,0 +1,228 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseFrontmatter } from '../frontmatter.js';
+import {
+  type BlockMetadataInfo,
+  type ExistingPageInfo,
+  importGraphifyWiki,
+  type NormalizationParams,
+  type WikiPageImport,
+} from '../normalization/import-graphify-wiki.js';
+
+const rootDir = path.resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
+const fixtureDir = path.join(rootDir, 'tests/fixtures/test-graphify-output');
+const wikiDir = path.join(fixtureDir, 'wiki');
+const now = '2026-05-02T12:00:00.000Z';
+
+describe('importGraphifyWiki', () => {
+  it('imports fixture wiki files into canonical page manifests', () => {
+    const result = importGraphifyWiki(baseParams());
+
+    expect(result.pagesCreated).toHaveLength(5);
+    expect(result.pagesUpdated).toHaveLength(0);
+    expect(result.graphReport?.statsJson).toMatchObject({ node_count: 10, edge_count: 9 });
+
+    const authPage = bySlug(result.pagesCreated, 'auth-system');
+    const jwtPage = bySlug(result.pagesCreated, 'jwt-authentication');
+    const indexPage = bySlug(result.pagesCreated, 'index');
+
+    expect(indexPage.pageType).toBe('index');
+    expect(indexPage.repoPath).toBe('spaces/rd-platform/index.md');
+    expect(authPage.pageType).toBe('community');
+    expect(authPage.repoPath).toBe('spaces/rd-platform/communities/auth-system.md');
+    expect(jwtPage.pageType).toBe('god_node');
+    expect(jwtPage.repoPath).toBe('spaces/rd-platform/god-nodes/jwt-authentication.md');
+    expect(authPage.blockMetadata.map(block => block.blockId)).toEqual([
+      'overview',
+      'key-components',
+      'relationships',
+      'sources',
+    ]);
+    expect(authPage.sections.map(section => section.heading)).toContain('JWT Authentication');
+
+    const parsed = parseFrontmatter(authPage.contentMarkdown);
+    expect(parsed.frontmatter).toMatchObject({
+      page_id: 'rd-platform.community.auth_system',
+      title: 'Auth System',
+      space_id: 'rd-platform',
+      page_type: 'community',
+      status: 'draft',
+      curation_status: 'auto_generated',
+      source: 'graphify',
+      graphify_run_id: 'gf_001',
+      graphify_schema_version: 'v1',
+      managed_by: 'graphify',
+      source_document_ids: ['doc-auth', 'doc-rbac'],
+      version: 1,
+      created_by: 'graphify',
+      created_at: now,
+      updated_at: now,
+    });
+    expect(result.indexUpdateManifest.pagesAdded).toContain('rd-platform.community.auth_system');
+    expect(result.gitCommits[0]?.message).toBe(
+      '[rd-platform][graphify][gf_001] add 5 pages: index, auth-system, permission-system, jwt-authentication, rbac-permission-model',
+    );
+  });
+
+  it('updates existing pages with incremented versions on a second import', () => {
+    const first = importGraphifyWiki(baseParams());
+    const second = importGraphifyWiki({
+      ...baseParams(),
+      runId: 'gf_002',
+      existingPages: existingPagesFrom(first.pagesCreated),
+      existingBlockMetadata: blockMetadataFrom(first.pagesCreated),
+    });
+
+    expect(second.pagesCreated).toHaveLength(0);
+    expect(second.pagesUpdated).toHaveLength(5);
+    expect(bySlug(second.pagesUpdated, 'auth-system').versionNo).toBe(2);
+    expect(parseFrontmatter(bySlug(second.pagesUpdated, 'auth-system').contentMarkdown).frontmatter.version).toBe(2);
+  });
+
+  it('preserves human-owned blocks and creates graphify suggestion proposals', () => {
+    const first = importGraphifyWiki(baseParams());
+    const authPage = bySlug(first.pagesCreated, 'auth-system');
+    const humanContent = '## Key Components\n\nHuman-written component notes stay intact.';
+    const humanHash = hash(humanContent);
+    const existingPages = existingPagesFrom(first.pagesCreated);
+    const existingBlockMetadata = blockMetadataFrom(first.pagesCreated);
+
+    existingPages.set(authPage.pageId, {
+      ...existingPages.get(authPage.pageId)!,
+      contentMarkdown: authPage.contentMarkdown.replace(
+        /<!-- graphify:managed:start id="key-components" run="gf_001" -->[\s\S]*?<!-- graphify:managed:end -->/,
+        `<!-- graphify:human:start id="key-components" run="human-edit" -->\n${humanContent}\n<!-- graphify:human:end -->`,
+      ),
+    });
+    existingBlockMetadata.set(
+      authPage.pageId,
+      existingBlockMetadata.get(authPage.pageId)!.map(block =>
+        block.blockId === 'key-components' ? { ...block, owner: 'human', contentHash: humanHash, editable: true } : block,
+      ),
+    );
+
+    const result = importGraphifyWiki({
+      ...baseParams(),
+      runId: 'gf_003',
+      existingPages,
+      existingBlockMetadata,
+    });
+    const updatedAuth = bySlug(result.pagesUpdated, 'auth-system');
+
+    expect(updatedAuth.contentMarkdown).toContain('Human-written component notes stay intact.');
+    expect(updatedAuth.contentMarkdown).not.toContain('JWT tokens serve as the primary authentication mechanism.');
+    expect(updatedAuth.blockMetadata.find(block => block.blockId === 'key-components')).toMatchObject({
+      owner: 'human',
+      editable: true,
+      contentHash: humanHash,
+    });
+    expect(result.proposalsCreated).toHaveLength(1);
+    expect(result.proposalsCreated[0]).toMatchObject({
+      pageId: authPage.pageId,
+      blockId: 'key-components',
+      proposalType: 'graphify_suggestion',
+    });
+    expect(result.proposalsCreated[0]?.diffJson.graphifyContent).toContain('JWT tokens serve');
+  });
+
+  it('archives existing community pages missing after re-clustering', () => {
+    const existingPages = new Map<string, ExistingPageInfo>([
+      [
+        'rd-platform.community.legacy_cluster',
+        {
+          pageId: 'rd-platform.community.legacy_cluster',
+          slug: 'legacy-cluster',
+          currentVersionNo: 1,
+          status: 'published',
+          pageType: 'community',
+        },
+      ],
+    ]);
+    const result = importGraphifyWiki({
+      ...baseParams(),
+      existingPages,
+    });
+
+    expect(result.indexUpdateManifest.pagesArchived).toEqual(['rd-platform.community.legacy_cluster']);
+  });
+
+  it('keeps GRAPH_REPORT.md out of pages and stores it in graphReport', () => {
+    const params = baseParams();
+    params.wikiFiles.set('GRAPH_REPORT.md', readFileSync(path.join(fixtureDir, 'GRAPH_REPORT.md'), 'utf8'));
+
+    const result = importGraphifyWiki(params);
+
+    expect(result.pagesCreated.some(page => page.slug === 'GRAPH_REPORT')).toBe(false);
+    expect(result.graphReport?.reportMarkdown).toContain('# Graph Report');
+  });
+});
+
+function baseParams(): NormalizationParams {
+  return {
+    tenantId: 'tenant-1',
+    spaceId: 'rd-platform',
+    spaceSlug: 'rd-platform',
+    runId: 'gf_001',
+    communityLabels: ['Auth System', 'Permission System'],
+    godNodeLabels: ['JWT Authentication', 'RBAC Permission Model'],
+    stableKeys: new Map([
+      ['JWT Authentication', 'jwtstablekeyabcdef'],
+      ['RBAC Permission Model', 'rbacstablekeyabcdef'],
+    ]),
+    wikiFiles: new Map([
+      ['index.md', readFileSync(path.join(wikiDir, 'index.md'), 'utf8')],
+      ['auth-system.md', readFileSync(path.join(wikiDir, 'auth-system.md'), 'utf8')],
+      ['permission-system.md', readFileSync(path.join(wikiDir, 'permission-system.md'), 'utf8')],
+      ['jwt-authentication.md', readFileSync(path.join(wikiDir, 'jwt-authentication.md'), 'utf8')],
+      ['rbac-permission-model.md', readFileSync(path.join(wikiDir, 'rbac-permission-model.md'), 'utf8')],
+    ]),
+    reportMarkdown: readFileSync(path.join(fixtureDir, 'GRAPH_REPORT.md'), 'utf8'),
+    existingPages: new Map(),
+    existingBlockMetadata: new Map(),
+    sourceDocumentIds: ['doc-auth', 'doc-rbac'],
+    now,
+  };
+}
+
+function bySlug(pages: WikiPageImport[], slug: string): WikiPageImport {
+  const page = pages.find(candidate => candidate.slug === slug);
+  if (!page) {
+    throw new Error(`Missing page for slug ${slug}`);
+  }
+
+  return page;
+}
+
+function existingPagesFrom(pages: WikiPageImport[]): Map<string, ExistingPageInfo> {
+  return new Map(
+    pages.map(page => [
+      page.pageId,
+      {
+        pageId: page.pageId,
+        slug: page.slug,
+        currentVersionNo: page.versionNo,
+        status: readString(page.frontmatter.status, 'draft'),
+        pageType: page.pageType,
+        contentMarkdown: page.contentMarkdown,
+        createdAt: readString(page.frontmatter.created_at, now),
+      },
+    ]),
+  );
+}
+
+function blockMetadataFrom(pages: WikiPageImport[]): Map<string, BlockMetadataInfo[]> {
+  return new Map(pages.map(page => [page.pageId, page.blockMetadata]));
+}
+
+function hash(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}

--- a/packages/wiki-core/src/__tests__/normalization-safe-filename.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-safe-filename.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { safeFilename, uniqueSlug } from '../normalization/safe-filename.js';
+
+describe('normalization safe filename', () => {
+  it('replaces spaces with underscores', () => {
+    expect(safeFilename('Auth SSO Service')).toBe('Auth_SSO_Service');
+  });
+
+  it('replaces slashes and colons with hyphens', () => {
+    expect(safeFilename('Auth/SSO: Service')).toBe('Auth-SSO-_Service');
+  });
+
+  it('preserves unicode characters', () => {
+    expect(safeFilename('数据库 设计')).toBe('数据库_设计');
+  });
+
+  it('returns the same slug when there is no collision', () => {
+    expect(uniqueSlug('auth', new Set())).toBe('auth');
+  });
+
+  it('appends _2 for the first collision', () => {
+    expect(uniqueSlug('auth', new Set(['auth']))).toBe('auth_2');
+  });
+
+  it('appends _3 for a double collision', () => {
+    expect(uniqueSlug('auth', new Set(['auth', 'auth_2']))).toBe('auth_3');
+  });
+});

--- a/packages/wiki-core/src/__tests__/normalization-sanitize-markdown.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-sanitize-markdown.test.ts
@@ -39,4 +39,11 @@ describe('sanitizeMarkdown', () => {
   it('removes javascript markdown links but preserves link text', () => {
     expect(sanitizeMarkdown('[click](javascript:alert(1))')).toBe('click');
   });
+
+  it('handles long script payloads without pathological regex behavior', () => {
+    const payload = 'x'.repeat(10000);
+
+    expect(sanitizeMarkdown(`<script>${payload}</script>Body`)).toBe('Body');
+    expect(sanitizeMarkdown(`<script>${payload}`)).toBe(payload);
+  });
 });

--- a/packages/wiki-core/src/__tests__/normalization-sanitize-markdown.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-sanitize-markdown.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeMarkdown } from '../normalization/sanitize-markdown.js';
+
+describe('sanitizeMarkdown', () => {
+  it('removes script tags and their content', () => {
+    expect(sanitizeMarkdown('# Title\n<script>alert("xss")</script>\nBody')).toBe('# Title\n\nBody');
+  });
+
+  it('preserves graphify comments while stripping other HTML tags', () => {
+    const sanitized = sanitizeMarkdown('<!-- graphify:managed:start id="a" run="r" --><b>Bold</b><!-- note -->');
+
+    expect(sanitized).toContain('<!-- graphify:managed:start id="a" run="r" -->');
+    expect(sanitized).toContain('Bold');
+    expect(sanitized).not.toContain('<b>');
+    expect(sanitized).not.toContain('<!-- note -->');
+  });
+
+  it('removes data URIs from HTML attributes and markdown images', () => {
+    const sanitized = sanitizeMarkdown('<img src="data:text/html;base64,abc">\n![x](data:image/png;base64,abc)');
+
+    expect(sanitized).not.toContain('data:');
+  });
+
+  it('removes event handler attributes', () => {
+    const sanitized = sanitizeMarkdown('<a href="https://example.com" onclick="alert(1)">link</a>');
+
+    expect(sanitized).toBe('link');
+    expect(sanitized).not.toContain('onclick');
+  });
+
+  it('removes iframe object and embed tags completely', () => {
+    const sanitized = sanitizeMarkdown('<iframe src="x">bad</iframe><object>bad</object><embed src="x">ok');
+
+    expect(sanitized).toBe('ok');
+    expect(sanitized).not.toContain('bad');
+  });
+
+  it('removes javascript markdown links but preserves link text', () => {
+    expect(sanitizeMarkdown('[click](javascript:alert(1))')).toBe('click');
+  });
+});

--- a/packages/wiki-core/src/index.ts
+++ b/packages/wiki-core/src/index.ts
@@ -7,3 +7,8 @@ export * from './sections.js';
 export * from './version.js';
 export * from './repo-init.js';
 export * from './source-links.js';
+export * from './normalization/safe-filename.js';
+export * from './normalization/identify-page-type.js';
+export * from './normalization/sanitize-markdown.js';
+export * from './normalization/block-markers.js';
+export * from './normalization/import-graphify-wiki.js';

--- a/packages/wiki-core/src/normalization/block-markers.ts
+++ b/packages/wiki-core/src/normalization/block-markers.ts
@@ -1,0 +1,117 @@
+export interface BlockMarker {
+  blockId: string;
+  owner: 'graphify' | 'human';
+  runId: string;
+}
+
+interface HeadingBlock {
+  blockId: string;
+  start: number;
+  end: number;
+  content: string;
+}
+
+const h2Pattern = /^##(?!#)[ \t]+(.+?)\s*#*\s*$/gm;
+
+export function injectBlockMarkers(content: string, runId: string): string {
+  const blocks = extractH2Blocks(content);
+  if (blocks.length === 0) {
+    return content;
+  }
+
+  let result = content.slice(0, blocks[0]?.start ?? 0);
+
+  for (const block of blocks) {
+    result += wrapGraphifyBlock(block.content, block.blockId, runId);
+  }
+
+  return result;
+}
+
+export function parseBlockMarkers(content: string): BlockMarker[] {
+  const markers: BlockMarker[] = [];
+  const pattern =
+    /<!--\s*(?:(graphify):(managed|human)|(human):curated):start\s+id="([^"]+)"(?:\s+run="([^"]*)")?\s*-->/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(content)) !== null) {
+    markers.push({
+      blockId: match[4] ?? '',
+      owner: match[2] === 'managed' ? 'graphify' : 'human',
+      runId: match[5] ?? '',
+    });
+  }
+
+  return markers;
+}
+
+export function blockIdFromHeading(heading: string, fallbackIndex = 0): string {
+  return slugifyHeading(heading) || `section-${fallbackIndex}`;
+}
+
+export function wrapGraphifyBlock(content: string, blockId: string, runId: string): string {
+  return `<!-- graphify:managed:start id="${escapeMarkerAttribute(blockId)}" run="${escapeMarkerAttribute(runId)}" -->\n${content.trimEnd()}\n<!-- graphify:managed:end -->\n`;
+}
+
+export function wrapHumanBlock(content: string, blockId: string, runId: string): string {
+  return `<!-- graphify:human:start id="${escapeMarkerAttribute(blockId)}" run="${escapeMarkerAttribute(runId)}" -->\n${content.trimEnd()}\n<!-- graphify:human:end -->\n`;
+}
+
+export function extractMarkedBlocks(content: string): Map<string, string> {
+  const blocks = new Map<string, string>();
+  const pattern =
+    /<!--\s*(?:(?:graphify):(managed|human)|(?:human):curated):start\s+id="([^"]+)"(?:\s+run="[^"]*")?\s*-->([\s\S]*?)<!--\s*(?:(?:graphify):(managed|human)|(?:human):curated):end\s*-->/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(content)) !== null) {
+    const blockId = match[2];
+    const blockContent = match[3];
+    if (blockId && blockContent !== undefined) {
+      blocks.set(blockId, blockContent.trim());
+    }
+  }
+
+  return blocks;
+}
+
+export function extractH2Blocks(content: string): HeadingBlock[] {
+  const matches = Array.from(content.matchAll(h2Pattern));
+  const seenSlugs = new Set<string>();
+
+  return matches.map((match, index) => {
+    const heading = (match[1] ?? '').trim().replace(/\s+#*$/, '');
+    const nextMatch = matches[index + 1];
+    const start = match.index ?? 0;
+    const end = nextMatch?.index ?? content.length;
+    const baseBlockId = blockIdFromHeading(heading, index);
+    let blockId = baseBlockId;
+    let suffix = 2;
+
+    while (seenSlugs.has(blockId)) {
+      blockId = `${baseBlockId}-${suffix}`;
+      suffix += 1;
+    }
+    seenSlugs.add(blockId);
+
+    return {
+      blockId,
+      start,
+      end,
+      content: content.slice(start, end).trimEnd(),
+    };
+  });
+}
+
+function slugifyHeading(heading: string): string {
+  return heading
+    .toLowerCase()
+    .trim()
+    .replace(/\p{P}+/gu, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function escapeMarkerAttribute(value: string): string {
+  return value.replace(/"/g, '&quot;');
+}

--- a/packages/wiki-core/src/normalization/identify-page-type.ts
+++ b/packages/wiki-core/src/normalization/identify-page-type.ts
@@ -1,0 +1,35 @@
+import type { WikiPageType } from '../page-id.js';
+import { safeFilename } from './safe-filename.js';
+
+export function identifyPageType(
+  filename: string,
+  communityLabels: string[],
+  godNodeLabels: string[],
+): WikiPageType {
+  const name = filename.replace(/\.md$/i, '');
+  if (name === 'index') {
+    return 'index';
+  }
+
+  const communityFilenames = new Set(communityLabels.flatMap(labelVariants));
+  if (communityFilenames.has(name) || communityFilenames.has(normalizeForComparison(name))) {
+    return 'community';
+  }
+
+  const godNodeFilenames = new Set(godNodeLabels.flatMap(labelVariants));
+  if (godNodeFilenames.has(name) || godNodeFilenames.has(normalizeForComparison(name))) {
+    return 'god_node';
+  }
+
+  return 'generated_article';
+}
+
+function labelVariants(label: string): string[] {
+  const safe = safeFilename(label);
+
+  return [safe, normalizeForComparison(safe)];
+}
+
+function normalizeForComparison(value: string): string {
+  return value.toLowerCase().replace(/[_-]+/g, '-');
+}

--- a/packages/wiki-core/src/normalization/import-graphify-wiki.ts
+++ b/packages/wiki-core/src/normalization/import-graphify-wiki.ts
@@ -14,6 +14,8 @@ import { identifyPageType } from './identify-page-type.js';
 import { safeFilename } from './safe-filename.js';
 import { sanitizeMarkdown } from './sanitize-markdown.js';
 
+const SAFE_PATH_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
 export interface NormalizationParams {
   tenantId: string;
   spaceId: string;
@@ -39,6 +41,7 @@ export interface ExistingPageInfo {
   title?: string;
   repoPath?: string;
   contentMarkdown?: string;
+  contentHash?: string;
   createdAt?: string;
 }
 
@@ -115,6 +118,7 @@ export function importGraphifyWiki(params: NormalizationParams): NormalizationRe
     existingBlockMetadata,
     sourceDocumentIds,
   } = params;
+  const safeSpaceId = safePath(spaceId, 'spaceId');
 
   const pagesCreated: WikiPageImport[] = [];
   const pagesUpdated: WikiPageImport[] = [];
@@ -135,7 +139,7 @@ export function importGraphifyWiki(params: NormalizationParams): NormalizationRe
     const pageType = identifyPageType(filename, communityLabels, godNodeLabels);
     const title = resolveTitle(fileStem, pageType, communityLabels, godNodeLabels);
     const baseSlug = safeFilename(fileStem);
-    const pageId = buildPageId(spaceId, pageType, fileStem, title, baseSlug, stableKeys);
+    const pageId = buildPageId(safeSpaceId, pageType, fileStem, title, baseSlug, stableKeys, communityLabels);
     const existingPage = existingPages.get(pageId);
     const slug = existingPage ? existingPage.slug : resolveSlug(baseSlug, runId, usedSlugs, existingPageBySlug);
     usedSlugs.add(slug);
@@ -144,8 +148,14 @@ export function importGraphifyWiki(params: NormalizationParams): NormalizationRe
       incomingCommunityPageIds.add(pageId);
     }
 
-    const repoPath = repoPathForPage(spaceId, pageType, slug);
+    const repoPath = repoPathForPage(safeSpaceId, pageType, slug);
     const sanitized = sanitizeMarkdown(rawContent);
+    const newContentHash = hashContent(sanitized);
+    if (existingPage?.contentHash === newContentHash) {
+      pagesUnchanged.push(pageId);
+      continue;
+    }
+
     const ownership = buildContentWithBlockOwnership({
       pageId,
       sanitizedContent: sanitized,
@@ -160,7 +170,7 @@ export function importGraphifyWiki(params: NormalizationParams): NormalizationRe
     const frontmatter: WikiFrontmatter = {
       page_id: pageId,
       title,
-      space_id: spaceId,
+      space_id: safeSpaceId,
       page_type: pageType,
       status: normalizeStatus(existingPage?.status),
       curation_status: ownership.blockMetadata.some(block => block.owner === 'human') ? 'mixed' : 'auto_generated',
@@ -188,7 +198,7 @@ export function importGraphifyWiki(params: NormalizationParams): NormalizationRe
       frontmatter: frontmatter as unknown as Record<string, unknown>,
       versionNo,
       source: 'graphify',
-      sections: extractSections(ownership.finalContent, pageId),
+      sections: extractSections(fullContent, pageId),
       blockMetadata: ownership.blockMetadata,
     };
 
@@ -320,13 +330,14 @@ function buildPageId(
   title: string,
   baseSlug: string,
   stableKeys: Map<string, string>,
+  communityLabels: string[],
 ): string {
   if (pageType === 'index') {
     return generatePageId(spaceId, 'index', 'root');
   }
 
   if (pageType === 'community') {
-    return generatePageId(spaceId, 'community', communityKey(fileStem));
+    return generatePageId(spaceId, 'community', communityKey(fileStem, communityLabels));
   }
 
   if (pageType === 'god_node') {
@@ -425,13 +436,15 @@ function repoPathForPage(spaceId: string, pageType: WikiPageType, slug: string):
     return `spaces/${spaceId}/index.md`;
   }
 
+  const safeSlug = safeSlugPathSegment(slug);
+
   const typeDir: Record<Exclude<WikiPageType, 'index'>, string> = {
     community: 'communities',
     god_node: 'god-nodes',
     generated_article: 'pages',
   };
 
-  return `spaces/${spaceId}/${typeDir[pageType]}/${slug}.md`;
+  return `spaces/${spaceId}/${typeDir[pageType]}/${safeSlug}.md`;
 }
 
 function parseReportStats(markdown: string): Record<string, unknown> {
@@ -512,8 +525,13 @@ function normalizeStatus(status: string | undefined): WikiFrontmatter['status'] 
   return 'draft';
 }
 
-function communityKey(fileStem: string): string {
-  return fileStem.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'community';
+function communityKey(fileStem: string, communityLabels: string[]): string {
+  const matchingLabel =
+    communityLabels.find(label => safeFilename(label) === fileStem) ??
+    communityLabels.find(label => labelMatchesStem(label, fileStem));
+  const keySource = matchingLabel ?? fileStem;
+
+  return keySource.toLowerCase().replace(/[^a-z0-9]/g, '_') || 'community';
 }
 
 function normalizeForComparison(value: string): string {
@@ -526,6 +544,22 @@ function stripFrontmatter(markdown: string): string {
 
 function basename(path: string): string {
   return path.split('/').pop() ?? path;
+}
+
+function safePath(value: string, name: string): string {
+  if (!SAFE_PATH_RE.test(value)) {
+    throw new Error(`Invalid ${name} for path: ${value}`);
+  }
+
+  return value;
+}
+
+function safeSlugPathSegment(slug: string): string {
+  if (slug.includes('/') || slug.includes('\\') || slug === '.' || slug === '..') {
+    throw new Error(`Invalid slug for path: ${slug}`);
+  }
+
+  return slug;
 }
 
 function hashContent(content: string): string {

--- a/packages/wiki-core/src/normalization/import-graphify-wiki.ts
+++ b/packages/wiki-core/src/normalization/import-graphify-wiki.ts
@@ -1,0 +1,538 @@
+import { createHash } from 'node:crypto';
+
+import { generateFrontmatter } from '../frontmatter.js';
+import { generatePageId, type WikiPageType } from '../page-id.js';
+import { extractSections } from '../sections.js';
+import type { WikiFrontmatter, WikiSection } from '../types.js';
+import {
+  extractH2Blocks,
+  extractMarkedBlocks,
+  wrapGraphifyBlock,
+  wrapHumanBlock,
+} from './block-markers.js';
+import { identifyPageType } from './identify-page-type.js';
+import { safeFilename } from './safe-filename.js';
+import { sanitizeMarkdown } from './sanitize-markdown.js';
+
+export interface NormalizationParams {
+  tenantId: string;
+  spaceId: string;
+  spaceSlug: string;
+  runId: string;
+  communityLabels: string[];
+  godNodeLabels: string[];
+  stableKeys: Map<string, string>;
+  wikiFiles: Map<string, string>;
+  reportMarkdown: string;
+  existingPages: Map<string, ExistingPageInfo>;
+  existingBlockMetadata: Map<string, BlockMetadataInfo[]>;
+  sourceDocumentIds: string[];
+  now?: Date | string;
+}
+
+export interface ExistingPageInfo {
+  pageId: string;
+  slug: string;
+  currentVersionNo: number;
+  status: string;
+  pageType?: WikiPageType;
+  title?: string;
+  repoPath?: string;
+  contentMarkdown?: string;
+  createdAt?: string;
+}
+
+export interface BlockMetadataInfo {
+  blockId: string;
+  owner: 'graphify' | 'human';
+  contentHash: string;
+  editable?: boolean;
+  contentMarkdown?: string;
+}
+
+export interface WikiPageImport {
+  pageId: string;
+  title: string;
+  slug: string;
+  pageType: WikiPageType;
+  repoPath: string;
+  contentMarkdown: string;
+  frontmatter: Record<string, unknown>;
+  versionNo: number;
+  source: 'graphify';
+  sections: WikiSection[];
+  blockMetadata: Array<{ blockId: string; owner: 'graphify' | 'human'; contentHash: string; editable: boolean }>;
+}
+
+export interface ProposalInfo {
+  pageId: string;
+  blockId: string;
+  proposalType: 'graphify_suggestion';
+  diffJson: { humanContent: string; graphifyContent: string };
+}
+
+export interface IndexUpdateManifest {
+  pagesAdded: string[];
+  pagesUpdated: string[];
+  pagesArchived: string[];
+  graphNodesChanged: number;
+  graphEdgesChanged: number;
+}
+
+export interface GitCommitInfo {
+  author: string;
+  email: string;
+  message: string;
+}
+
+export interface NormalizationResult {
+  pagesCreated: WikiPageImport[];
+  pagesUpdated: WikiPageImport[];
+  pagesUnchanged: string[];
+  proposalsCreated: ProposalInfo[];
+  graphReport: { reportMarkdown: string; statsJson: Record<string, unknown> } | null;
+  indexUpdateManifest: IndexUpdateManifest;
+  gitCommits: GitCommitInfo[];
+}
+
+interface ContentOwnershipResult {
+  finalContent: string;
+  blockMetadata: WikiPageImport['blockMetadata'];
+  proposalsCreated: ProposalInfo[];
+}
+
+export function importGraphifyWiki(params: NormalizationParams): NormalizationResult {
+  const {
+    spaceId,
+    spaceSlug,
+    runId,
+    communityLabels,
+    godNodeLabels,
+    stableKeys,
+    wikiFiles,
+    reportMarkdown,
+    existingPages,
+    existingBlockMetadata,
+    sourceDocumentIds,
+  } = params;
+
+  const pagesCreated: WikiPageImport[] = [];
+  const pagesUpdated: WikiPageImport[] = [];
+  const pagesUnchanged: string[] = [];
+  const proposalsCreated: ProposalInfo[] = [];
+  const usedSlugs = new Set<string>(Array.from(existingPages.values()).map(page => page.slug));
+  const existingPageBySlug = new Map(Array.from(existingPages.values()).map(page => [page.slug, page]));
+  const incomingCommunityPageIds = new Set<string>();
+  const now = params.now instanceof Date ? params.now.toISOString() : (params.now ?? new Date().toISOString());
+
+  for (const [inputFilename, rawContent] of wikiFiles) {
+    const filename = basename(inputFilename);
+    if (filename === 'GRAPH_REPORT.md') {
+      continue;
+    }
+
+    const fileStem = filename.replace(/\.md$/i, '');
+    const pageType = identifyPageType(filename, communityLabels, godNodeLabels);
+    const title = resolveTitle(fileStem, pageType, communityLabels, godNodeLabels);
+    const baseSlug = safeFilename(fileStem);
+    const pageId = buildPageId(spaceId, pageType, fileStem, title, baseSlug, stableKeys);
+    const existingPage = existingPages.get(pageId);
+    const slug = existingPage ? existingPage.slug : resolveSlug(baseSlug, runId, usedSlugs, existingPageBySlug);
+    usedSlugs.add(slug);
+
+    if (pageType === 'community') {
+      incomingCommunityPageIds.add(pageId);
+    }
+
+    const repoPath = repoPathForPage(spaceId, pageType, slug);
+    const sanitized = sanitizeMarkdown(rawContent);
+    const ownership = buildContentWithBlockOwnership({
+      pageId,
+      sanitizedContent: sanitized,
+      runId,
+      existingPage,
+      existingBlocks: existingBlockMetadata.get(pageId) ?? [],
+    });
+
+    proposalsCreated.push(...ownership.proposalsCreated);
+
+    const versionNo = existingPage ? existingPage.currentVersionNo + 1 : 1;
+    const frontmatter: WikiFrontmatter = {
+      page_id: pageId,
+      title,
+      space_id: spaceId,
+      page_type: pageType,
+      status: normalizeStatus(existingPage?.status),
+      curation_status: ownership.blockMetadata.some(block => block.owner === 'human') ? 'mixed' : 'auto_generated',
+      source: 'graphify',
+      graphify_run_id: runId,
+      graphify_schema_version: 'v1',
+      managed_by: 'graphify',
+      source_document_ids: sourceDocumentIds,
+      graph_node_ids: [],
+      version: versionNo,
+      acl_hash: '',
+      created_by: 'graphify',
+      created_at: existingPage?.createdAt ?? now,
+      updated_at: now,
+    };
+
+    const fullContent = generateFrontmatter(frontmatter, ownership.finalContent);
+    const pageImport: WikiPageImport = {
+      pageId,
+      title,
+      slug,
+      pageType,
+      repoPath,
+      contentMarkdown: fullContent,
+      frontmatter: frontmatter as unknown as Record<string, unknown>,
+      versionNo,
+      source: 'graphify',
+      sections: extractSections(ownership.finalContent, pageId),
+      blockMetadata: ownership.blockMetadata,
+    };
+
+    if (existingPage) {
+      pagesUpdated.push(pageImport);
+    } else {
+      pagesCreated.push(pageImport);
+    }
+  }
+
+  const pagesArchived = computeArchivedCommunityPages(existingPages, incomingCommunityPageIds);
+  const graphReport = reportMarkdown
+    ? {
+        reportMarkdown,
+        statsJson: parseReportStats(reportMarkdown),
+      }
+    : null;
+
+  const gitCommits: GitCommitInfo[] = [
+    {
+      author: 'graphify',
+      email: 'graphify@cherrygraph.local',
+      message: buildCommitMessage(spaceSlug, runId, pagesCreated, pagesUpdated),
+    },
+  ];
+
+  return {
+    pagesCreated,
+    pagesUpdated,
+    pagesUnchanged,
+    proposalsCreated,
+    graphReport,
+    indexUpdateManifest: {
+      pagesAdded: pagesCreated.map(page => page.pageId),
+      pagesUpdated: pagesUpdated.map(page => page.pageId),
+      pagesArchived,
+      graphNodesChanged: readNumericStat(graphReport?.statsJson, 'node_count'),
+      graphEdgesChanged: readNumericStat(graphReport?.statsJson, 'edge_count'),
+    },
+    gitCommits,
+  };
+}
+
+function buildContentWithBlockOwnership(args: {
+  pageId: string;
+  sanitizedContent: string;
+  runId: string;
+  existingPage: ExistingPageInfo | undefined;
+  existingBlocks: BlockMetadataInfo[];
+}): ContentOwnershipResult {
+  const h2Blocks = extractH2Blocks(args.sanitizedContent);
+  if (h2Blocks.length === 0) {
+    return {
+      finalContent: args.sanitizedContent,
+      blockMetadata: [],
+      proposalsCreated: [],
+    };
+  }
+
+  const humanBlocks = new Map(args.existingBlocks.filter(block => block.owner === 'human').map(block => [block.blockId, block]));
+  const existingContentByBlock = getExistingContentByBlock(args.existingPage);
+  const blockMetadata: ContentOwnershipResult['blockMetadata'] = [];
+  const proposalsCreated: ProposalInfo[] = [];
+  let finalContent = args.sanitizedContent.slice(0, h2Blocks[0]?.start ?? 0);
+
+  for (const block of h2Blocks) {
+    const humanBlock = humanBlocks.get(block.blockId);
+
+    if (humanBlock) {
+      const preservedContent =
+        humanBlock.contentMarkdown ?? existingContentByBlock.get(block.blockId) ?? block.content;
+      const graphifyHash = hashContent(block.content);
+
+      if (graphifyHash !== humanBlock.contentHash) {
+        proposalsCreated.push({
+          pageId: args.pageId,
+          blockId: block.blockId,
+          proposalType: 'graphify_suggestion',
+          diffJson: {
+            humanContent: preservedContent,
+            graphifyContent: block.content,
+          },
+        });
+      }
+
+      finalContent += wrapHumanBlock(preservedContent, block.blockId, args.runId);
+      blockMetadata.push({
+        blockId: block.blockId,
+        owner: 'human',
+        contentHash: humanBlock.contentHash || hashContent(preservedContent),
+        editable: true,
+      });
+    } else {
+      finalContent += wrapGraphifyBlock(block.content, block.blockId, args.runId);
+      blockMetadata.push({
+        blockId: block.blockId,
+        owner: 'graphify',
+        contentHash: hashContent(block.content),
+        editable: false,
+      });
+    }
+  }
+
+  return {
+    finalContent: finalContent.trimEnd(),
+    blockMetadata,
+    proposalsCreated,
+  };
+}
+
+function getExistingContentByBlock(existingPage: ExistingPageInfo | undefined): Map<string, string> {
+  if (!existingPage?.contentMarkdown) {
+    return new Map();
+  }
+
+  const body = stripFrontmatter(existingPage.contentMarkdown);
+  const markedBlocks = extractMarkedBlocks(body);
+  if (markedBlocks.size > 0) {
+    return markedBlocks;
+  }
+
+  return new Map(extractH2Blocks(body).map(block => [block.blockId, block.content]));
+}
+
+function buildPageId(
+  spaceId: string,
+  pageType: WikiPageType,
+  fileStem: string,
+  title: string,
+  baseSlug: string,
+  stableKeys: Map<string, string>,
+): string {
+  if (pageType === 'index') {
+    return generatePageId(spaceId, 'index', 'root');
+  }
+
+  if (pageType === 'community') {
+    return generatePageId(spaceId, 'community', communityKey(fileStem));
+  }
+
+  if (pageType === 'god_node') {
+    const stableKey = lookupStableKey(stableKeys, title, fileStem) ?? hashContent(title).slice(0, 16);
+    return generatePageId(spaceId, 'god_node', stableKey.slice(0, 12));
+  }
+
+  return generatePageId(spaceId, 'generated_article', hashContent(baseSlug).slice(0, 12));
+}
+
+function resolveTitle(fileStem: string, pageType: WikiPageType, communityLabels: string[], godNodeLabels: string[]): string {
+  const labels = pageType === 'community' ? communityLabels : pageType === 'god_node' ? godNodeLabels : [];
+  const matchedLabel = labels.find(label => labelMatchesStem(label, fileStem));
+
+  if (matchedLabel) {
+    return matchedLabel;
+  }
+
+  if (fileStem === 'index') {
+    return 'Wiki Index';
+  }
+
+  return fileStem.replace(/[_-]+/g, ' ').trim() || fileStem;
+}
+
+function labelMatchesStem(label: string, fileStem: string): boolean {
+  const variants = new Set([safeFilename(label), normalizeForComparison(safeFilename(label))]);
+  return variants.has(fileStem) || variants.has(normalizeForComparison(fileStem));
+}
+
+function lookupStableKey(stableKeys: Map<string, string>, title: string, fileStem: string): string | undefined {
+  const candidates = [
+    title,
+    fileStem,
+    safeFilename(title),
+    normalizeForComparison(title),
+    normalizeForComparison(fileStem),
+    title.toLowerCase(),
+    fileStem.toLowerCase(),
+  ];
+
+  for (const candidate of candidates) {
+    const stableKey = stableKeys.get(candidate);
+    if (stableKey) {
+      return stableKey;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveSlug(
+  baseSlug: string,
+  runId: string,
+  usedSlugs: Set<string>,
+  existingPageBySlug: Map<string, ExistingPageInfo>,
+): string {
+  if (!usedSlugs.has(baseSlug)) {
+    return baseSlug;
+  }
+
+  if (existingPageBySlug.has(baseSlug)) {
+    return makeGraphifyCollisionSlug(baseSlug, runId, usedSlugs);
+  }
+
+  return makeDedupedSlug(baseSlug, usedSlugs);
+}
+
+function makeGraphifyCollisionSlug(baseSlug: string, runId: string, usedSlugs: Set<string>): string {
+  const suffix = `_gf_${runId.slice(0, 8)}`;
+  let candidate = `${baseSlug}${suffix}`;
+  let index = 2;
+
+  while (usedSlugs.has(candidate)) {
+    candidate = `${baseSlug}${suffix}_${index}`;
+    index += 1;
+  }
+
+  return candidate;
+}
+
+function makeDedupedSlug(baseSlug: string, usedSlugs: Set<string>): string {
+  let index = 2;
+  let candidate = `${baseSlug}_${index}`;
+
+  while (usedSlugs.has(candidate)) {
+    index += 1;
+    candidate = `${baseSlug}_${index}`;
+  }
+
+  return candidate;
+}
+
+function repoPathForPage(spaceId: string, pageType: WikiPageType, slug: string): string {
+  if (pageType === 'index') {
+    return `spaces/${spaceId}/index.md`;
+  }
+
+  const typeDir: Record<Exclude<WikiPageType, 'index'>, string> = {
+    community: 'communities',
+    god_node: 'god-nodes',
+    generated_article: 'pages',
+  };
+
+  return `spaces/${spaceId}/${typeDir[pageType]}/${slug}.md`;
+}
+
+function parseReportStats(markdown: string): Record<string, unknown> {
+  const stats: Record<string, unknown> = {};
+  const nodeCount = findCount(markdown, ['nodes?', '实体']);
+  const edgeCount = findCount(markdown, ['edges?', '关系']);
+  const pageCount = findCount(markdown, ['pages?', '页面']);
+
+  if (nodeCount !== null) {
+    stats.node_count = nodeCount;
+  }
+  if (edgeCount !== null) {
+    stats.edge_count = edgeCount;
+  }
+  if (pageCount !== null) {
+    stats.wiki_page_count = pageCount;
+  }
+
+  return stats;
+}
+
+function findCount(markdown: string, labels: string[]): number | null {
+  for (const label of labels) {
+    const labelThenNumber = new RegExp(`${label}[^0-9]*(\\d+)`, 'i');
+    const numberThenLabel = new RegExp(`(\\d+)\\s*${label}`, 'i');
+    const labelMatch = markdown.match(labelThenNumber);
+    const numberMatch = markdown.match(numberThenLabel);
+    const rawValue = labelMatch?.[1] ?? numberMatch?.[1];
+
+    if (rawValue) {
+      return Number.parseInt(rawValue, 10);
+    }
+  }
+
+  return null;
+}
+
+function buildCommitMessage(
+  spaceSlug: string,
+  runId: string,
+  pagesCreated: WikiPageImport[],
+  pagesUpdated: WikiPageImport[],
+): string {
+  const parts: string[] = [];
+
+  if (pagesCreated.length > 0) {
+    parts.push(`add ${pagesCreated.length} page${pagesCreated.length === 1 ? '' : 's'}`);
+  }
+  if (pagesUpdated.length > 0) {
+    parts.push(`update ${pagesUpdated.length} page${pagesUpdated.length === 1 ? '' : 's'}`);
+  }
+
+  const slugs = [...pagesCreated, ...pagesUpdated].map(page => page.slug).join(', ');
+  const summary = parts.length > 0 ? `${parts.join(', ')}: ${slugs}` : 'no changes';
+
+  return `[${spaceSlug}][graphify][${runId}] ${summary}`;
+}
+
+function computeArchivedCommunityPages(
+  existingPages: Map<string, ExistingPageInfo>,
+  incomingCommunityPageIds: Set<string>,
+): string[] {
+  return Array.from(existingPages.values())
+    .filter(page => isCommunityPage(page))
+    .filter(page => !incomingCommunityPageIds.has(page.pageId))
+    .map(page => page.pageId);
+}
+
+function isCommunityPage(page: ExistingPageInfo): boolean {
+  return page.pageType === 'community' || page.pageId.includes('.community.');
+}
+
+function normalizeStatus(status: string | undefined): WikiFrontmatter['status'] {
+  if (status === 'published' || status === 'archived') {
+    return status;
+  }
+
+  return 'draft';
+}
+
+function communityKey(fileStem: string): string {
+  return fileStem.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'community';
+}
+
+function normalizeForComparison(value: string): string {
+  return value.toLowerCase().replace(/[_\s-]+/g, '-');
+}
+
+function stripFrontmatter(markdown: string): string {
+  return markdown.replace(/^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/, '');
+}
+
+function basename(path: string): string {
+  return path.split('/').pop() ?? path;
+}
+
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function readNumericStat(stats: Record<string, unknown> | undefined, key: string): number {
+  const value = stats?.[key];
+  return typeof value === 'number' ? value : 0;
+}

--- a/packages/wiki-core/src/normalization/safe-filename.ts
+++ b/packages/wiki-core/src/normalization/safe-filename.ts
@@ -1,0 +1,16 @@
+export function safeFilename(label: string): string {
+  return label.replace(/\//g, '-').replace(/ /g, '_').replace(/:/g, '-');
+}
+
+export function uniqueSlug(slug: string, existingSlugs: Set<string>): string {
+  if (!existingSlugs.has(slug)) {
+    return slug;
+  }
+
+  let index = 2;
+  while (existingSlugs.has(`${slug}_${index}`)) {
+    index += 1;
+  }
+
+  return `${slug}_${index}`;
+}

--- a/packages/wiki-core/src/normalization/sanitize-markdown.ts
+++ b/packages/wiki-core/src/normalization/sanitize-markdown.ts
@@ -1,21 +1,30 @@
 const graphifyCommentPlaceholder = '__GRAPHIFY_COMMENT_PLACEHOLDER__';
 const allowedImageDomains = new Set(['assets.cherrygraph.local']);
+const dangerousOpenTagPattern = /<(script|iframe|object|embed)\b[^>]{0,2048}>/gi;
+const maxDangerousBlockContentLength = 10000;
+const maxClosingTagLength = 128;
 
 export function sanitizeMarkdown(content: string): string {
-  let result = content.replace(/<(script|iframe|object|embed)\b[^>]*>[\s\S]*?<\/\1>/gi, '');
-  result = result.replace(/<(script|iframe|object|embed)\b[^>]*\/?>/gi, '');
+  let result = stripDangerousHtmlBlocks(content);
+  result = result.replace(/<(script|iframe|object|embed)\b[^>]{0,2048}\/?>/gi, '');
 
   const graphifyComments: string[] = [];
-  result = result.replace(/<!--\s*graphify:[\s\S]*?-->/gi, match => {
+  result = result.replace(/<!--\s*graphify:[\s\S]{0,10000}?-->/gi, match => {
     const index = graphifyComments.push(match) - 1;
     return `${graphifyCommentPlaceholder}${index}__`;
   });
 
-  result = result.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
-  result = result.replace(/\s+(?:src|href)\s*=\s*(?:"data:[^"]*"|'data:[^']*'|data:[^\s>]+)/gi, '');
-  result = result.replace(/\s+(?:src|href)\s*=\s*(?:"javascript:[^"]*"|'javascript:[^']*'|javascript:[^\s>]+)/gi, '');
-  result = result.replace(/<!--[\s\S]*?-->/g, '');
-  result = result.replace(/<(?!!--)[^>]+>/g, '');
+  result = result.replace(/\s+on[a-z][\w:-]{0,63}\s*=\s*(?:"[^"\r\n]{0,2048}"|'[^'\r\n]{0,2048}'|[^\s>"']{1,2048})/gi, '');
+  result = result.replace(
+    /\s+(?:src|href)\s*=\s*(?:"\s*data:[^"\r\n]{0,4096}"|'\s*data:[^'\r\n]{0,4096}'|\s*data:[^\s>]{0,4096})/gi,
+    '',
+  );
+  result = result.replace(
+    /\s+(?:src|href)\s*=\s*(?:"\s*javascript:[^"\r\n]{0,4096}"|'\s*javascript:[^'\r\n]{0,4096}'|\s*javascript:[^\s>]{0,4096})/gi,
+    '',
+  );
+  result = result.replace(/<!--[\s\S]{0,10000}?-->/g, '');
+  result = result.replace(/<\/?[A-Za-z][A-Za-z0-9:-]*(?:\s+[^>]{0,2048})?\s*\/?>/g, '');
 
   result = sanitizeMarkdownUris(result);
 
@@ -26,12 +35,56 @@ export function sanitizeMarkdown(content: string): string {
   return result;
 }
 
+function stripDangerousHtmlBlocks(content: string): string {
+  let result = '';
+  let cursor = 0;
+  dangerousOpenTagPattern.lastIndex = 0;
+
+  for (let match = dangerousOpenTagPattern.exec(content); match; match = dangerousOpenTagPattern.exec(content)) {
+    const tagName = (match[1] ?? '').toLowerCase();
+    const openStart = match.index;
+    const openEnd = dangerousOpenTagPattern.lastIndex;
+    const closeEnd = findDangerousClosingTagEnd(content, tagName, openEnd);
+
+    result += content.slice(cursor, openStart);
+    if (closeEnd === -1) {
+      cursor = openEnd;
+    } else {
+      cursor = closeEnd;
+      dangerousOpenTagPattern.lastIndex = closeEnd;
+    }
+  }
+
+  return result + content.slice(cursor);
+}
+
+function findDangerousClosingTagEnd(content: string, tagName: string, fromIndex: number): number {
+  const searchEnd = Math.min(
+    content.length,
+    fromIndex + maxDangerousBlockContentLength + maxClosingTagLength,
+  );
+  const searchWindow = content.slice(fromIndex, searchEnd).toLowerCase();
+  const closingTagStartInWindow = searchWindow.indexOf(`</${tagName}`);
+
+  if (closingTagStartInWindow === -1 || closingTagStartInWindow > maxDangerousBlockContentLength) {
+    return -1;
+  }
+
+  const closingTagStart = fromIndex + closingTagStartInWindow;
+  const closingTagEnd = content.indexOf('>', closingTagStart);
+  if (closingTagEnd === -1 || closingTagEnd - closingTagStart > maxClosingTagLength) {
+    return -1;
+  }
+
+  return closingTagEnd + 1;
+}
+
 function sanitizeMarkdownUris(content: string): string {
-  let result = content.replace(/!\[([^\]]*)\]\(\s*(?:data|javascript):[^\n]*\)/gi, (_match, alt: string) => alt);
+  let result = content.replace(/!\[([^\]\r\n]{0,2048})\]\(\s*(?:data|javascript):[^\r\n]{0,4096}\)/gi, (_match, alt: string) => alt);
 
-  result = result.replace(/\[([^\]]+)\]\(\s*(?:data|javascript):[^\n]*\)/gi, (_match, text: string) => text);
+  result = result.replace(/\[([^\]\r\n]{1,2048})\]\(\s*(?:data|javascript):[^\r\n]{0,4096}\)/gi, (_match, text: string) => text);
 
-  result = result.replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, (match, alt: string, rawUrl: string) => {
+  result = result.replace(/!\[([^\]\r\n]{0,2048})\]\(([^)\s\r\n]{1,2048})(?:\s+"[^"\r\n]{0,1024}")?\)/g, (match, alt: string, rawUrl: string) => {
     if (isAllowedImageUrl(rawUrl)) {
       return match;
     }
@@ -39,7 +92,7 @@ function sanitizeMarkdownUris(content: string): string {
     return alt ? alt : '';
   });
 
-  result = result.replace(/\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, (match, text: string, rawUrl: string) => {
+  result = result.replace(/\[([^\]\r\n]{1,2048})\]\(([^)\s\r\n]{1,2048})(?:\s+"[^"\r\n]{0,1024}")?\)/g, (match, text: string, rawUrl: string) => {
     if (isUnsafeUri(rawUrl)) {
       return text;
     }

--- a/packages/wiki-core/src/normalization/sanitize-markdown.ts
+++ b/packages/wiki-core/src/normalization/sanitize-markdown.ts
@@ -1,0 +1,73 @@
+const graphifyCommentPlaceholder = '__GRAPHIFY_COMMENT_PLACEHOLDER__';
+const allowedImageDomains = new Set(['assets.cherrygraph.local']);
+
+export function sanitizeMarkdown(content: string): string {
+  let result = content.replace(/<(script|iframe|object|embed)\b[^>]*>[\s\S]*?<\/\1>/gi, '');
+  result = result.replace(/<(script|iframe|object|embed)\b[^>]*\/?>/gi, '');
+
+  const graphifyComments: string[] = [];
+  result = result.replace(/<!--\s*graphify:[\s\S]*?-->/gi, match => {
+    const index = graphifyComments.push(match) - 1;
+    return `${graphifyCommentPlaceholder}${index}__`;
+  });
+
+  result = result.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+  result = result.replace(/\s+(?:src|href)\s*=\s*(?:"data:[^"]*"|'data:[^']*'|data:[^\s>]+)/gi, '');
+  result = result.replace(/\s+(?:src|href)\s*=\s*(?:"javascript:[^"]*"|'javascript:[^']*'|javascript:[^\s>]+)/gi, '');
+  result = result.replace(/<!--[\s\S]*?-->/g, '');
+  result = result.replace(/<(?!!--)[^>]+>/g, '');
+
+  result = sanitizeMarkdownUris(result);
+
+  for (let index = 0; index < graphifyComments.length; index += 1) {
+    result = result.replace(`${graphifyCommentPlaceholder}${index}__`, graphifyComments[index] ?? '');
+  }
+
+  return result;
+}
+
+function sanitizeMarkdownUris(content: string): string {
+  let result = content.replace(/!\[([^\]]*)\]\(\s*(?:data|javascript):[^\n]*\)/gi, (_match, alt: string) => alt);
+
+  result = result.replace(/\[([^\]]+)\]\(\s*(?:data|javascript):[^\n]*\)/gi, (_match, text: string) => text);
+
+  result = result.replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, (match, alt: string, rawUrl: string) => {
+    if (isAllowedImageUrl(rawUrl)) {
+      return match;
+    }
+
+    return alt ? alt : '';
+  });
+
+  result = result.replace(/\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, (match, text: string, rawUrl: string) => {
+    if (isUnsafeUri(rawUrl)) {
+      return text;
+    }
+
+    return match;
+  });
+
+  return result;
+}
+
+function isAllowedImageUrl(rawUrl: string): boolean {
+  if (rawUrl.startsWith('_attachments/') || rawUrl.startsWith('./_attachments/')) {
+    return true;
+  }
+
+  if (isUnsafeUri(rawUrl)) {
+    return false;
+  }
+
+  try {
+    const url = new URL(rawUrl);
+    return (url.protocol === 'https:' || url.protocol === 'http:') && allowedImageDomains.has(url.hostname);
+  } catch {
+    return !/^[a-z][a-z0-9+.-]*:/i.test(rawUrl);
+  }
+}
+
+function isUnsafeUri(rawUrl: string): boolean {
+  const normalized = rawUrl.trim().toLowerCase();
+  return normalized.startsWith('data:') || normalized.startsWith('javascript:');
+}


### PR DESCRIPTION
## Summary

- Add normalization sub-module for converting Graphify flat wiki/ output to Canonical Wiki Repo structure
- Implement identifyPageType, safeFilename, uniqueSlug, sanitizeMarkdown (Doc 12 §6.3)
- Section-level block ownership markers (graphify:managed/human:curated) per Doc 21 §9.7
- importGraphifyWiki main orchestrator with conflict detection, frontmatter generation (17 fields), proposal creation
- Content hash comparison for pagesUnchanged detection, spaceId path validation

## Test plan

- [x] npm run build passes
- [x] npm test — 587 tests passing (102 test files)
- [x] Unit tests: safe-filename, identify-page-type, sanitize-markdown, block-markers
- [x] Integration test: fixture import with correct types/paths/frontmatter/block metadata
- [x] Human block preservation + proposal creation, unchanged detection tests

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `d8ffa9907bc87d238c55e3c5cd956cae85bab82f`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/95#issuecomment-4363539697) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/95#issuecomment-4363539738) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/95#issuecomment-4363539795) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/95#issuecomment-4363539832)
- Key findings addressed: community page_id derivation, pagesUnchanged detection, section offset alignment, spaceId path validation, sanitizer ReDoS hardening

Closes #87