### PR TITLE
feat(stage-6): indexer-worker full implementation (#104)

### DIFF
--- a/apps/indexer-worker/package.json
+++ b/apps/indexer-worker/package.json
@@ -14,7 +14,16 @@
     "test": "vitest run --config ../../vitest.config.ts"
   },
   "dependencies": {
+    "@cherrygraph/ai-core": "workspace:*",
     "@cherrygraph/job-core": "workspace:*",
-    "bullmq": "^5.76.3"
+    "@cherrygraph/rag-core": "workspace:*",
+    "@cherrygraph/shared": "workspace:*",
+    "bullmq": "^5.76.3",
+    "drizzle-orm": "^0.45.2",
+    "pg": "^8.20.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.20.0"
   }
 }

--- a/apps/indexer-worker/src/__tests__/indexer-worker.test.ts
+++ b/apps/indexer-worker/src/__tests__/indexer-worker.test.ts
@@ -1,0 +1,622 @@
+import type { Job as BullMQJob } from 'bullmq';
+import { createHash } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EmbeddingProvider } from '@cherrygraph/ai-core';
+import type { JobDatabase, JobRow, RedisJobLockClient } from '@cherrygraph/job-core';
+import { JobStatus } from '@cherrygraph/job-core';
+import {
+  embeddings,
+  wikiChunks,
+  wikiPageVersions,
+  wikiPages,
+  wikiSections,
+} from '@cherrygraph/shared';
+
+import type { IndexerPayload } from '../indexer-payload.js';
+import { IndexerWorker } from '../indexer-worker.js';
+import type { IndexSnapshotRow } from '../snapshot-manager.js';
+
+const now = new Date('2026-05-03T00:00:00.000Z');
+const modelConfigId = 'model-config-1';
+
+describe('IndexerWorker', () => {
+  let embeddingProvider: MockEmbeddingProvider;
+  let worker: HarnessIndexerWorker;
+
+  beforeEach(() => {
+    embeddingProvider = new MockEmbeddingProvider();
+    worker = new HarnessIndexerWorker(embeddingProvider);
+  });
+
+  it('4.T1 validates job payloads', async () => {
+    worker.pages = [createPublishedPage('page-1', 'hello')];
+
+    await expect(worker.run(createJob())).resolves.toMatchObject({ chunk_count: 1 });
+
+    await expect(
+      worker.run(
+        createJob({
+          payload_json: {
+            space_id: 'space-1',
+            trigger: 'manual_rebuild',
+            scope: 'full',
+          },
+        }),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('4.T2 runs the full flow for 10 pages and indexes all chunks', async () => {
+    worker.pages = Array.from({ length: 10 }, (_, pageIndex) => createPublishedPage(`page-${pageIndex}`, 'unused'));
+    worker.sectionsByVersion = new Map(
+      worker.pages.map((page, pageIndex) => [
+        page.version.id,
+        Array.from({ length: 5 }, (_, sectionIndex) =>
+          createSection(page, sectionIndex, `page ${pageIndex} section ${sectionIndex}`),
+        ),
+      ]),
+    );
+
+    const result = await worker.run(createJob());
+
+    expect(result.chunk_count).toBe(50);
+    expect(worker.insertedChunks).toHaveLength(50);
+    expect(worker.insertedEmbeddings).toHaveLength(50);
+    expect(worker.insertedChunks.every((chunk) => chunk.index_status === 'indexed')).toBe(true);
+    expect(worker.snapshots.at(-1)).toMatchObject({
+      id: result.snapshot_id,
+      status: 'activated',
+      chunk_count: 50,
+    });
+    expect(worker.activeSnapshotId).toBe(result.snapshot_id);
+  });
+
+  it('4.T3 excludes draft pages from chunking', async () => {
+    worker.pages = [createPublishedPage('published', 'public content'), createPublishedPage('draft', 'draft content', 'draft')];
+
+    await worker.run(createJob());
+
+    expect(worker.insertedChunks).toHaveLength(1);
+    expect(worker.insertedChunks[0]?.wiki_page_pk).toBe('published-pk');
+  });
+
+  it('4.T4 moves snapshots through ready, activated, and superseded states', async () => {
+    worker.snapshots = [createSnapshot('old-snapshot', 'activated')];
+    worker.activeSnapshotId = 'old-snapshot';
+    worker.pages = [createPublishedPage('page-1', 'hello')];
+
+    const result = await worker.run(createJob());
+
+    expect(worker.statusTransitions).toEqual([
+      { snapshotId: result.snapshot_id, status: 'ready' },
+      { snapshotId: result.snapshot_id, status: 'activated' },
+      { snapshotId: 'old-snapshot', status: 'superseded' },
+    ]);
+    expect(worker.snapshots.find((snapshot) => snapshot.id === 'old-snapshot')?.status).toBe('superseded');
+  });
+
+  it('4.T5 reuses embeddings when content_hash matches the active snapshot', async () => {
+    const page = createPublishedPage('page-1', 'unchanged');
+    worker.pages = [page];
+    worker.snapshots = [createSnapshot('old-snapshot', 'activated')];
+    worker.activeSnapshotId = 'old-snapshot';
+    worker.previousChunks = [
+      createPreviousChunk(page, {
+        content: 'unchanged',
+        content_hash: hashContent('unchanged'),
+        embedding: [0.25, 0.75],
+      }),
+    ];
+
+    await worker.run(createJob());
+
+    expect(embeddingProvider.embedBatch).not.toHaveBeenCalled();
+    expect(worker.insertedEmbeddings).toHaveLength(1);
+    expect(worker.insertedEmbeddings[0]?.embedding).toEqual([0.25, 0.75]);
+  });
+
+  it('4.T6 activates atomically and leaves the active snapshot unchanged when activation fails', async () => {
+    worker.snapshots = [createSnapshot('old-snapshot', 'activated')];
+    worker.activeSnapshotId = 'old-snapshot';
+    worker.pages = [createPublishedPage('page-1', 'hello')];
+
+    await worker.run(createJob());
+    expect(worker.activeSnapshotId).not.toBe('old-snapshot');
+
+    const failingWorker = new HarnessIndexerWorker(new MockEmbeddingProvider());
+    failingWorker.snapshots = [createSnapshot('old-snapshot', 'activated')];
+    failingWorker.activeSnapshotId = 'old-snapshot';
+    failingWorker.pages = [createPublishedPage('page-1', 'hello')];
+    failingWorker.failActivation = true;
+
+    await expect(failingWorker.run(createJob())).rejects.toThrow('activation failed');
+    expect(failingWorker.activeSnapshotId).toBe('old-snapshot');
+    expect(failingWorker.snapshots.at(-1)?.status).toBe('building');
+  });
+
+  it('4.T7 isolates embedding failures from the active snapshot', async () => {
+    worker.snapshots = [createSnapshot('old-snapshot', 'activated')];
+    worker.activeSnapshotId = 'old-snapshot';
+    worker.pages = [createPublishedPage('page-1', 'hello')];
+    embeddingProvider.embedBatch.mockRejectedValueOnce(new Error('embedding unavailable'));
+
+    await expect(worker.run(createJob())).rejects.toThrow('embedding unavailable');
+
+    expect(worker.activeSnapshotId).toBe('old-snapshot');
+    expect(worker.snapshots.at(-1)?.status).toBe('building');
+    expect(worker.insertedChunks.every((chunk) => chunk.index_status === 'pending')).toBe(true);
+  });
+
+  it('4.T8 rejects concurrent indexing for the same space', async () => {
+    worker.buildingExists = true;
+    worker.pages = [createPublishedPage('page-1', 'hello')];
+
+    await expect(worker.run(createJob())).rejects.toMatchObject({ code: 'INDEXING_IN_PROGRESS' });
+    expect(worker.snapshots).toHaveLength(0);
+  });
+
+  it('4.T9 records progress events for each indexing stage', async () => {
+    worker.pages = [createPublishedPage('page-1', 'hello')];
+
+    const result = await worker.run(createJob());
+
+    expect(worker.events.map((event) => event.stage)).toEqual([
+      'indexing_started',
+      'chunks_created',
+      'embedding_progress',
+      'snapshot_activated',
+    ]);
+    expect(worker.events.at(-1)).toMatchObject({ snapshot_id: result.snapshot_id });
+  });
+
+  it('4.T10 rebuilds only the target page and copies other chunks for single_page scope', async () => {
+    const target = createPublishedPage('target', 'new target content');
+    const other = createPublishedPage('other', 'other content');
+    worker.pages = [target, other];
+    worker.snapshots = [createSnapshot('old-snapshot', 'activated')];
+    worker.activeSnapshotId = 'old-snapshot';
+    worker.previousChunks = [
+      createPreviousChunk(target, {
+        content: 'old target content',
+        content_hash: hashContent('old target content'),
+        embedding: [1, 1],
+      }),
+      createPreviousChunk(other, {
+        content: 'old other content',
+        content_hash: hashContent('old other content'),
+        embedding: [2, 2],
+      }),
+    ];
+
+    await worker.run(
+      createJob({
+        payload_json: createPayload({
+          scope: 'single_page',
+          trigger: 'manual_reindex',
+          page_id: 'target',
+        }),
+      }),
+    );
+
+    expect(worker.insertedChunks).toHaveLength(2);
+    expect(worker.insertedChunks.find((chunk) => chunk.wiki_page_pk === 'target-pk')?.content).toBe('new target content');
+    expect(worker.insertedChunks.find((chunk) => chunk.wiki_page_pk === 'other-pk')?.content).toBe('old other content');
+    expect(embeddingProvider.embedBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('4.T11 marks chunks indexed only after embeddings are written', async () => {
+    worker.pages = [createPublishedPage('page-1', 'hello')];
+    await worker.run(createJob());
+
+    expect(worker.insertedChunks[0]?.index_status).toBe('indexed');
+    expect(worker.insertedChunks[0]?.indexed_at).toBeInstanceOf(Date);
+
+    const failingWorker = new HarnessIndexerWorker(new MockEmbeddingProvider());
+    failingWorker.pages = [createPublishedPage('page-1', 'hello')];
+    failingWorker.mockEmbeddingProvider.embedBatch.mockRejectedValueOnce(new Error('embedding failed'));
+
+    await expect(failingWorker.run(createJob())).rejects.toThrow('embedding failed');
+    expect(failingWorker.insertedChunks[0]?.index_status).toBe('pending');
+    expect(failingWorker.insertedChunks[0]?.indexed_at).toBeNull();
+  });
+});
+
+class MockEmbeddingProvider implements EmbeddingProvider {
+  readonly embedBatch = vi.fn((texts: string[]) => Promise.resolve(texts.map((_, index) => [index, index + 1])));
+
+  getModelId(): string {
+    return 'text-embedding-test';
+  }
+}
+
+class HarnessIndexerWorker extends IndexerWorker {
+  pages: PageRow[] = [];
+  sectionsByVersion = new Map<string, SectionRow[]>();
+  snapshots: IndexSnapshotRow[] = [];
+  previousChunks: PreviousChunkRow[] = [];
+  insertedChunks: ChunkInsert[] = [];
+  insertedEmbeddings: EmbeddingInsert[] = [];
+  events: Array<Record<string, unknown>> = [];
+  statusTransitions: Array<{ snapshotId: string; status: string }> = [];
+  activeSnapshotId: string | undefined;
+  buildingExists = false;
+  failActivation = false;
+
+  constructor(readonly mockEmbeddingProvider: MockEmbeddingProvider) {
+    super({} as JobDatabase, new RedisStub(), mockEmbeddingProvider, 'indexer-worker-test');
+  }
+
+  run(job: JobRow): Promise<{ snapshot_id: string; chunk_count: number }> {
+    return this.process(job, { id: 'bull-1', data: { jobId: job.id } } as BullMQJob<
+      { jobId: string },
+      { snapshot_id: string; chunk_count: number },
+      string
+    >);
+  }
+
+  protected override recordProgress(_jobId: string, detail: Record<string, unknown>): Promise<void> {
+    this.events.push(detail);
+    return Promise.resolve();
+  }
+
+  protected override checkBuildingExists(spaceId: string): Promise<boolean> {
+    void spaceId;
+
+    return Promise.resolve(this.buildingExists);
+  }
+
+  protected override resolveEmbeddingModel(tenantId: string): Promise<ModelConfigRow> {
+    void tenantId;
+
+    return Promise.resolve({
+      id: modelConfigId,
+      provider: 'openai',
+      model_id: 'text-embedding-test',
+      base_url: null,
+      encrypted_api_key_ref: 'OPENAI_API_KEY',
+      embedding_dim: 2,
+    });
+  }
+
+  protected override createSnapshot(
+    payload: IndexerPayload,
+    embeddingModelId: string,
+    wikiRepoCommitHash: string,
+  ): Promise<IndexSnapshotRow> {
+    const snapshot = createSnapshot(`snapshot-${this.snapshots.length + 1}`, 'building', {
+      tenant_id: payload.tenant_id,
+      space_id: payload.space_id,
+      graphify_run_id: payload.graphify_run_id ?? null,
+      embedding_model_id: embeddingModelId,
+      wiki_repo_commit_hash: wikiRepoCommitHash,
+    });
+    this.snapshots.push(snapshot);
+    return Promise.resolve(snapshot);
+  }
+
+  protected override loadActiveSnapshot(spaceId: string): Promise<IndexSnapshotRow | undefined> {
+    void spaceId;
+
+    return Promise.resolve(this.snapshots.find((snapshot) => snapshot.id === this.activeSnapshotId));
+  }
+
+  protected override loadPublishedPages(payload: IndexerPayload): Promise<PageRow[]> {
+    const publishedPages = this.pages.filter((row) => row.version.status === 'published');
+    if (payload.scope === 'single_page') {
+      return Promise.resolve(publishedPages.filter((row) => row.page.page_id === payload.page_id));
+    }
+
+    return Promise.resolve(publishedPages);
+  }
+
+  protected override loadSections(pageVersionId: string): Promise<SectionRow[]> {
+    return Promise.resolve(this.sectionsByVersion.get(pageVersionId) ?? []);
+  }
+
+  protected override loadSnapshotChunks(spaceId: string, snapshotId: string): Promise<PreviousChunkRow[]> {
+    void spaceId;
+
+    return Promise.resolve(this.previousChunks.filter((row) => row.chunk.index_snapshot_id === snapshotId));
+  }
+
+  protected override computeSourceChain(page: PageRow) {
+    void page;
+
+    return Promise.resolve({
+      source_document_ids: [],
+      graph_node_ids: [],
+      graph_edge_ids: [],
+      edge_confidences: [],
+      chain_confidence: 1,
+    });
+  }
+
+  protected override buildAcl(page: PageRow) {
+    return Promise.resolve({
+      tenant_id: page.page.tenant_id,
+      space_id: page.page.space_id,
+      allowed_group_ids: [],
+      classification: 'internal',
+      page_id: page.page.page_id,
+      page_version: page.version.version_no,
+    });
+  }
+
+  protected override insertChunks(chunks: ChunkInsert[]): Promise<unknown> {
+    this.insertedChunks.push(...chunks.map((chunk) => ({ ...chunk, indexed_at: chunk.indexed_at ?? null })));
+    return Promise.resolve([]);
+  }
+
+  protected override insertEmbeddings(rows: EmbeddingInsert[]): Promise<unknown> {
+    this.insertedEmbeddings.push(...rows);
+    return Promise.resolve([]);
+  }
+
+  protected override markChunksIndexed(chunkIds: string[], indexedAt: Date): Promise<unknown> {
+    for (const chunk of this.insertedChunks) {
+      if (chunkIds.includes(chunk.id)) {
+        chunk.index_status = 'indexed';
+        chunk.indexed_at = indexedAt;
+      }
+    }
+
+    return Promise.resolve([]);
+  }
+
+  protected override markSnapshotReady(snapshotId: string, chunkCount: number): Promise<void> {
+    const snapshot = this.snapshots.find((item) => item.id === snapshotId);
+    if (snapshot !== undefined) {
+      snapshot.status = 'ready';
+      snapshot.chunk_count = chunkCount;
+      this.statusTransitions.push({ snapshotId, status: 'ready' });
+    }
+
+    return Promise.resolve();
+  }
+
+  protected override activateSnapshot(snapshotId: string, spaceId: string): Promise<void> {
+    void spaceId;
+
+    if (this.failActivation) {
+      return Promise.reject(new Error('activation failed'));
+    }
+
+    const newSnapshot = this.snapshots.find((snapshot) => snapshot.id === snapshotId);
+    if (newSnapshot !== undefined) {
+      newSnapshot.status = 'activated';
+      newSnapshot.activated_at = now;
+      this.statusTransitions.push({ snapshotId: newSnapshot.id, status: 'activated' });
+    }
+
+    for (const snapshot of this.snapshots) {
+      if (snapshot.id !== snapshotId && snapshot.status === 'activated') {
+        snapshot.status = 'superseded';
+        this.statusTransitions.push({ snapshotId: snapshot.id, status: 'superseded' });
+      }
+    }
+
+    this.activeSnapshotId = snapshotId;
+    return Promise.resolve();
+  }
+
+  protected override resetSnapshotToBuilding(snapshotId: string): Promise<void> {
+    const snapshot = this.snapshots.find((item) => item.id === snapshotId);
+    if (snapshot !== undefined) {
+      snapshot.status = 'building';
+      snapshot.activated_at = null;
+    }
+
+    return Promise.resolve();
+  }
+}
+
+class RedisStub implements RedisJobLockClient {
+  get(key: string): Promise<string | null> {
+    void key;
+
+    return Promise.resolve(null);
+  }
+
+  set(key: string, value: string, ...args: Array<string | number>): Promise<string | null> {
+    void key;
+    void value;
+    void args;
+
+    return Promise.resolve('OK');
+  }
+
+  eval(script: string, numKeys: number, ...args: Array<string | number>): Promise<number | string | null> {
+    void script;
+    void numKeys;
+    void args;
+
+    return Promise.resolve(1);
+  }
+}
+
+type PageRow = {
+  page: typeof wikiPages.$inferSelect;
+  version: typeof wikiPageVersions.$inferSelect;
+};
+
+type SectionRow = typeof wikiSections.$inferSelect;
+type ChunkInsert = typeof wikiChunks.$inferInsert & { id: string; content: string };
+type EmbeddingInsert = typeof embeddings.$inferInsert;
+type PreviousChunkRow = {
+  chunk: typeof wikiChunks.$inferSelect;
+  embedding: typeof embeddings.$inferSelect | null;
+};
+type ModelConfigRow = {
+  id: string;
+  provider: string;
+  model_id: string;
+  base_url: string | null;
+  encrypted_api_key_ref: string | null;
+  embedding_dim: number | null;
+};
+
+function createJob(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    queue_name: 'indexer',
+    type: 'reindex',
+    priority: 100,
+    status: JobStatus.RUNNING,
+    attempt_count: 0,
+    max_attempts: 3,
+    timeout_seconds: 600,
+    locked_by: 'worker-1',
+    locked_at: now,
+    next_run_at: null,
+    cancel_requested_at: null,
+    payload_json: createPayload(),
+    result_json: null,
+    error_json: null,
+    idempotency_key: null,
+    created_by: 'user-1',
+    created_at: now,
+    started_at: now,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function createPayload(overrides: Partial<IndexerPayload> = {}): IndexerPayload {
+  return {
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    trigger: 'manual_rebuild',
+    scope: 'full',
+    ...overrides,
+  };
+}
+
+function createPublishedPage(pageId: string, content: string, status = 'published'): PageRow {
+  return {
+    page: {
+      id: `${pageId}-pk`,
+      tenant_id: 'tenant-1',
+      space_id: 'space-1',
+      page_id: pageId,
+      title: pageId,
+      slug: pageId,
+      status,
+      current_version_id: `${pageId}-version`,
+      indexed_version_id: null,
+      sync_status: 'synced',
+      docmost_page_id: null,
+      created_by: null,
+      created_at: now,
+      updated_at: now,
+    },
+    version: {
+      id: `${pageId}-version`,
+      tenant_id: 'tenant-1',
+      space_id: 'space-1',
+      wiki_page_pk: `${pageId}-pk`,
+      page_id: pageId,
+      version_no: 1,
+      content_markdown: content,
+      frontmatter_json: {},
+      source: 'graphify',
+      graphify_run_id: null,
+      commit_hash: 'commit-1',
+      status,
+      created_by: null,
+      created_at: now,
+    },
+  };
+}
+
+function createSection(page: PageRow, sectionIndex: number, content: string): SectionRow {
+  return {
+    id: `${page.page.id}-section-${sectionIndex}`,
+    tenant_id: page.page.tenant_id,
+    space_id: page.page.space_id,
+    wiki_page_pk: page.page.id,
+    page_version_id: page.version.id,
+    section_id: `section-${sectionIndex}`,
+    heading: `Section ${sectionIndex}`,
+    level: 2,
+    section_index: sectionIndex,
+    start_offset: null,
+    end_offset: null,
+    content_hash: hashContent(content),
+    acl_json: {},
+    created_at: now,
+    content,
+  } as SectionRow & { content: string };
+}
+
+function createSnapshot(
+  id: string,
+  status: string,
+  overrides: Partial<IndexSnapshotRow> = {},
+): IndexSnapshotRow {
+  return {
+    id,
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    graphify_run_id: null,
+    wiki_repo_commit_hash: 'commit-1',
+    embedding_model_id: modelConfigId,
+    chunk_count: 0,
+    node_count: 0,
+    edge_count: 0,
+    status,
+    created_at: now,
+    activated_at: status === 'activated' ? now : null,
+    ...overrides,
+  };
+}
+
+function createPreviousChunk(
+  page: PageRow,
+  overrides: {
+    content: string;
+    content_hash: string;
+    embedding: number[];
+  },
+): PreviousChunkRow {
+  const chunkId = `${page.page.page_id}-old-chunk`;
+
+  return {
+    chunk: {
+      id: chunkId,
+      tenant_id: page.page.tenant_id,
+      space_id: page.page.space_id,
+      wiki_page_pk: page.page.id,
+      page_version_id: page.version.id,
+      section_id: null,
+      chunk_index: 0,
+      content: overrides.content,
+      content_hash: overrides.content_hash,
+      token_count: 1,
+      index_status: 'indexed',
+      index_snapshot_id: 'old-snapshot',
+      index_version: 'old-snapshot',
+      indexed_at: now,
+      embedding_model_id: modelConfigId,
+      injection_risk: false,
+      source_chain_json: {},
+      acl_json: {},
+      created_at: now,
+    },
+    embedding: {
+      id: `${chunkId}-embedding`,
+      tenant_id: page.page.tenant_id,
+      space_id: page.page.space_id,
+      chunk_id: chunkId,
+      model_config_id: modelConfigId,
+      embedding: overrides.embedding,
+      created_at: now,
+    },
+  };
+}
+
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}

--- a/apps/indexer-worker/src/__tests__/indexer-worker.test.ts
+++ b/apps/indexer-worker/src/__tests__/indexer-worker.test.ts
@@ -135,6 +135,21 @@ describe('IndexerWorker', () => {
     expect(failingWorker.snapshots.at(-1)?.status).toBe('building');
   });
 
+  it('does not reset the snapshot when a failure occurs after activation commits', async () => {
+    worker.snapshots = [createSnapshot('old-snapshot', 'activated')];
+    worker.activeSnapshotId = 'old-snapshot';
+    worker.pages = [createPublishedPage('page-1', 'hello')];
+    worker.failProgressStage = 'snapshot_activated';
+
+    await expect(worker.run(createJob())).rejects.toThrow('progress failed');
+
+    const newSnapshot = worker.snapshots.at(-1);
+    expect(worker.activeSnapshotId).toBe(newSnapshot?.id);
+    expect(newSnapshot?.status).toBe('activated');
+    expect(newSnapshot?.activated_at).toBe(now);
+    expect(worker.snapshots.find((snapshot) => snapshot.id === 'old-snapshot')?.status).toBe('superseded');
+  });
+
   it('4.T7 isolates embedding failures from the active snapshot', async () => {
     worker.snapshots = [createSnapshot('old-snapshot', 'activated')];
     worker.activeSnapshotId = 'old-snapshot';
@@ -242,6 +257,7 @@ class HarnessIndexerWorker extends IndexerWorker {
   activeSnapshotId: string | undefined;
   buildingExists = false;
   failActivation = false;
+  failProgressStage: string | undefined;
 
   constructor(readonly mockEmbeddingProvider: MockEmbeddingProvider) {
     super({} as JobDatabase, new RedisStub(), mockEmbeddingProvider, 'indexer-worker-test');
@@ -256,6 +272,10 @@ class HarnessIndexerWorker extends IndexerWorker {
   }
 
   protected override recordProgress(_jobId: string, detail: Record<string, unknown>): Promise<void> {
+    if (detail.stage === this.failProgressStage) {
+      return Promise.reject(new Error('progress failed'));
+    }
+
     this.events.push(detail);
     return Promise.resolve();
   }

--- a/apps/indexer-worker/src/indexer-payload.ts
+++ b/apps/indexer-worker/src/indexer-payload.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const indexerPayloadSchema = z
+  .object({
+    tenant_id: z.string().min(1),
+    space_id: z.string().min(1),
+    graphify_run_id: z.string().optional(),
+    trigger: z.enum(['graphify_completion', 'manual_reindex', 'manual_rebuild']),
+    scope: z.enum(['full', 'incremental', 'single_page']),
+    page_id: z.string().optional(),
+  })
+  .superRefine((payload, context) => {
+    if (payload.scope === 'single_page' && (payload.page_id === undefined || payload.page_id.length === 0)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['page_id'],
+        message: 'page_id is required for single_page indexing',
+      });
+    }
+  });
+
+export type IndexerPayload = z.infer<typeof indexerPayloadSchema>;

--- a/apps/indexer-worker/src/indexer-worker.ts
+++ b/apps/indexer-worker/src/indexer-worker.ts
@@ -6,6 +6,7 @@ import type { EmbeddingProvider } from '@cherrygraph/ai-core';
 import type { RedisJobLockClient, JobDatabase, JobRow } from '@cherrygraph/job-core';
 import {
   embeddings,
+  graphEdges,
   graphEvidenceRefs,
   indexSnapshots,
   model_configs,
@@ -94,6 +95,7 @@ export class IndexerWorker extends AbstractBullMQWorker<IndexerBullMQPayload, In
     void bullJob;
 
     let snapshotId: string | undefined;
+    let activationCommitted = false;
 
     try {
       const payload = indexerPayloadSchema.parse(job.payload_json);
@@ -140,6 +142,7 @@ export class IndexerWorker extends AbstractBullMQWorker<IndexerBullMQPayload, In
 
       await this.markSnapshotReady(snapshot.id, chunkPlans.length);
       await this.activateSnapshot(snapshot.id, payload.space_id);
+      activationCommitted = true;
       await this.recordProgress(job.id, {
         stage: 'snapshot_activated',
         snapshot_id: snapshot.id,
@@ -152,7 +155,7 @@ export class IndexerWorker extends AbstractBullMQWorker<IndexerBullMQPayload, In
     } catch (error) {
       await this.recordFailureProgress(job.id, error);
 
-      if (snapshotId !== undefined) {
+      if (snapshotId !== undefined && !activationCommitted) {
         await this.resetSnapshotToBuilding(snapshotId);
       }
 
@@ -283,8 +286,13 @@ export class IndexerWorker extends AbstractBullMQWorker<IndexerBullMQPayload, In
             edge_id: graphEvidenceRefs.edge_id,
             source_document_id: graphEvidenceRefs.source_document_id,
             confidence_contribution: graphEvidenceRefs.confidence_contribution,
+            source_node_id: graphEdges.source_node_id,
+            target_node_id: graphEdges.target_node_id,
+            confidence_label: graphEdges.confidence_label,
+            effective_confidence_score: graphEdges.effective_confidence_score,
           })
           .from(graphEvidenceRefs)
+          .leftJoin(graphEdges, eq(graphEdges.id, graphEvidenceRefs.edge_id))
           .where(and(eq(graphEvidenceRefs.page_id, pageId), eq(graphEvidenceRefs.page_version_id, pageVersionId))),
     });
   }

--- a/apps/indexer-worker/src/indexer-worker.ts
+++ b/apps/indexer-worker/src/indexer-worker.ts
@@ -1,0 +1,593 @@
+import type { Job as BullMQJob } from 'bullmq';
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+
+import type { EmbeddingProvider } from '@cherrygraph/ai-core';
+import type { RedisJobLockClient, JobDatabase, JobRow } from '@cherrygraph/job-core';
+import {
+  embeddings,
+  graphEvidenceRefs,
+  indexSnapshots,
+  model_configs,
+  sourceLinks,
+  space_permissions,
+  spaces,
+  wikiChunks,
+  wikiPageVersions,
+  wikiPages,
+  wikiSections,
+} from '@cherrygraph/shared';
+import {
+  buildAclJson,
+  chunkPage,
+  computeSourceChain,
+  type AclJson,
+  type SourceChainJson,
+} from '@cherrygraph/rag-core';
+import { AbstractBullMQWorker } from '@cherrygraph/job-core';
+
+import { indexerPayloadSchema, type IndexerPayload } from './indexer-payload.js';
+import { SnapshotManager, type IndexSnapshotRow } from './snapshot-manager.js';
+
+type IndexerBullMQPayload = { jobId: string };
+
+type IndexerResult = {
+  snapshot_id: string;
+  chunk_count: number;
+};
+
+type ModelConfigRow = Pick<
+  typeof model_configs.$inferSelect,
+  'id' | 'provider' | 'model_id' | 'base_url' | 'encrypted_api_key_ref' | 'embedding_dim'
+>;
+
+type PublishedPageRow = {
+  page: typeof wikiPages.$inferSelect;
+  version: typeof wikiPageVersions.$inferSelect;
+};
+
+type PreviousChunkRow = {
+  chunk: typeof wikiChunks.$inferSelect;
+  embedding: typeof embeddings.$inferSelect | null;
+};
+
+type SpaceConfigInput = {
+  graphify_config?: {
+    classification?: string | null;
+  } | null;
+};
+
+type ChunkInsert = typeof wikiChunks.$inferInsert;
+type EmbeddingInsert = typeof embeddings.$inferInsert;
+
+type ChunkPlan = {
+  chunk: ChunkInsert & { id: string; content: string };
+  reusedEmbedding?: number[];
+  copiedFromChunkId?: string;
+};
+
+const EMBEDDING_BATCH_SIZE = 128;
+const INDEX_STATUS_PENDING = 'pending';
+const INDEX_STATUS_INDEXED = 'indexed';
+
+export class IndexingInProgressError extends Error {
+  readonly code = 'INDEXING_IN_PROGRESS';
+  readonly retryable = false;
+
+  constructor(spaceId: string) {
+    super(`Indexing is already in progress for space ${spaceId}`);
+    this.name = 'IndexingInProgressError';
+  }
+}
+
+export class IndexerWorker extends AbstractBullMQWorker<IndexerBullMQPayload, IndexerResult> {
+  constructor(
+    db: JobDatabase,
+    redis: RedisJobLockClient,
+    private readonly embeddingProvider: EmbeddingProvider,
+    workerId: string,
+  ) {
+    super(db, redis, workerId);
+  }
+
+  protected async process(job: JobRow, bullJob: BullMQJob<IndexerBullMQPayload, IndexerResult, string>): Promise<IndexerResult> {
+    void bullJob;
+
+    let snapshotId: string | undefined;
+
+    try {
+      const payload = indexerPayloadSchema.parse(job.payload_json);
+      await this.recordProgress(job.id, {
+        stage: 'indexing_started',
+        tenant_id: payload.tenant_id,
+        space_id: payload.space_id,
+        scope: payload.scope,
+      });
+
+      if (await this.checkBuildingExists(payload.space_id)) {
+        throw new IndexingInProgressError(payload.space_id);
+      }
+
+      const embeddingModel = await this.resolveEmbeddingModel(payload.tenant_id);
+      const pages = await this.loadPublishedPages(payload);
+      const targetPage = this.resolveTargetPage(payload, pages);
+      const wikiRepoCommitHash = resolveWikiRepoCommitHash(pages);
+      const activeSnapshot = await this.loadActiveSnapshot(payload.space_id);
+      const previousChunks =
+        activeSnapshot === undefined ? [] : await this.loadSnapshotChunks(payload.space_id, activeSnapshot.id);
+      const previousByPosition = buildPreviousChunkMap(previousChunks, embeddingModel.id);
+
+      const snapshot = await this.createSnapshot(payload, embeddingModel.id, wikiRepoCommitHash);
+      snapshotId = snapshot.id;
+
+      const chunkPlans =
+        payload.scope === 'single_page'
+          ? await this.planSinglePageSnapshot(payload, snapshot.id, embeddingModel.id, targetPage, previousChunks, previousByPosition)
+          : await this.planRebuiltSnapshot(snapshot.id, embeddingModel.id, pages, previousByPosition);
+
+      await this.insertChunks(chunkPlans.map((plan) => plan.chunk));
+      await this.recordProgress(job.id, {
+        stage: 'chunks_created',
+        count: chunkPlans.length,
+        snapshot_id: snapshot.id,
+      });
+
+      await this.embedAndInsert(chunkPlans, embeddingModel.id, job.id);
+      await this.markChunksIndexed(
+        chunkPlans.map((plan) => plan.chunk.id),
+        new Date(),
+      );
+
+      await this.markSnapshotReady(snapshot.id, chunkPlans.length);
+      await this.activateSnapshot(snapshot.id, payload.space_id);
+      await this.recordProgress(job.id, {
+        stage: 'snapshot_activated',
+        snapshot_id: snapshot.id,
+      });
+
+      return {
+        snapshot_id: snapshot.id,
+        chunk_count: chunkPlans.length,
+      };
+    } catch (error) {
+      await this.recordFailureProgress(job.id, error);
+
+      if (snapshotId !== undefined) {
+        await this.resetSnapshotToBuilding(snapshotId);
+      }
+
+      throw error;
+    }
+  }
+
+  protected checkBuildingExists(spaceId: string): Promise<boolean> {
+    return SnapshotManager.checkBuildingExists(this.db, spaceId);
+  }
+
+  protected async resolveEmbeddingModel(tenantId: string): Promise<ModelConfigRow> {
+    const [modelConfig] = await this.db
+      .select({
+        id: model_configs.id,
+        provider: model_configs.provider,
+        model_id: model_configs.model_id,
+        base_url: model_configs.base_url,
+        encrypted_api_key_ref: model_configs.encrypted_api_key_ref,
+        embedding_dim: model_configs.embedding_dim,
+      })
+      .from(model_configs)
+      .where(and(eq(model_configs.tenant_id, tenantId), eq(model_configs.model_type, 'embedding'), eq(model_configs.enabled, true)))
+      .orderBy(asc(model_configs.created_at))
+      .limit(1);
+
+    if (modelConfig === undefined) {
+      throw new Error(`No enabled embedding model configured for tenant ${tenantId}`);
+    }
+
+    return modelConfig;
+  }
+
+  protected createSnapshot(
+    payload: IndexerPayload,
+    embeddingModelId: string,
+    wikiRepoCommitHash: string,
+  ): Promise<IndexSnapshotRow> {
+    return SnapshotManager.createSnapshot(
+      this.db,
+      payload.tenant_id,
+      payload.space_id,
+      embeddingModelId,
+      payload.graphify_run_id,
+      wikiRepoCommitHash,
+    );
+  }
+
+  protected async loadActiveSnapshot(spaceId: string): Promise<IndexSnapshotRow | undefined> {
+    const [space] = await this.db
+      .select({
+        active_index_snapshot_id: spaces.active_index_snapshot_id,
+      })
+      .from(spaces)
+      .where(eq(spaces.id, spaceId))
+      .limit(1);
+
+    if (space?.active_index_snapshot_id === null || space?.active_index_snapshot_id === undefined) {
+      return undefined;
+    }
+
+    const [snapshot] = await this.db
+      .select()
+      .from(indexSnapshots)
+      .where(eq(indexSnapshots.id, space.active_index_snapshot_id))
+      .limit(1);
+
+    return snapshot;
+  }
+
+  protected async loadPublishedPages(payload: IndexerPayload): Promise<PublishedPageRow[]> {
+    const rows = await this.db
+      .select({
+        page: wikiPages,
+        version: wikiPageVersions,
+      })
+      .from(wikiPages)
+      .innerJoin(wikiPageVersions, eq(wikiPages.current_version_id, wikiPageVersions.id))
+      .where(
+        and(
+          eq(wikiPages.tenant_id, payload.tenant_id),
+          eq(wikiPages.space_id, payload.space_id),
+          eq(wikiPageVersions.status, 'published'),
+          eq(wikiPages.current_version_id, wikiPageVersions.id),
+        ),
+      )
+      .orderBy(asc(wikiPages.page_id));
+
+    if (payload.scope !== 'single_page') {
+      return rows;
+    }
+
+    return rows.filter((row) => row.page.page_id === payload.page_id);
+  }
+
+  protected async loadSections(pageVersionId: string): Promise<Array<typeof wikiSections.$inferSelect>> {
+    return this.db
+      .select()
+      .from(wikiSections)
+      .where(eq(wikiSections.page_version_id, pageVersionId))
+      .orderBy(asc(wikiSections.section_index));
+  }
+
+  protected async loadSnapshotChunks(spaceId: string, snapshotId: string): Promise<PreviousChunkRow[]> {
+    return this.db
+      .select({
+        chunk: wikiChunks,
+        embedding: embeddings,
+      })
+      .from(wikiChunks)
+      .leftJoin(embeddings, eq(embeddings.chunk_id, wikiChunks.id))
+      .where(and(eq(wikiChunks.space_id, spaceId), eq(wikiChunks.index_snapshot_id, snapshotId)))
+      .orderBy(asc(wikiChunks.page_version_id), asc(wikiChunks.chunk_index));
+  }
+
+  protected async computeSourceChain(page: PublishedPageRow): Promise<SourceChainJson> {
+    return computeSourceChain(page.page.id, page.version.id, {
+      getSourceLinks: (pageVersionId) =>
+        this.db
+          .select({
+            source_document_id: sourceLinks.source_document_id,
+          })
+          .from(sourceLinks)
+          .where(eq(sourceLinks.page_version_id, pageVersionId)),
+      getGraphEvidenceRefs: (pageId, pageVersionId) =>
+        this.db
+          .select({
+            edge_id: graphEvidenceRefs.edge_id,
+            source_document_id: graphEvidenceRefs.source_document_id,
+            confidence_contribution: graphEvidenceRefs.confidence_contribution,
+          })
+          .from(graphEvidenceRefs)
+          .where(and(eq(graphEvidenceRefs.page_id, pageId), eq(graphEvidenceRefs.page_version_id, pageVersionId))),
+    });
+  }
+
+  protected async buildAcl(page: PublishedPageRow): Promise<AclJson> {
+    const [space] = await this.db
+      .select({
+        graphify_config: spaces.graphify_config,
+      })
+      .from(spaces)
+      .where(eq(spaces.id, page.page.space_id))
+      .limit(1);
+
+    return buildAclJson(page.page, page.version, normalizeSpaceConfig(space), {
+      getAllowedGroupIds: async (spaceId) => {
+        const rows = await this.db
+          .select({
+            group_id: space_permissions.group_id,
+          })
+          .from(space_permissions)
+          .where(eq(space_permissions.space_id, spaceId));
+
+        return [...new Set(rows.map((row) => row.group_id))];
+      },
+    });
+  }
+
+  protected insertChunks(chunks: ChunkInsert[]): Promise<unknown> {
+    if (chunks.length === 0) {
+      return Promise.resolve();
+    }
+
+    return this.db.insert(wikiChunks).values(chunks).returning();
+  }
+
+  protected insertEmbeddings(rows: EmbeddingInsert[]): Promise<unknown> {
+    if (rows.length === 0) {
+      return Promise.resolve();
+    }
+
+    return this.db.insert(embeddings).values(rows).returning();
+  }
+
+  protected markChunksIndexed(chunkIds: string[], indexedAt: Date): Promise<unknown> {
+    if (chunkIds.length === 0) {
+      return Promise.resolve();
+    }
+
+    return this.db
+      .update(wikiChunks)
+      .set({
+        index_status: INDEX_STATUS_INDEXED,
+        indexed_at: indexedAt,
+      })
+      .where(inArray(wikiChunks.id, chunkIds))
+      .returning();
+  }
+
+  protected markSnapshotReady(snapshotId: string, chunkCount: number): Promise<void> {
+    return SnapshotManager.markSnapshotReady(this.db, snapshotId, chunkCount);
+  }
+
+  protected activateSnapshot(snapshotId: string, spaceId: string): Promise<void> {
+    return SnapshotManager.activateSnapshot(this.db, snapshotId, spaceId);
+  }
+
+  protected resetSnapshotToBuilding(snapshotId: string): Promise<void> {
+    return SnapshotManager.markSnapshotBuilding(this.db, snapshotId);
+  }
+
+  private resolveTargetPage(payload: IndexerPayload, pages: PublishedPageRow[]): PublishedPageRow | undefined {
+    if (payload.scope !== 'single_page') {
+      return undefined;
+    }
+
+    const targetPage = pages.find((row) => row.page.page_id === payload.page_id);
+    if (targetPage === undefined) {
+      throw new Error(`Published page ${payload.page_id} was not found in space ${payload.space_id}`);
+    }
+
+    return targetPage;
+  }
+
+  private async planRebuiltSnapshot(
+    snapshotId: string,
+    embeddingModelId: string,
+    pages: PublishedPageRow[],
+    previousByPosition: Map<string, PreviousChunkRow>,
+  ): Promise<ChunkPlan[]> {
+    const plans: ChunkPlan[] = [];
+
+    for (const page of pages) {
+      plans.push(...(await this.planPageChunks(snapshotId, embeddingModelId, page, previousByPosition)));
+    }
+
+    return plans;
+  }
+
+  private async planSinglePageSnapshot(
+    payload: IndexerPayload,
+    snapshotId: string,
+    embeddingModelId: string,
+    targetPage: PublishedPageRow | undefined,
+    previousChunks: PreviousChunkRow[],
+    previousByPosition: Map<string, PreviousChunkRow>,
+  ): Promise<ChunkPlan[]> {
+    if (targetPage === undefined) {
+      throw new Error(`Published page ${payload.page_id} was not found in space ${payload.space_id}`);
+    }
+
+    const copiedPlans = previousChunks
+      .filter((row) => row.chunk.wiki_page_pk !== targetPage.page.id)
+      .map((row) => copyPreviousChunk(row, snapshotId, embeddingModelId));
+    const rebuiltPlans = await this.planPageChunks(snapshotId, embeddingModelId, targetPage, previousByPosition);
+
+    return [...copiedPlans, ...rebuiltPlans];
+  }
+
+  private async planPageChunks(
+    snapshotId: string,
+    embeddingModelId: string,
+    page: PublishedPageRow,
+    previousByPosition: Map<string, PreviousChunkRow>,
+  ): Promise<ChunkPlan[]> {
+    const [sections, sourceChain, acl] = await Promise.all([
+      this.loadSections(page.version.id),
+      this.computeSourceChain(page),
+      this.buildAcl(page),
+    ]);
+    const chunks = chunkPage(page.page, page.version, sections);
+
+    return chunks.map((chunk) => {
+      const previous = previousByPosition.get(chunkKey(page.version.id, chunk.chunk_index));
+      const previousEmbedding = previous?.embedding?.embedding;
+      const reusedEmbedding =
+        previous?.chunk.content_hash === chunk.content_hash && Array.isArray(previousEmbedding)
+          ? previousEmbedding
+          : undefined;
+
+      return {
+        chunk: {
+          id: randomUUID(),
+          tenant_id: page.page.tenant_id,
+          space_id: page.page.space_id,
+          wiki_page_pk: page.page.id,
+          page_version_id: page.version.id,
+          section_id: chunk.section_id,
+          chunk_index: chunk.chunk_index,
+          content: chunk.content,
+          content_hash: chunk.content_hash,
+          token_count: chunk.token_count,
+          index_status: INDEX_STATUS_PENDING,
+          index_snapshot_id: snapshotId,
+          index_version: snapshotId,
+          embedding_model_id: embeddingModelId,
+          injection_risk: chunk.injection_risk,
+          source_chain_json: sourceChain,
+          acl_json: acl,
+        },
+        ...(reusedEmbedding !== undefined ? { reusedEmbedding } : {}),
+        ...(previous?.chunk.id !== undefined && reusedEmbedding !== undefined ? { copiedFromChunkId: previous.chunk.id } : {}),
+      };
+    });
+  }
+
+  private async embedAndInsert(chunkPlans: ChunkPlan[], embeddingModelId: string, jobId: string): Promise<void> {
+    const embeddingsToInsert: EmbeddingInsert[] = [];
+    const chunksNeedingEmbeddings = chunkPlans.filter((plan) => plan.reusedEmbedding === undefined);
+
+    for (const plan of chunkPlans) {
+      if (plan.reusedEmbedding === undefined) {
+        continue;
+      }
+
+      embeddingsToInsert.push(createEmbeddingInsert(plan.chunk, embeddingModelId, plan.reusedEmbedding));
+    }
+
+    const totalBatches = Math.ceil(chunksNeedingEmbeddings.length / EMBEDDING_BATCH_SIZE);
+    if (totalBatches === 0) {
+      await this.recordProgress(jobId, {
+        stage: 'embedding_progress',
+        batch: 0,
+        total_batches: 0,
+        embedded_count: 0,
+      });
+    }
+
+    for (let start = 0; start < chunksNeedingEmbeddings.length; start += EMBEDDING_BATCH_SIZE) {
+      const batch = chunksNeedingEmbeddings.slice(start, start + EMBEDDING_BATCH_SIZE);
+      const batchNumber = Math.floor(start / EMBEDDING_BATCH_SIZE) + 1;
+      const vectors = await this.embeddingProvider.embedBatch(batch.map((plan) => plan.chunk.content));
+
+      if (vectors.length !== batch.length) {
+        throw new Error(`Embedding provider returned ${vectors.length} vectors for ${batch.length} chunks`);
+      }
+
+      for (const [index, vector] of vectors.entries()) {
+        const plan = batch[index];
+        if (plan === undefined) {
+          throw new Error('Embedding batch index mismatch');
+        }
+
+        embeddingsToInsert.push(createEmbeddingInsert(plan.chunk, embeddingModelId, vector));
+      }
+
+      await this.recordProgress(jobId, {
+        stage: 'embedding_progress',
+        batch: batchNumber,
+        total_batches: totalBatches,
+        embedded_count: Math.min(start + batch.length, chunksNeedingEmbeddings.length),
+      });
+    }
+
+    await this.insertEmbeddings(embeddingsToInsert);
+  }
+
+  private async recordFailureProgress(jobId: string, error: unknown): Promise<void> {
+    try {
+      await this.recordProgress(jobId, {
+        stage: 'indexing_failed',
+        error: normalizeErrorMessage(error),
+      });
+    } catch {
+      // Preserve the original processing failure.
+    }
+  }
+}
+
+function buildPreviousChunkMap(previousChunks: PreviousChunkRow[], embeddingModelId: string): Map<string, PreviousChunkRow> {
+  const previousByPosition = new Map<string, PreviousChunkRow>();
+
+  for (const row of previousChunks) {
+    if (row.chunk.embedding_model_id !== embeddingModelId) {
+      continue;
+    }
+
+    previousByPosition.set(chunkKey(row.chunk.page_version_id, row.chunk.chunk_index), row);
+  }
+
+  return previousByPosition;
+}
+
+function chunkKey(pageVersionId: string, chunkIndex: number): string {
+  return `${pageVersionId}:${chunkIndex}`;
+}
+
+function copyPreviousChunk(row: PreviousChunkRow, snapshotId: string, embeddingModelId: string): ChunkPlan {
+  const previousEmbedding = row.embedding?.embedding;
+  const reusedEmbedding = Array.isArray(previousEmbedding) ? previousEmbedding : undefined;
+
+  return {
+    chunk: {
+      id: randomUUID(),
+      tenant_id: row.chunk.tenant_id,
+      space_id: row.chunk.space_id,
+      wiki_page_pk: row.chunk.wiki_page_pk,
+      page_version_id: row.chunk.page_version_id,
+      section_id: row.chunk.section_id,
+      chunk_index: row.chunk.chunk_index,
+      content: row.chunk.content,
+      content_hash: row.chunk.content_hash,
+      token_count: row.chunk.token_count,
+      index_status: INDEX_STATUS_PENDING,
+      index_snapshot_id: snapshotId,
+      index_version: snapshotId,
+      embedding_model_id: embeddingModelId,
+      injection_risk: row.chunk.injection_risk,
+      source_chain_json: row.chunk.source_chain_json,
+      acl_json: row.chunk.acl_json,
+    },
+    ...(reusedEmbedding !== undefined ? { reusedEmbedding } : {}),
+    copiedFromChunkId: row.chunk.id,
+  };
+}
+
+function normalizeSpaceConfig(space: { graphify_config: unknown } | undefined): SpaceConfigInput | undefined {
+  if (space === undefined || typeof space.graphify_config !== 'object' || space.graphify_config === null) {
+    return undefined;
+  }
+
+  return space as SpaceConfigInput;
+}
+
+function createEmbeddingInsert(chunk: ChunkPlan['chunk'], embeddingModelId: string, embedding: number[]): EmbeddingInsert {
+  return {
+    id: randomUUID(),
+    tenant_id: chunk.tenant_id,
+    space_id: chunk.space_id,
+    chunk_id: chunk.id,
+    model_config_id: embeddingModelId,
+    embedding,
+  };
+}
+
+function resolveWikiRepoCommitHash(pages: PublishedPageRow[]): string {
+  return pages.find((row) => typeof row.version.commit_hash === 'string' && row.version.commit_hash.length > 0)?.version
+    .commit_hash ?? 'unknown';
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message.slice(0, 1_000);
+  }
+
+  return 'Indexing failed';
+}

--- a/apps/indexer-worker/src/indexer-worker.ts
+++ b/apps/indexer-worker/src/indexer-worker.ts
@@ -239,7 +239,6 @@ export class IndexerWorker extends AbstractBullMQWorker<IndexerBullMQPayload, In
           eq(wikiPages.tenant_id, payload.tenant_id),
           eq(wikiPages.space_id, payload.space_id),
           eq(wikiPageVersions.status, 'published'),
-          eq(wikiPages.current_version_id, wikiPageVersions.id),
         ),
       )
       .orderBy(asc(wikiPages.page_id));
@@ -425,7 +424,7 @@ export class IndexerWorker extends AbstractBullMQWorker<IndexerBullMQPayload, In
     const chunks = chunkPage(page.page, page.version, sections);
 
     return chunks.map((chunk) => {
-      const previous = previousByPosition.get(chunkKey(page.version.id, chunk.chunk_index));
+      const previous = previousByPosition.get(chunkKey(page.page.id, chunk.chunk_index));
       const previousEmbedding = previous?.embedding?.embedding;
       const reusedEmbedding =
         previous?.chunk.content_hash === chunk.content_hash && Array.isArray(previousEmbedding)
@@ -529,14 +528,14 @@ function buildPreviousChunkMap(previousChunks: PreviousChunkRow[], embeddingMode
       continue;
     }
 
-    previousByPosition.set(chunkKey(row.chunk.page_version_id, row.chunk.chunk_index), row);
+    previousByPosition.set(chunkKey(row.chunk.wiki_page_pk, row.chunk.chunk_index), row);
   }
 
   return previousByPosition;
 }
 
-function chunkKey(pageVersionId: string, chunkIndex: number): string {
-  return `${pageVersionId}:${chunkIndex}`;
+function chunkKey(pageId: string, chunkIndex: number): string {
+  return `${pageId}:${chunkIndex}`;
 }
 
 function copyPreviousChunk(row: PreviousChunkRow, snapshotId: string, embeddingModelId: string): ChunkPlan {

--- a/apps/indexer-worker/src/main.ts
+++ b/apps/indexer-worker/src/main.ts
@@ -1,10 +1,17 @@
-import { Worker, type Job } from 'bullmq';
+import type { Worker } from 'bullmq';
+import { eq, and, asc } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
 import type { Server } from 'node:http';
 import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+import type { Pool as PgPool } from 'pg';
 
-import { createBullMQConnection, QUEUE_INDEXING } from '@cherrygraph/job-core';
+import { createBullMQConnection, QUEUE_INDEXING, type RedisJobLockClient } from '@cherrygraph/job-core';
+import { OpenAIEmbeddingProvider, type EmbeddingProviderConfig } from '@cherrygraph/ai-core';
+import { model_configs } from '@cherrygraph/shared';
 
 import { closeHealthServer, startHealthServer } from './health.js';
+import { IndexerWorker } from './indexer-worker.js';
 
 const WORKER_NAME = 'indexer-worker';
 
@@ -22,32 +29,39 @@ function parseHealthPort(value: string | undefined): number {
 }
 
 export async function bootstrap(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (databaseUrl === undefined || databaseUrl.length === 0) {
+    throw new Error('DATABASE_URL is required to start indexer-worker');
+  }
+
   const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
   const healthPort = parseHealthPort(process.env.WORKER_HEALTH_PORT);
+  const pool = new pg.Pool({
+    connectionString: databaseUrl,
+    connectionTimeoutMillis: 5_000,
+    idleTimeoutMillis: 30_000,
+  });
+  const db = drizzle(pool);
   const connection = createBullMQConnection(redisUrl);
-  const worker = new Worker<unknown, unknown, string>(
-    QUEUE_INDEXING,
-    (job: Job<unknown, unknown, string>): Promise<void> => {
-      console.log(`${WORKER_NAME}: job received, no-op`, { jobId: job.id, jobName: job.name });
-      return Promise.resolve();
-    },
-    { connection },
-  );
+  const embeddingProvider = new OpenAIEmbeddingProvider(await resolveEmbeddingProviderConfig(db));
+  const indexerWorker = new IndexerWorker(db, connection as unknown as RedisJobLockClient, embeddingProvider, WORKER_NAME);
+  const worker = indexerWorker.createWorker(QUEUE_INDEXING, connection);
 
   worker.on('error', (error) => {
     console.error(`${WORKER_NAME}: worker error`, error);
   });
 
   const healthServer = await startHealthServer(WORKER_NAME, healthPort);
-  const shutdown = createShutdownHandler(worker, connection, healthServer);
+  const shutdown = createShutdownHandler(worker, connection, pool, healthServer);
   process.once('SIGTERM', shutdown);
   process.once('SIGINT', shutdown);
   console.log(`${WORKER_NAME}: started`, { queue: QUEUE_INDEXING, healthPort });
 }
 
 function createShutdownHandler(
-  worker: Worker<unknown, unknown, string>,
+  worker: Worker,
   connection: ReturnType<typeof createBullMQConnection>,
+  pool: PgPool,
   healthServer: Server,
 ): () => void {
   let shuttingDown = false;
@@ -58,20 +72,21 @@ function createShutdownHandler(
     }
 
     shuttingDown = true;
-    void shutdown(worker, connection, healthServer);
+    void shutdown(worker, connection, pool, healthServer);
   };
 }
 
 async function shutdown(
-  worker: Worker<unknown, unknown, string>,
+  worker: Worker,
   connection: ReturnType<typeof createBullMQConnection>,
+  pool: PgPool,
   healthServer: Server,
 ): Promise<void> {
   let shutdownFailed = false;
 
   try {
     console.log(`${WORKER_NAME}: shutting down`);
-    const results = await Promise.allSettled([worker.close(), connection.quit()]);
+    const results = await Promise.allSettled([worker.close(), connection.quit(), pool.end()]);
     for (const result of results) {
       if (result.status === 'rejected') {
         shutdownFailed = true;
@@ -96,6 +111,39 @@ async function shutdown(
   }
 
   console.log(`${WORKER_NAME}: stopped`);
+}
+
+async function resolveEmbeddingProviderConfig(
+  db: ReturnType<typeof drizzle>,
+): Promise<EmbeddingProviderConfig> {
+  const [modelConfig] = await db
+    .select({
+      provider: model_configs.provider,
+      modelId: model_configs.model_id,
+      baseUrl: model_configs.base_url,
+      encryptedApiKeyRef: model_configs.encrypted_api_key_ref,
+      embeddingDim: model_configs.embedding_dim,
+    })
+    .from(model_configs)
+    .where(and(eq(model_configs.model_type, 'embedding'), eq(model_configs.enabled, true)))
+    .orderBy(asc(model_configs.created_at))
+    .limit(1);
+
+  if (modelConfig === undefined) {
+    throw new Error('No enabled embedding model configured');
+  }
+
+  if (modelConfig.encryptedApiKeyRef === null) {
+    throw new Error(`Embedding model ${modelConfig.modelId} is missing encrypted_api_key_ref`);
+  }
+
+  return {
+    provider: modelConfig.provider,
+    modelId: modelConfig.modelId,
+    encryptedApiKeyRef: modelConfig.encryptedApiKeyRef,
+    ...(modelConfig.baseUrl !== null ? { baseUrl: modelConfig.baseUrl } : {}),
+    ...(modelConfig.embeddingDim !== null ? { embeddingDim: modelConfig.embeddingDim } : {}),
+  };
 }
 
 function isEntrypoint(): boolean {

--- a/apps/indexer-worker/src/snapshot-manager.ts
+++ b/apps/indexer-worker/src/snapshot-manager.ts
@@ -1,0 +1,113 @@
+import { and, eq, ne } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+
+import { indexSnapshots, spaces } from '@cherrygraph/shared';
+import type { JobDatabase } from '@cherrygraph/job-core';
+
+export type IndexSnapshotRow = typeof indexSnapshots.$inferSelect;
+
+const BUILDING_STATUS = 'building';
+const READY_STATUS = 'ready';
+const ACTIVATED_STATUS = 'activated';
+const SUPERSEDED_STATUS = 'superseded';
+
+export class SnapshotManager {
+  static async createSnapshot(
+    db: JobDatabase,
+    tenantId: string,
+    spaceId: string,
+    embeddingModelId: string,
+    graphifyRunId?: string,
+    wikiRepoCommitHash = 'unknown',
+  ): Promise<IndexSnapshotRow> {
+    const [snapshot] = await db
+      .insert(indexSnapshots)
+      .values({
+        id: randomUUID(),
+        tenant_id: tenantId,
+        space_id: spaceId,
+        ...(graphifyRunId !== undefined ? { graphify_run_id: graphifyRunId } : {}),
+        wiki_repo_commit_hash: wikiRepoCommitHash,
+        embedding_model_id: embeddingModelId,
+        chunk_count: 0,
+        status: BUILDING_STATUS,
+      })
+      .returning();
+
+    if (snapshot === undefined) {
+      throw new Error('Failed to create index snapshot');
+    }
+
+    return snapshot;
+  }
+
+  static async activateSnapshot(db: JobDatabase, snapshotId: string, spaceId: string): Promise<void> {
+    const now = new Date();
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(indexSnapshots)
+        .set({
+          status: ACTIVATED_STATUS,
+          activated_at: now,
+        })
+        .where(eq(indexSnapshots.id, snapshotId))
+        .returning();
+
+      await tx
+        .update(spaces)
+        .set({
+          active_index_snapshot_id: snapshotId,
+          updated_at: now,
+        })
+        .where(eq(spaces.id, spaceId))
+        .returning();
+
+      await tx
+        .update(indexSnapshots)
+        .set({
+          status: SUPERSEDED_STATUS,
+        })
+        .where(
+          and(
+            eq(indexSnapshots.space_id, spaceId),
+            eq(indexSnapshots.status, ACTIVATED_STATUS),
+            ne(indexSnapshots.id, snapshotId),
+          ),
+        )
+        .returning();
+    });
+  }
+
+  static async checkBuildingExists(db: JobDatabase, spaceId: string): Promise<boolean> {
+    const [snapshot] = await db
+      .select({ id: indexSnapshots.id })
+      .from(indexSnapshots)
+      .where(and(eq(indexSnapshots.space_id, spaceId), eq(indexSnapshots.status, BUILDING_STATUS)))
+      .limit(1);
+
+    return snapshot !== undefined;
+  }
+
+  static async markSnapshotReady(db: JobDatabase, snapshotId: string, chunkCount: number): Promise<void> {
+    await db
+      .update(indexSnapshots)
+      .set({
+        status: READY_STATUS,
+        chunk_count: chunkCount,
+      })
+      .where(eq(indexSnapshots.id, snapshotId))
+      .returning();
+  }
+
+  static async markSnapshotBuilding(db: JobDatabase, snapshotId: string): Promise<void> {
+    await db
+      .update(indexSnapshots)
+      .set({
+        status: BUILDING_STATUS,
+        activated_at: null,
+      })
+      .where(eq(indexSnapshots.id, snapshotId))
+      .returning();
+  }
+}

--- a/apps/indexer-worker/tsconfig.json
+++ b/apps/indexer-worker/tsconfig.json
@@ -11,6 +11,15 @@
   "exclude": ["dist", "node_modules"],
   "references": [
     {
+      "path": "../../packages/shared"
+    },
+    {
+      "path": "../../packages/ai-core"
+    },
+    {
+      "path": "../../packages/rag-core"
+    },
+    {
       "path": "../../packages/job-core"
     }
   ]

--- a/docs/schemas/schema.sql
+++ b/docs/schemas/schema.sql
@@ -349,7 +349,7 @@ CREATE TABLE wiki_chunks (
   source_chain_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   acl_json JSONB NOT NULL DEFAULT '{}'::jsonb,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  UNIQUE (page_version_id, chunk_index)
+  UNIQUE (index_snapshot_id, page_version_id, chunk_index)
 );
 
 -- Phase 1: 单模型，VECTOR 维度与 model_configs.embedding_dim 对应。

--- a/packages/shared/src/schema/__tests__/schema.test.ts
+++ b/packages/shared/src/schema/__tests__/schema.test.ts
@@ -181,7 +181,8 @@ describe('Drizzle core schema', () => {
     expect(schema.wikiChunks.acl_json.notNull).toBe(true);
     expect(schema.wikiChunks.created_at.getSQLType()).toBe('timestamp with time zone');
 
-    expect(uniqueColumns(schema.wikiChunks, 'wiki_chunks_page_version_id_chunk_index_unique')).toEqual([
+    expect(uniqueColumns(schema.wikiChunks, 'wiki_chunks_snapshot_page_version_chunk_unique')).toEqual([
+      'index_snapshot_id',
       'page_version_id',
       'chunk_index',
     ]);

--- a/packages/shared/src/schema/core.ts
+++ b/packages/shared/src/schema/core.ts
@@ -799,7 +799,11 @@ export const wikiChunks = pgTable(
     created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    unique('wiki_chunks_page_version_id_chunk_index_unique').on(table.page_version_id, table.chunk_index),
+    unique('wiki_chunks_snapshot_page_version_chunk_unique').on(
+      table.index_snapshot_id,
+      table.page_version_id,
+      table.chunk_index,
+    ),
     index('idx_wiki_chunks_space').on(table.tenant_id, table.space_id),
     index('idx_wiki_chunks_index_status').on(table.index_status, table.index_snapshot_id),
     // idx_wiki_chunks_fts is created by SQL migration because it requires a GIN to_tsvector expression.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,12 +159,34 @@ importers:
 
   apps/indexer-worker:
     dependencies:
+      '@cherrygraph/ai-core':
+        specifier: workspace:*
+        version: link:../../packages/ai-core
       '@cherrygraph/job-core':
         specifier: workspace:*
         version: link:../../packages/job-core
+      '@cherrygraph/rag-core':
+        specifier: workspace:*
+        version: link:../../packages/rag-core
+      '@cherrygraph/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       bullmq:
         specifier: ^5.76.3
         version: 5.76.3
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
 
   apps/web:
     dependencies:

--- a/schemas/migrations/0008_perpetual_kulan_gath.sql
+++ b/schemas/migrations/0008_perpetual_kulan_gath.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "wiki_chunks" DROP CONSTRAINT "wiki_chunks_page_version_id_chunk_index_unique";--> statement-breakpoint
+ALTER TABLE "wiki_chunks" ADD CONSTRAINT "wiki_chunks_snapshot_page_version_chunk_unique" UNIQUE("index_snapshot_id","page_version_id","chunk_index");

--- a/schemas/migrations/meta/0008_snapshot.json
+++ b/schemas/migrations/meta/0008_snapshot.json
@@ -1,0 +1,5012 @@
+{
+  "id": "963eed1e-8cbe-49a8-9e6e-cf6c185aca94",
+  "prevId": "eb06095c-668c-47f2-8451-6c0db500ff72",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_tenant_time": {
+          "name": "idx_audit_logs_tenant_time",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_tenant_id_tenants_id_fk": {
+          "name": "audit_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_actor_user_id_users_id_fk": {
+          "name": "audit_logs_actor_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embeddings": {
+      "name": "embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_embeddings_model": {
+          "name": "idx_embeddings_model",
+          "columns": [
+            {
+              "expression": "model_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embeddings_tenant_id_tenants_id_fk": {
+          "name": "embeddings_tenant_id_tenants_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "embeddings_space_id_spaces_id_fk": {
+          "name": "embeddings_space_id_spaces_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "embeddings_chunk_id_wiki_chunks_id_fk": {
+          "name": "embeddings_chunk_id_wiki_chunks_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "wiki_chunks",
+          "columnsFrom": [
+            "chunk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "embeddings_model_config_id_model_configs_id_fk": {
+          "name": "embeddings_model_config_id_model_configs_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "model_configs",
+          "columnsFrom": [
+            "model_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_blobs": {
+      "name": "file_blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_uri": {
+          "name": "storage_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_blobs_tenant_id_tenants_id_fk": {
+          "name": "file_blobs_tenant_id_tenants_id_fk",
+          "tableFrom": "file_blobs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_blobs_tenant_id_sha256_unique": {
+          "name": "file_blobs_tenant_id_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_communities": {
+      "name": "graph_communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_key": {
+          "name": "community_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "graph_communities_tenant_id_tenants_id_fk": {
+          "name": "graph_communities_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_communities",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_communities_space_id_spaces_id_fk": {
+          "name": "graph_communities_space_id_spaces_id_fk",
+          "tableFrom": "graph_communities",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_communities_graphify_run_id_graphify_runs_id_fk": {
+          "name": "graph_communities_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "graph_communities",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "graph_communities_tenant_id_space_id_graphify_run_id_community_key_unique": {
+          "name": "graph_communities_tenant_id_space_id_graphify_run_id_community_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "graphify_run_id",
+            "community_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_edges": {
+      "name": "graph_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence_label": {
+          "name": "confidence_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_confidence_score": {
+          "name": "raw_confidence_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_confidence_score": {
+          "name": "effective_confidence_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_count": {
+          "name": "evidence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "evidence_refs_json": {
+          "name": "evidence_refs_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_edges_source": {
+          "name": "idx_graph_edges_source",
+          "columns": [
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_edges_target": {
+          "name": "idx_graph_edges_target",
+          "columns": [
+            {
+              "expression": "target_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_edges_confidence": {
+          "name": "idx_graph_edges_confidence",
+          "columns": [
+            {
+              "expression": "confidence_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_confidence_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_edges_tenant_id_tenants_id_fk": {
+          "name": "graph_edges_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_edges_space_id_spaces_id_fk": {
+          "name": "graph_edges_space_id_spaces_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_edges_graphify_run_id_graphify_runs_id_fk": {
+          "name": "graph_edges_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_edges_source_node_id_graph_nodes_id_fk": {
+          "name": "graph_edges_source_node_id_graph_nodes_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "graph_nodes",
+          "columnsFrom": [
+            "source_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_edges_target_node_id_graph_nodes_id_fk": {
+          "name": "graph_edges_target_node_id_graph_nodes_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "graph_nodes",
+          "columnsFrom": [
+            "target_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_evidence_refs": {
+      "name": "graph_evidence_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_id": {
+          "name": "edge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_contribution": {
+          "name": "confidence_contribution",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_evidence_refs_edge": {
+          "name": "idx_graph_evidence_refs_edge",
+          "columns": [
+            {
+              "expression": "edge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_evidence_refs_page": {
+          "name": "idx_graph_evidence_refs_page",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_evidence_refs_source_doc": {
+          "name": "idx_graph_evidence_refs_source_doc",
+          "columns": [
+            {
+              "expression": "source_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_evidence_refs_tenant_id_tenants_id_fk": {
+          "name": "graph_evidence_refs_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_space_id_spaces_id_fk": {
+          "name": "graph_evidence_refs_space_id_spaces_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_edge_id_graph_edges_id_fk": {
+          "name": "graph_evidence_refs_edge_id_graph_edges_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "graph_edges",
+          "columnsFrom": [
+            "edge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_page_id_wiki_pages_id_fk": {
+          "name": "graph_evidence_refs_page_id_wiki_pages_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_page_version_id_wiki_page_versions_id_fk": {
+          "name": "graph_evidence_refs_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_section_id_wiki_sections_id_fk": {
+          "name": "graph_evidence_refs_section_id_wiki_sections_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "wiki_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_source_document_id_source_documents_id_fk": {
+          "name": "graph_evidence_refs_source_document_id_source_documents_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_node_aliases": {
+      "name": "graph_node_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_stable_key": {
+          "name": "node_stable_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'graphify'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_node_aliases_lookup": {
+          "name": "idx_graph_node_aliases_lookup",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_node_aliases_tenant_id_tenants_id_fk": {
+          "name": "graph_node_aliases_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_node_aliases",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_node_aliases_space_id_spaces_id_fk": {
+          "name": "graph_node_aliases_space_id_spaces_id_fk",
+          "tableFrom": "graph_node_aliases",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "graph_node_aliases_tenant_id_space_id_node_stable_key_alias_unique": {
+          "name": "graph_node_aliases_tenant_id_space_id_node_stable_key_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "node_stable_key",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_node_merges": {
+      "name": "graph_node_merges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stable_key": {
+          "name": "from_stable_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stable_key": {
+          "name": "to_stable_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_node_merges_from": {
+          "name": "idx_graph_node_merges_from",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_stable_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_node_merges_tenant_id_tenants_id_fk": {
+          "name": "graph_node_merges_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_node_merges",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_node_merges_space_id_spaces_id_fk": {
+          "name": "graph_node_merges_space_id_spaces_id_fk",
+          "tableFrom": "graph_node_merges",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_node_merges_created_by_users_id_fk": {
+          "name": "graph_node_merges_created_by_users_id_fk",
+          "tableFrom": "graph_node_merges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_nodes": {
+      "name": "graph_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_key": {
+          "name": "node_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stable_key": {
+          "name": "stable_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_label": {
+          "name": "norm_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_refs_json": {
+          "name": "source_refs_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_nodes_stable_key": {
+          "name": "idx_graph_nodes_stable_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stable_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_nodes_label_trgm": {
+          "name": "idx_graph_nodes_label_trgm",
+          "columns": [
+            {
+              "expression": "\"label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_nodes_tenant_id_tenants_id_fk": {
+          "name": "graph_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_nodes_space_id_spaces_id_fk": {
+          "name": "graph_nodes_space_id_spaces_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_nodes_graphify_run_id_graphify_runs_id_fk": {
+          "name": "graph_nodes_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_nodes_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "graph_nodes_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_nodes_page_version_id_wiki_page_versions_id_fk": {
+          "name": "graph_nodes_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "graph_nodes_tenant_id_space_id_graphify_run_id_node_key_unique": {
+          "name": "graph_nodes_tenant_id_space_id_graphify_run_id_node_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "graphify_run_id",
+            "node_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_reports": {
+      "name": "graph_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "graph_reports_tenant_id_tenants_id_fk": {
+          "name": "graph_reports_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_reports",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_reports_space_id_spaces_id_fk": {
+          "name": "graph_reports_space_id_spaces_id_fk",
+          "tableFrom": "graph_reports",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_reports_graphify_run_id_graphify_runs_id_fk": {
+          "name": "graph_reports_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "graph_reports",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graphify_runs": {
+      "name": "graphify_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input_version": {
+          "name": "input_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_version": {
+          "name": "output_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graphify_ref": {
+          "name": "graphify_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_json_uri": {
+          "name": "graph_json_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_output_uri": {
+          "name": "wiki_output_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_uri": {
+          "name": "report_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_html_uri": {
+          "name": "graph_html_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_graphify_runs_job": {
+          "name": "idx_graphify_runs_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graphify_runs_tenant_id_tenants_id_fk": {
+          "name": "graphify_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "graphify_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graphify_runs_space_id_spaces_id_fk": {
+          "name": "graphify_runs_space_id_spaces_id_fk",
+          "tableFrom": "graphify_runs",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graphify_runs_job_id_jobs_id_fk": {
+          "name": "graphify_runs_job_id_jobs_id_fk",
+          "tableFrom": "graphify_runs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graphify_runs_created_by_users_id_fk": {
+          "name": "graphify_runs_created_by_users_id_fk",
+          "tableFrom": "graphify_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_members_tenant_id_tenants_id_fk": {
+          "name": "group_members_tenant_id_tenants_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_members_group_id_user_id_pk": {
+          "name": "group_members_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_permission_version": {
+          "name": "idx_groups_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_tenant_id_tenants_id_fk": {
+          "name": "groups_tenant_id_tenants_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_tenant_id_name_unique": {
+          "name": "groups_tenant_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.index_snapshots": {
+      "name": "index_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_repo_commit_hash": {
+          "name": "wiki_repo_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "edge_count": {
+          "name": "edge_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_index_snapshots_space": {
+          "name": "idx_index_snapshots_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_index_snapshots_active": {
+          "name": "idx_index_snapshots_active",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "index_snapshots_tenant_id_tenants_id_fk": {
+          "name": "index_snapshots_tenant_id_tenants_id_fk",
+          "tableFrom": "index_snapshots",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "index_snapshots_space_id_spaces_id_fk": {
+          "name": "index_snapshots_space_id_spaces_id_fk",
+          "tableFrom": "index_snapshots",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "index_snapshots_graphify_run_id_graphify_runs_id_fk": {
+          "name": "index_snapshots_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "index_snapshots",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_events": {
+      "name": "job_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail_json": {
+          "name": "detail_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_job_events_job": {
+          "name": "idx_job_events_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_events_job_id_jobs_id_fk": {
+          "name": "job_events_job_id_jobs_id_fk",
+          "tableFrom": "job_events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_poll": {
+          "name": "idx_jobs_poll",
+          "columns": [
+            {
+              "expression": "queue_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_locked": {
+          "name": "idx_jobs_locked",
+          "columns": [
+            {
+              "expression": "locked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"locked_by\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_space": {
+          "name": "idx_jobs_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_tenant_id_tenants_id_fk": {
+          "name": "jobs_tenant_id_tenants_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "jobs_space_id_spaces_id_fk": {
+          "name": "jobs_space_id_spaces_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "jobs_created_by_users_id_fk": {
+          "name": "jobs_created_by_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jobs_tenant_id_idempotency_key_unique": {
+          "name": "jobs_tenant_id_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_configs": {
+      "name": "model_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key_ref": {
+          "name": "encrypted_api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_rpm": {
+          "name": "rate_limit_rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visible_group_ids": {
+          "name": "visible_group_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_configs_tenant_type": {
+          "name": "idx_model_configs_tenant_type",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_configs_tenant_id_tenants_id_fk": {
+          "name": "model_configs_tenant_id_tenants_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_configs_tenant_id_provider_model_id_unique": {
+          "name": "model_configs_tenant_id_provider_model_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "provider",
+            "model_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_block_metadata": {
+      "name": "page_block_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'graphify'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_editor": {
+          "name": "last_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editable": {
+          "name": "editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_page_blocks_page_version": {
+          "name": "idx_page_blocks_page_version",
+          "columns": [
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_page_blocks_owner": {
+          "name": "idx_page_blocks_owner",
+          "columns": [
+            {
+              "expression": "wiki_page_pk",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_block_metadata_tenant_id_tenants_id_fk": {
+          "name": "page_block_metadata_tenant_id_tenants_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "page_block_metadata_space_id_spaces_id_fk": {
+          "name": "page_block_metadata_space_id_spaces_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "page_block_metadata_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "page_block_metadata_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "page_block_metadata_page_version_id_wiki_page_versions_id_fk": {
+          "name": "page_block_metadata_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "page_block_metadata_last_editor_users_id_fk": {
+          "name": "page_block_metadata_last_editor_users_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "last_editor"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_block_metadata_page_version_id_block_id_unique": {
+          "name": "page_block_metadata_page_version_id_block_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_version_id",
+            "block_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_versions": {
+      "name": "permission_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_permissions_json": {
+          "name": "old_permissions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_permissions_json": {
+          "name": "new_permissions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_permission_versions_space": {
+          "name": "idx_permission_versions_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_permission_versions_subject": {
+          "name": "idx_permission_versions_subject",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_versions_tenant_id_tenants_id_fk": {
+          "name": "permission_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_versions_space_id_spaces_id_fk": {
+          "name": "permission_versions_space_id_spaces_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_versions_actor_user_id_users_id_fk": {
+          "name": "permission_versions_actor_user_id_users_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user": {
+          "name": "idx_sessions_user",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_refresh": {
+          "name": "idx_sessions_refresh",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_tenant_id_tenants_id_fk": {
+          "name": "sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_refresh_token_hash_unique": {
+          "name": "sessions_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_uri": {
+          "name": "source_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_hash": {
+          "name": "quote_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reference'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_source_links_page_version": {
+          "name": "idx_source_links_page_version",
+          "columns": [
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_source_links_source_doc": {
+          "name": "idx_source_links_source_doc",
+          "columns": [
+            {
+              "expression": "source_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_tenant_id_tenants_id_fk": {
+          "name": "source_links_tenant_id_tenants_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_space_id_spaces_id_fk": {
+          "name": "source_links_space_id_spaces_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "source_links_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_page_version_id_wiki_page_versions_id_fk": {
+          "name": "source_links_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_section_id_wiki_sections_id_fk": {
+          "name": "source_links_section_id_wiki_sections_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_source_document_id_source_documents_id_fk": {
+          "name": "source_links_source_document_id_source_documents_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_documents": {
+      "name": "source_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_blob_id": {
+          "name": "file_blob_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploaded'"
+        },
+        "parsed_uri": {
+          "name": "parsed_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_documents_tenant_id_tenants_id_fk": {
+          "name": "source_documents_tenant_id_tenants_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_space_id_spaces_id_fk": {
+          "name": "source_documents_space_id_spaces_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_file_blob_id_file_blobs_id_fk": {
+          "name": "source_documents_file_blob_id_file_blobs_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "file_blobs",
+          "columnsFrom": [
+            "file_blob_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_uploader_id_users_id_fk": {
+          "name": "source_documents_uploader_id_users_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_documents_space_id_file_blob_id_unique": {
+          "name": "source_documents_space_id_file_blob_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "space_id",
+            "file_blob_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_permissions": {
+      "name": "space_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_permissions_tenant_id_tenants_id_fk": {
+          "name": "space_permissions_tenant_id_tenants_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "space_permissions_space_id_spaces_id_fk": {
+          "name": "space_permissions_space_id_spaces_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "space_permissions_group_id_groups_id_fk": {
+          "name": "space_permissions_group_id_groups_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "space_permissions_space_id_group_id_permission_unique": {
+          "name": "space_permissions_space_id_group_id_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "space_id",
+            "group_id",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "docmost_space_id": {
+          "name": "docmost_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_repo_path": {
+          "name": "wiki_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_graphify_run_id": {
+          "name": "active_graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_index_snapshot_id": {
+          "name": "active_index_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_consistency_status": {
+          "name": "index_consistency_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "strict_knowledge_only": {
+          "name": "strict_knowledge_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "graphify_config": {
+          "name": "graphify_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "default_publish_policy": {
+          "name": "default_publish_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor_publish'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_spaces_consistency": {
+          "name": "idx_spaces_consistency",
+          "columns": [
+            {
+              "expression": "index_consistency_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_spaces_permission_version": {
+          "name": "idx_spaces_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_tenant_id_tenants_id_fk": {
+          "name": "spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "spaces_tenant_id_slug_unique": {
+          "name": "spaces_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_tenant_id_tenants_id_fk": {
+          "name": "system_settings_tenant_id_tenants_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_settings_tenant_id_category_key_unique": {
+          "name": "system_settings_tenant_id_category_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "category",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_permission_version": {
+          "name": "idx_users_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_tenant_id_email_unique": {
+          "name": "users_tenant_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_chunks": {
+      "name": "wiki_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_status": {
+          "name": "index_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "index_snapshot_id": {
+          "name": "index_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_version": {
+          "name": "index_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injection_risk": {
+          "name": "injection_risk",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_chain_json": {
+          "name": "source_chain_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_chunks_space": {
+          "name": "idx_wiki_chunks_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wiki_chunks_index_status": {
+          "name": "idx_wiki_chunks_index_status",
+          "columns": [
+            {
+              "expression": "index_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_chunks_tenant_id_tenants_id_fk": {
+          "name": "wiki_chunks_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_chunks_space_id_spaces_id_fk": {
+          "name": "wiki_chunks_space_id_spaces_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_chunks_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_chunks_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_chunks_page_version_id_wiki_page_versions_id_fk": {
+          "name": "wiki_chunks_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_chunks_section_id_wiki_sections_id_fk": {
+          "name": "wiki_chunks_section_id_wiki_sections_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "wiki_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_chunks_snapshot_page_version_chunk_unique": {
+          "name": "wiki_chunks_snapshot_page_version_chunk_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index_snapshot_id",
+            "page_version_id",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_page_versions": {
+      "name": "wiki_page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontmatter_json": {
+          "name": "frontmatter_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_versions_status": {
+          "name": "idx_wiki_versions_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_page_versions_tenant_id_tenants_id_fk": {
+          "name": "wiki_page_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_space_id_spaces_id_fk": {
+          "name": "wiki_page_versions_space_id_spaces_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_created_by_users_id_fk": {
+          "name": "wiki_page_versions_created_by_users_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_page_versions_wiki_page_pk_version_no_unique": {
+          "name": "wiki_page_versions_wiki_page_pk_version_no_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wiki_page_pk",
+            "version_no"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_pages": {
+      "name": "wiki_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_version_id": {
+          "name": "indexed_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "docmost_page_id": {
+          "name": "docmost_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_pages_indexed_version": {
+          "name": "idx_wiki_pages_indexed_version",
+          "columns": [
+            {
+              "expression": "indexed_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wiki_pages_current_indexed": {
+          "name": "idx_wiki_pages_current_indexed",
+          "columns": [
+            {
+              "expression": "current_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "indexed_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_pages_tenant_id_tenants_id_fk": {
+          "name": "wiki_pages_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_pages_space_id_spaces_id_fk": {
+          "name": "wiki_pages_space_id_spaces_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_pages_created_by_users_id_fk": {
+          "name": "wiki_pages_created_by_users_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_wiki_pages_current_version": {
+          "name": "fk_wiki_pages_current_version",
+          "tableFrom": "wiki_pages",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_wiki_pages_indexed_version": {
+          "name": "fk_wiki_pages_indexed_version",
+          "tableFrom": "wiki_pages",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "indexed_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_pages_tenant_id_space_id_page_id_unique": {
+          "name": "wiki_pages_tenant_id_space_id_page_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "page_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_sections": {
+      "name": "wiki_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "section_index": {
+          "name": "section_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_offset": {
+          "name": "end_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_sections_page_version": {
+          "name": "idx_wiki_sections_page_version",
+          "columns": [
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_sections_tenant_id_tenants_id_fk": {
+          "name": "wiki_sections_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_space_id_spaces_id_fk": {
+          "name": "wiki_sections_space_id_spaces_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_sections_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_page_version_id_wiki_page_versions_id_fk": {
+          "name": "wiki_sections_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_sections_page_version_id_section_id_unique": {
+          "name": "wiki_sections_page_version_id_section_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_version_id",
+            "section_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_update_proposals": {
+      "name": "wiki_update_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "diff_json": {
+          "name": "diff_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wiki_update_proposals_tenant_id_tenants_id_fk": {
+          "name": "wiki_update_proposals_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_update_proposals",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_update_proposals_space_id_spaces_id_fk": {
+          "name": "wiki_update_proposals_space_id_spaces_id_fk",
+          "tableFrom": "wiki_update_proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_update_proposals_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_update_proposals_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_update_proposals",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_update_proposals_graphify_run_id_graphify_runs_id_fk": {
+          "name": "wiki_update_proposals_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "wiki_update_proposals",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/schemas/migrations/meta/_journal.json
+++ b/schemas/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777804388923,
       "tag": "0007_public_whiplash",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777806987138,
+      "tag": "0008_perpetual_kulan_gath",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #104

Transforms the indexer-worker from a no-op BullMQ shell into a complete indexing pipeline:

- **IndexerWorker**: Extends `AbstractBullMQWorker`, orchestrates the full indexing flow
- **SnapshotManager**: Manages index_snapshot lifecycle (building→ready→activated→superseded) with atomic activation transaction
- **Pipeline**: Published-only page selection → rag-core chunking with real source_chain/ACL from DB (joined graph_edges) → ai-core embedding with incremental content_hash dedup (keyed by wiki_page_pk) → batch DB writes
- **Features**: Concurrent mutex (INDEXING_IN_PROGRESS), failure isolation (activationCommitted flag), single-page scope with chunk copy, progress event reporting
- **Schema fix**: UNIQUE constraint changed to `(index_snapshot_id, page_version_id, chunk_index)` to support immutable multi-snapshot chunk rows (migration 0008)

### Files Changed
- `apps/indexer-worker/src/` — 4 source files + 1 test file (+1454 lines)
- `packages/shared/src/schema/core.ts` — UNIQUE constraint fix
- `schemas/migrations/0008_perpetual_kulan_gath.sql` — Constraint migration
- `docs/schemas/schema.sql` — Authoritative schema update

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `394af7b64ec1b16bb89d3365f923e0236a009eb4`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/107#issuecomment-4366051454) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/107#issuecomment-4366051501) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/107#issuecomment-4366051553) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/107#issuecomment-4366051615)
- Key findings addressed: Snapshot-scoped UNIQUE constraint (migration 0008), activation failure isolation (activationCommitted flag), graph_edges join for complete source chain, dedup key changed to wiki_page_pk

## Test Plan

- [x] Build passes, 664 tests pass (113 test files)
- [x] 4.T1-4.T11 all covered (11 test cases + 1 regression test)