### PR TITLE
feat(stage-7): chat web UI — streaming + citations + sessions (#113)

### DIFF
--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -111,6 +111,7 @@ export type CitationResponse = {
   index: number;
   chunk_id: string;
   wiki_page_pk: string;
+  page_id: string;
   section_id: string | null;
   relevance_score: number;
   source_chain_json: Record<string, unknown>;
@@ -141,6 +142,7 @@ type SearchRow = {
   id: string;
   content: string;
   wiki_page_pk: string;
+  page_id: string | null;
   section_id: string | null;
   source_chain_json: Record<string, unknown> | null;
   injection_risk: boolean;
@@ -607,7 +609,7 @@ export class ChatService {
   private createVectorSearchFn(): VectorSearchFn {
     return async (params): Promise<SearchHit[]> => {
       const query = sql`
-        SELECT wc.id, wc.content, wc.wiki_page_pk, wc.section_id, wc.source_chain_json,
+        SELECT wc.id, wc.content, wc.wiki_page_pk, wp.page_id, wc.section_id, wc.source_chain_json,
                wc.injection_risk, wp.title as page_title, ws.heading as section_title,
                1 - (e.embedding <=> ${toPgVectorLiteral(params.queryEmbedding)}::vector) as score
         FROM wiki_chunks wc
@@ -640,7 +642,7 @@ export class ChatService {
       }
 
       const query = sql`
-        SELECT wc.id, wc.content, wc.wiki_page_pk, wc.section_id, wc.source_chain_json,
+        SELECT wc.id, wc.content, wc.wiki_page_pk, wp.page_id, wc.section_id, wc.source_chain_json,
                wc.injection_risk, wp.title as page_title, ws.heading as section_title,
                ts_rank_cd(to_tsvector('simple', wc.content), to_tsquery('simple', ${tsQuery})) as score
         FROM wiki_chunks wc
@@ -785,13 +787,15 @@ function truncateHistoryForBudget(
 }
 
 function toCitationResponse(result: RetrievalResult, index: number, fallback: boolean): CitationResponse {
+  const scj = normalizeJsonRecord(result.sourceChainJson);
   return {
     index,
     chunk_id: result.chunkId,
     wiki_page_pk: result.wikiPagePk,
+    page_id: typeof scj.page_id === 'string' ? scj.page_id : result.wikiPagePk,
     section_id: result.sectionId,
     relevance_score: result.score,
-    source_chain_json: normalizeJsonRecord(result.sourceChainJson),
+    source_chain_json: scj,
     display_text: formatCitationDisplayText(result),
     page_title: result.pageTitle,
     section_title: result.sectionTitle,
@@ -863,7 +867,7 @@ function normalizeSearchRows(result: SqlQueryResult<SearchRow>): SearchHit[] {
     score: normalizeScore(row.score),
     wikiPagePk: row.wiki_page_pk,
     sectionId: row.section_id,
-    sourceChainJson: normalizeSourceChainJson(row.source_chain_json),
+    sourceChainJson: { ...normalizeSourceChainJson(row.source_chain_json), page_id: row.page_id ?? row.wiki_page_pk },
     injectionRisk: row.injection_risk,
     pageTitle: row.page_title ?? 'Untitled',
     sectionTitle: row.section_title,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,12 +12,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "rehype-highlight": "^7.0.2",
+    "eventsource-parser": "^3.0.8",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-dropzone": "^15.0.0",
     "react-markdown": "^10.1.0",
     "react-router": "^7.14.2",
+    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,8 +25,7 @@ export function AppRoutes() {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/login" element={<Login />} />
-      <Route path="/chat" element={<Chat />} />
-      <Route path="/chat/:id" element={<Chat />} />
+      <Route path="/spaces/:spaceId/chat" element={<Chat />} />
       <Route path="/spaces/:spaceId/wiki" element={<Wiki />} />
       <Route path="/spaces/:spaceId/wiki/:pageId" element={<Wiki />} />
       <Route path="/spaces/:spaceId/wiki/:pageId/history" element={<Wiki />} />

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -53,10 +53,17 @@ describe('App routing', () => {
     expect(screen.getByRole('heading', { name: 'Login' })).toBeInTheDocument();
   });
 
-  it('renders Chat for /chat', () => {
-    renderRoute('/chat');
+  it('redirects unauthenticated chat access to /login', () => {
+    renderRoute('/spaces/test-space/chat');
 
-    expect(screen.getByRole('heading', { name: 'Chat' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Login' })).toBeInTheDocument();
+  });
+
+  it('renders Chat for /spaces/:spaceId/chat', async () => {
+    mockChatSessionsApi();
+    renderRoute('/spaces/test-space/chat', ADMIN_USER);
+
+    expect(await screen.findByRole('heading', { name: 'Chat' })).toBeInTheDocument();
   });
 
   it('renders Wiki for /spaces/:spaceId/wiki', async () => {
@@ -118,12 +125,6 @@ describe('App routing', () => {
       expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
       unmount();
     }
-  });
-
-  it('renders Chat for /chat/:id', () => {
-    renderRoute('/chat/conv-123');
-
-    expect(screen.queryAllByRole('heading', { name: 'Chat' }).length).toBeGreaterThan(0);
   });
 
   it('renders Wiki for /spaces/:spaceId/wiki/:pageId', async () => {
@@ -377,6 +378,32 @@ function mockWikiListApi(): void {
             pagination: {
               page: 1,
               per_page: 20,
+              total: 0,
+              has_next: false,
+            },
+          },
+        }));
+      }
+
+      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+    }),
+  );
+}
+
+function mockChatSessionsApi(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path.startsWith('/api/spaces/test-space/chat/sessions')) {
+        return Promise.resolve(jsonResponse({
+          data: [],
+          meta: {
+            request_id: 'req-chat-sessions',
+            pagination: {
+              page: 1,
+              per_page: 50,
               total: 0,
               has_next: false,
             },

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AuthProvider, type AuthUser } from '../lib/auth.js';
+import Chat, { ChatMessageBubble, MessageInput, SessionSidebar } from '../pages/Chat.js';
+import { CHAT_INPUT_MAX_LENGTH, ChatStreamError, type ChatCitation, type ChatMessage } from '../hooks/useChatStream.js';
+
+const testUser: AuthUser = {
+  id: 'user-1',
+  email: 'viewer@example.com',
+  name: 'Viewer',
+  role: 'viewer',
+  groups: [],
+  spaces: [{ id: 'space-1', name: 'Space One', role: 'viewer' }],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('Chat message rendering', () => {
+  it('renders user and assistant bubbles', () => {
+    renderWithRouter(
+      <>
+        <ChatMessageBubble message={buildMessage({ role: 'user', content: 'Hello wiki' })} spaceId="space-1" />
+        <ChatMessageBubble
+          message={buildMessage({ role: 'assistant', content: 'Hello **back** from CherryWiki' })}
+          spaceId="space-1"
+        />
+      </>,
+    );
+
+    expect(screen.getByLabelText('user message')).toHaveTextContent('Hello wiki');
+    expect(screen.getByLabelText('assistant message')).toHaveTextContent('Hello back from CherryWiki');
+    expect(screen.getByText('back')).toHaveProperty('tagName', 'STRONG');
+  });
+
+  it('routes citation clicks to the wiki page', async () => {
+    const citation = buildCitation({ index: 1, source_chain_json: { page_id: 'target-page' } });
+
+    render(
+      <MemoryRouter initialEntries={['/spaces/space-1/chat']}>
+        <Routes>
+          <Route
+            path="/spaces/:spaceId/chat"
+            element={
+              <ChatMessageBubble
+                message={buildMessage({ role: 'assistant', content: 'Use this source [^1].', citations: [citation] })}
+                spaceId="space-1"
+              />
+            }
+          />
+          <Route path="/spaces/:spaceId/wiki/:pageId" element={<h1>Wiki target</h1>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '[1]' }));
+
+    expect(await screen.findByRole('heading', { name: 'Wiki target' })).toBeInTheDocument();
+  });
+});
+
+describe('Session sidebar', () => {
+  it('renders sessions ordered by the provided list', () => {
+    renderWithRouter(
+      <SessionSidebar
+        sessions={[
+          {
+            id: 'session-new',
+            title: 'Latest chat',
+            created_at: '2026-05-02T10:00:00.000Z',
+            updated_at: '2026-05-02T11:00:00.000Z',
+          },
+          {
+            id: 'session-old',
+            title: null,
+            created_at: '2026-05-01T10:00:00.000Z',
+            updated_at: '2026-05-01T11:00:00.000Z',
+          },
+        ]}
+        activeSessionId="session-new"
+        isLoading={false}
+        onNewChat={vi.fn()}
+        onSelectSession={vi.fn()}
+        onDeleteSession={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole('button', { name: /Latest chat/ })[0]).toHaveClass('active');
+    expect(screen.getByText('Chat session-')).toBeInTheDocument();
+  });
+});
+
+describe('Message input', () => {
+  it('enforces the 4000 character limit', async () => {
+    const onSend = vi.fn<(message: string) => Promise<void>>().mockResolvedValue(undefined);
+    renderWithRouter(<MessageInput disabled={false} isStreaming={false} onSend={onSend} />);
+
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>('Message');
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(CHAT_INPUT_MAX_LENGTH + 25) } });
+
+    expect(textarea.value).toHaveLength(CHAT_INPUT_MAX_LENGTH);
+    expect(screen.getByText(`${CHAT_INPUT_MAX_LENGTH}/${CHAT_INPUT_MAX_LENGTH}`)).toHaveClass('warning');
+
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend.mock.calls[0]?.[0]).toHaveLength(CHAT_INPUT_MAX_LENGTH);
+  });
+});
+
+describe('Chat error state', () => {
+  it('shows the configured no-model error message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>((input, init) => {
+        const path = getRequestPath(input);
+
+        if (path === '/api/spaces/space-1/chat/sessions' && init?.method !== 'POST') {
+          return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-sessions' } }));
+        }
+
+        if (path === '/api/chat/completions') {
+          return Promise.resolve(
+            jsonResponse(
+              {
+                error: {
+                  code: 'NO_CHAT_MODEL_CONFIGURED',
+                  message: 'No enabled chat model configured',
+                },
+              },
+              422,
+            ),
+          );
+        }
+
+        return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+      }),
+    );
+
+    renderChatRoute();
+
+    const textarea = await screen.findByLabelText('Message');
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(await screen.findByText('请联系管理员配置聊天模型')).toBeInTheDocument();
+  });
+
+  it('maps no-model stream errors to the configured copy', () => {
+    const error = new ChatStreamError({
+      code: 'NO_CHAT_MODEL_CONFIGURED',
+      message: 'No enabled chat model configured',
+      status: 422,
+    });
+
+    expect(error.code).toBe('NO_CHAT_MODEL_CONFIGURED');
+  });
+});
+
+function renderChatRoute(): void {
+  render(
+    <MemoryRouter initialEntries={['/spaces/space-1/chat']}>
+      <AuthProvider initialSession={{ user: testUser, accessToken: 'test-token' }}>
+        <Routes>
+          <Route path="/spaces/:spaceId/chat" element={<Chat />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+function renderWithRouter(element: ReactElement): void {
+  render(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+function buildMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'message-1',
+    session_id: 'session-1',
+    role: 'assistant',
+    content: 'Assistant reply',
+    citations: [],
+    usage: null,
+    created_at: '2026-05-01T10:00:00.000Z',
+    status: 'complete',
+    ...overrides,
+  };
+}
+
+function buildCitation(overrides: Partial<ChatCitation> = {}): ChatCitation {
+  return {
+    index: 1,
+    chunk_id: 'chunk-1',
+    wiki_page_pk: 'wiki-page-pk-1',
+    section_id: 'section-1',
+    relevance_score: 0.87,
+    source_chain_json: {},
+    display_text: 'Auth / SSO',
+    page_title: 'Auth',
+    section_title: 'SSO',
+    fallback: false,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function getRequestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input.split('?')[0] ?? input;
+  }
+
+  if (input instanceof URL) {
+    return input.pathname;
+  }
+
+  return input.url.split('?')[0] ?? input.url;
+}

--- a/apps/web/src/__tests__/wiki.test.tsx
+++ b/apps/web/src/__tests__/wiki.test.tsx
@@ -134,7 +134,7 @@ describe('WikiVersionHistory', () => {
     renderWithRouter(<WikiVersionHistory spaceId="space-1" pageId="page-1" />);
 
     expect(await screen.findByText('version-2')).toBeInTheDocument();
-    expect(screen.getByText('Graphify')).toBeInTheDocument();
+    expect(screen.getAllByText('Graphify').length).toBeGreaterThan(0);
     expect(screen.getByText('version-1')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Rollback' })).toBeInTheDocument();
   });

--- a/apps/web/src/components/SpaceNav.tsx
+++ b/apps/web/src/components/SpaceNav.tsx
@@ -1,0 +1,28 @@
+import { NavLink } from 'react-router';
+
+type SpaceNavProps = {
+  spaceId: string;
+};
+
+const SPACE_NAV_ITEMS = [
+  { label: 'Wiki', path: 'wiki' },
+  { label: 'Chat', path: 'chat' },
+  { label: 'Uploads', path: 'uploads' },
+  { label: 'Graphify', path: 'graphify' },
+] as const;
+
+export default function SpaceNav({ spaceId }: SpaceNavProps) {
+  return (
+    <nav className="space-nav" aria-label="Space navigation">
+      {SPACE_NAV_ITEMS.map((item) => (
+        <NavLink
+          key={item.path}
+          to={`/spaces/${encodeURIComponent(spaceId)}/${item.path}`}
+          className={({ isActive }) => (isActive ? 'space-nav-link active' : 'space-nav-link')}
+        >
+          {item.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/hooks/useChatStream.ts
+++ b/apps/web/src/hooks/useChatStream.ts
@@ -1,0 +1,604 @@
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+
+export const CHAT_INPUT_MAX_LENGTH = 4000;
+
+export type ChatRole = 'user' | 'assistant';
+
+export type ChatCitation = {
+  index: number;
+  chunk_id: string;
+  wiki_page_pk: string;
+  section_id: string | null;
+  relevance_score: number;
+  source_chain_json: Record<string, unknown>;
+  display_text: string;
+  page_title: string;
+  section_title: string | null;
+  fallback: boolean;
+};
+
+export type ChatMessageStatus = 'complete' | 'streaming' | 'error';
+
+export type ChatUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
+export type ChatMessage = {
+  id: string;
+  session_id: string | null;
+  role: ChatRole;
+  content: string;
+  citations: ChatCitation[];
+  usage: ChatUsage | null;
+  created_at: string;
+  status: ChatMessageStatus;
+  error?: string;
+};
+
+export type ChatApiMessage = {
+  id: string;
+  session_id: string;
+  role: string;
+  content: string;
+  citations_json: unknown[];
+  created_at: string;
+};
+
+export type ChatApiSessionDetail = {
+  id: string;
+  messages: ChatApiMessage[];
+};
+
+export class ChatStreamError extends Error {
+  readonly code: string;
+  readonly status: number | null;
+
+  constructor(input: { code: string; message: string; status?: number | null }) {
+    super(input.message);
+    this.name = 'ChatStreamError';
+    this.code = input.code;
+    this.status = input.status ?? null;
+  }
+}
+
+type UseChatStreamParams = {
+  spaceId: string;
+  accessToken: string | null;
+  onSession?: (sessionId: string) => void;
+};
+
+type SendMessageOptions = {
+  sessionId?: string | null;
+};
+
+export function useChatStream({ spaceId, accessToken, onSession }: UseChatStreamParams) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<ChatStreamError | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const messagesRef = useRef<ChatMessage[]>([]);
+  const isStreamingRef = useRef(false);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  useEffect(() => {
+    isStreamingRef.current = isStreaming;
+  }, [isStreaming]);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const loadSession = useCallback((session: ChatApiSessionDetail) => {
+    abortControllerRef.current?.abort();
+    setSessionId(session.id);
+    setMessages(normalizeChatMessages(session.messages));
+    setError(null);
+    setIsStreaming(false);
+  }, []);
+
+  const startNewSession = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setSessionId(null);
+    setMessages([]);
+    setError(null);
+    setIsStreaming(false);
+  }, []);
+
+  const sendMessage = useCallback(
+    async (rawContent: string, options: SendMessageOptions = {}): Promise<void> => {
+      const content = rawContent.trim();
+
+      if (content.length === 0 || content.length > CHAT_INPUT_MAX_LENGTH || isStreamingRef.current) {
+        return;
+      }
+
+      const requestSessionId = options.sessionId ?? sessionId;
+      const userMessageId = createLocalMessageId('user');
+      const assistantMessageId = createLocalMessageId('assistant');
+      const now = new Date().toISOString();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      isStreamingRef.current = true;
+      setIsStreaming(true);
+      setError(null);
+      setMessages((current) => [
+        ...current,
+        {
+          id: userMessageId,
+          session_id: requestSessionId,
+          role: 'user',
+          content,
+          citations: [],
+          usage: null,
+          created_at: now,
+          status: 'complete',
+        },
+        {
+          id: assistantMessageId,
+          session_id: requestSessionId,
+          role: 'assistant',
+          content: '',
+          citations: [],
+          usage: null,
+          created_at: now,
+          status: 'streaming',
+        },
+      ]);
+
+      let doneReceived = false;
+      let streamError: ChatStreamError | null = null;
+
+      try {
+        const response = await fetch('/api/chat/completions', {
+          method: 'POST',
+          credentials: 'include',
+          signal: controller.signal,
+          headers: buildStreamHeaders(accessToken),
+          body: JSON.stringify({
+            space_id: spaceId,
+            message: content,
+            ...(requestSessionId !== null && requestSessionId.length > 0 ? { session_id: requestSessionId } : {}),
+          }),
+        });
+
+        if (!response.ok) {
+          throw await parseErrorResponse(response);
+        }
+
+        if (response.body === null) {
+          throw new ChatStreamError({
+            code: 'STREAM_INTERRUPTED',
+            message: '响应中断，请重试',
+            status: response.status,
+          });
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        const parser = createParser({
+          onEvent: (event) => {
+            const result = handleStreamEvent(event, assistantMessageId, setMessages, setSessionId, onSession);
+            if (result.done) {
+              doneReceived = true;
+            }
+            if (result.error !== null) {
+              streamError = result.error;
+              setError(result.error);
+            }
+          },
+          onError: (parseError) => {
+            streamError = new ChatStreamError({
+              code: 'STREAM_INTERRUPTED',
+              message: parseError.message,
+            });
+            setError(streamError);
+            markAssistantError(assistantMessageId, streamError.message, setMessages);
+          },
+        });
+
+        while (true) {
+          const result = await reader.read();
+          if (result.done) {
+            break;
+          }
+
+          parser.feed(decoder.decode(result.value, { stream: true }));
+        }
+
+        const remaining = decoder.decode();
+        if (remaining.length > 0) {
+          parser.feed(remaining);
+        }
+        parser.reset({ consume: true });
+
+        if (!doneReceived && streamError === null) {
+          throw new ChatStreamError({
+            code: 'STREAM_INTERRUPTED',
+            message: '响应中断，请重试',
+          });
+        }
+
+        if (streamError === null) {
+          setMessages((current) =>
+            current.map((message) =>
+              message.id === assistantMessageId && message.status === 'streaming'
+                ? { ...message, status: 'complete' }
+                : message,
+            ),
+          );
+        }
+      } catch (err) {
+        if (isAbortError(err)) {
+          return;
+        }
+
+        const nextError = normalizeStreamError(err);
+        setError(nextError);
+        markAssistantError(assistantMessageId, nextError.message, setMessages);
+      } finally {
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null;
+        }
+        isStreamingRef.current = false;
+        setIsStreaming(false);
+      }
+    },
+    [accessToken, onSession, sessionId, spaceId],
+  );
+
+  const retry = useCallback(async (): Promise<void> => {
+    const lastUserMessage = [...messagesRef.current].reverse().find((message) => message.role === 'user');
+    if (lastUserMessage === undefined) {
+      return;
+    }
+
+    await sendMessage(lastUserMessage.content, { sessionId });
+  }, [sendMessage, sessionId]);
+
+  return {
+    messages,
+    sessionId,
+    isStreaming,
+    error,
+    sendMessage,
+    retry,
+    loadSession,
+    startNewSession,
+  };
+}
+
+export function normalizeChatMessages(rows: ChatApiMessage[]): ChatMessage[] {
+  return rows
+    .filter((row) => row.role === 'user' || row.role === 'assistant')
+    .map((row) => ({
+      id: row.id,
+      session_id: row.session_id,
+      role: row.role as ChatRole,
+      content: row.content,
+      citations: normalizeCitationArray(row.citations_json),
+      usage: null,
+      created_at: row.created_at,
+      status: 'complete',
+    }));
+}
+
+export function getChatErrorMessage(error: ChatStreamError | null): string | null {
+  if (error === null) {
+    return null;
+  }
+
+  if (error.code === 'NO_CHAT_MODEL_CONFIGURED') {
+    return '请联系管理员配置聊天模型';
+  }
+
+  if (error.code === 'NO_INDEXED_CONTENT') {
+    return '知识库正在构建中，请稍后再试';
+  }
+
+  if (error.code === 'STREAM_INTERRUPTED') {
+    return '响应中断，请重试';
+  }
+
+  if (error.code === 'NETWORK_ERROR') {
+    return '连接失败';
+  }
+
+  return error.message.length > 0 ? error.message : '连接失败';
+}
+
+function buildStreamHeaders(accessToken: string | null): Headers {
+  const headers = new Headers();
+  headers.set('Accept', 'text/event-stream');
+  headers.set('Content-Type', 'application/json');
+
+  if (accessToken !== null && accessToken.length > 0) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+
+  return headers;
+}
+
+function handleStreamEvent(
+  event: EventSourceMessage,
+  assistantMessageId: string,
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
+  setSessionId: Dispatch<SetStateAction<string | null>>,
+  onSession: ((sessionId: string) => void) | undefined,
+): { done: boolean; error: ChatStreamError | null } {
+  if (event.data === '[DONE]') {
+    return { done: true, error: null };
+  }
+
+  const data = parseEventData(event.data);
+  const eventType = event.event ?? 'message';
+
+  if (eventType === 'session') {
+    const nextSessionId = readString(data, 'session_id');
+    if (nextSessionId !== null) {
+      setSessionId(nextSessionId);
+      setMessages((current) =>
+        current.map((message) => (message.session_id === null ? { ...message, session_id: nextSessionId } : message)),
+      );
+      onSession?.(nextSessionId);
+    }
+    return { done: false, error: null };
+  }
+
+  if (eventType === 'content') {
+    const delta = readString(data, 'delta') ?? '';
+    if (delta.length > 0) {
+      setMessages((current) =>
+        current.map((message) =>
+          message.id === assistantMessageId
+            ? { ...message, content: `${message.content}${delta}`, status: 'streaming' }
+            : message,
+        ),
+      );
+    }
+    return { done: false, error: null };
+  }
+
+  if (eventType === 'citations') {
+    const citations = normalizeCitationArray(readUnknown(data, 'citations'));
+    setMessages((current) =>
+      current.map((message) => (message.id === assistantMessageId ? { ...message, citations } : message)),
+    );
+    return { done: false, error: null };
+  }
+
+  if (eventType === 'usage') {
+    const usage = normalizeUsage(data);
+    setMessages((current) =>
+      current.map((message) => (message.id === assistantMessageId ? { ...message, usage } : message)),
+    );
+    return { done: false, error: null };
+  }
+
+  if (eventType === 'error') {
+    const nextError = new ChatStreamError({
+      code: readString(data, 'code') ?? 'API_ERROR',
+      message: readString(data, 'message') ?? 'Chat completion failed',
+    });
+    markAssistantError(assistantMessageId, nextError.message, setMessages);
+    return { done: false, error: nextError };
+  }
+
+  return { done: false, error: null };
+}
+
+function markAssistantError(
+  assistantMessageId: string,
+  message: string,
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
+): void {
+  setMessages((current) =>
+    current.map((chatMessage) =>
+      chatMessage.id === assistantMessageId
+        ? {
+            ...chatMessage,
+            status: 'error',
+            error: message,
+          }
+        : chatMessage,
+    ),
+  );
+}
+
+async function parseErrorResponse(response: Response): Promise<ChatStreamError> {
+  const body = await readJsonBody(response);
+  const code = readErrorCode(body);
+  const message = readErrorMessage(body) ?? response.statusText ?? 'Request failed';
+
+  return new ChatStreamError({
+    code,
+    message,
+    status: response.status,
+  });
+}
+
+function normalizeStreamError(error: unknown): ChatStreamError {
+  if (error instanceof ChatStreamError) {
+    return error;
+  }
+
+  if (error instanceof Error && error.message.length > 0) {
+    return new ChatStreamError({
+      code: 'NETWORK_ERROR',
+      message: '连接失败',
+    });
+  }
+
+  return new ChatStreamError({
+    code: 'NETWORK_ERROR',
+    message: '连接失败',
+  });
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function readErrorCode(body: unknown): string {
+  if (!isRecord(body)) {
+    return 'API_ERROR';
+  }
+
+  const nestedError = body.error;
+  if (isRecord(nestedError) && typeof nestedError.code === 'string') {
+    return nestedError.code;
+  }
+
+  if (typeof body.code === 'string') {
+    return body.code;
+  }
+
+  return 'API_ERROR';
+}
+
+function readErrorMessage(body: unknown): string | null {
+  if (!isRecord(body)) {
+    return null;
+  }
+
+  const nestedError = body.error;
+  if (isRecord(nestedError) && typeof nestedError.message === 'string') {
+    return nestedError.message;
+  }
+
+  if (typeof body.message === 'string') {
+    return body.message;
+  }
+
+  return null;
+}
+
+function parseEventData(data: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(data) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeCitationArray(value: unknown): ChatCitation[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map(normalizeCitation).filter((citation): citation is ChatCitation => citation !== null);
+}
+
+function normalizeCitation(value: unknown): ChatCitation | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const index = readNumber(value, 'index');
+  const chunkId = readString(value, 'chunk_id') ?? '';
+  const wikiPagePk = readString(value, 'wiki_page_pk') ?? '';
+  const relevanceScore = readNumber(value, 'relevance_score');
+  const sourceChainJson = readRecord(value, 'source_chain_json') ?? {};
+  const displayText = readString(value, 'display_text') ?? readString(value, 'page_title') ?? 'Source';
+  const pageTitle = readString(value, 'page_title') ?? displayText;
+
+  if (index === null || wikiPagePk.length === 0) {
+    return null;
+  }
+
+  return {
+    index,
+    chunk_id: chunkId,
+    wiki_page_pk: wikiPagePk,
+    section_id: readString(value, 'section_id'),
+    relevance_score: relevanceScore ?? 0,
+    source_chain_json: sourceChainJson,
+    display_text: displayText,
+    page_title: pageTitle,
+    section_title: readString(value, 'section_title'),
+    fallback: readBoolean(value, 'fallback') ?? false,
+  };
+}
+
+function normalizeUsage(value: unknown): ChatUsage | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const promptTokens = readNumber(value, 'prompt_tokens');
+  const completionTokens = readNumber(value, 'completion_tokens');
+  const totalTokens = readNumber(value, 'total_tokens');
+
+  if (promptTokens === null || completionTokens === null || totalTokens === null) {
+    return null;
+  }
+
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: totalTokens,
+  };
+}
+
+function readUnknown(record: Record<string, unknown>, key: string): unknown {
+  return record[key];
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key];
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function readBoolean(record: Record<string, unknown>, key: string): boolean | null {
+  const value = record[key];
+  return typeof value === 'boolean' ? value : null;
+}
+
+function readRecord(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const value = record[key];
+  return isRecord(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+function createLocalMessageId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}

--- a/apps/web/src/hooks/useChatStream.ts
+++ b/apps/web/src/hooks/useChatStream.ts
@@ -9,6 +9,7 @@ export type ChatCitation = {
   index: number;
   chunk_id: string;
   wiki_page_pk: string;
+  page_id?: string;
   section_id: string | null;
   relevance_score: number;
   source_chain_json: Record<string, unknown>;

--- a/apps/web/src/lib/adminTypes.ts
+++ b/apps/web/src/lib/adminTypes.ts
@@ -2,7 +2,7 @@ export type Role = 'owner' | 'admin' | 'space_admin' | 'editor' | 'viewer' | 'au
 
 export const ROLE_OPTIONS: Role[] = ['owner', 'admin', 'space_admin', 'editor', 'viewer', 'auditor'];
 
-export const SPACE_PERMISSION_OPTIONS = ['space:view', 'space:edit', 'space:admin'] as const;
+export const SPACE_PERMISSION_OPTIONS = ['space:view', 'space:edit', 'space:admin', 'chat:use'] as const;
 
 export type SpacePermission = (typeof SPACE_PERMISSION_OPTIONS)[number];
 

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -186,9 +186,9 @@ export function isAdminRole(role: string): boolean {
 }
 
 const SPACE_ROLE_PERMISSIONS: Record<SpaceRole, readonly string[]> = {
-  viewer: [],
-  editor: ['wiki:publish'],
-  admin: ['wiki:publish', 'wiki:rollback'],
+  viewer: ['space:view', 'chat:use'],
+  editor: ['space:view', 'space:edit', 'chat:use', 'wiki:publish'],
+  admin: ['space:view', 'space:edit', 'space:admin', 'chat:use', 'wiki:publish', 'wiki:rollback'],
 };
 
 function checkSpacePermission(user: AuthUser | null, spaceId: string, permission: string): boolean {

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -1,3 +1,518 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Navigate, useNavigate, useParams } from 'react-router';
+import rehypeHighlight from 'rehype-highlight';
+import remarkGfm from 'remark-gfm';
+import SpaceNav from '../components/SpaceNav.js';
+import { EmptyState, ErrorBanner, LoadingState, formatDate, getErrorMessage } from '../components/adminUi.js';
+import {
+  CHAT_INPUT_MAX_LENGTH,
+  getChatErrorMessage,
+  useChatStream,
+  type ChatApiSessionDetail,
+  type ChatCitation,
+  type ChatMessage,
+} from '../hooks/useChatStream.js';
+import { api } from '../lib/api.js';
+import { useAuth } from '../lib/auth.js';
+import NotFound from './NotFound.js';
+
+type ChatSession = {
+  id: string;
+  title: string | null;
+  updated_at: string;
+  created_at: string;
+};
+
+type MessageInputProps = {
+  disabled: boolean;
+  isStreaming: boolean;
+  onSend: (message: string) => Promise<void> | void;
+};
+
+type SessionSidebarProps = {
+  sessions: ChatSession[];
+  activeSessionId: string | null;
+  isLoading: boolean;
+  onNewChat: () => void;
+  onSelectSession: (sessionId: string) => void;
+  onDeleteSession: (session: ChatSession) => void;
+};
+
+type ChatMessageBubbleProps = {
+  message: ChatMessage;
+  spaceId: string;
+};
+
 export default function Chat() {
-  return <h1>Chat</h1>;
+  const { spaceId = '' } = useParams();
+  const { accessToken, hasSpacePermission, isAuthenticated, user } = useAuth();
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(true);
+  const [sessionsError, setSessionsError] = useState<string | null>(null);
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+
+  const loadSessions = useCallback(
+    async (background = false) => {
+      if (!isAuthenticated || spaceId.length === 0) {
+        setSessions([]);
+        setSessionsLoading(false);
+        return;
+      }
+
+      if (!background) {
+        setSessionsLoading(true);
+      }
+      setSessionsError(null);
+
+      try {
+        const response = await api.getWrapped<ChatSession[]>(
+          `/spaces/${encodeURIComponent(spaceId)}/chat/sessions`,
+          {
+            page: 1,
+            limit: 50,
+          },
+        );
+        setSessions(sortSessions(response.data));
+      } catch (err) {
+        setSessionsError(getErrorMessage(err));
+      } finally {
+        if (!background) {
+          setSessionsLoading(false);
+        }
+      }
+    },
+    [isAuthenticated, spaceId],
+  );
+
+  const {
+    messages,
+    sessionId,
+    isStreaming,
+    error: streamError,
+    sendMessage,
+    retry,
+    loadSession,
+    startNewSession,
+  } = useChatStream({
+    spaceId,
+    accessToken,
+    onSession: () => {
+      void loadSessions(true);
+    },
+  });
+
+  useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  useEffect(() => {
+    if (typeof messagesEndRef.current?.scrollIntoView === 'function') {
+      messagesEndRef.current.scrollIntoView({ block: 'end' });
+    }
+  }, [messages]);
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (spaceId.length === 0) {
+    return <NotFound />;
+  }
+
+  if (!hasSpacePermission(spaceId, 'chat:use')) {
+    return (
+      <main className="forbidden-page">
+        <section className="forbidden-panel">
+          <p className="eyebrow">403</p>
+          <h1>Access denied</h1>
+          <p>{user?.email ?? 'This user'} does not have chat access for this space.</p>
+        </section>
+      </main>
+    );
+  }
+
+  async function openSession(nextSessionId: string): Promise<void> {
+    setSessionsError(null);
+    setIsMobileSidebarOpen(false);
+
+    try {
+      const detail = await api.get<ChatApiSessionDetail>(
+        `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(nextSessionId)}`,
+      );
+      loadSession(detail);
+    } catch (err) {
+      setSessionsError(getErrorMessage(err));
+    }
+  }
+
+  async function deleteSession(session: ChatSession): Promise<void> {
+    if (!window.confirm(`Delete chat "${getSessionTitle(session)}"?`)) {
+      return;
+    }
+
+    setSessionsError(null);
+
+    try {
+      await api.delete<{ deleted: true }>(
+        `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(session.id)}`,
+      );
+      setSessions((current) => current.filter((item) => item.id !== session.id));
+      if (session.id === sessionId) {
+        startNewSession();
+      }
+    } catch (err) {
+      setSessionsError(getErrorMessage(err));
+    }
+  }
+
+  function newChat(): void {
+    startNewSession();
+    setIsMobileSidebarOpen(false);
+  }
+
+  async function handleSend(message: string): Promise<void> {
+    await sendMessage(message, { sessionId });
+    await loadSessions(true);
+  }
+
+  const chatErrorMessage = getChatErrorMessage(streamError);
+
+  return (
+    <div className="chat-page">
+      {isMobileSidebarOpen ? (
+        <button
+          className="chat-sidebar-backdrop"
+          type="button"
+          aria-label="Close sessions"
+          onClick={() => setIsMobileSidebarOpen(false)}
+        />
+      ) : null}
+
+      <aside className={`chat-session-sidebar${isMobileSidebarOpen ? ' open' : ''}`} aria-label="Chat sessions">
+        <div className="chat-sidebar-header">
+          <div>
+            <span className="eyebrow">Space</span>
+            <strong>Cherry Chat</strong>
+          </div>
+          <button className="icon-button chat-sidebar-close" type="button" onClick={() => setIsMobileSidebarOpen(false)}>
+            x
+          </button>
+        </div>
+        <SpaceNav spaceId={spaceId} />
+        <ErrorBanner error={sessionsError} />
+        <SessionSidebar
+          sessions={sessions}
+          activeSessionId={sessionId}
+          isLoading={sessionsLoading}
+          onNewChat={newChat}
+          onSelectSession={(nextSessionId) => {
+            void openSession(nextSessionId);
+          }}
+          onDeleteSession={(session) => {
+            void deleteSession(session);
+          }}
+        />
+      </aside>
+
+      <main className="chat-main">
+        <header className="chat-topbar">
+          <button className="button button-secondary chat-mobile-menu" type="button" onClick={() => setIsMobileSidebarOpen(true)}>
+            Menu
+          </button>
+          <div>
+            <span className="eyebrow">Knowledge Chat</span>
+            <h1>Chat</h1>
+          </div>
+          <SpaceNav spaceId={spaceId} />
+        </header>
+
+        <section className="chat-message-list" aria-label="Chat messages">
+          {messages.length === 0 ? (
+            <EmptyState label="开始新的对话" />
+          ) : (
+            messages.map((message) => <ChatMessageBubble key={message.id} message={message} spaceId={spaceId} />)
+          )}
+          <div ref={messagesEndRef} />
+        </section>
+
+        {chatErrorMessage !== null ? (
+          <div className="chat-error-bar" role="alert">
+            <span>{chatErrorMessage}</span>
+            {streamError?.code !== 'NO_CHAT_MODEL_CONFIGURED' ? (
+              <button
+                className="button button-secondary"
+                type="button"
+                disabled={isStreaming}
+                onClick={() => {
+                  void retry();
+                }}
+              >
+                Retry
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+
+        <MessageInput disabled={isStreaming} isStreaming={isStreaming} onSend={handleSend} />
+      </main>
+    </div>
+  );
+}
+
+export function MessageInput({ disabled, isStreaming, onSend }: MessageInputProps) {
+  const [value, setValue] = useState('');
+  const trimmedLength = value.trim().length;
+  const isAtLimit = value.length >= CHAT_INPUT_MAX_LENGTH;
+
+  async function submit(): Promise<void> {
+    if (disabled || trimmedLength === 0 || value.length > CHAT_INPUT_MAX_LENGTH) {
+      return;
+    }
+
+    const message = value;
+    setValue('');
+    await onSend(message);
+  }
+
+  return (
+    <form
+      className="chat-input-panel"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submit();
+      }}
+    >
+      <label htmlFor="chat-message-input">Message</label>
+      <textarea
+        id="chat-message-input"
+        value={value}
+        maxLength={CHAT_INPUT_MAX_LENGTH}
+        rows={3}
+        disabled={disabled}
+        placeholder={isStreaming ? 'Streaming response...' : 'Ask about this space'}
+        onChange={(event) => setValue(event.target.value.slice(0, CHAT_INPUT_MAX_LENGTH))}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+            void submit();
+          }
+        }}
+      />
+      <div className="chat-input-footer">
+        <span className={`chat-character-count${isAtLimit ? ' warning' : ''}`}>
+          {value.length}/{CHAT_INPUT_MAX_LENGTH}
+        </span>
+        {isStreaming ? <span className="chat-stream-label">Streaming...</span> : null}
+        <button className="button button-primary" type="submit" disabled={disabled || trimmedLength === 0}>
+          Send
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export function SessionSidebar({
+  sessions,
+  activeSessionId,
+  isLoading,
+  onNewChat,
+  onSelectSession,
+  onDeleteSession,
+}: SessionSidebarProps) {
+  return (
+    <div className="chat-session-list-panel">
+      <button className="button button-primary chat-new-button" type="button" onClick={onNewChat}>
+        New Chat
+      </button>
+      {isLoading ? (
+        <LoadingState label="Loading sessions..." />
+      ) : sessions.length === 0 ? (
+        <EmptyState label="开始新的对话" />
+      ) : (
+        <ol className="chat-session-list">
+          {sessions.map((session) => {
+            const title = getSessionTitle(session);
+            return (
+              <li key={session.id}>
+                <button
+                  className={`chat-session-item${session.id === activeSessionId ? ' active' : ''}`}
+                  type="button"
+                  onClick={() => onSelectSession(session.id)}
+                >
+                  <strong>{title}</strong>
+                  <span>{formatDate(session.updated_at)}</span>
+                </button>
+                <button
+                  className="icon-button chat-session-delete"
+                  type="button"
+                  aria-label={`Delete ${title}`}
+                  onClick={() => onDeleteSession(session)}
+                >
+                  x
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+export function ChatMessageBubble({ message, spaceId }: ChatMessageBubbleProps) {
+  return (
+    <article className={`chat-message-row ${message.role}`} aria-label={`${message.role} message`}>
+      <div className={`chat-message-bubble ${message.role}`}>
+        {message.role === 'assistant' ? (
+          <>
+            {message.status === 'streaming' && message.content.length === 0 ? (
+              <TypingIndicator />
+            ) : (
+              <AssistantMarkdown content={message.content} citations={message.citations} spaceId={spaceId} />
+            )}
+            <CitationPanel citations={message.citations} spaceId={spaceId} />
+          </>
+        ) : (
+          <p className="chat-user-content">{message.content}</p>
+        )}
+        {message.status === 'error' ? <p className="chat-message-error">{message.error ?? '响应中断，请重试'}</p> : null}
+      </div>
+    </article>
+  );
+}
+
+function AssistantMarkdown({ content, citations, spaceId }: { content: string; citations: ChatCitation[]; spaceId: string }) {
+  const navigate = useNavigate();
+  const markdown = useMemo(() => content.replace(/\[\^(\d+)]/g, '[$1](citation:$1)'), [content]);
+
+  function openCitation(index: number): void {
+    const citation = citations.find((item) => item.index === index);
+    if (citation === undefined) {
+      return;
+    }
+
+    void navigate(buildCitationPath(spaceId, citation));
+  }
+
+  return (
+    <div className="chat-markdown">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        urlTransform={transformMarkdownUrl}
+        components={{
+          a: ({ href, children }) => {
+            if (href?.startsWith('citation:') === true) {
+              const index = Number(href.slice('citation:'.length));
+              return (
+                <button className="chat-citation-ref" type="button" onClick={() => openCitation(index)}>
+                  [{Number.isFinite(index) ? index : children}]
+                </button>
+              );
+            }
+
+            return (
+              <a href={href} target="_blank" rel="noreferrer">
+                {children}
+              </a>
+            );
+          },
+          img: (props) => <img {...props} referrerPolicy="no-referrer" loading="lazy" />,
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+function CitationPanel({ citations, spaceId }: { citations: ChatCitation[]; spaceId: string }) {
+  const navigate = useNavigate();
+
+  if (citations.length === 0) {
+    return null;
+  }
+
+  return (
+    <details className="chat-citations" open>
+      <summary>Citations ({citations.length})</summary>
+      <ol>
+        {citations.map((citation) => (
+          <li key={`${citation.index}-${citation.chunk_id || citation.wiki_page_pk}`}>
+            <button
+              className="chat-citation-card"
+              type="button"
+              onClick={() => {
+                void navigate(buildCitationPath(spaceId, citation));
+              }}
+            >
+              <span className="chat-citation-index">[{citation.index}]</span>
+              <span>
+                <strong>{citation.page_title}</strong>
+                <small>{citation.section_title ?? 'No section'}</small>
+              </span>
+              <span className="status-badge status-neutral">{formatCitationScore(citation.relevance_score)}</span>
+            </button>
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
+function TypingIndicator() {
+  return (
+    <div className="chat-typing-indicator" aria-label="Assistant is typing">
+      <span />
+      <span />
+      <span />
+    </div>
+  );
+}
+
+function sortSessions(sessions: ChatSession[]): ChatSession[] {
+  return [...sessions].sort((left, right) => new Date(right.updated_at).getTime() - new Date(left.updated_at).getTime());
+}
+
+function getSessionTitle(session: ChatSession): string {
+  if (session.title !== null && session.title.trim().length > 0) {
+    return session.title;
+  }
+
+  return `Chat ${session.id.slice(0, 8)}`;
+}
+
+function buildCitationPath(spaceId: string, citation: ChatCitation): string {
+  return `/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(getCitationPageId(citation))}`;
+}
+
+export function getCitationPageId(citation: ChatCitation): string {
+  const sourcePageId = citation.source_chain_json.page_id;
+  return typeof sourcePageId === 'string' && sourcePageId.length > 0 ? sourcePageId : citation.wiki_page_pk;
+}
+
+function formatCitationScore(score: number): string {
+  if (!Number.isFinite(score)) {
+    return '0.00';
+  }
+
+  if (score >= 0 && score <= 1) {
+    return `${Math.round(score * 100)}%`;
+  }
+
+  return score.toFixed(2);
+}
+
+function transformMarkdownUrl(url: string): string {
+  if (url.startsWith('citation:')) {
+    return url;
+  }
+
+  if (url.startsWith('https://') || url.startsWith('http://') || url.startsWith('mailto:')) {
+    return url;
+  }
+
+  return '';
 }

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -133,16 +133,21 @@ export default function Chat() {
     );
   }
 
+  const sessionSwitchRef = useRef(0);
+
   async function openSession(nextSessionId: string): Promise<void> {
     setSessionsError(null);
     setIsMobileSidebarOpen(false);
+    const switchVersion = ++sessionSwitchRef.current;
 
     try {
       const detail = await api.get<ChatApiSessionDetail>(
         `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(nextSessionId)}`,
       );
+      if (sessionSwitchRef.current !== switchVersion) return;
       loadSession(detail);
     } catch (err) {
+      if (sessionSwitchRef.current !== switchVersion) return;
       setSessionsError(getErrorMessage(err));
     }
   }
@@ -419,7 +424,7 @@ function AssistantMarkdown({ content, citations, spaceId }: { content: string; c
               </a>
             );
           },
-          img: (props) => <img {...props} referrerPolicy="no-referrer" loading="lazy" />,
+          img: () => null,
         }}
       >
         {markdown}
@@ -489,6 +494,7 @@ function buildCitationPath(spaceId: string, citation: ChatCitation): string {
 }
 
 export function getCitationPageId(citation: ChatCitation): string {
+  if (typeof citation.page_id === 'string' && citation.page_id.length > 0) return citation.page_id;
   const sourcePageId = citation.source_chain_json.page_id;
   return typeof sourcePageId === 'string' && sourcePageId.length > 0 ? sourcePageId : citation.wiki_page_pk;
 }

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   formatLabel,
   getErrorMessage,
 } from '../components/adminUi.js';
+import SpaceNav from '../components/SpaceNav.js';
 import {
   cancelGraphifyRun,
   getGraphifyReport,
@@ -158,6 +159,7 @@ export default function GraphifyRunDetailPage() {
         description="Inspect Graphify metadata, import statistics, reports, and failures."
         actions={
           <>
+            <SpaceNav spaceId={spaceId} />
             <button
               className="button button-secondary"
               type="button"

--- a/apps/web/src/pages/GraphifyRunsPage.tsx
+++ b/apps/web/src/pages/GraphifyRunsPage.tsx
@@ -9,6 +9,7 @@ import {
   formatLabel,
   getErrorMessage,
 } from '../components/adminUi.js';
+import SpaceNav from '../components/SpaceNav.js';
 import { type ApiMeta } from '../lib/api.js';
 import {
   GRAPHIFY_TRIGGER_TYPES,
@@ -177,6 +178,7 @@ export default function GraphifyRunsPage() {
         description="Create and track Graphify output imports for this space."
         actions={
           <>
+            <SpaceNav spaceId={spaceId} />
             <button
               className="button button-secondary"
               type="button"

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { Navigate } from 'react-router';
 import { useAuth } from '../lib/auth';
 
 export default function Home() {
-  const { isAuthenticated, isAdmin } = useAuth();
+  const { isAuthenticated, isAdmin, user } = useAuth();
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
@@ -12,5 +12,10 @@ export default function Home() {
     return <Navigate to="/admin" replace />;
   }
 
-  return <Navigate to="/chat" replace />;
+  const firstSpace = user?.spaces?.[0];
+  if (firstSpace !== undefined) {
+    return <Navigate to={`/spaces/${encodeURIComponent(firstSpace.id)}/chat`} replace />;
+  }
+
+  return <h1>No spaces available</h1>;
 }

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Navigate, useParams } from 'react-router';
+import SpaceNav from '../../components/SpaceNav';
 import { ErrorBanner, LoadingState, PageHeader, getErrorMessage } from '../../components/adminUi';
 import { useUploadPolling } from '../../hooks/useUploadPolling';
 import { type ApiMeta, api } from '../../lib/api';
@@ -166,15 +167,18 @@ export default function UploadCenter() {
         title="Upload Center"
         description="Upload files and URLs, then track processing status for this space."
         actions={
-          <button
-            className="button button-secondary"
-            type="button"
-            onClick={() => {
-              void loadUploads();
-            }}
-          >
-            Refresh
-          </button>
+          <>
+            <SpaceNav spaceId={spaceId} />
+            <button
+              className="button button-secondary"
+              type="button"
+              onClick={() => {
+                void loadUploads();
+              }}
+            >
+              Refresh
+            </button>
+          </>
         }
       />
 

--- a/apps/web/src/pages/wiki/WikiPageDetail.tsx
+++ b/apps/web/src/pages/wiki/WikiPageDetail.tsx
@@ -10,6 +10,7 @@ import {
   formatDate,
   getErrorMessage,
 } from '../../components/adminUi.js';
+import SpaceNav from '../../components/SpaceNav.js';
 import { ApiError } from '../../lib/api.js';
 import { useAuth } from '../../lib/auth.js';
 import { wikiApi, type WikiPage, type WikiPageContent } from '../../lib/wikiApi.js';
@@ -101,6 +102,7 @@ export default function WikiPageDetail({ spaceId, pageId, versionId }: WikiPageD
           : {})}
         actions={
           <>
+            <SpaceNav spaceId={spaceId} />
             <Link className="button button-secondary" to={`/spaces/${encodeURIComponent(spaceId)}/wiki`}>
               Back to Wiki
             </Link>

--- a/apps/web/src/pages/wiki/WikiPageList.tsx
+++ b/apps/web/src/pages/wiki/WikiPageList.tsx
@@ -8,6 +8,7 @@ import {
   formatDate,
   getErrorMessage,
 } from '../../components/adminUi.js';
+import SpaceNav from '../../components/SpaceNav.js';
 import { type ApiMeta } from '../../lib/api.js';
 import { wikiApi, type WikiPage } from '../../lib/wikiApi.js';
 import { WIKI_PAGE_SIZE, WikiStatusBadge, getFirstItemIndex, getLastItemIndex } from './wikiUi.js';
@@ -92,7 +93,11 @@ export default function WikiPageList({ spaceId }: WikiPageListProps) {
 
   return (
     <main className="admin-content wiki-page">
-      <PageHeader title="Wiki" description="Read canonical pages generated for this knowledge space." />
+      <PageHeader
+        title="Wiki"
+        description="Read canonical pages generated for this knowledge space."
+        actions={<SpaceNav spaceId={spaceId} />}
+      />
 
       <ErrorBanner error={error} />
 

--- a/apps/web/src/pages/wiki/WikiVersionHistory.tsx
+++ b/apps/web/src/pages/wiki/WikiVersionHistory.tsx
@@ -9,6 +9,7 @@ import {
   formatLabel,
   getErrorMessage,
 } from '../../components/adminUi.js';
+import SpaceNav from '../../components/SpaceNav.js';
 import { ApiError, type ApiMeta } from '../../lib/api.js';
 import { useAuth } from '../../lib/auth.js';
 import { wikiApi, type WikiPage, type WikiPageVersion } from '../../lib/wikiApi.js';
@@ -109,9 +110,12 @@ export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHisto
         title="Version History"
         {...(page !== null ? { description: page.title } : {})}
         actions={
-          <Link className="button button-secondary" to={`/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}`}>
-            Back to Page
-          </Link>
+          <>
+            <SpaceNav spaceId={spaceId} />
+            <Link className="button button-secondary" to={`/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(pageId)}`}>
+              Back to Page
+            </Link>
+          </>
         }
       />
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -787,6 +787,433 @@ tbody tr:last-child td {
   padding-left: 14px;
 }
 
+.space-nav {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.space-nav-link {
+  min-height: 32px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-2);
+  font-size: 0.86rem;
+  font-weight: 800;
+  padding: 7px 10px;
+  text-decoration: none;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.space-nav-link:hover {
+  border-color: var(--color-text-4);
+  background: var(--color-background-soft);
+  color: var(--color-text-1);
+}
+
+.space-nav-link.active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-mute);
+  color: var(--color-primary-hover);
+}
+
+.chat-page {
+  display: grid;
+  min-height: 100vh;
+  grid-template-columns: 320px minmax(0, 1fr);
+  background: var(--color-background);
+}
+
+.chat-session-sidebar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  height: 100vh;
+  min-width: 0;
+  flex-direction: column;
+  gap: 16px;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface);
+  padding: 18px;
+}
+
+.chat-sidebar-header,
+.chat-topbar,
+.chat-input-footer,
+.chat-citation-card,
+.chat-session-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.chat-sidebar-header strong {
+  color: var(--color-text-1);
+}
+
+.chat-sidebar-close {
+  display: none;
+}
+
+.chat-session-list-panel {
+  display: grid;
+  min-height: 0;
+  gap: 12px;
+}
+
+.chat-new-button {
+  width: 100%;
+}
+
+.chat-session-list {
+  display: grid;
+  min-height: 0;
+  gap: 8px;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.chat-session-list li {
+  align-items: stretch;
+}
+
+.chat-session-item {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  gap: 5px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-2);
+  padding: 10px 11px;
+  text-align: left;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.chat-session-item:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-background-hover);
+  color: var(--color-text-1);
+}
+
+.chat-session-item.active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-mute);
+  color: var(--color-primary-hover);
+}
+
+.chat-session-item strong,
+.chat-session-item span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-session-item span {
+  color: var(--color-text-3);
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+
+.chat-session-delete {
+  flex: 0 0 auto;
+  align-self: center;
+}
+
+.chat-main {
+  display: grid;
+  min-width: 0;
+  height: 100vh;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
+  background: var(--color-background);
+}
+
+.chat-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-overlay);
+  padding: 14px 22px;
+  backdrop-filter: blur(12px);
+}
+
+.chat-topbar h1 {
+  margin: 0;
+  color: var(--color-text-1);
+  font-size: 1.45rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.chat-mobile-menu {
+  display: none;
+}
+
+.chat-message-list {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  overflow-y: auto;
+  padding: 22px;
+}
+
+.chat-message-row {
+  display: flex;
+}
+
+.chat-message-row.user {
+  justify-content: flex-end;
+}
+
+.chat-message-row.assistant {
+  justify-content: flex-start;
+}
+
+.chat-message-bubble {
+  max-width: min(760px, 84%);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+}
+
+.chat-message-bubble.user {
+  border-color: var(--color-info);
+  background: var(--color-info);
+  color: var(--color-background);
+}
+
+.chat-message-bubble.assistant {
+  background: var(--color-surface);
+  color: var(--color-text-1);
+}
+
+.chat-user-content {
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.chat-markdown {
+  overflow-wrap: anywhere;
+}
+
+.chat-markdown > :first-child {
+  margin-top: 0;
+}
+
+.chat-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.chat-markdown p,
+.chat-markdown li {
+  line-height: 1.65;
+}
+
+.chat-markdown a {
+  color: var(--color-link);
+}
+
+.chat-markdown table {
+  min-width: 0;
+}
+
+.chat-markdown pre {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  padding: 12px;
+}
+
+.chat-markdown :not(pre) > code {
+  border-radius: var(--radius-xs);
+  background: var(--color-background-soft);
+  padding: 2px 5px;
+}
+
+.chat-citation-ref {
+  display: inline;
+  min-height: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-link);
+  font-size: 0.75em;
+  font-weight: 900;
+  line-height: 1;
+  padding: 0 2px;
+  vertical-align: super;
+}
+
+.chat-citations {
+  margin-top: 12px;
+  border-top: 1px solid var(--color-border);
+  padding-top: 10px;
+}
+
+.chat-citations summary {
+  cursor: pointer;
+  color: var(--color-text-2);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.chat-citations ol {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+}
+
+.chat-citation-card {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background-soft);
+  color: var(--color-text-1);
+  padding: 10px;
+  text-align: left;
+}
+
+.chat-citation-card:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-background-hover);
+}
+
+.chat-citation-card span:nth-child(2) {
+  display: grid;
+  flex: 1;
+  gap: 3px;
+  min-width: 0;
+}
+
+.chat-citation-card strong,
+.chat-citation-card small {
+  overflow-wrap: anywhere;
+}
+
+.chat-citation-card small {
+  color: var(--color-text-3);
+}
+
+.chat-citation-index {
+  color: var(--color-link);
+  font-weight: 900;
+}
+
+.chat-message-error {
+  margin: 10px 0 0;
+  color: var(--color-error);
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.chat-typing-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+}
+
+.chat-typing-indicator span {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-full);
+  animation: chat-typing 900ms infinite ease-in-out;
+  background: var(--color-text-3);
+}
+
+.chat-typing-indicator span:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.chat-typing-indicator span:nth-child(3) {
+  animation-delay: 240ms;
+}
+
+.chat-error-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-top: 1px solid var(--color-error-border);
+  background: var(--color-error-soft);
+  color: var(--color-error);
+  padding: 10px 22px;
+  font-weight: 800;
+}
+
+.chat-input-panel {
+  display: grid;
+  gap: 8px;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
+  padding: 14px 22px 18px;
+}
+
+.chat-input-panel label {
+  color: var(--color-text-2);
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.chat-input-panel textarea {
+  min-height: 86px;
+  max-height: 180px;
+  resize: vertical;
+}
+
+.chat-character-count,
+.chat-stream-label {
+  color: var(--color-text-3);
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.chat-character-count.warning {
+  color: var(--color-warning);
+}
+
+.chat-sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9;
+  display: none;
+  border: 0;
+  background: var(--color-backdrop);
+  padding: 0;
+}
+
+@keyframes chat-typing {
+  0%,
+  80%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+
+  40% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+}
+
 .upload-metadata-json {
   margin: 0;
   overflow-x: auto;
@@ -1233,6 +1660,59 @@ dd {
 
   .span-2 {
     grid-column: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .chat-page {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-session-sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(88vw, 340px);
+    transform: translateX(-100%);
+    transition: transform var(--transition-normal);
+    box-shadow: var(--shadow-modal);
+  }
+
+  .chat-session-sidebar.open {
+    transform: translateX(0);
+  }
+
+  .chat-sidebar-backdrop {
+    display: block;
+  }
+
+  .chat-sidebar-close,
+  .chat-mobile-menu {
+    display: inline-grid;
+  }
+
+  .chat-main {
+    height: 100vh;
+  }
+
+  .chat-topbar {
+    align-items: flex-start;
+    padding: 12px 16px;
+  }
+
+  .chat-topbar .space-nav {
+    display: none;
+  }
+
+  .chat-message-list {
+    padding: 16px;
+  }
+
+  .chat-message-bubble {
+    max-width: 94%;
+  }
+
+  .chat-input-panel {
+    padding: 12px 16px 16px;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
 
   apps/web:
     dependencies:
+      eventsource-parser:
+        specifier: ^3.0.8
+        version: 3.0.8
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -3025,6 +3028,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -8006,6 +8013,8 @@ snapshots:
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
+
+  eventsource-parser@3.0.8: {}
 
   expect-type@1.3.0: {}
 


### PR DESCRIPTION
## Summary
- /spaces/:spaceId/chat route with streaming message rendering
- useChatStream hook (fetch + ReadableStream + SSE parsing)
- Citation [N] superscript + collapsible panel + correct page_id wiki navigation
- Session sidebar with create/switch/delete + race guard
- Error/empty states, dark mode, responsive layout
- Markdown images disabled for security
- 6 new tests, 59 total tests zero regression

## Test plan
- [x] Message rendering, citation display, session list
- [x] Character limit, error states
- [x] Full build passes, 59 tests pass

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `dd4948caca99f6520e564c2980a79cce82203b8d`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/118#issuecomment-4366573298) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/118#issuecomment-4366573351) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/118#issuecomment-4366573408) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/118#issuecomment-4366573464)
- Key findings addressed: citation page_id routing, session switch race guard, markdown image security

Closes #113