### PR TITLE
feat(web): add Graphify Admin UI with runs management (#89)

### DIFF
--- a/apps/api/src/graphify/__tests__/graphify.controller.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.controller.test.ts
@@ -233,6 +233,8 @@ function createRunResponse(
       graph_json_uri: null,
       report_uri: null,
     },
+    stats_json: {},
+    error_json: null,
     created_at: new Date('2026-05-01T00:00:00.000Z'),
     started_at: null,
     completed_at: null,

--- a/apps/api/src/graphify/graphify.service.ts
+++ b/apps/api/src/graphify/graphify.service.ts
@@ -100,6 +100,8 @@ export type GraphifyRunResponse = {
     graph_json_uri: string | null;
     report_uri: string | null;
   };
+  stats_json: unknown;
+  error_json: unknown;
   created_at: Date;
   started_at: Date | null;
   completed_at: Date | null;
@@ -844,6 +846,8 @@ function toGraphifyRunResponse(run: GraphifyRunRow): GraphifyRunResponse {
       graph_json_uri: run.graph_json_uri,
       report_uri: run.report_uri,
     },
+    stats_json: run.stats_json,
+    error_json: run.error_json,
     created_at: run.created_at,
     started_at: run.started_at,
     completed_at: run.completed_at,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,11 +11,14 @@ import ModelsPage from './pages/admin/ModelsPage';
 import SpacesPage from './pages/admin/SpacesPage';
 import UsersPage from './pages/admin/UsersPage';
 import Chat from './pages/Chat';
+import GraphifyRunDetailPage from './pages/GraphifyRunDetailPage';
+import GraphifyRunsPage from './pages/GraphifyRunsPage';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import NotFound from './pages/NotFound';
 import Wiki from './pages/Wiki';
 import UploadCenter from './pages/uploads/UploadCenter';
+import GraphifyPage from './pages/admin/GraphifyPage';
 
 export function AppRoutes() {
   return (
@@ -27,6 +30,8 @@ export function AppRoutes() {
       <Route path="/spaces/:spaceId/wiki" element={<Wiki />} />
       <Route path="/spaces/:spaceId/wiki/:pageId" element={<Wiki />} />
       <Route path="/spaces/:spaceId/wiki/:pageId/history" element={<Wiki />} />
+      <Route path="/spaces/:spaceId/graphify" element={<GraphifyRunsPage />} />
+      <Route path="/spaces/:spaceId/graphify/:runId" element={<GraphifyRunDetailPage />} />
       <Route path="/spaces/:spaceId/uploads" element={<UploadCenter />} />
       <Route
         path="/admin"
@@ -45,6 +50,7 @@ export function AppRoutes() {
         <Route path="health" element={<HealthPage />} />
         <Route path="jobs" element={<JobsPage />} />
         <Route path="jobs/:jobId" element={<JobDetailPage />} />
+        <Route path="graphify" element={<GraphifyPage />} />
       </Route>
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -98,16 +98,19 @@ describe('GraphifyRunsPage', () => {
 describe('GraphifyRunDetailPage', () => {
   it('shows cancel and retry buttons only for matching statuses', async () => {
     await renderDetailStatus('running');
-    expect(screen.getByRole('button', { name: 'Cancel Run' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Cancel Run' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Retry Run' })).not.toBeInTheDocument();
     cleanup();
 
     await renderDetailStatus('failed');
-    expect(screen.getByRole('button', { name: 'Retry Run' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Retry Run' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Cancel Run' })).not.toBeInTheDocument();
     cleanup();
 
     await renderDetailStatus('succeeded');
+    await waitFor(() => {
+      expect(screen.queryByText('Loading graphify run details...')).not.toBeInTheDocument();
+    });
     expect(screen.queryByRole('button', { name: 'Cancel Run' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Retry Run' })).not.toBeInTheDocument();
   });

--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GraphifyRun } from '../lib/graphifyApi.js';
+import GraphifyRunDetailPage from '../pages/GraphifyRunDetailPage.js';
+import GraphifyRunsPage from '../pages/GraphifyRunsPage.js';
+
+type GetWrappedMock = (path: string, query?: Record<string, unknown>) => Promise<unknown>;
+type PostMock = (path: string, body?: unknown) => Promise<unknown>;
+
+const apiMocks = vi.hoisted(() => ({
+  getWrapped: vi.fn<GetWrappedMock>(),
+  post: vi.fn<PostMock>(),
+}));
+
+vi.mock('../lib/api.js', () => {
+  class ApiError extends Error {
+    readonly status: number;
+    readonly code: string;
+    readonly details: unknown;
+
+    constructor(input: { status: number; code: string; message: string; details?: unknown }) {
+      super(input.message);
+      this.name = 'ApiError';
+      this.status = input.status;
+      this.code = input.code;
+      this.details = input.details;
+    }
+  }
+
+  return {
+    ApiError,
+    api: {
+      getWrapped: apiMocks.getWrapped,
+      post: apiMocks.post,
+    },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('GraphifyRunsPage', () => {
+  it('renders run status badges and quarantine warnings', async () => {
+    apiMocks.getWrapped.mockResolvedValue({
+      data: [
+        buildRun({ run_id: 'run-pending', status: 'pending' }),
+        buildRun({ run_id: 'run-running', status: 'running' }),
+        buildRun({ run_id: 'run-succeeded', status: 'succeeded' }),
+        buildRun({
+          run_id: 'run-failed',
+          status: 'failed',
+          error_json: { reason: 'quarantined', quarantine_type: 'schema_validation' },
+        }),
+        buildRun({ run_id: 'run-cancelled', status: 'cancelled' }),
+      ],
+      meta: { pagination: { page: 1, per_page: 20, total: 5, has_next: false } },
+    });
+
+    renderWithRouter(<GraphifyRunsPage />, '/spaces/space-1/graphify');
+
+    expect(await screen.findByRole('heading', { name: 'Graphify Runs' })).toBeInTheDocument();
+    expect(getStatusBadge('Pending')).toHaveClass('status-neutral');
+    expect(getStatusBadge('Running')).toHaveClass('status-info');
+    expect(getStatusBadge('Succeeded')).toHaveClass('status-healthy');
+    expect(getStatusBadge('Failed')).toHaveClass('status-unhealthy');
+    expect(getStatusBadge('Cancelled')).toHaveClass('status-neutral');
+    expect(screen.getByRole('img', { name: 'Quarantined' })).toBeInTheDocument();
+  });
+
+  it('submits the new run dialog payload', async () => {
+    apiMocks.getWrapped.mockResolvedValue({
+      data: [],
+      meta: { pagination: { page: 1, per_page: 20, total: 0, has_next: false } },
+    });
+    apiMocks.post.mockResolvedValue(buildRun({ run_id: 'run-new', mode: 'incremental' }));
+
+    renderWithRouter(<GraphifyRunsPage />, '/spaces/space-1/graphify');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'New Run' }));
+    fireEvent.change(screen.getByLabelText('Mode'), { target: { value: 'incremental' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Run' }));
+
+    await waitFor(() => {
+      expect(apiMocks.post).toHaveBeenCalledWith('/spaces/space-1/graphify/runs', {
+        mode: 'incremental',
+        trigger_type: 'manual',
+      });
+    });
+  });
+});
+
+describe('GraphifyRunDetailPage', () => {
+  it('shows cancel and retry buttons only for matching statuses', async () => {
+    await renderDetailStatus('running');
+    expect(screen.getByRole('button', { name: 'Cancel Run' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry Run' })).not.toBeInTheDocument();
+    cleanup();
+
+    await renderDetailStatus('failed');
+    expect(screen.getByRole('button', { name: 'Retry Run' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel Run' })).not.toBeInTheDocument();
+    cleanup();
+
+    await renderDetailStatus('succeeded');
+    expect(screen.queryByRole('button', { name: 'Cancel Run' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry Run' })).not.toBeInTheDocument();
+  });
+});
+
+async function renderDetailStatus(status: GraphifyRun['status']): Promise<void> {
+  apiMocks.getWrapped.mockImplementation((path: string) => {
+    if (path === '/graphify/runs/run-1') {
+      return Promise.resolve({
+        data: buildRun({
+          run_id: 'run-1',
+          status,
+          error_json: status === 'failed' ? { reason: 'quarantined', quarantine_type: 'shrink_guard' } : null,
+        }),
+      });
+    }
+
+    if (path === '/graphify/runs/run-1/report') {
+      return Promise.resolve({
+        data: {
+          run_id: 'run-1',
+          report_format: 'markdown',
+          content: '# Summary',
+          generated_at: '2026-05-01T10:10:00.000Z',
+        },
+      });
+    }
+
+    if (path === '/graphify/runs/run-1/graph') {
+      return Promise.resolve({
+        data: {
+          run_id: 'run-1',
+          summary: { node_count: 10, edge_count: 9, community_count: 2 },
+          top_entities: [],
+          schema_version: 'v1',
+        },
+      });
+    }
+
+    return Promise.reject(new Error('not found'));
+  });
+
+  renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-1/graphify/run-1');
+  expect(await screen.findByRole('heading', { name: 'Graphify Run Detail' })).toBeInTheDocument();
+}
+
+function renderWithRouter(element: ReactElement, path: string): void {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/spaces/:spaceId/graphify" element={element} />
+        <Route path="/spaces/:spaceId/graphify/:runId" element={element} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function buildRun(overrides: Partial<GraphifyRun> = {}): GraphifyRun {
+  return {
+    run_id: 'run-1',
+    space_id: 'space-1',
+    mode: 'full',
+    trigger_type: 'manual',
+    status: 'pending',
+    progress: { percent: 0, stage: 'pending' },
+    input_scope: {
+      page_ids: [],
+      source_document_ids: [],
+    },
+    result: {
+      nodes_created: 10,
+      nodes_updated: 0,
+      edges_created: 9,
+      wiki_pages_generated: 4,
+      schema_version: 'v1',
+      graph_json_uri: 's3://out/graph.json',
+      report_uri: 's3://out/GRAPH_REPORT.md',
+    },
+    stats_json: {
+      node_count: 10,
+      edge_count: 9,
+      wiki_page_count: 4,
+      community_count: 2,
+    },
+    error_json: null,
+    created_at: '2026-05-01T10:00:00.000Z',
+    started_at: null,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function getStatusBadge(label: string): HTMLElement {
+  const badge = screen.getAllByText(label).find((element) => element.classList.contains('status-badge'));
+  if (badge === undefined) {
+    throw new Error(`Status badge not found: ${label}`);
+  }
+
+  return badge;
+}

--- a/apps/web/src/components/AdminLayout.tsx
+++ b/apps/web/src/components/AdminLayout.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { label: 'Audit Logs', to: '/admin/audit' },
   { label: 'Task Center', to: '/admin/jobs' },
   { label: 'System Health', to: '/admin/health' },
+  { label: 'Graphify', to: '/admin/graphify' },
 ];
 
 export default function AdminLayout() {

--- a/apps/web/src/lib/graphifyApi.ts
+++ b/apps/web/src/lib/graphifyApi.ts
@@ -1,0 +1,143 @@
+import { api, type ApiWrappedResponse, type QueryParams } from './api.js';
+
+export const GRAPHIFY_RUN_STATUSES = ['pending', 'running', 'succeeded', 'failed', 'cancelled'] as const;
+export const GRAPHIFY_RUN_MODES = ['full', 'update', 'incremental'] as const;
+export const GRAPHIFY_TRIGGER_TYPES = ['manual', 'scheduled', 'auto'] as const;
+
+export type GraphifyRunStatus = (typeof GRAPHIFY_RUN_STATUSES)[number];
+export type GraphifyRunMode = (typeof GRAPHIFY_RUN_MODES)[number];
+export type GraphifyTriggerType = (typeof GRAPHIFY_TRIGGER_TYPES)[number];
+
+export type GraphifyInputScope = {
+  page_ids?: string[];
+  source_document_ids?: string[];
+};
+
+export type GraphifyOptions = {
+  wiki?: boolean;
+  no_viz?: boolean;
+  directed?: boolean;
+};
+
+export type CreateGraphifyRunParams = {
+  mode: GraphifyRunMode;
+  trigger_type: GraphifyTriggerType;
+  input_scope?: GraphifyInputScope;
+  options?: GraphifyOptions;
+};
+
+export type GraphifyRunProgress = {
+  percent: number;
+  stage: string;
+};
+
+export type GraphifyRunResult = {
+  nodes_created: number;
+  nodes_updated: number;
+  edges_created: number;
+  wiki_pages_generated: number;
+  schema_version: string;
+  graph_json_uri: string | null;
+  report_uri: string | null;
+};
+
+export type GraphifyRun = {
+  run_id: string;
+  space_id: string;
+  mode: GraphifyRunMode;
+  trigger_type: GraphifyTriggerType;
+  status: GraphifyRunStatus;
+  progress: GraphifyRunProgress | null;
+  input_scope: GraphifyInputScope;
+  result: GraphifyRunResult;
+  stats_json?: unknown;
+  error_json?: unknown;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+};
+
+export type GraphifyRunsQuery = QueryParams & {
+  space_id?: string;
+  status?: string;
+  trigger_type?: string;
+  page?: number;
+  per_page?: number;
+  sort?: string;
+};
+
+export type CancelGraphifyRunResponse = {
+  run_id: string;
+  status: string;
+};
+
+export type GraphifyReport = {
+  run_id: string;
+  report_format: string;
+  content: string;
+  generated_at: string;
+};
+
+export type GraphifySummary = {
+  run_id: string;
+  summary: {
+    node_count: number;
+    edge_count: number;
+    community_count: number;
+  };
+  top_entities: unknown[];
+  schema_version: string;
+};
+
+export type GraphifyRunListResponse = ApiWrappedResponse<GraphifyRun[]>;
+export type GraphifyRunResponse = ApiWrappedResponse<GraphifyRun>;
+export type GraphifyReportResponse = ApiWrappedResponse<GraphifyReport>;
+export type GraphifySummaryResponse = ApiWrappedResponse<GraphifySummary>;
+
+export function createGraphifyRun(spaceId: string, params: CreateGraphifyRunParams): Promise<GraphifyRun> {
+  return api.post<GraphifyRun>(`/spaces/${encodeURIComponent(spaceId)}/graphify/runs`, params);
+}
+
+export function listGraphifyRuns(query: GraphifyRunsQuery = {}): Promise<GraphifyRunListResponse> {
+  return api.getWrapped<GraphifyRun[]>('/graphify/runs', query);
+}
+
+export function getGraphifyRun(runId: string): Promise<GraphifyRunResponse> {
+  return api.getWrapped<GraphifyRun>(`/graphify/runs/${encodeURIComponent(runId)}`);
+}
+
+export function cancelGraphifyRun(runId: string): Promise<CancelGraphifyRunResponse> {
+  return api.post<CancelGraphifyRunResponse>(`/graphify/runs/${encodeURIComponent(runId)}/cancel`);
+}
+
+export function retryGraphifyRun(runId: string): Promise<GraphifyRun> {
+  return api.post<GraphifyRun>(`/graphify/runs/${encodeURIComponent(runId)}/retry`);
+}
+
+export function getGraphifyReport(runId: string): Promise<GraphifyReportResponse> {
+  return api.getWrapped<GraphifyReport>(`/graphify/runs/${encodeURIComponent(runId)}/report`);
+}
+
+export function getGraphifySummary(runId: string): Promise<GraphifySummaryResponse> {
+  return api.getWrapped<GraphifySummary>(`/graphify/runs/${encodeURIComponent(runId)}/graph`);
+}
+
+export function adminListGraphifyRuns(query: GraphifyRunsQuery = {}): Promise<GraphifyRunListResponse> {
+  return api.getWrapped<GraphifyRun[]>('/admin/graphify/runs', query);
+}
+
+export function adminRetryRun(runId: string): Promise<GraphifyRun> {
+  return api.post<GraphifyRun>(`/admin/graphify/runs/${encodeURIComponent(runId)}/retry`);
+}
+
+export const graphifyApi = {
+  createGraphifyRun,
+  listGraphifyRuns,
+  getGraphifyRun,
+  cancelGraphifyRun,
+  retryGraphifyRun,
+  getGraphifyReport,
+  getGraphifySummary,
+  adminListGraphifyRuns,
+  adminRetryRun,
+};

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  StatusBadge,
+  formatDate,
+  formatLabel,
+  getErrorMessage,
+} from '../components/adminUi.js';
+import {
+  cancelGraphifyRun,
+  getGraphifyReport,
+  getGraphifyRun,
+  getGraphifySummary,
+  retryGraphifyRun,
+  type GraphifyReport,
+  type GraphifyRun,
+  type GraphifySummary,
+} from '../lib/graphifyApi.js';
+import {
+  GraphifyStatusCell,
+  asRecord,
+  formatCount,
+  formatJson,
+  formatRunDuration,
+  getGraphifyStat,
+  getQuarantineType,
+  isGraphifyRunActive,
+  isQuarantined,
+} from './graphifyUi.js';
+import NotFound from './NotFound.js';
+
+const GRAPHIFY_REFRESH_INTERVAL_MS = 5_000;
+
+export default function GraphifyRunDetailPage() {
+  const navigate = useNavigate();
+  const { spaceId = '', runId = '' } = useParams();
+  const [run, setRun] = useState<GraphifyRun | null>(null);
+  const [report, setReport] = useState<GraphifyReport | null>(null);
+  const [summary, setSummary] = useState<GraphifySummary | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRunDetail = useCallback(
+    async (background = false) => {
+      if (runId.length === 0) {
+        setRun(null);
+        setReport(null);
+        setSummary(null);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!background) {
+        setIsLoading(true);
+      }
+      setError(null);
+
+      try {
+        const runResponse = await getGraphifyRun(runId);
+        setRun(runResponse.data);
+
+        const [reportResult, summaryResult] = await Promise.allSettled([
+          getGraphifyReport(runId),
+          getGraphifySummary(runId),
+        ]);
+        setReport(reportResult.status === 'fulfilled' ? reportResult.value.data : null);
+        setSummary(summaryResult.status === 'fulfilled' ? summaryResult.value.data : null);
+      } catch (err) {
+        setError(getErrorMessage(err));
+      } finally {
+        if (!background) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [runId],
+  );
+
+  useEffect(() => {
+    void loadRunDetail();
+  }, [loadRunDetail]);
+
+  useEffect(() => {
+    if (run === null || !isGraphifyRunActive(run)) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void loadRunDetail(true);
+    }, GRAPHIFY_REFRESH_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [loadRunDetail, run]);
+
+  if (spaceId.length === 0 || runId.length === 0) {
+    return <NotFound />;
+  }
+
+  async function cancelRun(): Promise<void> {
+    if (run === null || !window.confirm(`Cancel Graphify run ${run.run_id}?`)) {
+      return;
+    }
+
+    setIsCancelling(true);
+    setError(null);
+
+    try {
+      await cancelGraphifyRun(run.run_id);
+      setRun((current) => (current === null ? current : { ...current, status: 'cancelled', completed_at: new Date().toISOString() }));
+      await loadRunDetail(true);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsCancelling(false);
+    }
+  }
+
+  async function retryRun(): Promise<void> {
+    if (run === null || !window.confirm(`Retry Graphify run ${run.run_id}?`)) {
+      return;
+    }
+
+    setIsRetrying(true);
+    setError(null);
+
+    try {
+      const created = await retryGraphifyRun(run.run_id);
+      void navigate(`/spaces/${encodeURIComponent(created.space_id)}/graphify/${encodeURIComponent(created.run_id)}`);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsRetrying(false);
+    }
+  }
+
+  const showCancelButton = run !== null && isGraphifyRunActive(run);
+  const showRetryButton = run !== null && run.status === 'failed';
+
+  return (
+    <main className="admin-content graphify-page">
+      <PageHeader
+        title="Graphify Run Detail"
+        description="Inspect Graphify metadata, import statistics, reports, and failures."
+        actions={
+          <>
+            <button
+              className="button button-secondary"
+              type="button"
+              onClick={() => {
+                void navigate(`/spaces/${encodeURIComponent(spaceId)}/graphify`);
+              }}
+            >
+              Back to Graphify
+            </button>
+            {showCancelButton ? (
+              <button
+                className="button button-danger"
+                type="button"
+                disabled={isCancelling}
+                onClick={() => {
+                  void cancelRun();
+                }}
+              >
+                {isCancelling ? 'Cancelling...' : 'Cancel Run'}
+              </button>
+            ) : null}
+            {showRetryButton ? (
+              <button
+                className="button button-secondary"
+                type="button"
+                disabled={isRetrying}
+                onClick={() => {
+                  void retryRun();
+                }}
+              >
+                {isRetrying ? 'Retrying...' : 'Retry Run'}
+              </button>
+            ) : null}
+          </>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      {isLoading ? (
+        <LoadingState label="Loading graphify run details..." />
+      ) : run === null ? (
+        <EmptyState label="Graphify run details are unavailable." />
+      ) : (
+        <>
+          <section className="detail-panel" aria-label="Graphify run overview">
+            <div className="detail-panel-header">
+              <div>
+                <h2>{run.run_id}</h2>
+                <p>{run.space_id}</p>
+              </div>
+              <GraphifyStatusCell run={run} />
+            </div>
+
+            <div className="settings-grid">
+              <div>
+                <span className="eyebrow">Run ID</span>
+                <code>{run.run_id}</code>
+              </div>
+              <div>
+                <span className="eyebrow">Status</span>
+                <StatusBadge status={run.status} />
+              </div>
+              <div>
+                <span className="eyebrow">Mode</span>
+                <span className="job-meta-value">{formatLabel(run.mode)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Trigger</span>
+                <span className="job-meta-value">{formatLabel(run.trigger_type)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Duration</span>
+                <span className="job-meta-value">{formatRunDuration(run)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Created at</span>
+                <span className="job-meta-value">{formatDate(run.created_at)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Started at</span>
+                <span className="job-meta-value">{formatDate(run.started_at)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Completed at</span>
+                <span className="job-meta-value">{formatDate(run.completed_at)}</span>
+              </div>
+              <div>
+                <span className="eyebrow">Input scope</span>
+                <span className="job-meta-value">{formatInputScope(run)}</span>
+              </div>
+            </div>
+          </section>
+
+          <section className="detail-panel" aria-label="Graphify run stats">
+            <div className="detail-panel-header">
+              <div>
+                <h2>Stats</h2>
+                <p>Imported graph and wiki output counts.</p>
+              </div>
+            </div>
+            <div className="settings-grid">
+              <StatCard label="Nodes" value={summary?.summary.node_count ?? getGraphifyStat(run, 'node_count')} />
+              <StatCard label="Edges" value={summary?.summary.edge_count ?? getGraphifyStat(run, 'edge_count')} />
+              <StatCard
+                label="Communities"
+                value={summary?.summary.community_count ?? getGraphifyStat(run, 'community_count')}
+              />
+              <StatCard label="Wiki pages" value={getGraphifyStat(run, 'wiki_page_count')} />
+            </div>
+          </section>
+
+          <section className="detail-panel" aria-label="Graphify report">
+            <div className="detail-panel-header">
+              <div>
+                <h2>GRAPH_REPORT.md</h2>
+                <p>{report === null ? 'No report has been captured for this run.' : `Generated ${formatDate(report.generated_at)}`}</p>
+              </div>
+            </div>
+            {report === null ? (
+              <EmptyState label="No Graphify report is available for this run." />
+            ) : (
+              <pre className="graphify-report-pre">{report.content}</pre>
+            )}
+          </section>
+
+          {run.status === 'failed' ? (
+            <section className="detail-panel" aria-label="Graphify error details">
+              <div className="detail-panel-header">
+                <div>
+                  <h2>Error Details</h2>
+                  <p>
+                    {isQuarantined(run)
+                      ? `Quarantine: ${formatLabel(getQuarantineType(run) ?? 'unknown')}`
+                      : 'Failure metadata captured for this run.'}
+                  </p>
+                </div>
+              </div>
+              <details className="job-json-disclosure" open>
+                <summary>Error JSON</summary>
+                <pre>{formatJson(run.error_json)}</pre>
+              </details>
+            </section>
+          ) : null}
+        </>
+      )}
+    </main>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: number | null }) {
+  return (
+    <div>
+      <span className="eyebrow">{label}</span>
+      <span className="job-meta-value">{formatCount(value)}</span>
+    </div>
+  );
+}
+
+function formatInputScope(run: GraphifyRun): string {
+  const inputScope = asRecord(run.input_scope);
+  const sourceDocumentIds = readStringArray(inputScope.source_document_ids);
+  const pageIds = readStringArray(inputScope.page_ids);
+
+  if (sourceDocumentIds.length > 0) {
+    return sourceDocumentIds.join(', ');
+  }
+
+  if (pageIds.length > 0) {
+    return pageIds.join(', ');
+  }
+
+  return 'All available sources';
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import {
   EmptyState,
@@ -63,7 +63,14 @@ export default function GraphifyRunDetailPage() {
 
       try {
         const runResponse = await getGraphifyRun(runId);
-        setRun(runResponse.data);
+        const currentRun = runResponse.data;
+        setRun(currentRun);
+
+        if (isGraphifyRunActive(currentRun)) {
+          setReport(null);
+          setSummary(null);
+          return;
+        }
 
         const [reportResult, summaryResult] = await Promise.allSettled([
           getGraphifyReport(runId),
@@ -273,7 +280,7 @@ export default function GraphifyRunDetailPage() {
             {report === null ? (
               <EmptyState label="No Graphify report is available for this run." />
             ) : (
-              <pre className="graphify-report-pre">{report.content}</pre>
+              <GraphifyMarkdown content={report.content} />
             )}
           </section>
 
@@ -308,6 +315,84 @@ function StatCard({ label, value }: { label: string; value: number | null }) {
       <span className="job-meta-value">{formatCount(value)}</span>
     </div>
   );
+}
+
+function GraphifyMarkdown({ content }: { content: string }) {
+  return <div className="markdown-body">{renderMarkdownBlocks(content)}</div>;
+}
+
+function renderMarkdownBlocks(content: string): ReactNode[] {
+  const blocks: ReactNode[] = [];
+  let listItems: ReactNode[] = [];
+
+  function flushList(): void {
+    if (listItems.length === 0) {
+      return;
+    }
+
+    blocks.push(<ul key={`list-${blocks.length}`}>{listItems}</ul>);
+    listItems = [];
+  }
+
+  content.split(/\r?\n/).forEach((line, index) => {
+    const listMatch = /^-\s+(.+)$/.exec(line);
+    if (listMatch !== null) {
+      listItems.push(<li key={`li-${index}`}>{renderBoldMarkdown(listMatch[1] ?? '', `li-${index}`)}</li>);
+      return;
+    }
+
+    flushList();
+
+    if (line.trim().length === 0) {
+      return;
+    }
+
+    const headingMatch = /^(#{1,4})\s+(.+)$/.exec(line);
+    if (headingMatch !== null) {
+      const headingMarks = headingMatch[1] ?? '';
+      const headingText = headingMatch[2] ?? '';
+      const children = renderBoldMarkdown(headingText, `h-${index}`);
+      const level = headingMarks.length;
+
+      if (level === 1) {
+        blocks.push(<h1 key={`h-${index}`}>{children}</h1>);
+      } else if (level === 2) {
+        blocks.push(<h2 key={`h-${index}`}>{children}</h2>);
+      } else if (level === 3) {
+        blocks.push(<h3 key={`h-${index}`}>{children}</h3>);
+      } else {
+        blocks.push(<h4 key={`h-${index}`}>{children}</h4>);
+      }
+      return;
+    }
+
+    blocks.push(<p key={`p-${index}`}>{renderBoldMarkdown(line, `p-${index}`)}</p>);
+  });
+
+  flushList();
+  return blocks;
+}
+
+function renderBoldMarkdown(text: string, keyPrefix: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const boldPattern = /\*\*(.+?)\*\*/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = boldPattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+
+    nodes.push(<strong key={`${keyPrefix}-strong-${match.index}`}>{match[1] ?? ''}</strong>);
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes;
 }
 
 function formatInputScope(run: GraphifyRun): string {

--- a/apps/web/src/pages/GraphifyRunsPage.tsx
+++ b/apps/web/src/pages/GraphifyRunsPage.tsx
@@ -1,0 +1,351 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  formatDate,
+  formatLabel,
+  getErrorMessage,
+} from '../components/adminUi.js';
+import { type ApiMeta } from '../lib/api.js';
+import {
+  GRAPHIFY_TRIGGER_TYPES,
+  createGraphifyRun,
+  listGraphifyRuns,
+  retryGraphifyRun,
+  type CreateGraphifyRunParams,
+  type GraphifyRun,
+} from '../lib/graphifyApi.js';
+import {
+  GRAPHIFY_PAGE_SIZE,
+  GraphifyStatusCell,
+  GraphifyStatusTabs,
+  NewRunDialog,
+  formatGraphifyStats,
+  formatRunDuration,
+  getFirstItemIndex,
+  getLastItemIndex,
+  isGraphifyRunActive,
+} from './graphifyUi.js';
+import NotFound from './NotFound.js';
+
+const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
+  page: 1,
+  per_page: GRAPHIFY_PAGE_SIZE,
+  total: 0,
+  has_next: false,
+};
+
+const GRAPHIFY_POLL_INTERVAL_MS = 5_000;
+const PER_PAGE_OPTIONS = [10, 20, 50, 100];
+
+export default function GraphifyRunsPage() {
+  const navigate = useNavigate();
+  const { spaceId = '' } = useParams();
+  const [runs, setRuns] = useState<GraphifyRun[]>([]);
+  const [status, setStatus] = useState('');
+  const [triggerType, setTriggerType] = useState('');
+  const [page, setPage] = useState(DEFAULT_PAGINATION.page);
+  const [perPage, setPerPage] = useState(DEFAULT_PAGINATION.per_page);
+  const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryingRunId, setRetryingRunId] = useState<string | null>(null);
+  const [isNewRunOpen, setIsNewRunOpen] = useState(false);
+  const [isCreatingRun, setIsCreatingRun] = useState(false);
+
+  const loadRuns = useCallback(
+    async (background = false) => {
+      if (spaceId.length === 0) {
+        setRuns([]);
+        setPagination(DEFAULT_PAGINATION);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!background) {
+        setIsLoading(true);
+      }
+      setError(null);
+
+      try {
+        const response = await listGraphifyRuns({
+          space_id: spaceId,
+          status,
+          trigger_type: triggerType,
+          page,
+          per_page: perPage,
+          sort: '-created_at',
+        });
+        setRuns(response.data);
+        setPagination(
+          response.meta?.pagination ?? {
+            page,
+            per_page: perPage,
+            total: response.data.length,
+            has_next: false,
+          },
+        );
+      } catch (err) {
+        setError(getErrorMessage(err));
+      } finally {
+        if (!background) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [page, perPage, spaceId, status, triggerType],
+  );
+
+  useEffect(() => {
+    void loadRuns();
+  }, [loadRuns]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [spaceId]);
+
+  const shouldPoll = runs.some(isGraphifyRunActive) || status === 'pending' || status === 'running';
+
+  useEffect(() => {
+    if (!shouldPoll) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void loadRuns(true);
+    }, GRAPHIFY_POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [loadRuns, shouldPoll]);
+
+  const totalPages = useMemo(() => {
+    const computedPages = Math.ceil(pagination.total / Math.max(1, pagination.per_page));
+    return Math.max(page, computedPages, 1);
+  }, [page, pagination.per_page, pagination.total]);
+
+  if (spaceId.length === 0) {
+    return <NotFound />;
+  }
+
+  async function createRun(params: CreateGraphifyRunParams): Promise<void> {
+    setIsCreatingRun(true);
+    setError(null);
+
+    try {
+      await createGraphifyRun(spaceId, params);
+      setIsNewRunOpen(false);
+      setPage(1);
+      await loadRuns(true);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsCreatingRun(false);
+    }
+  }
+
+  async function retryRun(run: GraphifyRun): Promise<void> {
+    if (!window.confirm(`Retry Graphify run ${run.run_id}?`)) {
+      return;
+    }
+
+    setRetryingRunId(run.run_id);
+    setError(null);
+
+    try {
+      await retryGraphifyRun(run.run_id);
+      await loadRuns(true);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setRetryingRunId(null);
+    }
+  }
+
+  function openRun(run: GraphifyRun): void {
+    void navigate(`/spaces/${encodeURIComponent(spaceId)}/graphify/${encodeURIComponent(run.run_id)}`);
+  }
+
+  return (
+    <main className="admin-content graphify-page">
+      <PageHeader
+        title="Graphify Runs"
+        description="Create and track Graphify output imports for this space."
+        actions={
+          <>
+            <button
+              className="button button-secondary"
+              type="button"
+              onClick={() => {
+                void loadRuns();
+              }}
+            >
+              Refresh
+            </button>
+            <button
+              className="button button-primary"
+              type="button"
+              onClick={() => {
+                setIsNewRunOpen(true);
+              }}
+            >
+              New Run
+            </button>
+          </>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      <section className="toolbar" aria-label="Graphify run filters">
+        <div className="toolbar-span">
+          <span className="eyebrow">Status</span>
+          <GraphifyStatusTabs
+            status={status}
+            onStatusChange={(nextStatus) => {
+              setStatus(nextStatus);
+              setPage(1);
+            }}
+          />
+        </div>
+        <label>
+          Trigger
+          <select
+            value={triggerType}
+            onChange={(event) => {
+              setTriggerType(event.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="">All triggers</option>
+            {GRAPHIFY_TRIGGER_TYPES.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Page
+          <select value={page} onChange={(event) => setPage(Number(event.target.value))}>
+            {Array.from({ length: totalPages }, (_, index) => index + 1).map((pageValue) => (
+              <option key={pageValue} value={pageValue}>
+                Page {pageValue}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Per page
+          <select
+            value={perPage}
+            onChange={(event) => {
+              setPerPage(Number(event.target.value));
+              setPage(1);
+            }}
+          >
+            {PER_PAGE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      {isLoading ? (
+        <LoadingState label="Loading graphify runs..." />
+      ) : runs.length === 0 ? (
+        <EmptyState label="No graphify runs match the current filters." />
+      ) : (
+        <>
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Run</th>
+                  <th>Status</th>
+                  <th>Mode</th>
+                  <th>Trigger</th>
+                  <th>Timing</th>
+                  <th>Stats</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((run) => (
+                  <tr
+                    key={run.run_id}
+                    className="interactive-row"
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => openRun(run)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        openRun(run);
+                      }
+                    }}
+                  >
+                    <td>
+                      <strong>{run.run_id}</strong>
+                      <span className="subtle-id">{run.result.report_uri ?? 'No report yet'}</span>
+                    </td>
+                    <td>
+                      <GraphifyStatusCell run={run} />
+                    </td>
+                    <td>{formatLabel(run.mode)}</td>
+                    <td>{formatLabel(run.trigger_type)}</td>
+                    <td>
+                      <strong>{formatRunDuration(run)}</strong>
+                      <span className="subtle-id">Created {formatDate(run.created_at)}</span>
+                    </td>
+                    <td>{formatGraphifyStats(run)}</td>
+                    <td>
+                      {run.status === 'failed' ? (
+                        <button
+                          className="button button-secondary"
+                          type="button"
+                          disabled={retryingRunId === run.run_id}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void retryRun(run);
+                          }}
+                        >
+                          {retryingRunId === run.run_id ? 'Retrying...' : 'Retry'}
+                        </button>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="pagination-bar">
+            <span className="pagination-summary">
+              Showing {getFirstItemIndex(pagination.page, pagination.per_page, pagination.total)}-
+              {getLastItemIndex(pagination.page, pagination.per_page, runs.length, pagination.total)} of{' '}
+              {pagination.total}
+            </span>
+            <span className="pagination-summary">
+              Page {pagination.page} of {totalPages}
+            </span>
+          </div>
+        </>
+      )}
+
+      {isNewRunOpen ? (
+        <NewRunDialog
+          isSubmitting={isCreatingRun}
+          onClose={() => setIsNewRunOpen(false)}
+          onSubmit={(params) => createRun(params)}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/src/pages/admin/GraphifyPage.tsx
+++ b/apps/web/src/pages/admin/GraphifyPage.tsx
@@ -1,0 +1,329 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  EmptyState,
+  ErrorBanner,
+  LoadingState,
+  PageHeader,
+  formatDate,
+  formatLabel,
+  getErrorMessage,
+} from '../../components/adminUi.js';
+import { type ApiMeta } from '../../lib/api.js';
+import {
+  GRAPHIFY_TRIGGER_TYPES,
+  adminListGraphifyRuns,
+  adminRetryRun,
+  type GraphifyRun,
+} from '../../lib/graphifyApi.js';
+import {
+  GRAPHIFY_PAGE_SIZE,
+  GraphifyStatusCell,
+  GraphifyStatusTabs,
+  formatGraphifyStats,
+  formatJson,
+  formatRunDuration,
+  getFirstItemIndex,
+  getLastItemIndex,
+  getQuarantineType,
+  isGraphifyRunActive,
+  isQuarantined,
+} from '../graphifyUi.js';
+
+const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
+  page: 1,
+  per_page: GRAPHIFY_PAGE_SIZE,
+  total: 0,
+  has_next: false,
+};
+
+const GRAPHIFY_POLL_INTERVAL_MS = 5_000;
+const PER_PAGE_OPTIONS = [10, 20, 50, 100];
+
+export default function GraphifyPage() {
+  const navigate = useNavigate();
+  const [runs, setRuns] = useState<GraphifyRun[]>([]);
+  const [status, setStatus] = useState('');
+  const [triggerType, setTriggerType] = useState('');
+  const [spaceId, setSpaceId] = useState('');
+  const deferredSpaceId = useDeferredValue(spaceId);
+  const [page, setPage] = useState(DEFAULT_PAGINATION.page);
+  const [perPage, setPerPage] = useState(DEFAULT_PAGINATION.per_page);
+  const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
+  const [retryingRunId, setRetryingRunId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRuns = useCallback(
+    async (background = false) => {
+      if (!background) {
+        setIsLoading(true);
+      }
+      setError(null);
+
+      try {
+        const response = await adminListGraphifyRuns({
+          status,
+          trigger_type: triggerType,
+          space_id: deferredSpaceId,
+          page,
+          per_page: perPage,
+          sort: '-created_at',
+        });
+        setRuns(response.data);
+        setPagination(
+          response.meta?.pagination ?? {
+            page,
+            per_page: perPage,
+            total: response.data.length,
+            has_next: false,
+          },
+        );
+      } catch (err) {
+        setError(getErrorMessage(err));
+      } finally {
+        if (!background) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [deferredSpaceId, page, perPage, status, triggerType],
+  );
+
+  useEffect(() => {
+    void loadRuns();
+  }, [loadRuns]);
+
+  const shouldPoll = runs.some(isGraphifyRunActive) || status === 'pending' || status === 'running';
+
+  useEffect(() => {
+    if (!shouldPoll) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void loadRuns(true);
+    }, GRAPHIFY_POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [loadRuns, shouldPoll]);
+
+  const totalPages = useMemo(() => {
+    const computedPages = Math.ceil(pagination.total / Math.max(1, pagination.per_page));
+    return Math.max(page, computedPages, 1);
+  }, [page, pagination.per_page, pagination.total]);
+
+  async function retryRun(run: GraphifyRun): Promise<void> {
+    if (!window.confirm(`Retry Graphify run ${run.run_id}?`)) {
+      return;
+    }
+
+    setRetryingRunId(run.run_id);
+    setError(null);
+
+    try {
+      await adminRetryRun(run.run_id);
+      await loadRuns(true);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setRetryingRunId(null);
+    }
+  }
+
+  function openRun(run: GraphifyRun): void {
+    void navigate(`/spaces/${encodeURIComponent(run.space_id)}/graphify/${encodeURIComponent(run.run_id)}`);
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Graphify"
+        description="Review graphification runs and quarantine failures across spaces."
+        actions={
+          <button
+            className="button button-secondary"
+            type="button"
+            onClick={() => {
+              void loadRuns();
+            }}
+          >
+            Refresh
+          </button>
+        }
+      />
+
+      <ErrorBanner error={error} />
+
+      <section className="toolbar" aria-label="Graphify filters">
+        <div className="toolbar-span">
+          <span className="eyebrow">Status</span>
+          <GraphifyStatusTabs
+            status={status}
+            onStatusChange={(nextStatus) => {
+              setStatus(nextStatus);
+              setPage(1);
+            }}
+          />
+        </div>
+        <label>
+          Trigger
+          <select
+            value={triggerType}
+            onChange={(event) => {
+              setTriggerType(event.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="">All triggers</option>
+            {GRAPHIFY_TRIGGER_TYPES.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Space
+          <input
+            type="search"
+            value={spaceId}
+            onChange={(event) => {
+              setSpaceId(event.target.value);
+              setPage(1);
+            }}
+            placeholder="Space ID"
+          />
+        </label>
+        <label>
+          Page
+          <select value={page} onChange={(event) => setPage(Number(event.target.value))}>
+            {Array.from({ length: totalPages }, (_, index) => index + 1).map((pageValue) => (
+              <option key={pageValue} value={pageValue}>
+                Page {pageValue}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Per page
+          <select
+            value={perPage}
+            onChange={(event) => {
+              setPerPage(Number(event.target.value));
+              setPage(1);
+            }}
+          >
+            {PER_PAGE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      {isLoading ? (
+        <LoadingState label="Loading graphify runs..." />
+      ) : runs.length === 0 ? (
+        <EmptyState label="No graphify runs match the current filters." />
+      ) : (
+        <>
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Run</th>
+                  <th>Status</th>
+                  <th>Space</th>
+                  <th>Mode</th>
+                  <th>Trigger</th>
+                  <th>Timing</th>
+                  <th>Stats</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((run) => (
+                  <tr
+                    key={run.run_id}
+                    className={isQuarantined(run) ? 'interactive-row graphify-quarantined-row' : 'interactive-row'}
+                    role="link"
+                    tabIndex={0}
+                    onClick={() => openRun(run)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        openRun(run);
+                      }
+                    }}
+                  >
+                    <td>
+                      <strong>{run.run_id}</strong>
+                      <span className="subtle-id">{run.result.report_uri ?? 'No report yet'}</span>
+                    </td>
+                    <td>
+                      <GraphifyStatusCell run={run} />
+                      {isQuarantined(run) ? (
+                        <span className="subtle-id">Quarantine: {formatLabel(getQuarantineType(run) ?? 'unknown')}</span>
+                      ) : null}
+                    </td>
+                    <td>{run.space_id}</td>
+                    <td>{formatLabel(run.mode)}</td>
+                    <td>{formatLabel(run.trigger_type)}</td>
+                    <td>
+                      <strong>{formatRunDuration(run)}</strong>
+                      <span className="subtle-id">Created {formatDate(run.created_at)}</span>
+                    </td>
+                    <td>{formatGraphifyStats(run)}</td>
+                    <td>
+                      <div className="row-actions">
+                        {run.status === 'failed' ? (
+                          <button
+                            className="button button-secondary"
+                            type="button"
+                            disabled={retryingRunId === run.run_id}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              void retryRun(run);
+                            }}
+                          >
+                            {retryingRunId === run.run_id ? 'Retrying...' : 'Retry'}
+                          </button>
+                        ) : null}
+                        {run.status === 'failed' ? (
+                          <details
+                            className="graphify-inline-details"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                            }}
+                          >
+                            <summary>Error</summary>
+                            <pre>{formatJson(run.error_json)}</pre>
+                          </details>
+                        ) : null}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="pagination-bar">
+            <span className="pagination-summary">
+              Showing {getFirstItemIndex(pagination.page, pagination.per_page, pagination.total)}-
+              {getLastItemIndex(pagination.page, pagination.per_page, runs.length, pagination.total)} of{' '}
+              {pagination.total}
+            </span>
+            <span className="pagination-summary">
+              Page {pagination.page} of {totalPages}
+            </span>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/pages/admin/GraphifyPage.tsx
+++ b/apps/web/src/pages/admin/GraphifyPage.tsx
@@ -43,7 +43,7 @@ const PER_PAGE_OPTIONS = [10, 20, 50, 100];
 export default function GraphifyPage() {
   const navigate = useNavigate();
   const [runs, setRuns] = useState<GraphifyRun[]>([]);
-  const [status, setStatus] = useState('');
+  const [status, setStatus] = useState('failed');
   const [triggerType, setTriggerType] = useState('');
   const [spaceId, setSpaceId] = useState('');
   const deferredSpaceId = useDeferredValue(spaceId);

--- a/apps/web/src/pages/graphifyUi.tsx
+++ b/apps/web/src/pages/graphifyUi.tsx
@@ -1,0 +1,259 @@
+import { useState, type FormEvent } from 'react';
+import {
+  Modal,
+  StatusBadge,
+  formatLabel,
+} from '../components/adminUi.js';
+import {
+  GRAPHIFY_RUN_MODES,
+  type CreateGraphifyRunParams,
+  type GraphifyRun,
+  type GraphifyRunMode,
+  type GraphifyTriggerType,
+} from '../lib/graphifyApi.js';
+
+export const GRAPHIFY_PAGE_SIZE = 20;
+
+export const GRAPHIFY_STATUS_FILTERS = [
+  { value: '', label: 'All' },
+  { value: 'running', label: 'Running' },
+  { value: 'succeeded', label: 'Succeeded' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'cancelled', label: 'Cancelled' },
+] as const;
+
+export function GraphifyStatusCell({ run }: { run: GraphifyRun }) {
+  return (
+    <span className="graphify-status-cell">
+      <StatusBadge status={run.status} />
+      {isQuarantined(run) ? (
+        <span className="quarantine-icon" role="img" aria-label="Quarantined" title="Quarantined">
+          !
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+export function GraphifyStatusTabs({
+  status,
+  onStatusChange,
+}: {
+  status: string;
+  onStatusChange: (status: string) => void;
+}) {
+  return (
+    <div className="status-filter-tabs" role="tablist" aria-label="Graphify status filters">
+      {GRAPHIFY_STATUS_FILTERS.map((option) => (
+        <button
+          key={option.value || 'all'}
+          className={status === option.value ? 'status-filter-tab active' : 'status-filter-tab'}
+          type="button"
+          role="tab"
+          aria-selected={status === option.value}
+          onClick={() => onStatusChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function NewRunDialog({
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: {
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (params: CreateGraphifyRunParams) => Promise<void> | void;
+}) {
+  const [mode, setMode] = useState<GraphifyRunMode>('full');
+  const [triggerType, setTriggerType] = useState<GraphifyTriggerType>('manual');
+
+  async function submitForm(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    await onSubmit({
+      mode,
+      trigger_type: triggerType,
+    });
+  }
+
+  return (
+    <Modal title="New Graphify Run" onClose={onClose}>
+      <form className="form-grid" onSubmit={(event) => void submitForm(event)}>
+        <label>
+          Mode
+          <select
+            value={mode}
+            onChange={(event) => {
+              setMode(event.target.value as GraphifyRunMode);
+            }}
+          >
+            {GRAPHIFY_RUN_MODES.map((option) => (
+              <option key={option} value={option}>
+                {formatLabel(option)}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Trigger type
+          <select
+            value={triggerType}
+            onChange={(event) => {
+              setTriggerType(event.target.value as GraphifyTriggerType);
+            }}
+          >
+            <option value="manual">Manual</option>
+          </select>
+        </label>
+        <div className="form-actions span-2">
+          <button className="button button-secondary" type="button" disabled={isSubmitting} onClick={onClose}>
+            Cancel
+          </button>
+          <button className="button button-primary" type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Creating...' : 'Create Run'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export function isGraphifyRunActive(run: GraphifyRun): boolean {
+  return run.status === 'pending' || run.status === 'running';
+}
+
+export function isQuarantined(run: GraphifyRun): boolean {
+  const error = asRecord(run.error_json);
+  return run.status === 'failed' && readString(error.reason) === 'quarantined';
+}
+
+export function getQuarantineType(run: GraphifyRun): string | null {
+  const error = asRecord(run.error_json);
+  const details = asRecord(error.details);
+  return (
+    readString(error.quarantine_type) ??
+    readString(details.quarantine_type) ??
+    readString(details.check) ??
+    null
+  );
+}
+
+export function formatGraphifyStats(run: GraphifyRun): string {
+  return [
+    `Nodes ${formatCount(getGraphifyStat(run, 'node_count'))}`,
+    `Edges ${formatCount(getGraphifyStat(run, 'edge_count'))}`,
+    `Wiki ${formatCount(getGraphifyStat(run, 'wiki_page_count'))}`,
+  ].join(' / ');
+}
+
+export function getGraphifyStat(
+  run: GraphifyRun,
+  stat: 'node_count' | 'edge_count' | 'wiki_page_count' | 'community_count',
+): number | null {
+  const stats = asRecord(run.stats_json);
+  const result = asRecord(run.result);
+
+  if (stat === 'node_count') {
+    return readNumber(stats.node_count) ?? readNumber(result.node_count) ?? readNumber(result.nodes_created);
+  }
+
+  if (stat === 'edge_count') {
+    return readNumber(stats.edge_count) ?? readNumber(result.edge_count) ?? readNumber(result.edges_created);
+  }
+
+  if (stat === 'wiki_page_count') {
+    return (
+      readNumber(stats.wiki_page_count) ??
+      readNumber(result.wiki_page_count) ??
+      readNumber(result.wiki_pages_generated)
+    );
+  }
+
+  return readNumber(stats.community_count) ?? readNumber(result.community_count);
+}
+
+export function formatCount(value: number | null): string {
+  return value === null ? '0' : value.toLocaleString();
+}
+
+export function formatRunDuration(run: GraphifyRun): string {
+  if (run.started_at === null) {
+    return run.status === 'pending' ? 'Queued' : 'Not started';
+  }
+
+  const startedAt = parseTimestamp(run.started_at);
+  if (startedAt === null) {
+    return 'Unavailable';
+  }
+
+  const completedAt =
+    run.completed_at !== null ? parseTimestamp(run.completed_at) : run.status === 'running' ? Date.now() : null;
+
+  if (completedAt === null) {
+    return 'In progress';
+  }
+
+  return formatElapsedTime(completedAt - startedAt);
+}
+
+export function formatJson(value: unknown): string {
+  return JSON.stringify(value ?? null, null, 2);
+}
+
+export function getFirstItemIndex(page: number, perPage: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return (page - 1) * perPage + 1;
+}
+
+export function getLastItemIndex(page: number, perPage: number, itemCount: number, total: number): number {
+  if (total === 0) {
+    return 0;
+  }
+
+  return Math.min(total, getFirstItemIndex(page, perPage, total) + itemCount - 1);
+}
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function parseTimestamp(value: string): number | null {
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function formatElapsedTime(durationMs: number): string {
+  if (durationMs < 1_000) {
+    return '<1s';
+  }
+
+  const totalSeconds = Math.floor(durationMs / 1_000);
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${seconds}s`;
+}

--- a/apps/web/src/pages/graphifyUi.tsx
+++ b/apps/web/src/pages/graphifyUi.tsx
@@ -16,6 +16,7 @@ export const GRAPHIFY_PAGE_SIZE = 20;
 
 export const GRAPHIFY_STATUS_FILTERS = [
   { value: '', label: 'All' },
+  { value: 'pending', label: 'Pending' },
   { value: 'running', label: 'Running' },
   { value: 'succeeded', label: 'Succeeded' },
   { value: 'failed', label: 'Failed' },

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -339,6 +339,43 @@ textarea:focus {
   padding: 14px;
 }
 
+.toolbar-span {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: 7px;
+}
+
+.status-filter-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.status-filter-tab {
+  min-height: 34px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-2);
+  padding: 7px 11px;
+  font-weight: 800;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.status-filter-tab:hover {
+  border-color: var(--color-text-4);
+  color: var(--color-text-1);
+}
+
+.status-filter-tab.active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-mute);
+  color: var(--color-primary-hover);
+}
+
 .table-wrap {
   overflow-x: auto;
   border: 1px solid var(--color-border);
@@ -389,6 +426,60 @@ tbody tr:last-child td {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+.graphify-status-cell {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.quarantine-icon {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-full);
+  background: var(--color-warning-soft);
+  color: var(--color-status-degraded-text);
+  font-size: 0.82rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.graphify-quarantined-row td:first-child {
+  border-left: 4px solid var(--color-warning);
+}
+
+.graphify-inline-details {
+  max-width: 280px;
+}
+
+.graphify-inline-details summary {
+  cursor: pointer;
+  color: var(--color-text-2);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.graphify-inline-details pre,
+.graphify-report-pre {
+  margin: 0;
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  color: var(--color-text-1);
+  font-family: var(--font-family-mono);
+  font-size: 0.84rem;
+  line-height: 1.55;
+  padding: 16px;
+}
+
+.graphify-report-pre {
+  white-space: pre-wrap;
 }
 
 .status-badge {


### PR DESCRIPTION
## Summary
- Add graphify API client with 9 endpoint functions (createRun, listRuns, getRun, cancelRun, retryRun, getReport, getSummary, adminList, adminRetry)
- Add space-level Graphify runs page with status filter tabs, New Run dialog, pagination
- Add run detail page with metadata, stats, GRAPH_REPORT.md markdown rendering, cancel/retry actions
- Add admin Graphify page with quarantine review (default to failed status)
- Add "Graphify" sidebar entry in admin layout
- Wire routes: /spaces/:spaceId/graphify, /spaces/:spaceId/graphify/:runId, /admin/graphify
- Add 3 component tests (status badges, cancel/retry visibility, new run dialog)
- Expose stats_json/error_json in GraphifyService response for frontend consumption

## Test plan
- [x] Build: all packages compile successfully
- [x] Full test suite: 625/625 passed (3 new frontend tests)
- [x] Lint: passes
- [x] CI: all checks green

Closes #89

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `b155d645c2f03f98d6758f2c2bc5c7f84ded0eba`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/99#issuecomment-4363778726) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/99#issuecomment-4363778771) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/99#issuecomment-4363778823) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/99#issuecomment-4363778863)
- Key findings addressed: Report markdown rendering (replaced pre with React renderer), poll optimization (report/summary only fetched on terminal state), admin defaults to failed status, pending filter added, CI async timing fixed