### PR TITLE
feat(bridge): Docmost Fork Bridge Module (#121)

### DIFF
--- a/apps/api/src/spaces/space.service.ts
+++ b/apps/api/src/spaces/space.service.ts
@@ -135,7 +135,7 @@ export class SpaceService {
     const [countRow] = await this.db.select({ total: count() }).from(spaces).where(where);
 
     const spaceIds = rows.map((r) => r.id);
-    const statsMap = spaceIds.length > 0 ? await this.batchSpaceStats(spaceIds) : new Map();
+    const statsMap = spaceIds.length > 0 ? await this.batchSpaceStats(spaceIds) : new Map<string, SpaceCounts>();
 
     return paginatedResponse(
       rows.map((r) => toSpaceListItem(r, statsMap.get(r.id))),

--- a/openspec/changes/stage9-docmost-fork-bridge/.openspec.yaml
+++ b/openspec/changes/stage9-docmost-fork-bridge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/stage9-docmost-fork-bridge/design.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/design.md
@@ -1,0 +1,180 @@
+## Context
+
+Phase 1（Stage 0-8）已交付完整的知识生产和消费闭环。Phase 2 引入 Docmost 作为协作编辑层。Stage 9 的任务是建立 Cherry API ↔ Docmost Fork 之间的双向通信通道（Bridge），Stage 10 在此基础上实现双向同步和人工编辑。
+
+当前状态：
+- Cherry API 已有完整的 Space/权限/审计/Job 基础设施
+- wiki-core 已有 Canonical Wiki Repo、页面版本、发布状态机
+- Docmost v0.80.1 是 NestJS + Fastify + Drizzle ORM + React 技术栈（与 Cherry API 同栈）
+- Docmost 模块注册在 `apps/server/src/app.module.ts`，非核心集成放 `integrations/`
+
+约束：
+- Fork 红线：不改 Docmost 核心编辑器/权限/存储/UI
+- 不新增 Docmost Drizzle migration
+- 不引入新 npm 依赖到 Docmost Fork
+- Cherry API 是权限唯一主数据源
+
+## Goals / Non-Goals
+
+**Goals:**
+- Docmost Fork 暴露 Bridge API 供 Cherry 拉取/推送页面
+- Docmost 页面/附件生命周期事件可通知 Cherry API
+- 双向通信受 HMAC-SHA256 签名保护，防重放
+- Cherry 侧 webhook 接收幂等可追踪
+- Bridge 契约测试覆盖所有场景，确保 rebase 后可回归
+
+**Non-Goals:**
+- 双向同步逻辑（Stage 10）
+- 权限映射同步（Stage 10）
+- 人工区块保护/候选更新（Stage 10）
+- Docmost UI 增强（Cherry Web 旁路面板）
+- wiki-sync-worker 实现（Stage 10）
+- Markdown ↔ Tiptap round-trip（Stage 10）
+
+## Decisions
+
+### D1: Bridge 模块位置 — `integrations/bridge/`
+
+**选择**: 放在 Docmost 的 `apps/server/src/integrations/bridge/`。
+
+**理由**:
+- Docmost 现有非核心集成（如 health）已在 `integrations/` 下
+- 独立目录，rebase 冲突风险最低
+- 不触及 core/ 目录
+
+**替代方案**:
+- 放在 `core/bridge/` — 语义不对，Bridge 不是 Docmost 核心功能
+- 独立微服务 — 增加部署复杂度，且需要直接读 Docmost DB
+
+### D2: 事件通知机制 — EventEmitter + HTTP POST
+
+**选择**: Docmost 页面/附件 service 在保存/删除后 emit 内部事件，Bridge 模块监听事件后异步 HTTP POST 到 Cherry API。
+
+**理由**:
+- 不改变原保存逻辑，仅追加旁路通知
+- 异步 POST 不阻塞用户操作
+- 失败不影响 Docmost 本身功能
+- NestJS 原生 EventEmitter 无需额外依赖
+
+**替代方案**:
+- 同步 POST 在保存链路中 — 阻塞用户体验，Cherry API 不可用时 Docmost 保存失败
+- 消息队列（BullMQ）— Docmost 侧不引入 Redis 依赖，过度设计
+- 数据库 outbox pattern — 违反"不新增 migration"红线
+
+### D3: 鉴权方案 — HMAC-SHA256 + Bearer + Timestamp + Nonce（三重防护）
+
+**选择**: 双向通信均使用 HMAC-SHA256 签名 + Bearer token + 请求 timestamp + 唯一 nonce（Doc 12 §4B.2 要求的三重防护）。
+
+**理由**:
+- HMAC 验证请求完整性和来源身份
+- timestamp 窗口（5 分钟）防粗粒度重放
+- nonce（UUID）+ Redis SETNX（TTL=10min）防窗口内精确重放
+- Bearer token 作为快速预检，HMAC 作为深度验证
+- event_id 幂等作为最终兜底
+- 无需 mTLS 或 OAuth 复杂度
+
+**签名算法**:
+```
+payload = timestamp + "\n" + nonce + "\n" + method + "\n" + path + "\n" + body_hash
+signature = HMAC-SHA256(secret, payload)
+Header: X-Bridge-Signature: sha256=<hex>
+Header: X-Bridge-Timestamp: <unix_seconds>
+Header: X-Bridge-Nonce: <uuid>
+Header: Authorization: Bearer <DOCMOST_BRIDGE_SECRET>
+```
+
+**Secret 轮换**: 支持 `DOCMOST_BRIDGE_SECRET_NEXT` 环境变量。验签时先尝试当前 key，失败再尝试 next key。轮换窗口 24h，过渡期内新旧 key 均可验证。
+
+**替代方案**:
+- mTLS — 运维复杂度高，内网场景过度
+- API Key only — 无重放防护
+- JWT — 增加 token 管理复杂度
+- 仅 timestamp 无 nonce — Doc 12 §4B.2 明确要求三重防护，5 分钟窗口内仍可重放
+
+### D4: 幂等策略 — event_id 唯一约束
+
+**选择**: 每个 webhook 事件携带 UUID `event_id`，Cherry 侧 bridge_events 表对 event_id 建 UNIQUE 约束，重复插入返回 `deduplicated=true`。
+
+**理由**:
+- 简单可靠，利用数据库唯一约束
+- 无需分布式锁或 Redis
+- 重复请求幂等返回 200，不产生副作用
+
+**替代方案**:
+- Redis SET NX 去重 — 额外依赖，TTL 过期后仍可能重复
+- 应用层 SELECT + INSERT — 并发竞态
+
+### D5: Cherry 侧 bridge_events 存储 — 独立表 + delivery 追踪
+
+**选择**: Cherry API 侧新增 bridge_events（事件主表）+ webhook_deliveries（投递记录）两张表。
+
+**理由**:
+- 事件和投递分离，支持重试追踪
+- 可审计每次投递的状态码和延迟
+- 为 Stage 10 wiki-sync-worker 提供事件队列
+
+**表结构要点**:
+- bridge_events: id, event_id(unique), event_type, source(docmost/cherry), space_id, page_id, payload(jsonb), status(received/processing/processed/failed), received_at, processed_at
+- webhook_deliveries: id, bridge_event_id(fk), direction(inbound/outbound), attempt, status_code, response_time_ms, error, created_at
+
+### D6: Docker 网络隔离 — cherry-net 内网通信
+
+**选择**: Docmost 服务加入 cherry-net Docker 网络，Bridge 端口不映射到宿主机。
+
+**理由**:
+- Bridge API 仅允许 Cherry API 调用
+- 外部无法直接访问 /api/internal/bridge/*
+- Nginx 只代理 Docmost 的用户面路由
+
+### D7: Git Submodule 管理
+
+**选择**: `external/docmost/` 作为 git submodule 引用 Fork repo 的 `cherrygraph-bridge` 分支。
+
+**理由**:
+- 独立版本控制，rebase 独立于主仓库
+- CI 可独立运行 Bridge 契约测试
+- 主仓库不包含 Docmost 完整代码
+
+### D8: 快速保存去重 — 2s Debounce Window
+
+**选择**: 同一页面 2 秒内多次保存只发送最后一次的 webhook 事件。
+
+**理由**:
+- Docmost 富文本编辑器可能触发高频自动保存
+- 避免 Cherry 侧收到大量冗余事件（P2-E10 要求）
+- 使用内存 debounce map（pageId → timer），不依赖外部存储
+
+**替代方案**:
+- 全部发送让 Cherry 侧去重 — 增加 Cherry 负担和网络流量
+- 更长窗口（5s/10s） — 延迟过大，用户感知不到同步
+
+## Risks / Trade-offs
+
+| 风险 | 缓解 |
+|---|---|
+| Docmost upstream 更新导致 page service 钩子点失效 | Bridge 契约测试 CI 在每次 rebase 后自动运行；钩子点尽量用 EventEmitter 解耦 |
+| EventEmitter 异步通知丢失（Docmost 进程崩溃） | Cherry 侧定时 reconcile（Stage 10 实现），本 Stage 容忍短暂丢失 |
+| HMAC secret 泄露 | Docker 网络隔离兜底 + rate limiting 纵深防御；secret 从环境变量注入，不入代码；支持双 key 快速轮换 |
+| Nonce Redis 不可用 | 降级为仅 timestamp 校验（日志告警），不阻断请求；Redis 恢复后自动恢复三重防护 |
+| Docmost 页面 ID 与 Cherry wiki_pages ID 映射 | bridge_events.payload 携带 docmost_page_id，Stage 10 建立映射表 |
+| Fork 维护长期成本 | 最小改动原则（仅 integrations/bridge/ + 3 处极小改动），每月 rebase + 手动验收 checklist |
+| page_block_metadata 表 Stage 9 预建但无数据写入 | 仅 DDL，无运行时影响；Stage 10 负责写入逻辑 |
+
+## Migration Plan
+
+1. Fork docmost/docmost v0.80.1 到 DankerMu/docmost，创建 cherrygraph-bridge 分支
+2. 在 Fork 中开发 Bridge 模块，通过契约测试
+3. 主仓库添加 git submodule 引用
+4. Cherry API 侧添加 bridge_events/webhook_deliveries migration
+5. Docker Compose 添加 docmost profile（默认不启动，`--profile docmost` 启用）
+6. Nginx 添加 phase2 配置文件（不影响 phase1 配置）
+
+**回滚**: 移除 submodule 引用，Docker Compose 不启动 docmost profile，Cherry API bridge 模块可独立禁用（环境变量开关）。
+
+## Open Questions
+
+1. Docmost v0.80.1 的 page service 保存钩子点具体在哪个函数？需要读源码确认 EventEmitter 注入位置。
+2. Docmost 的 Tiptap JSON 转 Markdown 是否有现成工具函数可复用？特别是 HTML comment node 的处理（graphify:managed markers）。
+3. 附件存储是否需要与 Cherry MinIO 统一 bucket，还是 Docmost 自管附件、Bridge 只同步元数据？
+4. Redis 连接：Docmost Fork 的 Bridge 是否可复用 Docmost 已有的 Redis 连接（如有），还是需要独立配置 BRIDGE_REDIS_URL？
+5. Space service 的 "membership change" 钩子点在哪？需确认 Docmost 是否有 space member 变更事件可供订阅。

--- a/openspec/changes/stage9-docmost-fork-bridge/proposal.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+Phase 1 已交付完整的"上传 → Graphify → Canonical Wiki → 索引 → Chat 引用"闭环，但系统缺少协作编辑能力——Wiki 页面只能由 Graphify 自动生成，无法人工修改。Stage 9 将 Fork Docmost 开源版，在其中新增最小化的 Bridge 模块（`/api/internal/bridge/*`），使 Cherry API 可以与 Docmost 互通页面数据和事件通知，为 Stage 10 的双向同步奠定通信基础。
+
+## What Changes
+
+### Docmost Fork 侧（external/docmost/）
+
+- Fork docmost/docmost v0.80.1（commit `980521f`），创建 `cherrygraph-bridge` 分支，以 git submodule 形式引入
+- 新增 `apps/server/src/integrations/bridge/` 模块（Bridge NestJS Module）：
+  - BridgeAuthGuard：HMAC-SHA256 + Bearer token + timestamp 重放防护
+  - Page export controller：GET /api/internal/bridge/pages/{id}/export?format=markdown
+  - Page import controller：PUT /api/internal/bridge/pages/{id}/import（overwrite_policy: create_only/update/force）
+  - Page events controller：页面保存/删除后 POST Cherry API webhook
+  - Attachment events controller：附件创建/删除后 POST Cherry API webhook
+  - Sync status controller：GET /api/internal/bridge/spaces/{id}/sync-status + /health
+- 修改 app.module.ts 添加 BridgeModule import（仅一行）
+- 修改 main.ts excludedPaths 添加 `/api/internal/bridge`（跳过 workspaceId 检查）
+- page service 追加 EventEmitter 通知（page.saved / page.deleted，不改原保存逻辑）
+- attachment service 追加 EventEmitter 通知（attachment.created / attachment.deleted，不改存储层）
+- space service 追加 EventEmitter 通知（space.updated，属性/成员变更时触发）
+- Permission projection controller：PUT /api/internal/bridge/spaces/{id}/permissions（接收 Cherry 权限推送）
+
+### Cherry API 侧
+
+- 新增 `apps/api/src/bridge/` 模块：
+  - POST /api/internal/docmost/events/page-saved
+  - POST /api/internal/docmost/events/page-deleted
+  - POST /api/internal/docmost/events/attachment-created
+  - POST /api/internal/docmost/events/attachment-deleted
+  - POST /api/internal/docmost/events/space-updated
+- 新增 Drizzle schema：bridge_events + webhook_deliveries + page_block_metadata（预建 Schema，为 Stage 10 准备）
+- BridgeEventService：event_id 幂等去重、事件持久化、delivery 追踪、rate limiting
+- Nonce 防重放：Redis SETNX（TTL=10min）+ 双 key 轮换支持
+- Cherry 侧 BridgeAuthGuard：验证 Docmost 发来请求的 HMAC 签名
+
+### 基础设施
+
+- Docker Compose 新增 docmost profile 服务（cherry-net 网络内）
+- Nginx Phase 2 配置代理 Docmost
+- CI 新增 bridge-contract-tests job
+
+## Capabilities
+
+### New Capabilities
+
+- `bridge-docmost-module`: Docmost Fork 内 Bridge NestJS 模块——路由注册、HMAC+Bearer+timestamp+nonce 四重鉴权、excludedPaths 配置、签名工具、双 key 轮换、Docker 网络隔离约束、Fork 红线验收条件
+- `bridge-page-export`: Docmost 页面 Markdown 导出——返回 frontmatter + content + content_hash，保留 graphify:managed HTML comment 标记（P2-E3）
+- `bridge-page-import`: Docmost 页面 Markdown 导入——支持 overwrite_policy，保留 graphify:managed 标记 round-trip fidelity（P2-E3）
+- `bridge-webhooks`: Docmost 生命周期 webhook——5 种事件（page.saved/deleted + attachment.created/deleted + space.updated）POST Cherry API，含 HMAC+nonce 签��� + 快速保存去重（P2-E10）
+- `bridge-sync-status`: Bridge 健康状态、同步状态查询、附件下载代理、权限推送端点（PUT permissions）
+- `cherry-bridge-receiver`: Cherry API 侧 webhook 接收——HMAC+nonce 验签、event_id 幂等去重、rate limiting、bridge_events 持久化、webhook_deliveries 追踪、完整审计
+- `bridge-schema`: Drizzle ORM 表定义——bridge_events + webhook_deliveries + page_block_metadata（预建）+ bridge_nonces（Redis）+ Zod validation + migration
+- `bridge-contract-tests`: Bridge 契约测试套件——覆盖 HMAC/nonce/dual-key/导出/导入/marker 保留/5 种事件/重试/去重/sync-status/permissions 共 20+ 场景
+
+### Modified Capabilities
+
+（无——本 Stage 不修改已有 spec 的需求定义）
+
+## Impact
+
+- **Schema**: `packages/shared/src/schema/core.ts` 新增 bridge_events、webhook_deliveries、page_block_metadata 三张表 + 索引 + Zod schema
+- **API**: Cherry API 新增 `/api/internal/docmost/events/*`（5 种事件）；Docmost Fork 新增 `/api/internal/bridge/*` 路由组（含 permissions 端点）
+- **Web**: 本 Stage 无前端变更
+- **依赖**: Docmost Fork 不引入新 npm 依赖（crypto 内置）；Cherry API 侧无新依赖；两侧复用已有 Redis 连接（nonce 存储）
+- **权限**: Bridge 接口仅内网服务调用，不经过用户权限系统，由 HMAC+nonce secret 保护 + rate limiting
+- **审计**: 新增 bridge.event_received / bridge.event_processed / bridge.hmac_rejected / bridge.nonce_reused / bridge.rate_limited / bridge.outbound_call 审计事件
+- **安全**: HMAC-SHA256 + nonce（Redis SETNX）+ timestamp 三重防护、双 key 轮换（24h 窗口）、Docker 网络隔离（cherry-net only，Nginx deny Bridge path）、rate limiting
+- **Docker**: docker-compose.yml 新增 docmost profile 服务（不映射 Bridge 端口），Nginx phase2 配置

--- a/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md
@@ -1,0 +1,150 @@
+## ADDED Requirements
+
+### Requirement: Contract test suite for Bridge API
+
+The system SHALL maintain a contract test suite using NestJS Testing Module + supertest that validates all Bridge API behaviors. These tests SHALL run in CI on every push to the cherrygraph-bridge branch and MUST pass before updating the submodule reference.
+
+#### Scenario: All contract tests pass on fresh build
+- **WHEN** `pnpm test:bridge` runs in the Docmost Fork CI
+- **THEN** all contract test scenarios pass (exit code 0)
+
+### Requirement: Page export contract test
+
+The test suite SHALL verify page export API behavior.
+
+#### Scenario: Export returns Markdown with hash
+- **WHEN** test calls GET /api/internal/bridge/pages/{docmost_page_id}/export?format=markdown
+- **THEN** response contains content (string), content_hash (hex SHA256), title, space_id, updated_at
+
+#### Scenario: Export 404 for missing page
+- **WHEN** test calls export with non-existent page ID
+- **THEN** response is 404 with BRIDGE_PAGE_NOT_FOUND error code
+
+#### Scenario: Export preserves graphify managed markers (P2-E3)
+- **WHEN** test exports a page containing `<!-- graphify:managed:section_abc -->` HTML comments
+- **THEN** response content includes the comment verbatim in correct position
+
+### Requirement: Page import contract test
+
+The test suite SHALL verify page import API behavior.
+
+#### Scenario: Import creates page (create_only)
+- **WHEN** test calls PUT /api/internal/bridge/pages/{new_id}/import with overwrite_policy=create_only
+- **THEN** response is 201 and subsequent export returns the imported content
+
+#### Scenario: Import conflict on hash mismatch
+- **WHEN** test calls PUT with overwrite_policy=update and stale expected_hash
+- **THEN** response is 409 with BRIDGE_HASH_CONFLICT and current_hash in body
+
+#### Scenario: Import preserves graphify managed markers (P2-E3)
+- **WHEN** test imports Markdown containing `<!-- graphify:managed:* -->` then exports
+- **THEN** the markers survive the round-trip (export content matches import on marker positions)
+
+### Requirement: HMAC authentication contract tests
+
+The test suite SHALL verify authentication edge cases.
+
+#### Scenario: Valid signature passes
+- **WHEN** test sends request with correctly computed HMAC signature (including nonce) and fresh timestamp
+- **THEN** response status is not 401
+
+#### Scenario: Wrong signature rejected
+- **WHEN** test sends request with tampered HMAC signature
+- **THEN** response is 401 with BRIDGE_HMAC_INVALID
+
+#### Scenario: Missing Bearer rejected
+- **WHEN** test sends request without Authorization header
+- **THEN** response is 401 with BRIDGE_AUTH_MISSING
+
+#### Scenario: Timestamp replay rejected
+- **WHEN** test sends request with X-Bridge-Timestamp set to 6 minutes ago
+- **THEN** response is 401 with BRIDGE_TIMESTAMP_EXPIRED
+
+#### Scenario: Nonce replay rejected
+- **WHEN** test sends two requests with the same X-Bridge-Nonce value
+- **THEN** second request returns 401 with BRIDGE_NONCE_REUSED
+
+#### Scenario: Dual-key rotation accepted
+- **WHEN** DOCMOST_BRIDGE_SECRET_NEXT is configured AND test signs with next key
+- **THEN** response status is not 401
+
+### Requirement: Webhook event delivery contract test
+
+The test suite SHALL verify that page save/delete/attachment events trigger correct webhook calls using a mock Cherry API HTTP server.
+
+#### Scenario: Page save event delivered to mock
+- **WHEN** test triggers a page save through Docmost's PageService
+- **THEN** mock Cherry API server receives POST /api/internal/docmost/events/page-saved with valid HMAC (including nonce) and correct payload schema
+
+#### Scenario: Page delete event delivered to mock
+- **WHEN** test triggers a page delete
+- **THEN** mock receives POST /api/internal/docmost/events/page-deleted with page_id and event_id
+
+#### Scenario: Attachment created event contains download_url
+- **WHEN** test triggers an attachment upload
+- **THEN** mock receives POST /api/internal/docmost/events/attachment-created with download_url matching /api/internal/bridge/attachments/{id}/download
+
+#### Scenario: Attachment deleted event delivered
+- **WHEN** test triggers an attachment deletion
+- **THEN** mock receives POST /api/internal/docmost/events/attachment-deleted with attachment_id
+
+#### Scenario: Space updated event delivered
+- **WHEN** test triggers a space property change
+- **THEN** mock receives POST /api/internal/docmost/events/space-updated with change_type
+
+#### Scenario: Webhook retry on 503
+- **WHEN** mock Cherry API returns 503 on first call then 200 on second
+- **THEN** the event is delivered successfully on retry (mock receives exactly 2 calls)
+
+#### Scenario: Rapid saves debounced (P2-E10)
+- **WHEN** test saves the same page twice within 1 second
+- **THEN** mock receives only one page-saved event (the latest)
+
+### Requirement: Sync status and health contract test
+
+The test suite SHALL verify sync status and health endpoints.
+
+#### Scenario: Health endpoint returns status
+- **WHEN** test calls GET /api/internal/bridge/health
+- **THEN** response contains status, version, uptime_seconds, cherry_api_reachable fields
+
+#### Scenario: Sync status for known space
+- **WHEN** test calls GET /api/internal/bridge/spaces/{known_space_id}/sync-status
+- **THEN** response contains status, page_count, last_event_at, pending_events fields
+
+#### Scenario: Sync status 404 for unknown space
+- **WHEN** test calls sync-status with non-existent space ID
+- **THEN** response is 404 with BRIDGE_SPACE_NOT_FOUND
+
+### Requirement: Permission endpoint contract test
+
+The test suite SHALL verify the permission projection endpoint.
+
+#### Scenario: Permission update accepted
+- **WHEN** test calls PUT /api/internal/bridge/spaces/{id}/permissions with valid payload
+- **THEN** response is 200 with accepted=true
+
+#### Scenario: Permission update 404 for unknown space
+- **WHEN** test calls permission update for non-existent space
+- **THEN** response is 404 with BRIDGE_SPACE_NOT_FOUND
+
+### Requirement: Idempotency contract test
+
+The test suite SHALL verify webhook idempotency behavior on the Cherry API receiver side.
+
+#### Scenario: Duplicate event_id returns deduplicated
+- **WHEN** test sends the same event_id twice to Cherry API mock receiver
+- **THEN** first response has deduplicated=false, second response has deduplicated=true, and only one record exists
+
+### Requirement: Rebase CI integration
+
+The contract test suite SHALL be configured to run automatically on every push to the cherrygraph-bridge branch via GitHub Actions. The workflow SHALL:
+1. Build Docmost from source
+2. Start test database + Redis (for nonce dedup)
+3. Start mock Cherry API server
+4. Run full contract test suite (HMAC + export/import + webhooks + idempotency + permissions)
+5. Report pass/fail status on the commit
+
+#### Scenario: CI blocks broken rebase
+- **WHEN** an upstream rebase breaks a Bridge controller
+- **THEN** CI fails and the PR/push is marked as failing, preventing submodule update

--- a/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-docmost-module/spec.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-docmost-module/spec.md
@@ -1,0 +1,109 @@
+## ADDED Requirements
+
+### Requirement: Bridge NestJS module registration
+
+The system SHALL register a BridgeModule in Docmost's `app.module.ts` imports array. The module SHALL be located at `apps/server/src/integrations/bridge/bridge.module.ts` and SHALL register all Bridge controllers and guards.
+
+#### Scenario: Module loads successfully on Docmost startup
+- **WHEN** Docmost server starts with DOCMOST_BRIDGE_SECRET environment variable set
+- **THEN** BridgeModule registers without error and Bridge endpoints become available
+
+#### Scenario: Module disabled when secret not configured
+- **WHEN** Docmost server starts without DOCMOST_BRIDGE_SECRET environment variable
+- **THEN** BridgeModule logs a warning and all Bridge endpoints return 503 Service Unavailable
+
+### Requirement: Bridge routes excluded from workspace middleware
+
+The system SHALL add `/api/internal/bridge` to the excludedPaths list in `main.ts` so Bridge routes bypass Docmost's workspaceId middleware. Only this specific prefix SHALL be excluded.
+
+#### Scenario: Bridge routes bypass workspace check
+- **WHEN** a request arrives at /api/internal/bridge/* with valid HMAC signature
+- **THEN** the request is processed without requiring X-Workspace-Id header
+
+#### Scenario: Non-bridge routes still require workspace
+- **WHEN** a request arrives at /api/pages/* without X-Workspace-Id header
+- **THEN** Docmost's workspace middleware rejects the request as before
+
+### Requirement: BridgeAuthGuard HMAC-SHA256 verification
+
+The system SHALL implement a BridgeAuthGuard that validates every request to /api/internal/bridge/* using:
+1. Bearer token in Authorization header matching DOCMOST_BRIDGE_SECRET
+2. HMAC-SHA256 signature in X-Bridge-Signature header
+3. Timestamp in X-Bridge-Timestamp header (Unix seconds)
+4. Nonce in X-Bridge-Nonce header (UUID, unique per request)
+
+The HMAC payload SHALL be: `${timestamp}\n${nonce}\n${method}\n${path}\n${bodyHash}` where bodyHash is SHA256 of the raw request body (empty string hash for GET requests).
+
+The system SHALL reject requests where the nonce has been seen within the past 10 minutes (using Redis SETNX with TTL=600s). This provides defense-in-depth beyond the timestamp window.
+
+#### Scenario: Valid signature accepted
+- **WHEN** request has correct Bearer token AND valid HMAC signature AND timestamp within 5 minutes AND fresh nonce
+- **THEN** request proceeds to the controller
+
+#### Scenario: Invalid HMAC signature rejected
+- **WHEN** request has correct Bearer token BUT invalid HMAC signature
+- **THEN** response is 401 with error code BRIDGE_HMAC_INVALID
+
+#### Scenario: Missing Bearer token rejected
+- **WHEN** request has no Authorization header or incorrect Bearer token
+- **THEN** response is 401 with error code BRIDGE_AUTH_MISSING
+
+#### Scenario: Expired timestamp rejected (replay protection)
+- **WHEN** request has valid signature BUT X-Bridge-Timestamp is older than 5 minutes from server time
+- **THEN** response is 401 with error code BRIDGE_TIMESTAMP_EXPIRED
+
+#### Scenario: Missing timestamp rejected
+- **WHEN** request has valid Bearer and HMAC but no X-Bridge-Timestamp header
+- **THEN** response is 401 with error code BRIDGE_TIMESTAMP_MISSING
+
+#### Scenario: Duplicate nonce rejected (replay protection)
+- **WHEN** request has valid signature and timestamp BUT X-Bridge-Nonce was already used within 10 minutes
+- **THEN** response is 401 with error code BRIDGE_NONCE_REUSED
+
+#### Scenario: Missing nonce rejected
+- **WHEN** request has valid Bearer, HMAC, and timestamp but no X-Bridge-Nonce header
+- **THEN** response is 401 with error code BRIDGE_NONCE_MISSING
+
+### Requirement: Secret rotation with dual-key window
+
+The system SHALL support dual-key rotation for DOCMOST_BRIDGE_SECRET. When `DOCMOST_BRIDGE_SECRET_NEXT` is set, the BridgeAuthGuard SHALL accept signatures computed with either the current or the next key. The rotation window SHALL be 24 hours, after which the old key MUST be removed and the next key becomes current.
+
+#### Scenario: Request signed with current key accepted
+- **WHEN** request is signed with DOCMOST_BRIDGE_SECRET (current)
+- **THEN** authentication succeeds
+
+#### Scenario: Request signed with next key accepted during rotation
+- **WHEN** DOCMOST_BRIDGE_SECRET_NEXT is configured AND request is signed with the next key
+- **THEN** authentication succeeds
+
+#### Scenario: Request signed with expired old key rejected
+- **WHEN** DOCMOST_BRIDGE_SECRET was rotated (old key removed) AND request is signed with the old key
+- **THEN** response is 401 with error code BRIDGE_HMAC_INVALID
+
+### Requirement: Fork development red lines as acceptance criteria
+
+The Bridge module SHALL NOT violate the following constraints (Doc 22 §5A):
+1. SHALL NOT depend on Docmost private/unexported APIs — only use public DI container services
+2. SHALL NOT add new Drizzle migrations to Docmost
+3. SHALL NOT introduce new npm dependencies to Docmost
+4. SHALL NOT add non-Bridge paths to excludedPaths
+
+#### Scenario: No private API usage
+- **WHEN** Bridge module code is reviewed
+- **THEN** all imported services are obtained via NestJS public DI (e.g., PageService, AttachmentService), no internal file imports
+
+#### Scenario: No new Drizzle migrations
+- **WHEN** `apps/server/src/db/migrations/` is checked after Bridge development
+- **THEN** no new migration files exist compared to baseline v0.80.1
+
+### Requirement: Docker network isolation
+
+The Bridge API endpoints SHALL only be accessible within the Docker cherry-net network. The Docmost service SHALL NOT map Bridge ports to the host machine. Nginx SHALL NOT proxy /api/internal/bridge/* to external traffic.
+
+#### Scenario: Bridge port not exposed to host
+- **WHEN** docker-compose.yml is inspected for the docmost service
+- **THEN** no port mapping exposes the Bridge API to the host (only internal cherry-net communication)
+
+#### Scenario: Nginx blocks Bridge path
+- **WHEN** an external request targets /api/internal/bridge/* through Nginx
+- **THEN** Nginx returns 404 or does not route the request to Docmost

--- a/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-page-export/spec.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-page-export/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Export page as Markdown
+
+The system SHALL expose GET /api/internal/bridge/pages/{docmost_page_id}/export?format=markdown that returns the page content converted to Markdown with frontmatter metadata.
+
+The response SHALL include:
+- `page_id`: Docmost internal page ID
+- `title`: Page title
+- `content`: Full Markdown content with frontmatter
+- `content_hash`: SHA256 hash of the content field (for optimistic locking)
+- `space_id`: Docmost space the page belongs to
+- `updated_at`: Last modification timestamp
+- `updated_by`: User ID who last modified
+
+#### Scenario: Successful page export
+- **WHEN** Cherry API requests GET /api/internal/bridge/pages/{docmost_page_id}/export?format=markdown with valid auth
+- **THEN** response is 200 with JSON containing page content as Markdown + content_hash + metadata
+
+#### Scenario: Page not found
+- **WHEN** Cherry API requests export for a non-existent page ID
+- **THEN** response is 404 with error code BRIDGE_PAGE_NOT_FOUND
+
+#### Scenario: Content hash stability
+- **WHEN** the same page is exported twice without modification
+- **THEN** both responses return identical content_hash values
+
+### Requirement: Tiptap to Markdown conversion
+
+The export controller SHALL convert Docmost's internal Tiptap JSON representation to GFM-compatible Markdown. The conversion SHALL preserve:
+- Headings (h1-h6)
+- Paragraphs and line breaks
+- Bold, italic, strikethrough, code inline
+- Code blocks with language annotation
+- Ordered and unordered lists
+- Tables
+- Links and images
+- Blockquotes
+- Task lists (checkboxes)
+- HTML comments (including `<!-- graphify:managed:* -->` block markers)
+
+#### Scenario: Rich content preserved in export
+- **WHEN** a page with tables, code blocks, and task lists is exported
+- **THEN** the Markdown output contains GFM table syntax, fenced code blocks with language, and `- [ ]`/`- [x]` task items
+
+#### Scenario: Unsupported blocks fallback
+- **WHEN** a page contains Tiptap blocks without Markdown equivalent (e.g., embeds)
+- **THEN** the block is exported as an HTML comment `<!-- unsupported: block_type -->` to preserve round-trip fidelity
+
+#### Scenario: Graphify block markers preserved in export (P2-E3)
+- **WHEN** a page contains `<!-- graphify:managed:section_id -->` HTML comments in its Tiptap content
+- **THEN** the Markdown export preserves these comments verbatim in their original positions
+
+#### Scenario: Nested block markers preserved
+- **WHEN** a page contains both `<!-- graphify:managed:start -->` and `<!-- graphify:managed:end -->` paired markers
+- **THEN** both markers appear in the exported Markdown with correct relative ordering

--- a/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-page-import/spec.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-page-import/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Import page from Markdown
+
+The system SHALL expose PUT /api/internal/bridge/pages/{docmost_page_id}/import that accepts Markdown content and updates the Docmost page's Tiptap document.
+
+Request body SHALL include:
+- `content`: Markdown string (with optional frontmatter)
+- `overwrite_policy`: One of `create_only` | `update` | `force`
+- `expected_hash`: (optional) content_hash from previous export for optimistic locking
+- `source`: Origin identifier (e.g., "graphify", "wiki-sync")
+
+#### Scenario: Create new page (create_only)
+- **WHEN** Cherry API sends PUT with overwrite_policy=create_only and page does not exist
+- **THEN** a new Docmost page is created with the provided Markdown converted to Tiptap, response is 201
+
+#### Scenario: Create_only fails for existing page
+- **WHEN** Cherry API sends PUT with overwrite_policy=create_only and page already exists
+- **THEN** response is 409 with error code BRIDGE_PAGE_EXISTS
+
+#### Scenario: Update existing page (update)
+- **WHEN** Cherry API sends PUT with overwrite_policy=update and matching expected_hash
+- **THEN** page content is updated, response is 200 with new content_hash
+
+#### Scenario: Optimistic lock conflict (update)
+- **WHEN** Cherry API sends PUT with overwrite_policy=update and expected_hash does not match current
+- **THEN** response is 409 with error code BRIDGE_HASH_CONFLICT and current content_hash in response
+
+#### Scenario: Force overwrite (force)
+- **WHEN** Cherry API sends PUT with overwrite_policy=force
+- **THEN** page content is overwritten regardless of current state, response is 200
+
+#### Scenario: Invalid page ID
+- **WHEN** Cherry API sends PUT to a non-existent page ID with overwrite_policy=update
+- **THEN** response is 404 with error code BRIDGE_PAGE_NOT_FOUND
+
+### Requirement: Markdown to Tiptap conversion
+
+The import controller SHALL convert GFM Markdown to Docmost's Tiptap JSON document format. The conversion SHALL handle the same element set as the export (headings, lists, tables, code blocks, links, images, task lists, blockquotes, HTML comments).
+
+#### Scenario: Markdown imported preserves structure
+- **WHEN** Markdown with headings, tables, and code blocks is imported
+- **THEN** the Tiptap document contains corresponding nodes with correct attributes
+
+#### Scenario: Frontmatter stripped from Tiptap content
+- **WHEN** Markdown with YAML frontmatter (--- delimited) is imported
+- **THEN** frontmatter is parsed for metadata but not rendered in the Tiptap document body
+
+#### Scenario: Graphify block markers preserved in import (P2-E3)
+- **WHEN** Markdown containing `<!-- graphify:managed:section_id -->` comments is imported
+- **THEN** the Tiptap document preserves these as HTML comment nodes in their original positions
+
+#### Scenario: Round-trip fidelity for block markers
+- **WHEN** a page with graphify:managed markers is exported then immediately re-imported
+- **THEN** the markers remain in identical positions and the content_hash after re-export matches the original

--- a/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-schema/spec.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-schema/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: bridge_events table definition
+
+The system SHALL define a `bridge_events` table in Drizzle ORM with the following columns:
+- `id`: UUID primary key (default gen_random_uuid())
+- `event_id`: VARCHAR(64) NOT NULL UNIQUE — external idempotency key from webhook
+- `event_type`: VARCHAR(50) NOT NULL — e.g., "page.saved", "page.deleted", "attachment.created", "attachment.deleted", "space.updated"
+- `source`: VARCHAR(20) NOT NULL DEFAULT 'docmost' — origin system
+- `space_id`: VARCHAR(64) — Docmost space ID (nullable for system events)
+- `page_id`: VARCHAR(64) — Docmost page ID (nullable)
+- `payload`: JSONB NOT NULL — full event payload
+- `status`: VARCHAR(20) NOT NULL DEFAULT 'received' — received | processing | processed | failed
+- `error_json`: JSONB — error details if status=failed
+- `received_at`: TIMESTAMP NOT NULL DEFAULT now()
+- `processed_at`: TIMESTAMP — when status transitioned to processed/failed
+- `created_at`: TIMESTAMP NOT NULL DEFAULT now()
+
+Indexes:
+- UNIQUE on event_id
+- INDEX on (space_id, event_type, received_at DESC)
+- INDEX on (status) WHERE status IN ('received', 'processing')
+
+#### Scenario: Schema matches Drizzle definition
+- **WHEN** migration runs on a clean database
+- **THEN** bridge_events table exists with all columns, types, defaults, and indexes as specified
+
+#### Scenario: Unique constraint prevents duplicate events
+- **WHEN** two INSERT statements with the same event_id execute
+- **THEN** the second INSERT fails with unique violation (application catches and returns deduplicated=true)
+
+### Requirement: webhook_deliveries table definition
+
+The system SHALL define a `webhook_deliveries` table in Drizzle ORM with the following columns:
+- `id`: UUID primary key (default gen_random_uuid())
+- `bridge_event_id`: UUID NOT NULL FK → bridge_events.id ON DELETE CASCADE
+- `direction`: VARCHAR(10) NOT NULL — 'inbound' | 'outbound'
+- `attempt`: INTEGER NOT NULL DEFAULT 1
+- `status_code`: INTEGER — HTTP status code (nullable for pending outbound)
+- `response_time_ms`: INTEGER — duration in milliseconds
+- `error`: TEXT — error message if failed
+- `created_at`: TIMESTAMP NOT NULL DEFAULT now()
+
+Indexes:
+- INDEX on (bridge_event_id, attempt)
+- INDEX on (direction, created_at DESC)
+
+#### Scenario: Delivery record created on webhook receipt
+- **WHEN** Cherry API receives an inbound webhook
+- **THEN** a webhook_deliveries record is created with direction='inbound', attempt=1, and status_code
+
+#### Scenario: Cascade delete on event removal
+- **WHEN** a bridge_event record is deleted
+- **THEN** all associated webhook_deliveries records are also deleted
+
+### Requirement: page_block_metadata table definition
+
+The system SHALL define a `page_block_metadata` table in Drizzle ORM to support Stage 10 block ownership tracking. The table is created in Stage 9 (schema only); merge logic is implemented in Stage 10.
+
+Columns:
+- `id`: UUID primary key (default gen_random_uuid())
+- `page_id`: UUID NOT NULL FK → wiki_pages.id ON DELETE CASCADE
+- `section_id`: VARCHAR(128) NOT NULL — matches graphify:managed marker section ID
+- `owner`: VARCHAR(20) NOT NULL DEFAULT 'graphify' — 'graphify' | 'human' | 'locked'
+- `last_modified_by`: UUID — user ID who last modified this block (nullable for graphify-owned)
+- `last_modified_at`: TIMESTAMP
+- `graphify_run_id`: UUID — which Graphify run produced this block (nullable for human-owned)
+- `created_at`: TIMESTAMP NOT NULL DEFAULT now()
+- `updated_at`: TIMESTAMP NOT NULL DEFAULT now()
+
+Indexes:
+- UNIQUE on (page_id, section_id)
+- INDEX on (page_id, owner)
+
+#### Scenario: Schema created for Stage 10 consumption
+- **WHEN** migration runs
+- **THEN** page_block_metadata table exists with all columns and indexes, ready for Stage 10 to write data
+
+#### Scenario: Unique constraint per page section
+- **WHEN** two INSERT statements with the same (page_id, section_id) execute
+- **THEN** the second INSERT fails with unique violation
+
+### Requirement: bridge_nonces Redis key pattern
+
+The system SHALL use Redis SETNX with key pattern `bridge:nonce:{nonce_value}` and TTL=600s (10 minutes) for nonce deduplication. This is NOT a database table but a Redis-based transient store.
+
+#### Scenario: Fresh nonce stored in Redis
+- **WHEN** a new nonce arrives and SETNX succeeds
+- **THEN** the nonce is stored with 600s TTL and request proceeds
+
+#### Scenario: Duplicate nonce detected via Redis
+- **WHEN** SETNX fails (key already exists)
+- **THEN** request is rejected with BRIDGE_NONCE_REUSED
+
+### Requirement: Zod validation schemas
+
+The system SHALL define Zod schemas for:
+- `bridgeEventSchema`: validates bridge_events insert/select shapes
+- `webhookDeliverySchema`: validates webhook_deliveries insert/select shapes
+- `pageBlockMetadataSchema`: validates page_block_metadata insert/select shapes
+- `bridgeWebhookPayloadSchema`: validates inbound webhook request body (event_id, event_type, timestamp, nonce, space_id, page_id, plus type-specific fields)
+- `bridgeEventStatusSchema`: enum of valid status values ('received', 'processing', 'processed', 'failed')
+- `bridgeEventTypeSchema`: enum of valid event types ('page.saved', 'page.deleted', 'attachment.created', 'attachment.deleted', 'space.updated')
+- `blockOwnerSchema`: enum of valid owner values ('graphify', 'human', 'locked')
+
+#### Scenario: Valid webhook payload passes validation
+- **WHEN** a well-formed page.saved payload is validated against bridgeWebhookPayloadSchema
+- **THEN** validation succeeds and returns typed object
+
+#### Scenario: Invalid payload rejected
+- **WHEN** a payload missing required event_id field is validated
+- **THEN** Zod throws ZodError with path pointing to missing field
+
+#### Scenario: Invalid event_type rejected
+- **WHEN** a payload with event_type="unknown.event" is validated
+- **THEN** Zod throws ZodError for invalid enum value

--- a/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-sync-status/spec.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-sync-status/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Space sync status query
+
+The system SHALL expose GET /api/internal/bridge/spaces/{docmost_space_id}/sync-status that returns the current synchronization health of a Docmost space.
+
+Response SHALL include:
+- `space_id`: Docmost space ID
+- `status`: One of `healthy` | `degraded` | `error` | `not_configured`
+- `page_count`: Total pages in the space
+- `last_event_at`: Timestamp of last webhook event sent for this space (nullable)
+- `last_import_at`: Timestamp of last successful page import (nullable)
+- `pending_events`: Count of events that failed delivery (tracked via in-memory counter, reset on Bridge restart)
+
+#### Scenario: Healthy space status
+- **WHEN** Cherry API queries sync status for a space with no pending failures
+- **THEN** response is 200 with status=healthy and accurate counts
+
+#### Scenario: Degraded status on pending events
+- **WHEN** a space has > 0 events that failed delivery and are pending retry
+- **THEN** response shows status=degraded with pending_events count
+
+#### Scenario: Unknown space
+- **WHEN** Cherry API queries sync status for a non-existent space ID
+- **THEN** response is 404 with error code BRIDGE_SPACE_NOT_FOUND
+
+### Requirement: Bridge health endpoint
+
+The system SHALL expose GET /api/internal/bridge/health that returns the overall Bridge module health.
+
+Response SHALL include:
+- `status`: `healthy` | `unhealthy`
+- `version`: Bridge module version string
+- `uptime_seconds`: Time since module initialization
+- `cherry_api_reachable`: Boolean indicating if Cherry API internal URL is reachable (last check within 60s)
+
+#### Scenario: Bridge healthy
+- **WHEN** Bridge module is running and Cherry API is reachable
+- **THEN** response is 200 with status=healthy and cherry_api_reachable=true
+
+#### Scenario: Bridge unhealthy (Cherry API unreachable)
+- **WHEN** Bridge module is running but Cherry API internal URL is not reachable
+- **THEN** response is 200 with status=unhealthy and cherry_api_reachable=false
+
+### Requirement: Attachment download proxy
+
+The system SHALL expose GET /api/internal/bridge/attachments/{attachment_id}/download that streams the attachment binary content for Cherry API to pull.
+
+#### Scenario: Download attachment
+- **WHEN** Cherry API requests GET /api/internal/bridge/attachments/{attachment_id}/download with valid auth
+- **THEN** response streams the attachment file with correct Content-Type and Content-Disposition headers
+
+#### Scenario: Attachment not found
+- **WHEN** Cherry API requests download for non-existent attachment ID
+- **THEN** response is 404 with error code BRIDGE_ATTACHMENT_NOT_FOUND
+
+### Requirement: Permission projection endpoint
+
+The system SHALL expose PUT /api/internal/bridge/spaces/{docmost_space_id}/permissions that receives permission updates from Cherry API and applies them to the Docmost space member visibility.
+
+Request body SHALL include:
+- `groups`: Array of `{group_id, permissions: ["view"|"edit"|"admin"]}` 
+- `version`: permission_version from Cherry (for consistency tracking)
+- `source`: "cherry_api"
+
+This endpoint enables Cherry API (the sole permission authority) to push permission state to Docmost. The implementation of reconciliation logic is in Stage 10; this Stage provides the receiving endpoint only.
+
+#### Scenario: Permission update accepted
+- **WHEN** Cherry API sends PUT with valid auth and well-formed permission payload
+- **THEN** response is 200 with `{accepted: true, version: <received_version>}`, Docmost space membership is updated
+
+#### Scenario: Invalid permission payload rejected
+- **WHEN** Cherry API sends PUT with malformed groups array
+- **THEN** response is 400 with error code BRIDGE_INVALID_PAYLOAD
+
+#### Scenario: Space not found for permissions
+- **WHEN** Cherry API sends PUT to a non-existent Docmost space ID
+- **THEN** response is 404 with error code BRIDGE_SPACE_NOT_FOUND

--- a/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-webhooks/spec.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/specs/bridge-webhooks/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: Page saved webhook notification
+
+The system SHALL POST to Cherry API at `{CHERRY_API_INTERNAL_URL}/api/internal/docmost/events/page-saved` after every successful page save in Docmost. The notification SHALL be asynchronous (fire-and-forget from the user's perspective) and SHALL NOT block the save operation.
+
+Payload SHALL include:
+- `event_id`: UUID v4 (unique per event)
+- `event_type`: "page.saved"
+- `timestamp`: Unix seconds when event was generated
+- `space_id`: Docmost space ID
+- `page_id`: Docmost page ID
+- `title`: Current page title
+- `updated_by`: User ID who saved
+- `content_hash`: SHA256 of current page Markdown content
+
+The request SHALL include X-Bridge-Signature, X-Bridge-Timestamp, and X-Bridge-Nonce headers computed using the shared DOCMOST_BRIDGE_SECRET.
+
+#### Scenario: Page save triggers webhook
+- **WHEN** a user saves a page in Docmost
+- **THEN** Cherry API receives POST /api/internal/docmost/events/page-saved within 5 seconds with correct payload and HMAC signature
+
+#### Scenario: Save succeeds even when Cherry API is unreachable
+- **WHEN** a user saves a page but Cherry API is down
+- **THEN** the page save completes successfully in Docmost; the webhook failure is logged but does not propagate to the user
+
+#### Scenario: Webhook retry on transient failure
+- **WHEN** Cherry API returns 5xx on first attempt
+- **THEN** the system retries up to 3 times with exponential backoff (1s, 5s, 25s) before giving up
+
+#### Scenario: Rapid consecutive saves deduplicated (P2-E10)
+- **WHEN** a user saves the same page twice within 2 seconds
+- **THEN** only the latest save generates a webhook event (earlier save is debounced/superseded)
+
+### Requirement: Page deleted webhook notification
+
+The system SHALL POST to `{CHERRY_API_INTERNAL_URL}/api/internal/docmost/events/page-deleted` after page deletion.
+
+Payload SHALL include:
+- `event_id`: UUID v4
+- `event_type`: "page.deleted"
+- `timestamp`: Unix seconds
+- `space_id`: Docmost space ID
+- `page_id`: Docmost page ID
+- `deleted_by`: User ID who deleted
+
+#### Scenario: Page deletion triggers webhook
+- **WHEN** a user deletes a page in Docmost
+- **THEN** Cherry API receives POST /api/internal/docmost/events/page-deleted with correct payload
+
+### Requirement: Attachment created webhook notification
+
+The system SHALL POST to `{CHERRY_API_INTERNAL_URL}/api/internal/docmost/events/attachment-created` after attachment upload.
+
+Payload SHALL include:
+- `event_id`: UUID v4
+- `event_type`: "attachment.created"
+- `timestamp`: Unix seconds
+- `space_id`: Docmost space ID
+- `page_id`: Associated page ID (nullable if workspace-level)
+- `attachment_id`: Docmost attachment ID
+- `filename`: Original filename
+- `mime_type`: Detected MIME type
+- `size_bytes`: File size
+- `download_url`: Relative URL for Bridge download API
+
+#### Scenario: Attachment upload triggers webhook
+- **WHEN** a user uploads an attachment in Docmost
+- **THEN** Cherry API receives POST /api/internal/docmost/events/attachment-created with download_url pointing to /api/internal/bridge/attachments/{id}/download
+
+### Requirement: Attachment deleted webhook notification
+
+The system SHALL POST to `{CHERRY_API_INTERNAL_URL}/api/internal/docmost/events/attachment-deleted` after attachment deletion.
+
+Payload SHALL include:
+- `event_id`: UUID v4
+- `event_type`: "attachment.deleted"
+- `timestamp`: Unix seconds
+- `space_id`: Docmost space ID
+- `page_id`: Associated page ID (nullable)
+- `attachment_id`: Docmost attachment ID
+- `deleted_by`: User ID who deleted
+
+#### Scenario: Attachment deletion triggers webhook
+- **WHEN** a user deletes an attachment in Docmost
+- **THEN** Cherry API receives POST /api/internal/docmost/events/attachment-deleted with attachment_id and space_id
+
+### Requirement: Space updated webhook notification
+
+The system SHALL POST to `{CHERRY_API_INTERNAL_URL}/api/internal/docmost/events/space-updated` when a Docmost space's properties or membership changes.
+
+Payload SHALL include:
+- `event_id`: UUID v4
+- `event_type`: "space.updated"
+- `timestamp`: Unix seconds
+- `space_id`: Docmost space ID
+- `change_type`: One of "properties" | "membership" | "permissions"
+- `updated_by`: User ID who made the change
+
+#### Scenario: Space property change triggers webhook
+- **WHEN** a space name or settings are modified in Docmost
+- **THEN** Cherry API receives POST /api/internal/docmost/events/space-updated with change_type="properties"
+
+### Requirement: Webhook signature generation
+
+All outbound webhooks from Docmost to Cherry API SHALL include HMAC-SHA256 signature headers using the same algorithm as BridgeAuthGuard:
+- X-Bridge-Signature: `sha256=<hex>`
+- X-Bridge-Timestamp: `<unix_seconds>`
+- X-Bridge-Nonce: `<uuid>`
+- Authorization: `Bearer <DOCMOST_BRIDGE_SECRET>`
+
+The HMAC payload SHALL be: `${timestamp}\n${nonce}\n${method}\n${path}\n${bodyHash}`.
+
+#### Scenario: Cherry API can verify webhook authenticity
+- **WHEN** Cherry API receives a webhook from Docmost
+- **THEN** the X-Bridge-Signature can be verified using the shared DOCMOST_BRIDGE_SECRET, timestamp, nonce, and request body

--- a/openspec/changes/stage9-docmost-fork-bridge/specs/cherry-bridge-receiver/spec.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/specs/cherry-bridge-receiver/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Webhook event reception
+
+The Cherry API SHALL expose internal endpoints to receive Docmost Bridge events:
+- POST /api/internal/docmost/events/page-saved
+- POST /api/internal/docmost/events/page-deleted
+- POST /api/internal/docmost/events/attachment-created
+- POST /api/internal/docmost/events/attachment-deleted
+- POST /api/internal/docmost/events/space-updated
+
+These endpoints SHALL validate the incoming HMAC signature (including nonce) using the shared DOCMOST_BRIDGE_SECRET before processing. The system SHALL support dual-key rotation: if DOCMOST_BRIDGE_SECRET_NEXT is set, signatures computed with either key SHALL be accepted.
+
+#### Scenario: Valid event received and persisted
+- **WHEN** Docmost sends a webhook with valid HMAC signature, fresh nonce, and new event_id
+- **THEN** the event is persisted to bridge_events table with status=received, response is 200 with `{accepted: true, event_id: "..."}`
+
+#### Scenario: Invalid HMAC rejected
+- **WHEN** a request arrives at /api/internal/docmost/events/* with invalid signature
+- **THEN** response is 401, event is NOT persisted, audit log records bridge.hmac_rejected
+
+#### Scenario: Expired timestamp rejected
+- **WHEN** a request arrives with X-Bridge-Timestamp older than 5 minutes
+- **THEN** response is 401 with error code BRIDGE_TIMESTAMP_EXPIRED
+
+#### Scenario: Duplicate nonce rejected
+- **WHEN** a request arrives with an X-Bridge-Nonce that was already seen within 10 minutes
+- **THEN** response is 401 with error code BRIDGE_NONCE_REUSED
+
+### Requirement: Event idempotency
+
+The Cherry API SHALL enforce idempotent event processing using the event_id field. Duplicate event_id submissions SHALL NOT create new records or trigger new processing.
+
+#### Scenario: First submission accepted
+- **WHEN** an event with new event_id arrives
+- **THEN** event is persisted and response includes `{accepted: true, deduplicated: false}`
+
+#### Scenario: Duplicate submission deduplicated
+- **WHEN** an event with an already-processed event_id arrives
+- **THEN** no new record is created, response is 200 with `{accepted: true, deduplicated: true}`
+
+#### Scenario: Concurrent duplicate handled
+- **WHEN** two requests with the same event_id arrive simultaneously
+- **THEN** exactly one record is persisted (UNIQUE constraint), both requests return 200
+
+### Requirement: Rate limiting for Bridge endpoints
+
+The Cherry API SHALL enforce rate limiting on Bridge webhook endpoints to provide defense-in-depth against key compromise or misconfigured clients:
+- Per-source IP: 100 requests/minute
+- Per-space_id: 200 requests/minute
+- Global: 1000 requests/minute
+
+Rate limit exceeded SHALL return 429 Too Many Requests.
+
+#### Scenario: Normal traffic within limits
+- **WHEN** Docmost sends events at normal pace (< 100/min per IP)
+- **THEN** all requests are processed normally
+
+#### Scenario: Rate limit exceeded
+- **WHEN** a source sends > 100 requests/minute from the same IP
+- **THEN** response is 429 with Retry-After header, event NOT persisted
+
+### Requirement: Webhook delivery tracking
+
+The Cherry API SHALL record each inbound webhook delivery in the webhook_deliveries table for observability and debugging.
+
+Each delivery record SHALL include:
+- bridge_event_id (FK to bridge_events)
+- direction: "inbound"
+- attempt: sequence number (always 1 for inbound)
+- status_code: HTTP status returned to caller
+- response_time_ms: processing duration
+- created_at: receipt timestamp
+
+#### Scenario: Successful delivery recorded
+- **WHEN** a valid webhook is processed successfully
+- **THEN** webhook_deliveries has a record with status_code=200 and response_time_ms populated
+
+#### Scenario: Failed delivery recorded
+- **WHEN** a webhook is rejected (401 or 500)
+- **THEN** webhook_deliveries has a record with the actual status_code and error details
+
+### Requirement: Bridge event audit logging
+
+The Cherry API SHALL emit audit events for Bridge operations:
+- `bridge.event_received`: Event accepted and persisted (includes event_id, event_type, space_id)
+- `bridge.event_processed`: Event fully processed by downstream consumer
+- `bridge.hmac_rejected`: Authentication failure (includes source IP, failure reason)
+- `bridge.nonce_reused`: Nonce replay attempt detected
+- `bridge.rate_limited`: Rate limit triggered (includes source IP, space_id)
+- `bridge.outbound_call`: Cherry → Docmost API call (export/import/permissions)
+
+#### Scenario: Successful event audited
+- **WHEN** a valid webhook event is received
+- **THEN** audit_logs contains a bridge.event_received entry with event_id, event_type, space_id
+
+#### Scenario: Rejected request audited
+- **WHEN** an HMAC validation fails
+- **THEN** audit_logs contains a bridge.hmac_rejected entry with source IP and failure reason
+
+#### Scenario: Outbound call audited
+- **WHEN** Cherry API calls Docmost Bridge (export/import/permissions)
+- **THEN** audit_logs contains a bridge.outbound_call entry with target endpoint and response status

--- a/openspec/changes/stage9-docmost-fork-bridge/tasks.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/tasks.md
@@ -1,0 +1,111 @@
+## 1. Docmost Fork Setup
+
+- [ ] 1.1 Fork docmost/docmost v0.80.1 到 DankerMu/docmost，创建 cherrygraph-bridge 分支（基于 tag v0.80.1 / commit 980521f）
+- [ ] 1.2 在主仓库添加 git submodule：`git submodule add -b cherrygraph-bridge <fork-url> external/docmost`
+- [ ] 1.3 验证 Docmost 本地构建通过（pnpm install + pnpm build）
+- [ ] 1.4 在 .env.example 中添加 DOCMOST_BRIDGE_SECRET、DOCMOST_BRIDGE_SECRET_NEXT（可选）和 CHERRY_API_INTERNAL_URL 环境变量
+
+## 2. Bridge Module Skeleton (Docmost Fork)
+
+- [ ] 2.1 创建 `apps/server/src/integrations/bridge/bridge.module.ts`，注册所有 controllers 和 guards；实现 secret 未配置时 503 降级逻辑
+- [ ] 2.2 创建 `apps/server/src/integrations/bridge/bridge-signature.ts`，实现 HMAC-SHA256 签名计算与验证（payload 包含 timestamp + nonce + method + path + bodyHash）
+- [ ] 2.3 创建 `apps/server/src/integrations/bridge/bridge-auth.guard.ts`，实现 BridgeAuthGuard（Bearer + HMAC + timestamp + nonce Redis SETNX 去重 + 双 key 轮换支持）
+- [ ] 2.4 修改 `apps/server/src/app.module.ts` 添加 BridgeModule import（一行）
+- [ ] 2.5 修改 `apps/server/src/main.ts` excludedPaths 添加 `/api/internal/bridge`
+- [ ] 2.6 创建 `apps/server/src/integrations/bridge/dto/` 目录，定义 Bridge 请求/响应 DTO
+- [ ] 2.7 创建 `apps/server/src/integrations/bridge/README.md` 说明 Fork 改动范围、红线约束（§5A-1~4）和 rebase 流程
+- [ ] 2.8 验证红线合规：确认所有引用的 Docmost service 均为 public export（PageService/AttachmentService/SpaceService），无私有 API 依赖
+
+## 3. Page Export API (Docmost Fork)
+
+- [ ] 3.1 创建 `page-export.controller.ts`，实现 GET /api/internal/bridge/pages/{docmost_page_id}/export?format=markdown
+- [ ] 3.2 实现 Tiptap JSON → GFM Markdown 转换（利用 Docmost 现有 prosemirror/tiptap 工具，不引入新依赖）
+- [ ] 3.3 确保转换保留 HTML comments（特别是 `<!-- graphify:managed:* -->` 标记）——P2-E3 要求
+- [ ] 3.4 实现 content_hash 计算（SHA256 of Markdown content）
+- [ ] 3.5 处理 page not found（404 + BRIDGE_PAGE_NOT_FOUND）
+
+## 4. Page Import API (Docmost Fork)
+
+- [ ] 4.1 创建 `page-import.controller.ts`，实现 PUT /api/internal/bridge/pages/{docmost_page_id}/import
+- [ ] 4.2 实现 GFM Markdown → Tiptap JSON 转换（复用/适配 Docmost 内部 parser）
+- [ ] 4.3 确保转换保留 HTML comments（`<!-- graphify:managed:* -->` 标记在 Tiptap 中作为 HTML comment node 存储）——P2-E3 要求
+- [ ] 4.4 实现 overwrite_policy 逻辑：create_only（409 if exists）/ update（hash check）/ force
+- [ ] 4.5 实现 optimistic lock：expected_hash 校验，不匹配返回 409 + BRIDGE_HASH_CONFLICT + current_hash
+- [ ] 4.6 实现 frontmatter 解析（提取 metadata，不渲染到 Tiptap body）
+
+## 5. Webhook Event Emitters (Docmost Fork)
+
+- [ ] 5.1 在 page service 保存逻辑后追加 EventEmitter.emit('bridge:page.saved', payload)，不改变原保存流程
+- [ ] 5.2 在 page service 删除逻辑后追加 EventEmitter.emit('bridge:page.deleted', payload)
+- [ ] 5.3 在 attachment service 上传逻辑后追加 EventEmitter.emit('bridge:attachment.created', payload)
+- [ ] 5.4 在 attachment service 删除逻辑后追加 EventEmitter.emit('bridge:attachment.deleted', payload)
+- [ ] 5.5 在 space service 属性/成员变更后追加 EventEmitter.emit('bridge:space.updated', payload)
+- [ ] 5.6 创建 Bridge event listener service：监听 EventEmitter 事件，异步 POST Cherry API（fire-and-forget）
+- [ ] 5.7 实现 webhook HTTP 客户端：带 HMAC+Nonce 签名的 POST 请求、3 次指数退避重试（1s/5s/25s）、失败日志
+- [ ] 5.8 实现 event_id 生成（UUID v4）和 payload 组装
+- [ ] 5.9 实现同页快速保存去重（2s debounce window，仅发送最新 save 事件）——P2-E10 要求
+
+## 6. Sync Status, Health & Permissions (Docmost Fork)
+
+- [ ] 6.1 创建 `sync-status.controller.ts`，实现 GET /api/internal/bridge/spaces/{docmost_space_id}/sync-status
+- [ ] 6.2 创建 GET /api/internal/bridge/health 端点（version + uptime + cherry_api_reachable）
+- [ ] 6.3 创建 GET /api/internal/bridge/attachments/{attachment_id}/download 附件下载代理
+- [ ] 6.4 实现 cherry_api_reachable 定时探测（60s 间隔 HEAD 请求）
+- [ ] 6.5 创建 `permissions.controller.ts`，实现 PUT /api/internal/bridge/spaces/{docmost_space_id}/permissions（接收 Cherry 权限推送，更新 Docmost space 成员可见性）
+- [ ] 6.6 实现 pending_events 内存计数器（按 space 统计失败投递数，Bridge 重启归零）
+
+## 7. Cherry API Bridge Schema & Migration
+
+- [ ] 7.1 在 `packages/shared/src/schema/core.ts` 定义 bridge_events 表（Drizzle ORM，event_type 支持 5 种事件）
+- [ ] 7.2 在 `packages/shared/src/schema/core.ts` 定义 webhook_deliveries 表（Drizzle ORM + FK cascade）
+- [ ] 7.3 在 `packages/shared/src/schema/core.ts` 定义 page_block_metadata 表（Drizzle ORM，为 Stage 10 预建 schema）
+- [ ] 7.4 在 `packages/shared/src/schema/validation.ts` 定义 Zod schemas：bridgeEventSchema / webhookDeliverySchema / pageBlockMetadataSchema / bridgeWebhookPayloadSchema / bridgeEventStatusSchema / bridgeEventTypeSchema / blockOwnerSchema
+- [ ] 7.5 生成并验证 Drizzle migration 文件（bridge_events + webhook_deliveries + page_block_metadata）
+- [ ] 7.6 编写 schema 单元测试（Zod validation round-trip、status/event_type enum、nonce 字段、payload 校验）
+
+## 8. Cherry API Bridge Receiver Module
+
+- [ ] 8.1 创建 `apps/api/src/bridge/bridge.module.ts` 模块结构
+- [ ] 8.2 创建 `apps/api/src/bridge/bridge-auth.guard.ts`：验证 Docmost 发来请求的 HMAC 签名（含 nonce 校验 via Redis SETNX + 双 key 轮换）
+- [ ] 8.3 创建 `apps/api/src/bridge/bridge-event.service.ts`：event_id 幂等去重（UNIQUE 约束 catch）、事件持久化、delivery 记录
+- [ ] 8.4 创建 `apps/api/src/bridge/bridge-event.controller.ts`：POST /api/internal/docmost/events/page-saved
+- [ ] 8.5 添加 POST /api/internal/docmost/events/page-deleted 端点
+- [ ] 8.6 添加 POST /api/internal/docmost/events/attachment-created 端点
+- [ ] 8.7 添加 POST /api/internal/docmost/events/attachment-deleted 端点
+- [ ] 8.8 添加 POST /api/internal/docmost/events/space-updated 端点
+- [ ] 8.9 实现 webhook_deliveries 记录（direction=inbound, status_code, response_time_ms）
+- [ ] 8.10 实现 rate limiting（per-IP 100/min、per-space 200/min、global 1000/min，超限返回 429）
+- [ ] 8.11 实现审计日志：bridge.event_received / bridge.event_processed / bridge.hmac_rejected / bridge.nonce_reused / bridge.rate_limited / bridge.outbound_call
+- [ ] 8.12 编写 Cherry 侧 Bridge service 单元测试（幂等去重、HMAC+nonce 验证、双 key 轮换、delivery 记录、rate limit、审计）
+
+## 9. Infrastructure
+
+- [ ] 9.1 Docker Compose 添加 docmost 服务定义（profile=docmost，cherry-net 网络，依赖 postgres + redis；**不映射 Bridge 端口到宿主机**）
+- [ ] 9.2 创建 `docs/ops/nginx.phase2.conf.example` 添加 Docmost 用户面代理（/docmost/ → docmost:3000），**显式 deny /api/internal/bridge/ 外部访问**
+- [ ] 9.3 更新 `docs/ops/env.example` 添加 DOCMOST_BRIDGE_SECRET、DOCMOST_BRIDGE_SECRET_NEXT 和相关配置
+- [ ] 9.4 更新 `docs/ops/docker-compose.skeleton.yml` 或主 compose 文件
+- [ ] 9.5 验证 Docker 网络隔离：Bridge 端口不出现在 docker-compose ports 映射中（添加检查脚本或 CI lint）
+
+## 10. Contract Tests
+
+- [ ] 10.1 在 Docmost Fork 创建 `apps/server/src/integrations/bridge/__tests__/` 测试目录
+- [ ] 10.2 编写 HMAC 鉴权契约测试（valid/invalid/missing Bearer/expired timestamp/nonce reused/nonce missing/dual-key rotation — 7 个场景）
+- [ ] 10.3 编写 page export 契约测试（成功导出 + 404 + hash 稳定性 + graphify:managed marker 保留）
+- [ ] 10.4 编写 page import 契约测试（create_only/update/force/conflict + graphify:managed marker round-trip）
+- [ ] 10.5 编写 webhook 投递契约测试（mock Cherry API，验证 page.saved/page.deleted/attachment.created/attachment.deleted/space.updated 5 种事件 payload）
+- [ ] 10.6 编写 webhook 重试契约测试（mock 先返回 503 再返回 200，验证重试行为）
+- [ ] 10.7 编写快速保存去重契约测试（同页 1s 内保存两次，mock 只收到 1 个事件）——P2-E10
+- [ ] 10.8 编写幂等契约测试（重复 event_id 验证）
+- [ ] 10.9 编写 sync-status + health 契约测试（健康/降级/404 场景）
+- [ ] 10.10 编写 permissions 端点契约测试（成功/400/404 场景）
+- [ ] 10.11 在 Cherry API 侧编写 bridge receiver 集成测试（`apps/api/src/bridge/__tests__/`，含 rate limit 测试）
+- [ ] 10.12 创建 `.github/workflows/bridge-rebase-check.yml` CI 配置（cherrygraph-bridge 分支推送触发，含 Redis + mock Cherry API + 全量契约测试）
+
+## 11. Documentation & Alignment
+
+- [ ] 11.1 更新 `docs/project/26_需求追踪矩阵.md` Phase 2 追踪表，填充 Stage 9 测试列（P2-E5/E6/E7 部分覆盖，标注 Stage 归属）
+- [ ] 11.2 更新 `docs/schemas/openapi.yaml` 添加 Bridge internal API 定义（含 permissions 端点和 5 种 webhook 事件）
+- [ ] 11.3 更新 `docs/schemas/schema.sql` 添加 bridge_events / webhook_deliveries / page_block_metadata DDL
+- [ ] 11.4 验证 Stage 9 开工门禁：需求/API/Schema/测试四列无空
+- [ ] 11.5 创建 rebase 手动验收 checklist（Doc 22 §7.3：Docmost 前端 CRUD、附件上传、Cherry Chat 端到端同步、权限变更可见性）
+- [ ] 11.6 创建 Stage 9 回滚方案文档（Doc 22 §8 五步流程：回退 submodule → Docmost 只读 → 暂停回写 → 用旧索引 → reconcile）


### PR DESCRIPTION
## Summary

- Add Bridge module to Docmost Fork (cherrygraph-bridge branch) with HMAC-SHA256 + Bearer + timestamp + nonce auth guard
- Implement page export/import controllers with graphify:managed HTML comment marker round-trip preservation
- Add 5 webhook event emitters (page.saved/deleted, attachment.created/deleted, space.updated) with 2s debounce and 3x exponential backoff retry
- Add sync-status, health, permissions, and attachment download proxy endpoints
- Support dual-key rotation for DOCMOST_BRIDGE_SECRET migration
- Include Stage 9 OpenSpec artifacts
- Fix pre-existing lint error in space.service.ts

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `e5f36d3451745c53b0926d6d60c48c748c3a2859`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/124#issuecomment-4375874003) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/124#issuecomment-4375874089) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/124#issuecomment-4375874166) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/124#issuecomment-4375874242)
- Key findings addressed: create_only soft-delete check, export response fields, sha256= signature prefix, dead wildcard handler, debounce cancel on delete, descendant delete events, code-block HTML comment safety, frontmatter parsing/validation, permissions groups DTO, webhook flat payloads, cached health probe, shutdown cleanup, fetch timeout

## Test plan

- [x] TypeScript compilation passes
- [x] No new dependencies or migrations
- [x] Red line compliance verified
- [ ] Contract tests (deferred to Issue #123)