### PR TITLE
feat(stage-6): API indexing triggers + admin rebuild + matrix update (#105)

### DIFF
--- a/apps/api/src/admin/__tests__/admin-index.test.ts
+++ b/apps/api/src/admin/__tests__/admin-index.test.ts
@@ -208,7 +208,7 @@ class ScriptedAdminDb {
     this.selectResults.push(result);
   }
 
-  select(_fields?: unknown): ScriptedQueryBuilder {
+  select(): ScriptedQueryBuilder {
     return new ScriptedQueryBuilder(this.selectResults.shift() ?? []);
   }
 }
@@ -216,15 +216,15 @@ class ScriptedAdminDb {
 class ScriptedQueryBuilder implements PromiseLike<unknown[]> {
   constructor(private readonly result: unknown[]) {}
 
-  from(_table?: unknown): this {
+  from(): this {
     return this;
   }
 
-  where(_where?: unknown): this {
+  where(): this {
     return this;
   }
 
-  limit(_limit?: number): this {
+  limit(): this {
     return this;
   }
 
@@ -343,7 +343,7 @@ function getHttpCode(methodName: keyof AdminIndexController): unknown {
 function createGuardContext(methodName: keyof AdminIndexController, request: unknown): ExecutionContext {
   const descriptor = Object.getOwnPropertyDescriptor(AdminIndexController.prototype, methodName);
   return {
-    getHandler: () => descriptor?.value,
+    getHandler: () => descriptor?.value as () => unknown,
     getClass: () => AdminIndexController,
     switchToHttp: () => ({
       getRequest: () => request,

--- a/apps/api/src/admin/__tests__/admin-index.test.ts
+++ b/apps/api/src/admin/__tests__/admin-index.test.ts
@@ -1,0 +1,352 @@
+import 'reflect-metadata';
+
+import { HttpException, HttpStatus, type ExecutionContext } from '@nestjs/common';
+import { HTTP_CODE_METADATA } from '@nestjs/common/constants.js';
+import { Reflector } from '@nestjs/core';
+import {
+  JobRepository,
+  QueueFactory,
+  QUEUE_INDEXING,
+  type JobRow,
+} from '@cherrygraph/job-core';
+import { PERMISSIONS_METADATA_KEY, RbacGuard } from '@cherrygraph/auth-core';
+import { ErrorCode } from '@cherrygraph/shared';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AuditEntry, AuditService } from '../../audit/audit.service.js';
+import {
+  TEST_SPACE_ID,
+  TEST_TENANT_ID,
+  TEST_USER_ID,
+  getHttpExceptionCode,
+  getRejectedHttpException,
+} from '../../users/__tests__/user-group-service-test-utils.js';
+import { AdminIndexController } from '../admin-index.controller.js';
+import { AdminIndexService } from '../admin-index.service.js';
+
+describe('AdminIndexController', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('applies admin permissions and 202 response metadata', () => {
+    expect(getMetadata('rebuildIndex')).toEqual(['admin']);
+    expect(getHttpCode('rebuildIndex')).toBe(HttpStatus.ACCEPTED);
+  });
+
+  it('creates a full rebuild job by default, enqueues it, and audits', async () => {
+    const { controller, db, audit } = createControllerContext();
+    const queue = createQueueMock();
+    const job = createJobRow({ id: 'job-full' });
+    db.queueSelect([{ id: TEST_SPACE_ID }]);
+    db.queueSelect([]);
+    const createJobSpy = vi.spyOn(JobRepository, 'create').mockResolvedValue(job);
+    vi.spyOn(QueueFactory, 'createQueue').mockReturnValue(queue as never);
+
+    const result = await controller.rebuildIndex(TEST_SPACE_ID, {}, undefined, createRequest());
+
+    expect(result).toEqual({ data: job });
+    expect(createJobSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        tenant_id: TEST_TENANT_ID,
+        space_id: TEST_SPACE_ID,
+        queue_name: QUEUE_INDEXING,
+        type: 'reindex',
+        payload_json: {
+          tenant_id: TEST_TENANT_ID,
+          space_id: TEST_SPACE_ID,
+          trigger: 'manual_rebuild',
+          scope: 'full',
+        },
+        created_by: TEST_USER_ID,
+      }),
+    );
+    expect(queue.add).toHaveBeenCalledWith('reindex', { jobId: 'job-full' });
+    expect(queue.close).toHaveBeenCalledTimes(1);
+    expect(audit.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'admin.index.rebuild',
+        resource_type: 'space',
+        resource_id: TEST_SPACE_ID,
+        space_id: TEST_SPACE_ID,
+        request_id: 'req-1',
+        metadata_json: {
+          reindex_job_id: 'job-full',
+          trigger: 'manual_rebuild',
+          scope: 'full',
+        },
+      }) as AuditEntry,
+    );
+  });
+
+  it('supports incremental rebuild scope and idempotency key job creation', async () => {
+    const { controller, db } = createControllerContext();
+    const queue = createQueueMock();
+    const job = createJobRow({ id: 'job-incremental' });
+    db.queueSelect([]);
+    db.queueSelect([{ id: TEST_SPACE_ID }]);
+    db.queueSelect([]);
+    const createJobSpy = vi.spyOn(JobRepository, 'create').mockResolvedValue(job);
+    vi.spyOn(QueueFactory, 'createQueue').mockReturnValue(queue as never);
+
+    const result = await controller.rebuildIndex(
+      TEST_SPACE_ID,
+      { scope: 'incremental', reason: 'refresh changed pages' },
+      'idem-key-1',
+      createRequest(),
+    );
+
+    expect(result).toEqual({ data: job });
+    expect(createJobSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        idempotency_key: 'idem-key-1',
+        payload_json: {
+          tenant_id: TEST_TENANT_ID,
+          space_id: TEST_SPACE_ID,
+          trigger: 'manual_rebuild',
+          scope: 'incremental',
+          reason: 'refresh changed pages',
+        },
+      }),
+    );
+  });
+
+  it('RBAC rejects non-admin rebuild requests', async () => {
+    const guard = new RbacGuard(new Reflector());
+
+    try {
+      await guard.canActivate(createGuardContext('rebuildIndex', createRequest('editor')));
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpException);
+      expect((err as HttpException).getStatus()).toBe(403);
+      expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+      return;
+    }
+
+    throw new Error('Expected RBAC guard to reject non-admin rebuild request');
+  });
+
+  it('returns 404 when the space is missing', async () => {
+    const { service, db } = createControllerContext();
+    db.queueSelect([]);
+
+    const err = await getRejectedHttpException(
+      service.rebuildIndex(TEST_SPACE_ID, {}, createAdminContext()),
+    );
+
+    expect(err.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.SPACE_NOT_FOUND);
+  });
+
+  it('returns 409 when an index rebuild is already running', async () => {
+    const { service, db } = createControllerContext();
+    db.queueSelect([{ id: TEST_SPACE_ID }]);
+    db.queueSelect([{ id: 'snapshot-building' }]);
+
+    const err = await getRejectedHttpException(
+      service.rebuildIndex(TEST_SPACE_ID, {}, createAdminContext()),
+    );
+
+    expect(err.getStatus()).toBe(409);
+    expect(getHttpExceptionCode(err)).toBe('REBUILD_ALREADY_RUNNING');
+  });
+
+  it('returns the same idempotent job without creating a duplicate or enqueueing twice', async () => {
+    const { controller, db } = createControllerContext();
+    const queue = createQueueMock();
+    const job = createJobRow({ id: 'job-idempotent', idempotency_key: 'idem-key-1' });
+    db.queueSelect([]);
+    db.queueSelect([{ id: TEST_SPACE_ID }]);
+    db.queueSelect([]);
+    db.queueSelect([job]);
+    const createJobSpy = vi.spyOn(JobRepository, 'create').mockResolvedValue(job);
+    vi.spyOn(QueueFactory, 'createQueue').mockReturnValue(queue as never);
+
+    const first = await controller.rebuildIndex(TEST_SPACE_ID, {}, 'idem-key-1', createRequest());
+    const second = await controller.rebuildIndex(TEST_SPACE_ID, {}, 'idem-key-1', createRequest());
+
+    expect(first).toEqual({ data: job });
+    expect(second).toEqual({ data: job });
+    expect(createJobSpy).toHaveBeenCalledTimes(1);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createControllerContext(): {
+  controller: AdminIndexController;
+  service: AdminIndexService;
+  db: ScriptedAdminDb;
+  audit: {
+    push: ReturnType<typeof vi.fn<(entry: AuditEntry) => void>>;
+  };
+} {
+  const db = new ScriptedAdminDb();
+  const audit = {
+    push: vi.fn<(entry: AuditEntry) => void>(),
+  };
+  const service = new AdminIndexService(db.asDrizzle(), audit as unknown as AuditService, createRedisMock() as never);
+
+  return {
+    controller: new AdminIndexController(service),
+    service,
+    db,
+    audit,
+  };
+}
+
+class ScriptedAdminDb {
+  readonly selectResults: unknown[][] = [];
+
+  asDrizzle(): NodePgDatabase {
+    return this as unknown as NodePgDatabase;
+  }
+
+  queueSelect(result: unknown[]): void {
+    this.selectResults.push(result);
+  }
+
+  select(_fields?: unknown): ScriptedQueryBuilder {
+    return new ScriptedQueryBuilder(this.selectResults.shift() ?? []);
+  }
+}
+
+class ScriptedQueryBuilder implements PromiseLike<unknown[]> {
+  constructor(private readonly result: unknown[]) {}
+
+  from(_table?: unknown): this {
+    return this;
+  }
+
+  where(_where?: unknown): this {
+    return this;
+  }
+
+  limit(_limit?: number): this {
+    return this;
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.result).then(onfulfilled ?? undefined, onrejected ?? undefined);
+  }
+}
+
+function createRequest(role = 'admin'): {
+  user: {
+    sub: string;
+    tenant_id: string;
+    email: string;
+    role: string;
+    group_ids: string[];
+    token_use: 'access';
+  };
+  ip: string;
+  headers: Record<string, string>;
+} {
+  return {
+    user: {
+      sub: TEST_USER_ID,
+      tenant_id: TEST_TENANT_ID,
+      email: 'admin@example.com',
+      role,
+      group_ids: ['group-1'],
+      token_use: 'access',
+    },
+    ip: '127.0.0.1',
+    headers: {
+      'user-agent': 'vitest',
+      'x-request-id': 'req-1',
+    },
+  };
+}
+
+function createAdminContext(): {
+  tenantId: string;
+  actorUserId: string;
+} {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: TEST_USER_ID,
+  };
+}
+
+function createRedisMock(): {
+  get: ReturnType<typeof vi.fn<(key: string) => Promise<string | null>>>;
+  set: ReturnType<typeof vi.fn<(key: string, value: string, ...args: Array<string | number>) => Promise<string | null>>>;
+  eval: ReturnType<typeof vi.fn<() => Promise<number>>>;
+} {
+  return {
+    get: vi.fn(() => Promise.resolve(null)),
+    set: vi.fn(() => Promise.resolve('OK')),
+    eval: vi.fn(() => Promise.resolve(1)),
+  };
+}
+
+function createQueueMock(): {
+  add: ReturnType<typeof vi.fn<(name: string, data: { jobId: string }) => Promise<void>>>;
+  close: ReturnType<typeof vi.fn<() => Promise<void>>>;
+} {
+  return {
+    add: vi.fn(() => Promise.resolve()),
+    close: vi.fn(() => Promise.resolve()),
+  };
+}
+
+function createJobRow(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-rebuild',
+    tenant_id: TEST_TENANT_ID,
+    space_id: TEST_SPACE_ID,
+    queue_name: QUEUE_INDEXING,
+    type: 'reindex',
+    priority: 100,
+    status: 'pending',
+    attempt_count: 0,
+    max_attempts: 3,
+    timeout_seconds: null,
+    locked_by: null,
+    locked_at: null,
+    next_run_at: null,
+    cancel_requested_at: null,
+    payload_json: {
+      tenant_id: TEST_TENANT_ID,
+      space_id: TEST_SPACE_ID,
+      trigger: 'manual_rebuild',
+      scope: 'full',
+    },
+    result_json: null,
+    error_json: null,
+    idempotency_key: null,
+    created_by: TEST_USER_ID,
+    created_at: new Date('2026-05-01T00:00:00.000Z'),
+    started_at: null,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function getMetadata(methodName: keyof AdminIndexController): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(AdminIndexController.prototype, methodName);
+  return Reflect.getMetadata(PERMISSIONS_METADATA_KEY, descriptor?.value as object);
+}
+
+function getHttpCode(methodName: keyof AdminIndexController): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(AdminIndexController.prototype, methodName);
+  return Reflect.getMetadata(HTTP_CODE_METADATA, descriptor?.value as object);
+}
+
+function createGuardContext(methodName: keyof AdminIndexController, request: unknown): ExecutionContext {
+  const descriptor = Object.getOwnPropertyDescriptor(AdminIndexController.prototype, methodName);
+  return {
+    getHandler: () => descriptor?.value,
+    getClass: () => AdminIndexController,
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+}

--- a/apps/api/src/admin/admin-index.controller.ts
+++ b/apps/api/src/admin/admin-index.controller.ts
@@ -1,0 +1,71 @@
+import { Body, Controller, Headers, HttpCode, HttpException, HttpStatus, Param, Post, Req } from '@nestjs/common';
+import { Permissions, type AuthenticatedRequestUser } from '@cherrygraph/auth-core';
+import type { JobRow } from '@cherrygraph/job-core';
+import { ErrorCode } from '@cherrygraph/shared';
+
+import { AdminIndexService, type AdminIndexContext } from './admin-index.service.js';
+
+type RequestWithAuth = {
+  user?: AuthenticatedRequestUser & {
+    permissions?: string[];
+  };
+  ip?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  id?: string;
+};
+
+@Controller('admin')
+export class AdminIndexController {
+  constructor(private readonly adminIndexService: AdminIndexService) {}
+
+  @Post('spaces/:spaceId/rebuild-index')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @Permissions('admin')
+  async rebuildIndex(
+    @Param('spaceId') spaceId: string,
+    @Body() body: { scope?: string; reason?: string } | undefined,
+    @Headers('x-idempotency-key') idempotencyKey: string | undefined,
+    @Req() request: RequestWithAuth,
+  ): Promise<{ data: JobRow }> {
+    const user = getAuthenticatedUser(request);
+    const data = await this.adminIndexService.rebuildIndex(
+      spaceId,
+      body ?? {},
+      buildAdminIndexContext(request, user),
+      idempotencyKey,
+    );
+
+    return { data };
+  }
+}
+
+function getAuthenticatedUser(request: RequestWithAuth): AuthenticatedRequestUser & { permissions?: string[] } {
+  if (request.user === undefined) {
+    throw new HttpException(
+      {
+        code: ErrorCode.UNAUTHENTICATED,
+        message: 'Unauthenticated',
+      },
+      HttpStatus.UNAUTHORIZED,
+    );
+  }
+
+  return request.user;
+}
+
+function buildAdminIndexContext(
+  request: RequestWithAuth,
+  user: AuthenticatedRequestUser & { permissions?: string[] },
+): AdminIndexContext {
+  const userAgent = request.headers?.['user-agent'];
+  const requestId = request.headers?.['x-request-id'];
+
+  return {
+    tenantId: user.tenant_id,
+    actorUserId: user.sub,
+    ...(request.ip !== undefined ? { ip: request.ip } : {}),
+    ...(typeof userAgent === 'string' ? { userAgent } : {}),
+    ...(typeof requestId === 'string' ? { requestId } : {}),
+    ...(request.id !== undefined ? { requestId: request.id } : {}),
+  };
+}

--- a/apps/api/src/admin/admin-index.module.ts
+++ b/apps/api/src/admin/admin-index.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { AdminIndexController } from './admin-index.controller.js';
+import { AdminIndexService } from './admin-index.service.js';
+
+@Module({
+  controllers: [AdminIndexController],
+  providers: [AdminIndexService],
+})
+export class AdminIndexModule {}

--- a/apps/api/src/admin/admin-index.service.ts
+++ b/apps/api/src/admin/admin-index.service.ts
@@ -148,9 +148,19 @@ export class AdminIndexService {
   }
 }
 
+const VALID_REBUILD_SCOPES = new Set(['full', 'incremental']);
+
 function normalizeScope(scope: string | undefined): string {
   const normalized = scope?.trim();
-  return normalized === undefined || normalized.length === 0 ? 'full' : normalized;
+  if (normalized === undefined || normalized.length === 0) {
+    return 'full';
+  }
+
+  if (!VALID_REBUILD_SCOPES.has(normalized)) {
+    throwApiError('INVALID_SCOPE', `Invalid rebuild scope: ${normalized}. Must be 'full' or 'incremental'.`, HttpStatus.BAD_REQUEST);
+  }
+
+  return normalized;
 }
 
 function throwApiError(code: ErrorCode | string, message: string, status: HttpStatus): never {

--- a/apps/api/src/admin/admin-index.service.ts
+++ b/apps/api/src/admin/admin-index.service.ts
@@ -127,7 +127,7 @@ export class AdminIndexService {
       .where(and(eq(jobs.tenant_id, tenantId), eq(jobs.idempotency_key, idempotencyKey)))
       .limit(1);
 
-    return job as JobRow | undefined;
+    return job;
   }
 
   private async enqueueIndexingJob(jobId: string): Promise<void> {

--- a/apps/api/src/admin/admin-index.service.ts
+++ b/apps/api/src/admin/admin-index.service.ts
@@ -1,0 +1,158 @@
+import { HttpException, HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
+import {
+  JobRepository,
+  QueueFactory,
+  QUEUE_INDEXING,
+  jobs,
+  type BullMQConnection,
+  type JobRow,
+} from '@cherrygraph/job-core';
+import { ErrorCode, indexSnapshots, spaces } from '@cherrygraph/shared';
+import { and, eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { AuditService } from '../audit/audit.service.js';
+import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
+import { DRIZZLE } from '../database/drizzle.constants.js';
+
+type AdminIndexDatabase = NodePgDatabase;
+
+export type AdminIndexContext = {
+  tenantId: string;
+  actorUserId: string;
+  ip?: string;
+  userAgent?: string;
+  requestId?: string;
+};
+
+@Injectable()
+export class AdminIndexService {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: AdminIndexDatabase,
+    private readonly auditService: AuditService,
+    @Optional() @Inject(REDIS_CLIENT) private readonly redis?: OptionalRedisClient,
+  ) {}
+
+  async rebuildIndex(
+    spaceId: string,
+    input: { scope?: string; reason?: string } = {},
+    context: AdminIndexContext,
+    idempotencyKey?: string,
+  ): Promise<JobRow> {
+    const existingJob = await this.findIdempotentJob(context.tenantId, idempotencyKey);
+    if (existingJob !== undefined) {
+      return existingJob;
+    }
+
+    await this.assertSpaceExists(context.tenantId, spaceId);
+    await this.assertNoBuildingSnapshot(context.tenantId, spaceId);
+
+    const scope = normalizeScope(input.scope);
+    const job = await JobRepository.create(this.db, {
+      tenant_id: context.tenantId,
+      space_id: spaceId,
+      queue_name: QUEUE_INDEXING,
+      type: 'reindex',
+      payload_json: {
+        tenant_id: context.tenantId,
+        space_id: spaceId,
+        trigger: 'manual_rebuild',
+        scope,
+        ...(input.reason !== undefined ? { reason: input.reason } : {}),
+      },
+      ...(idempotencyKey !== undefined ? { idempotency_key: idempotencyKey } : {}),
+      created_by: context.actorUserId,
+    });
+
+    await this.enqueueIndexingJob(job.id);
+    this.auditService.push({
+      tenant_id: context.tenantId,
+      actor_user_id: context.actorUserId,
+      action: 'admin.index.rebuild',
+      resource_type: 'space',
+      resource_id: spaceId,
+      space_id: spaceId,
+      ...(context.ip !== undefined ? { ip: context.ip } : {}),
+      ...(context.userAgent !== undefined ? { user_agent: context.userAgent } : {}),
+      ...(context.requestId !== undefined ? { request_id: context.requestId } : {}),
+      metadata_json: {
+        reindex_job_id: job.id,
+        trigger: 'manual_rebuild',
+        scope,
+        ...(input.reason !== undefined ? { reason: input.reason } : {}),
+      },
+    });
+
+    return job;
+  }
+
+  private async assertSpaceExists(tenantId: string, spaceId: string): Promise<void> {
+    const [space] = await this.db
+      .select({ id: spaces.id })
+      .from(spaces)
+      .where(and(eq(spaces.tenant_id, tenantId), eq(spaces.id, spaceId)))
+      .limit(1);
+
+    if (space === undefined) {
+      throwApiError(ErrorCode.SPACE_NOT_FOUND, 'Space not found', HttpStatus.NOT_FOUND);
+    }
+  }
+
+  private async assertNoBuildingSnapshot(tenantId: string, spaceId: string): Promise<void> {
+    const [existing] = await this.db
+      .select({ id: indexSnapshots.id })
+      .from(indexSnapshots)
+      .where(
+        and(
+          eq(indexSnapshots.tenant_id, tenantId),
+          eq(indexSnapshots.space_id, spaceId),
+          eq(indexSnapshots.status, 'building'),
+        ),
+      )
+      .limit(1);
+
+    if (existing !== undefined) {
+      throwApiError('REBUILD_ALREADY_RUNNING', 'An index rebuild is already running for this space', HttpStatus.CONFLICT);
+    }
+  }
+
+  private async findIdempotentJob(tenantId: string, idempotencyKey: string | undefined): Promise<JobRow | undefined> {
+    if (idempotencyKey === undefined || idempotencyKey.trim().length === 0) {
+      return undefined;
+    }
+
+    const [job] = await this.db
+      .select()
+      .from(jobs)
+      .where(and(eq(jobs.tenant_id, tenantId), eq(jobs.idempotency_key, idempotencyKey)))
+      .limit(1);
+
+    return job as JobRow | undefined;
+  }
+
+  private async enqueueIndexingJob(jobId: string): Promise<void> {
+    const queue = QueueFactory.createQueue<{ jobId: string }>(QUEUE_INDEXING, this.getRequiredRedis());
+    try {
+      await queue.add('reindex', { jobId });
+    } finally {
+      await queue.close();
+    }
+  }
+
+  private getRequiredRedis(): BullMQConnection {
+    if (this.redis === undefined) {
+      throwApiError(ErrorCode.INTERNAL_ERROR, 'Redis is not configured', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    return this.redis;
+  }
+}
+
+function normalizeScope(scope: string | undefined): string {
+  const normalized = scope?.trim();
+  return normalized === undefined || normalized.length === 0 ? 'full' : normalized;
+}
+
+function throwApiError(code: ErrorCode | string, message: string, status: HttpStatus): never {
+  throw new HttpException({ code, message }, status);
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { IdempotencyMiddleware } from './common/middleware/idempotency.middlewar
 import { RequestContextMiddleware } from './common/middleware/request-context.middleware.js';
 import { RedisModule } from './common/redis/redis.module.js';
 import { AdminHealthModule } from './admin/admin-health.module.js';
+import { AdminIndexModule } from './admin/admin-index.module.js';
 import { AuditModule } from './audit/audit.module.js';
 import { AuthModule } from './auth/auth.module.js';
 import { DrizzleModule } from './database/drizzle.module.js';
@@ -39,6 +40,7 @@ import { WikiModule } from './wiki/wiki.module.js';
     WikiModule,
     HealthModule,
     AdminHealthModule,
+    AdminIndexModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
+++ b/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
@@ -3,6 +3,8 @@ import {
   JobRepository,
   JobStateMachine,
   JobStatus,
+  QueueFactory,
+  QUEUE_INDEXING,
   RedisJobLock,
   type JobRow,
 } from '@cherrygraph/job-core';
@@ -219,6 +221,133 @@ describe('InternalJobsService', () => {
       }),
     );
     expect(releaseSpy).toHaveBeenCalledWith(expect.anything(), 'job-1', 'worker-1');
+  });
+
+  it('creates and enqueues an indexing job when graphify completion succeeds', async () => {
+    const db = createDb();
+    const redis = createRedisMock();
+    const graphifyService = {
+      handleRunCompletion: vi.fn(() => Promise.resolve({ status: 'succeeded' })),
+    };
+    const service = new InternalJobsService(
+      db.asDb() as never,
+      redis.asClient() as never,
+      undefined,
+      undefined,
+      graphifyService as never,
+    );
+    const runningJob = createJobRow({
+      id: 'graphify-job-1',
+      tenant_id: 'tenant-1',
+      space_id: 'space-1',
+      type: 'graphify',
+      status: JobStatus.RUNNING,
+      locked_by: 'worker-1',
+      locked_at: new Date('2026-04-30T11:55:00.000Z'),
+      started_at: new Date('2026-04-30T11:55:00.000Z'),
+      payload_json: { run_id: 'run-1' },
+    });
+    const completedJob = createJobRow({
+      ...runningJob,
+      status: JobStatus.SUCCEEDED,
+      locked_by: null,
+      locked_at: null,
+      result_json: { graph_json_uri: 's3://bucket/graph.json' },
+      completed_at: new Date('2026-04-30T12:00:00.000Z'),
+    });
+    const indexingJob = createJobRow({
+      id: 'index-job-1',
+      tenant_id: 'tenant-1',
+      space_id: 'space-1',
+      queue_name: QUEUE_INDEXING,
+      type: 'reindex',
+    });
+    const queue = createQueueMock();
+
+    vi.spyOn(JobRepository, 'findById').mockResolvedValue(runningJob);
+    vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(true);
+    vi.spyOn(JobStateMachine, 'transition').mockResolvedValue(completedJob);
+    vi.spyOn(JobEventRepository, 'create').mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+    vi.spyOn(RedisJobLock, 'release').mockResolvedValue(true);
+    const createJobSpy = vi.spyOn(JobRepository, 'create').mockResolvedValue(indexingJob);
+    const createQueueSpy = vi.spyOn(QueueFactory, 'createQueue').mockReturnValue(queue as never);
+
+    await service.reportComplete('graphify-job-1', {
+      worker_id: 'worker-1',
+      result_json: { graph_json_uri: 's3://bucket/graph.json' },
+    });
+
+    expect(graphifyService.handleRunCompletion).toHaveBeenCalledWith('run-1', {
+      graph_json_uri: 's3://bucket/graph.json',
+    });
+    expect(createJobSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        tenant_id: 'tenant-1',
+        space_id: 'space-1',
+        queue_name: QUEUE_INDEXING,
+        type: 'reindex',
+        payload_json: {
+          tenant_id: 'tenant-1',
+          space_id: 'space-1',
+          graphify_run_id: 'run-1',
+          trigger: 'graphify_completion',
+          scope: 'full',
+        },
+        created_by: 'user-1',
+      }),
+    );
+    expect(createQueueSpy).toHaveBeenCalledWith(QUEUE_INDEXING, expect.anything());
+    expect(queue.add).toHaveBeenCalledWith('reindex', { jobId: 'index-job-1' });
+    expect(queue.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not enqueue indexing when graphify completion handling fails before import finishes', async () => {
+    const db = createDb();
+    const redis = createRedisMock();
+    const graphifyService = {
+      handleRunCompletion: vi.fn(() => Promise.reject(new Error('quarantined output'))),
+    };
+    const service = new InternalJobsService(
+      db.asDb() as never,
+      redis.asClient() as never,
+      undefined,
+      undefined,
+      graphifyService as never,
+    );
+    const runningJob = createJobRow({
+      id: 'graphify-job-1',
+      type: 'graphify',
+      status: JobStatus.RUNNING,
+      locked_by: 'worker-1',
+      locked_at: new Date('2026-04-30T11:55:00.000Z'),
+      started_at: new Date('2026-04-30T11:55:00.000Z'),
+      payload_json: { run_id: 'run-1' },
+    });
+    const completedJob = createJobRow({
+      ...runningJob,
+      status: JobStatus.SUCCEEDED,
+      locked_by: null,
+      locked_at: null,
+      result_json: { graph_json_uri: 's3://bucket/graph.json' },
+      completed_at: new Date('2026-04-30T12:00:00.000Z'),
+    });
+
+    vi.spyOn(JobRepository, 'findById').mockResolvedValue(runningJob);
+    vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(true);
+    vi.spyOn(JobStateMachine, 'transition').mockResolvedValue(completedJob);
+    vi.spyOn(JobEventRepository, 'create').mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+    vi.spyOn(RedisJobLock, 'release').mockResolvedValue(true);
+    const createJobSpy = vi.spyOn(JobRepository, 'create');
+    const createQueueSpy = vi.spyOn(QueueFactory, 'createQueue');
+
+    await service.reportComplete('graphify-job-1', {
+      worker_id: 'worker-1',
+      result_json: { graph_json_uri: 's3://bucket/graph.json' },
+    });
+
+    expect(createJobSpy).not.toHaveBeenCalled();
+    expect(createQueueSpy).not.toHaveBeenCalled();
   });
 
   it('completes upload validation when a validation job succeeds', async () => {
@@ -629,6 +758,8 @@ describe('InternalJobsService', () => {
     vi.spyOn(JobStateMachine, 'transition').mockResolvedValue(failedJob);
     vi.spyOn(JobEventRepository, 'create').mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
     vi.spyOn(RedisJobLock, 'release').mockResolvedValue(true);
+    const createJobSpy = vi.spyOn(JobRepository, 'create');
+    const createQueueSpy = vi.spyOn(QueueFactory, 'createQueue');
 
     const result = await service.reportFailure('job-1', {
       worker_id: 'worker-1',
@@ -640,6 +771,8 @@ describe('InternalJobsService', () => {
     expect(graphifyService.handleRunFailure).toHaveBeenCalledWith('run-1', {
       error_json: errorJson,
     });
+    expect(createJobSpy).not.toHaveBeenCalled();
+    expect(createQueueSpy).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -1023,6 +1156,16 @@ function createService(): InternalJobsService {
 
 function createDb<Row = unknown>(rows: Row[] = []): TestDb<Row> {
   return new TestDb(rows);
+}
+
+function createQueueMock(): {
+  add: ReturnType<typeof vi.fn<(name: string, data: { jobId: string }) => Promise<void>>>;
+  close: ReturnType<typeof vi.fn<() => Promise<void>>>;
+} {
+  return {
+    add: vi.fn(() => Promise.resolve()),
+    close: vi.fn(() => Promise.resolve()),
+  };
 }
 
 class TestDb<Row = unknown> {

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -650,7 +650,15 @@ export class InternalJobsService {
     const runId = readString(payload.run_id) ?? job.id;
 
     try {
-      await this.graphifyService.handleRunCompletion(runId, asJsonRecord(job.result_json));
+      const completedRun = await this.graphifyService.handleRunCompletion(runId, asJsonRecord(job.result_json));
+      if (completedRun.status !== 'succeeded') {
+        getApiLogger().warn(
+          { job_id: job.id, run_id: runId, run_status: completedRun.status },
+          'Graphify run completion did not transition to succeeded — skipping indexing trigger',
+        );
+        return;
+      }
+
       const indexJob = await JobRepository.create(this.db, {
         tenant_id: job.tenant_id,
         space_id: job.space_id,

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -1,12 +1,15 @@
 import { HttpException, HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
 import { Interval } from '@nestjs/schedule';
 import {
+  QueueFactory,
+  QUEUE_INDEXING,
   JobConflictError,
   JobEventRepository,
   JobRepository,
   JobStateMachine,
   JobStatus,
   RedisJobLock,
+  type BullMQConnection,
   jobs,
   type JobRow,
 } from '@cherrygraph/job-core';
@@ -648,6 +651,31 @@ export class InternalJobsService {
 
     try {
       await this.graphifyService.handleRunCompletion(runId, asJsonRecord(job.result_json));
+      const indexJob = await JobRepository.create(this.db, {
+        tenant_id: job.tenant_id,
+        space_id: job.space_id,
+        queue_name: QUEUE_INDEXING,
+        type: 'reindex',
+        payload_json: {
+          tenant_id: job.tenant_id,
+          space_id: job.space_id,
+          graphify_run_id: readString(payload.run_id),
+          trigger: 'graphify_completion',
+          scope: 'full',
+        },
+        created_by: job.created_by,
+      });
+
+      const redis = this.getRequiredRedis();
+      const queue = QueueFactory.createQueue<{ jobId: string }>(
+        QUEUE_INDEXING,
+        redis as unknown as BullMQConnection,
+      );
+      try {
+        await queue.add('reindex', { jobId: indexJob.id });
+      } finally {
+        await queue.close();
+      }
     } catch (err) {
       getApiLogger().error(
         { err, job_id: job.id, run_id: runId },

--- a/apps/api/src/wiki/__tests__/wiki.controller.test.ts
+++ b/apps/api/src/wiki/__tests__/wiki.controller.test.ts
@@ -1,7 +1,9 @@
 import 'reflect-metadata';
 
-import { HttpException, HttpStatus } from '@nestjs/common';
-import { PERMISSIONS_METADATA_KEY } from '@cherrygraph/auth-core';
+import { HttpException, HttpStatus, type ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { HTTP_CODE_METADATA } from '@nestjs/common/constants.js';
+import { PERMISSIONS_METADATA_KEY, RbacGuard } from '@cherrygraph/auth-core';
 import { ErrorCode } from '@cherrygraph/shared';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -23,6 +25,8 @@ describe('WikiController', () => {
     expect(getMetadata('listVersions')).toEqual(['space:view']);
     expect(getMetadata('publish')).toEqual(['wiki:publish']);
     expect(getMetadata('rollback')).toEqual(['wiki:rollback']);
+    expect(getMetadata('reindexPage')).toEqual(['wiki:publish']);
+    expect(getHttpCode('reindexPage')).toBe(HttpStatus.ACCEPTED);
   });
 
   it('dispatches list pages requests to the service', async () => {
@@ -134,6 +138,57 @@ describe('WikiController', () => {
     );
   });
 
+  it('dispatches reindex requests with idempotency and audit context', async () => {
+    const { controller, service } = createControllerContext();
+    service.reindexPage.mockResolvedValue({
+      page_id: 'page-1',
+      reindex_job_id: 'job-reindex',
+      status: 'accepted',
+    });
+
+    const result = await controller.reindexPage(TEST_SPACE_ID, 'page-1', 'idem-key-1', createRequest());
+
+    expect(result).toEqual({
+      data: {
+        page_id: 'page-1',
+        reindex_job_id: 'job-reindex',
+        status: 'accepted',
+      },
+    });
+    expect(service.reindexPage).toHaveBeenCalledWith(
+      TEST_TENANT_ID,
+      TEST_SPACE_ID,
+      'page-1',
+      TEST_USER_ID,
+      'idem-key-1',
+      expect.objectContaining({
+        requestId: 'req-1',
+      }) as Record<string, unknown>,
+    );
+  });
+
+  it('RBAC rejects reindex requests without wiki publish permission', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const request = {
+      ...createRequest('editor'),
+      params: { spaceId: TEST_SPACE_ID },
+      space_permissions: {
+        [TEST_SPACE_ID]: ['space:view'],
+      },
+    };
+
+    try {
+      await guard.canActivate(createGuardContext('reindexPage', request));
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpException);
+      expect((err as HttpException).getStatus()).toBe(403);
+      expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+      return;
+    }
+
+    throw new Error('Expected RBAC guard to reject missing wiki:publish permission');
+  });
+
   it.each([
     {
       method: 'getPage' as const,
@@ -150,6 +205,12 @@ describe('WikiController', () => {
       code: ErrorCode.VERSION_ALREADY_PUBLISHED,
       invoke: (controller: WikiController) =>
         controller.publish(TEST_SPACE_ID, 'page-1', { version_id: 'version-1' }, createRequest()),
+    },
+    {
+      method: 'reindexPage' as const,
+      code: ErrorCode.WIKI_PAGE_NOT_FOUND,
+      invoke: (controller: WikiController) =>
+        controller.reindexPage(TEST_SPACE_ID, 'missing', undefined, createRequest()),
     },
   ])('propagates $code errors from $method', async ({ method, code, invoke }) => {
     const { controller, service } = createControllerContext();
@@ -184,6 +245,7 @@ function createControllerContext(): {
     listVersions: ReturnType<typeof vi.fn<WikiService['listVersions']>>;
     publish: ReturnType<typeof vi.fn<WikiService['publish']>>;
     rollback: ReturnType<typeof vi.fn<WikiService['rollback']>>;
+    reindexPage: ReturnType<typeof vi.fn<WikiService['reindexPage']>>;
   };
 } {
   const service = {
@@ -193,6 +255,7 @@ function createControllerContext(): {
     listVersions: vi.fn<WikiService['listVersions']>(),
     publish: vi.fn<WikiService['publish']>(),
     rollback: vi.fn<WikiService['rollback']>(),
+    reindexPage: vi.fn<WikiService['reindexPage']>(),
   };
 
   return {
@@ -201,7 +264,7 @@ function createControllerContext(): {
   };
 }
 
-function createRequest(): {
+function createRequest(role = 'editor'): {
   user: {
     sub: string;
     tenant_id: string;
@@ -218,7 +281,7 @@ function createRequest(): {
       sub: TEST_USER_ID,
       tenant_id: TEST_TENANT_ID,
       email: 'user@example.com',
-      role: 'editor',
+      role,
       group_ids: ['group-1'],
       token_use: 'access',
     },
@@ -255,4 +318,20 @@ function createPaginatedResult<T>(data: T[]): PaginatedResponse<T> {
 function getMetadata(methodName: keyof WikiController): unknown {
   const descriptor = Object.getOwnPropertyDescriptor(WikiController.prototype, methodName);
   return Reflect.getMetadata(PERMISSIONS_METADATA_KEY, descriptor?.value as object);
+}
+
+function getHttpCode(methodName: keyof WikiController): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(WikiController.prototype, methodName);
+  return Reflect.getMetadata(HTTP_CODE_METADATA, descriptor?.value as object);
+}
+
+function createGuardContext(methodName: keyof WikiController, request: unknown): ExecutionContext {
+  const descriptor = Object.getOwnPropertyDescriptor(WikiController.prototype, methodName);
+  return {
+    getHandler: () => descriptor?.value,
+    getClass: () => WikiController,
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
 }

--- a/apps/api/src/wiki/__tests__/wiki.controller.test.ts
+++ b/apps/api/src/wiki/__tests__/wiki.controller.test.ts
@@ -328,7 +328,7 @@ function getHttpCode(methodName: keyof WikiController): unknown {
 function createGuardContext(methodName: keyof WikiController, request: unknown): ExecutionContext {
   const descriptor = Object.getOwnPropertyDescriptor(WikiController.prototype, methodName);
   return {
-    getHandler: () => descriptor?.value,
+    getHandler: () => descriptor?.value as () => unknown,
     getClass: () => WikiController,
     switchToHttp: () => ({
       getRequest: () => request,

--- a/apps/api/src/wiki/__tests__/wiki.service.test.ts
+++ b/apps/api/src/wiki/__tests__/wiki.service.test.ts
@@ -1,6 +1,7 @@
 import { ErrorCode, sourceLinks, wikiPageVersions, wikiPages } from '@cherrygraph/shared';
+import { JobRepository, QueueFactory, QUEUE_INDEXING, type JobRow } from '@cherrygraph/job-core';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AuditEntry, AuditService } from '../../audit/audit.service.js';
 import {
@@ -17,6 +18,10 @@ type WikiPageVersionRow = typeof wikiPageVersions.$inferSelect;
 type SourceLinkRow = typeof sourceLinks.$inferSelect;
 
 describe('WikiService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('listPages returns a paginated response', async () => {
     const { service, db } = createServiceContext();
     db.queueSelect([
@@ -223,6 +228,104 @@ describe('WikiService', () => {
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.VERSION_NOT_FOUND);
   });
 
+  it('creates a single-page reindex job, enqueues it, and writes audit', async () => {
+    const { service, db, audit } = createServiceContext({ redis: createRedisMock() });
+    const queue = createQueueMock();
+    const indexJob = createJobRow({ id: 'job-reindex' });
+    db.queueSelect([]);
+    db.queueSelect([{ page: createPageRow(), currentVersion: { source: 'graphify', frontmatter_json: {} } }]);
+    db.queueSelect([]);
+    const createJobSpy = vi.spyOn(JobRepository, 'create').mockResolvedValue(indexJob);
+    vi.spyOn(QueueFactory, 'createQueue').mockReturnValue(queue as never);
+
+    const result = await service.reindexPage(
+      TEST_TENANT_ID,
+      TEST_SPACE_ID,
+      'page-1',
+      TEST_USER_ID,
+      'idem-key-1',
+      { requestId: 'req-1' },
+    );
+
+    expect(result).toEqual({
+      page_id: 'page-1',
+      reindex_job_id: 'job-reindex',
+      status: 'accepted',
+    });
+    expect(createJobSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        tenant_id: TEST_TENANT_ID,
+        space_id: TEST_SPACE_ID,
+        queue_name: QUEUE_INDEXING,
+        type: 'reindex',
+        payload_json: {
+          tenant_id: TEST_TENANT_ID,
+          space_id: TEST_SPACE_ID,
+          page_id: 'page-1',
+          trigger: 'manual_reindex',
+          scope: 'single_page',
+        },
+        idempotency_key: 'idem-key-1',
+        created_by: TEST_USER_ID,
+      }),
+    );
+    expect(queue.add).toHaveBeenCalledWith('reindex', { jobId: 'job-reindex' });
+    expect(queue.close).toHaveBeenCalledTimes(1);
+    expect(audit.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'wiki.page.reindex',
+        resource_type: 'wiki_page',
+        resource_id: 'page-1',
+        space_id: TEST_SPACE_ID,
+        request_id: 'req-1',
+        metadata_json: {
+          reindex_job_id: 'job-reindex',
+          trigger: 'manual_reindex',
+          scope: 'single_page',
+        },
+      }) as AuditEntry,
+    );
+  });
+
+  it('returns 409 when a building index snapshot already exists for page reindex', async () => {
+    const { service, db } = createServiceContext({ redis: createRedisMock() });
+    db.queueSelect([{ page: createPageRow(), currentVersion: { source: 'graphify', frontmatter_json: {} } }]);
+    db.queueSelect([{ id: 'snapshot-building' }]);
+
+    const err = await getRejectedHttpException(
+      service.reindexPage(TEST_TENANT_ID, TEST_SPACE_ID, 'page-1', TEST_USER_ID),
+    );
+
+    expect(err.getStatus()).toBe(409);
+    expect(getHttpExceptionCode(err)).toBe('REINDEX_ALREADY_RUNNING');
+  });
+
+  it('returns the idempotent reindex job without creating or enqueueing another job', async () => {
+    const { service, db, audit } = createServiceContext({ redis: createRedisMock() });
+    const existingJob = createJobRow({ id: 'job-existing', idempotency_key: 'idem-key-1' });
+    db.queueSelect([existingJob]);
+    const createJobSpy = vi.spyOn(JobRepository, 'create');
+    const createQueueSpy = vi.spyOn(QueueFactory, 'createQueue');
+
+    const result = await service.reindexPage(
+      TEST_TENANT_ID,
+      TEST_SPACE_ID,
+      'page-1',
+      TEST_USER_ID,
+      'idem-key-1',
+    );
+
+    expect(result).toEqual({
+      page_id: 'page-1',
+      reindex_job_id: 'job-existing',
+      status: 'accepted',
+    });
+    expect(createJobSpy).not.toHaveBeenCalled();
+    expect(createQueueSpy).not.toHaveBeenCalled();
+    expect(audit.push).not.toHaveBeenCalled();
+  });
+
   it('creates source links', async () => {
     const { service, db } = createServiceContext();
     db.queueSelect([createVersionRow()]);
@@ -316,7 +419,7 @@ describe('WikiService', () => {
   });
 });
 
-function createServiceContext(): {
+function createServiceContext(options: { redis?: unknown } = {}): {
   service: WikiService;
   db: ScriptedWikiDb;
   audit: {
@@ -327,9 +430,31 @@ function createServiceContext(): {
   const audit = {
     push: vi.fn<(entry: AuditEntry) => void>(),
   };
-  const service = new WikiService(db.asDrizzle(), audit as unknown as AuditService);
+  const service = new WikiService(db.asDrizzle(), audit as unknown as AuditService, options.redis as never);
 
   return { service, db, audit };
+}
+
+function createRedisMock(): {
+  get: ReturnType<typeof vi.fn<(key: string) => Promise<string | null>>>;
+  set: ReturnType<typeof vi.fn<(key: string, value: string, ...args: Array<string | number>) => Promise<string | null>>>;
+  eval: ReturnType<typeof vi.fn<() => Promise<number>>>;
+} {
+  return {
+    get: vi.fn(() => Promise.resolve(null)),
+    set: vi.fn(() => Promise.resolve('OK')),
+    eval: vi.fn(() => Promise.resolve(1)),
+  };
+}
+
+function createQueueMock(): {
+  add: ReturnType<typeof vi.fn<(name: string, data: { jobId: string }) => Promise<void>>>;
+  close: ReturnType<typeof vi.fn<() => Promise<void>>>;
+} {
+  return {
+    add: vi.fn(() => Promise.resolve()),
+    close: vi.fn(() => Promise.resolve()),
+  };
 }
 
 type OperationRecord = {
@@ -533,6 +658,40 @@ function createSourceLinkRow(overrides: Partial<SourceLinkRow> = {}): SourceLink
     quote_hash: 'quote-hash-1',
     evidence_type: 'quote',
     created_at: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createJobRow(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-reindex',
+    tenant_id: TEST_TENANT_ID,
+    space_id: TEST_SPACE_ID,
+    queue_name: QUEUE_INDEXING,
+    type: 'reindex',
+    priority: 100,
+    status: 'pending',
+    attempt_count: 0,
+    max_attempts: 3,
+    timeout_seconds: null,
+    locked_by: null,
+    locked_at: null,
+    next_run_at: null,
+    cancel_requested_at: null,
+    payload_json: {
+      tenant_id: TEST_TENANT_ID,
+      space_id: TEST_SPACE_ID,
+      page_id: 'page-1',
+      trigger: 'manual_reindex',
+      scope: 'single_page',
+    },
+    result_json: null,
+    error_json: null,
+    idempotency_key: null,
+    created_by: TEST_USER_ID,
+    created_at: new Date('2026-05-01T00:00:00.000Z'),
+    started_at: null,
+    completed_at: null,
     ...overrides,
   };
 }

--- a/apps/api/src/wiki/wiki.controller.ts
+++ b/apps/api/src/wiki/wiki.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, HttpException, HttpStatus, Param, Post, Query, Req } from '@nestjs/common';
+import { Body, Controller, Get, Headers, HttpCode, HttpException, HttpStatus, Param, Post, Query, Req } from '@nestjs/common';
 import { Permissions, type AuthenticatedRequestUser } from '@cherrygraph/auth-core';
 import { ErrorCode } from '@cherrygraph/shared';
 
@@ -106,6 +106,28 @@ export class WikiController {
       user.sub,
       buildAuditContext(request),
     );
+  }
+
+  @Post(':pageId/reindex')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @Permissions('wiki:publish')
+  async reindexPage(
+    @Param('spaceId') spaceId: string,
+    @Param('pageId') pageId: string,
+    @Headers('x-idempotency-key') idempotencyKey: string | undefined,
+    @Req() request: RequestWithAuth,
+  ): Promise<{ data: Awaited<ReturnType<WikiService['reindexPage']>> }> {
+    const user = getAuthenticatedUser(request);
+    const data = await this.wikiService.reindexPage(
+      user.tenant_id,
+      spaceId,
+      pageId,
+      user.sub,
+      idempotencyKey,
+      buildAuditContext(request),
+    );
+
+    return { data };
   }
 }
 

--- a/apps/api/src/wiki/wiki.service.ts
+++ b/apps/api/src/wiki/wiki.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
 import {
   batchCreateSourceLinks as normalizeSourceLinks,
   createSourceLink as normalizeSourceLink,
@@ -6,7 +6,22 @@ import {
   PublishStateMachine,
   type SourceLink,
 } from '@cherrygraph/wiki-core';
-import { ErrorCode, sourceLinks, wikiPageVersions, wikiPages, wikiSections } from '@cherrygraph/shared';
+import {
+  ErrorCode,
+  indexSnapshots,
+  sourceLinks,
+  wikiPageVersions,
+  wikiPages,
+  wikiSections,
+} from '@cherrygraph/shared';
+import {
+  JobRepository,
+  QueueFactory,
+  QUEUE_INDEXING,
+  jobs,
+  type BullMQConnection,
+  type JobRow,
+} from '@cherrygraph/job-core';
 import { and, asc, count, desc, eq, ilike, sql, type SQL } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { createHash, randomUUID } from 'node:crypto';
@@ -19,6 +34,7 @@ import {
 } from '../common/dto/pagination.dto.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { AuditService } from '../audit/audit.service.js';
+import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
 
 type WikiDatabase = NodePgDatabase;
 type WikiPageRow = typeof wikiPages.$inferSelect;
@@ -89,6 +105,12 @@ export type WikiRollbackResponse = {
   published_by: string;
 };
 
+export type WikiReindexResponse = {
+  page_id: string;
+  reindex_job_id: string;
+  status: 'accepted';
+};
+
 export type CreateSourceLinkInput = {
   wiki_page_pk: string;
   page_version_id: string;
@@ -118,6 +140,7 @@ export class WikiService {
   constructor(
     @Inject(DRIZZLE) private readonly db: WikiDatabase,
     private readonly auditService: AuditService,
+    @Optional() @Inject(REDIS_CLIENT) private readonly redis?: OptionalRedisClient,
   ) {}
 
   async listPages(
@@ -350,6 +373,59 @@ export class WikiService {
     };
   }
 
+  async reindexPage(
+    tenantId: string,
+    spaceId: string,
+    pageId: string,
+    actorUserId: string,
+    idempotencyKey?: string,
+    auditContext: WikiAuditContext = {},
+  ): Promise<WikiReindexResponse> {
+    const existingJob = await this.findIdempotentJob(tenantId, idempotencyKey);
+    if (existingJob !== undefined) {
+      return toReindexResponse(pageId, existingJob);
+    }
+
+    await this.requirePage(tenantId, spaceId, pageId);
+    await this.assertNoBuildingSnapshot(tenantId, spaceId, 'REINDEX_ALREADY_RUNNING', 'A reindex job is already running for this space');
+
+    const job = await JobRepository.create(this.db, {
+      tenant_id: tenantId,
+      space_id: spaceId,
+      queue_name: QUEUE_INDEXING,
+      type: 'reindex',
+      payload_json: {
+        tenant_id: tenantId,
+        space_id: spaceId,
+        page_id: pageId,
+        trigger: 'manual_reindex',
+        scope: 'single_page',
+      },
+      ...(idempotencyKey !== undefined ? { idempotency_key: idempotencyKey } : {}),
+      created_by: actorUserId,
+    });
+
+    await this.enqueueIndexingJob(job.id);
+    this.auditService.push({
+      tenant_id: tenantId,
+      actor_user_id: actorUserId,
+      action: 'wiki.page.reindex',
+      resource_type: 'wiki_page',
+      resource_id: pageId,
+      space_id: spaceId,
+      ...(auditContext.ip !== undefined ? { ip: auditContext.ip } : {}),
+      ...(auditContext.userAgent !== undefined ? { user_agent: auditContext.userAgent } : {}),
+      ...(auditContext.requestId !== undefined ? { request_id: auditContext.requestId } : {}),
+      metadata_json: {
+        reindex_job_id: job.id,
+        trigger: 'manual_reindex',
+        scope: 'single_page',
+      },
+    });
+
+    return toReindexResponse(pageId, job);
+  }
+
   async createSourceLink(
     tenantId: string,
     spaceId: string,
@@ -452,6 +528,60 @@ export class WikiService {
     }
 
     return row.page;
+  }
+
+  private async findIdempotentJob(tenantId: string, idempotencyKey: string | undefined): Promise<JobRow | undefined> {
+    if (idempotencyKey === undefined || idempotencyKey.trim().length === 0) {
+      return undefined;
+    }
+
+    const [job] = await this.db
+      .select()
+      .from(jobs)
+      .where(and(eq(jobs.tenant_id, tenantId), eq(jobs.idempotency_key, idempotencyKey)))
+      .limit(1);
+
+    return job as JobRow | undefined;
+  }
+
+  private async assertNoBuildingSnapshot(
+    tenantId: string,
+    spaceId: string,
+    code: string,
+    message: string,
+  ): Promise<void> {
+    const [existing] = await this.db
+      .select({ id: indexSnapshots.id })
+      .from(indexSnapshots)
+      .where(
+        and(
+          eq(indexSnapshots.tenant_id, tenantId),
+          eq(indexSnapshots.space_id, spaceId),
+          eq(indexSnapshots.status, 'building'),
+        ),
+      )
+      .limit(1);
+
+    if (existing !== undefined) {
+      throwApiError(code, message, HttpStatus.CONFLICT);
+    }
+  }
+
+  private async enqueueIndexingJob(jobId: string): Promise<void> {
+    const queue = QueueFactory.createQueue<{ jobId: string }>(QUEUE_INDEXING, this.getRequiredRedis());
+    try {
+      await queue.add('reindex', { jobId });
+    } finally {
+      await queue.close();
+    }
+  }
+
+  private getRequiredRedis(): BullMQConnection {
+    if (this.redis === undefined) {
+      throwApiError(ErrorCode.INTERNAL_ERROR, 'Redis is not configured', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    return this.redis;
   }
 
   private async findPageVersion(
@@ -626,6 +756,14 @@ function toVersionResponse(version: WikiPageVersionRow, currentVersionId: string
   };
 }
 
+function toReindexResponse(pageId: string, job: JobRow): WikiReindexResponse {
+  return {
+    page_id: pageId,
+    reindex_job_id: job.id,
+    status: 'accepted',
+  };
+}
+
 function toSourceLinkInsert(
   tenantId: string,
   spaceId: string,
@@ -747,6 +885,6 @@ function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, '\\$&');
 }
 
-function throwApiError(code: ErrorCode, message: string, status: HttpStatus): never {
+function throwApiError(code: ErrorCode | string, message: string, status: HttpStatus): never {
   throw new HttpException({ code, message }, status);
 }

--- a/apps/api/src/wiki/wiki.service.ts
+++ b/apps/api/src/wiki/wiki.service.ts
@@ -541,7 +541,7 @@ export class WikiService {
       .where(and(eq(jobs.tenant_id, tenantId), eq(jobs.idempotency_key, idempotencyKey)))
       .limit(1);
 
-    return job as JobRow | undefined;
+    return job;
   }
 
   private async assertNoBuildingSnapshot(

--- a/docs/project/26_需求追踪矩阵.md
+++ b/docs/project/26_需求追踪矩阵.md
@@ -39,7 +39,7 @@
 | Wiki 版本历史 | GET /api/spaces/{id}/wiki/pages/{pid}/versions | wiki_page_versions | `apps/api/src/wiki/__tests__/wiki.service.test.ts`, `apps/web/src/__tests__/wiki.test.tsx` | 版本列表按时间倒序 |
 | Source Links 证据链 | 内部 wiki.service | source_links | `apps/api/src/wiki/__tests__/wiki.service.test.ts` | CRUD + tenant 隔离 + 引用完整性 |
 | wiki-core 领域逻辑 | N/A（纯函数包） | N/A | `packages/wiki-core/src/__tests__/` (8 test files, 42 tests) | frontmatter/slug/pageId/状态机/sections/version/repo-init/source-links |
-| 索引构建 | 内部 indexer job | wiki_chunks, embeddings, index_snapshots | P1-E2 | index_status=indexed |
+| 索引构建 | 内部 indexer job | wiki_chunks, embeddings, index_snapshots | `apps/indexer-worker/src/__tests__/indexer-worker.test.ts`, `apps/api/src/wiki/__tests__/wiki.controller.test.ts`, `apps/api/src/admin/__tests__/admin-index.test.ts` | index_status=indexed |
 | Chat 引用 Wiki | POST /api/chat/completions | chat_messages, answer_citations | P1-E2 step6 | citations 非空 |
 | Chat 只引用 Published Wiki | POST /api/chat/completions | wiki_chunks (index_snapshot) | P1-E5 | 未发布内容不返回 |
 | Chat 无知识降级 | POST /api/chat/completions | chat_messages | P1-E5 + §4.1 | strict=no_hit / 宽松=model_knowledge |

--- a/docs/project/26_需求追踪矩阵.md
+++ b/docs/project/26_需求追踪矩阵.md
@@ -39,7 +39,7 @@
 | Wiki 版本历史 | GET /api/spaces/{id}/wiki/pages/{pid}/versions | wiki_page_versions | `apps/api/src/wiki/__tests__/wiki.service.test.ts`, `apps/web/src/__tests__/wiki.test.tsx` | 版本列表按时间倒序 |
 | Source Links 证据链 | 内部 wiki.service | source_links | `apps/api/src/wiki/__tests__/wiki.service.test.ts` | CRUD + tenant 隔离 + 引用完整性 |
 | wiki-core 领域逻辑 | N/A（纯函数包） | N/A | `packages/wiki-core/src/__tests__/` (8 test files, 42 tests) | frontmatter/slug/pageId/状态机/sections/version/repo-init/source-links |
-| 索引构建 | 内部 indexer job | wiki_chunks, embeddings, index_snapshots | `apps/indexer-worker/src/__tests__/indexer-worker.test.ts`, `apps/api/src/wiki/__tests__/wiki.controller.test.ts`, `apps/api/src/admin/__tests__/admin-index.test.ts` | index_status=indexed |
+| 索引构建 | 内部 indexer job | wiki_chunks, embeddings, index_snapshots | `apps/indexer-worker/src/__tests__/indexer-worker.test.ts`, `apps/api/src/wiki/__tests__/wiki.controller.test.ts`, `apps/api/src/wiki/__tests__/wiki.service.test.ts`, `apps/api/src/admin/__tests__/admin-index.test.ts`, `apps/api/src/internal/__tests__/internal-jobs.service.test.ts` | index_status=indexed |
 | Chat 引用 Wiki | POST /api/chat/completions | chat_messages, answer_citations | P1-E2 step6 | citations 非空 |
 | Chat 只引用 Published Wiki | POST /api/chat/completions | wiki_chunks (index_snapshot) | P1-E5 | 未发布内容不返回 |
 | Chat 无知识降级 | POST /api/chat/completions | chat_messages | P1-E5 + §4.1 | strict=no_hit / 宽松=model_knowledge |


### PR DESCRIPTION
## Summary

Closes #105

Final Stage 6 issue — API indexing triggers, admin rebuild endpoint, and requirements matrix update:

- **Graphify completion trigger**: Creates reindex job only when run transitions to `succeeded`
- **POST /spaces/:spaceId/wiki/pages/:pageId/reindex**: wiki:publish permission, 202/403/404/409, X-Idempotency-Key
- **POST /admin/spaces/:spaceId/rebuild-index**: admin guard, validated scope (full/incremental only), 202/403/404/409
- **Requirements matrix**: Updated with all test file paths

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `f4889324e080bf130f15543c1616529392390954`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/108#issuecomment-4366130944) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/108#issuecomment-4366130996) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/108#issuecomment-4366131058) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/108#issuecomment-4366131111)
- Key findings addressed: Graphify succeeded-only trigger, admin scope validation, ESLint errors resolved, complete matrix paths

## Test Plan

- [x] Build + lint + 679 tests pass (114 test files)