### PR TITLE
feat(bridge): contract tests + infrastructure + docs (#123)

### DIFF
--- a/.github/workflows/bridge-contract-tests.yml
+++ b/.github/workflows/bridge-contract-tests.yml
@@ -1,0 +1,79 @@
+name: Bridge Contract Tests
+
+on:
+  push:
+    branches:
+      - cherrygraph-bridge
+  pull_request:
+    paths:
+      - apps/api/src/bridge/**
+      - packages/shared/src/schema/**
+      - docs/schemas/openapi-bridge.yaml
+      - docker-compose.yml
+      - .github/workflows/bridge-contract-tests.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bridge-contract-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cherry-api-receiver:
+    name: Cherry API receiver
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: cherrygraph
+          POSTGRES_PASSWORD: cherrygraph
+          POSTGRES_DB: cherrygraph_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U cherrygraph -d cherrygraph_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:8-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      NODE_ENV: test
+      DATABASE_URL: postgresql://cherrygraph:cherrygraph@localhost:5432/cherrygraph_test
+      REDIS_URL: redis://localhost:6379
+      DOCMOST_BRIDGE_SECRET: bridge-current-secret
+      DOCMOST_BRIDGE_SECRET_NEXT: bridge-next-secret
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify Bridge network isolation
+        run: node scripts/verify-bridge-isolation.mjs
+
+      - name: Run bridge receiver tests
+        run: pnpm exec vitest run apps/api/src/bridge/__tests__/bridge-receiver.test.ts --config vitest.config.ts

--- a/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
@@ -1,0 +1,448 @@
+import 'reflect-metadata';
+
+import { FastifyAdapter, type NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import {
+  ErrorCode,
+  bridgeEvents,
+  webhookDeliveries,
+  type BridgeEventType,
+  type BridgeWebhookPayload,
+} from '@cherrygraph/shared';
+import crypto, { randomUUID } from 'node:crypto';
+import request, { type Response } from 'supertest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { configureApp } from '../../main.js';
+import { getApiLogger } from '../../common/logger/logger.module.js';
+import { REDIS_CLIENT } from '../../common/redis/redis.module.js';
+import { DRIZZLE } from '../../database/drizzle.constants.js';
+import { BridgeAuthGuard } from '../bridge-auth.guard.js';
+import { BridgeEventController } from '../bridge-event.controller.js';
+import { BridgeEventService } from '../bridge-event.service.js';
+import { BridgeRateLimitGuard } from '../bridge-rate-limit.guard.js';
+
+const CURRENT_SECRET = 'bridge-current-secret';
+const NEXT_SECRET = 'bridge-next-secret';
+const BASE_PATH = '/api/internal/docmost/events';
+
+type TestResponseData = {
+  accepted: true;
+  event_id: string;
+  deduplicated: boolean;
+};
+
+type BridgeReceiverTestContext = {
+  app: NestFastifyApplication;
+  db: InMemoryBridgeDatabase;
+  redis: InMemoryBridgeRedis;
+};
+
+const originalBridgeSecret = process.env.DOCMOST_BRIDGE_SECRET;
+const originalBridgeSecretNext = process.env.DOCMOST_BRIDGE_SECRET_NEXT;
+let context: BridgeReceiverTestContext | undefined;
+
+describe('Bridge receiver contract', () => {
+  beforeEach(async () => {
+    getApiLogger().level = 'silent';
+    process.env.DOCMOST_BRIDGE_SECRET = CURRENT_SECRET;
+    process.env.DOCMOST_BRIDGE_SECRET_NEXT = NEXT_SECRET;
+    context = await createBridgeReceiverTestContext();
+  });
+
+  afterEach(async () => {
+    await context?.app.close();
+    context = undefined;
+    restoreBridgeSecrets();
+  });
+
+  it('accepts a request with a valid HMAC signature', async () => {
+    const response = await sendSignedBridgeEvent(requireContext(), '/page-saved', createPayload('page.saved')).expect(200);
+
+    expect(getResponseData(response).accepted).toBe(true);
+    expect(getResponseData(response).deduplicated).toBe(false);
+  });
+
+  it('rejects a tampered HMAC signature with BRIDGE_HMAC_INVALID', async () => {
+    const response = await sendSignedBridgeEvent(requireContext(), '/page-saved', createPayload('page.saved'), {
+      signature: `sha256=${'0'.repeat(64)}`,
+    }).expect(401);
+
+    expect(getErrorCode(response)).toBe(ErrorCode.BRIDGE_HMAC_INVALID);
+  });
+
+  it('rejects a request without Authorization bearer with BRIDGE_AUTH_MISSING', async () => {
+    const response = await sendSignedBridgeEvent(requireContext(), '/page-saved', createPayload('page.saved'), {
+      omitAuthorization: true,
+    }).expect(401);
+
+    expect(getErrorCode(response)).toBe(ErrorCode.BRIDGE_AUTH_MISSING);
+  });
+
+  it('rejects a request with an expired timestamp with BRIDGE_TIMESTAMP_EXPIRED', async () => {
+    const response = await sendSignedBridgeEvent(requireContext(), '/page-saved', createPayload('page.saved'), {
+      timestamp: String(Math.floor(Date.now() / 1000) - 6 * 60),
+    }).expect(401);
+
+    expect(getErrorCode(response)).toBe(ErrorCode.BRIDGE_TIMESTAMP_EXPIRED);
+  });
+
+  it('rejects a reused nonce with BRIDGE_NONCE_REUSED', async () => {
+    const nonce = randomUUID();
+
+    await sendSignedBridgeEvent(requireContext(), '/page-saved', createPayload('page.saved'), { nonce }).expect(200);
+    const response = await sendSignedBridgeEvent(requireContext(), '/page-saved', createPayload('page.saved'), {
+      nonce,
+    }).expect(401);
+
+    expect(getErrorCode(response)).toBe(ErrorCode.BRIDGE_NONCE_REUSED);
+  });
+
+  it('accepts a request signed with DOCMOST_BRIDGE_SECRET_NEXT during dual-key rotation', async () => {
+    const response = await sendSignedBridgeEvent(requireContext(), '/page-saved', createPayload('page.saved'), {
+      secret: NEXT_SECRET,
+      bearer: NEXT_SECRET,
+    }).expect(200);
+
+    expect(getResponseData(response).accepted).toBe(true);
+  });
+
+  it('deduplicates repeated event_id values without rejecting distinct nonces', async () => {
+    const eventId = randomUUID();
+    const firstPayload = createPayload('page.saved', { event_id: eventId });
+    const secondPayload = createPayload('page.saved', { event_id: eventId });
+
+    const firstResponse = await sendSignedBridgeEvent(requireContext(), '/page-saved', firstPayload).expect(200);
+    const secondResponse = await sendSignedBridgeEvent(requireContext(), '/page-saved', secondPayload).expect(200);
+
+    expect(getResponseData(firstResponse)).toEqual(
+      expect.objectContaining({
+        event_id: eventId,
+        deduplicated: false,
+      }),
+    );
+    expect(getResponseData(secondResponse)).toEqual(
+      expect.objectContaining({
+        event_id: eventId,
+        deduplicated: true,
+      }),
+    );
+    expect(requireContext().db.eventCount(eventId)).toBe(1);
+  });
+
+  it('returns 429 when the per-IP Bridge rate limit is exceeded', async () => {
+    const testContext = requireContext();
+
+    for (let index = 0; index < 100; index += 1) {
+      await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved')).expect(200);
+    }
+
+    const response = await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved')).expect(429);
+    expect(getErrorCode(response)).toBe(ErrorCode.RATE_LIMITED);
+  });
+
+  it.each([
+    ['/page-saved', 'page.saved', { page_id: 'page-1', content_hash: 'a'.repeat(64) }],
+    ['/page-deleted', 'page.deleted', { page_id: 'page-1' }],
+    ['/attachment-created', 'attachment.created', { page_id: 'page-1', attachment_id: 'att-1', filename: 'guide.pdf' }],
+    ['/attachment-deleted', 'attachment.deleted', { page_id: 'page-1', attachment_id: 'att-1' }],
+    ['/space-updated', 'space.updated', { change_type: 'permissions' }],
+  ] as const)('POST %s accepts a valid %s payload', async (path, eventType, overrides) => {
+    const response = await sendSignedBridgeEvent(
+      requireContext(),
+      path,
+      createPayload(eventType, overrides),
+    ).expect(200);
+
+    expect(getResponseData(response)).toEqual(
+      expect.objectContaining({
+        accepted: true,
+        deduplicated: false,
+      }),
+    );
+  });
+});
+
+async function createBridgeReceiverTestContext(): Promise<BridgeReceiverTestContext> {
+  const redis = new InMemoryBridgeRedis();
+  const db = new InMemoryBridgeDatabase();
+  const moduleRef = await Test.createTestingModule({
+    controllers: [BridgeEventController],
+    providers: [
+      BridgeAuthGuard,
+      BridgeRateLimitGuard,
+      BridgeEventService,
+      { provide: DRIZZLE, useValue: db },
+      { provide: REDIS_CLIENT, useValue: redis },
+    ],
+  }).compile();
+
+  const app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter({ logger: false }), {
+    rawBody: true,
+  });
+  configureApp(app);
+  await app.init();
+  await app.getHttpAdapter().getInstance().ready();
+
+  return { app, db, redis };
+}
+
+function sendSignedBridgeEvent(
+  testContext: BridgeReceiverTestContext,
+  path: string,
+  payload: BridgeWebhookPayload,
+  options: Partial<{
+    bearer: string;
+    nonce: string;
+    omitAuthorization: boolean;
+    secret: string;
+    signature: string;
+    timestamp: string;
+  }> = {},
+): request.Test {
+  const endpoint = `${BASE_PATH}${path}`;
+  const timestamp = options.timestamp ?? String(Math.floor(Date.now() / 1000));
+  const nonce = options.nonce ?? randomUUID();
+  const body = JSON.stringify(payload);
+  const secret = options.secret ?? CURRENT_SECRET;
+  const signature = options.signature ?? signBridgeRequest(secret, timestamp, nonce, 'POST', endpoint, body);
+  const requestBuilder = request(testContext.app.getHttpAdapter().getInstance().server)
+    .post(endpoint)
+    .set('Content-Type', 'application/json')
+    .set('X-Bridge-Timestamp', timestamp)
+    .set('X-Bridge-Nonce', nonce)
+    .set('X-Bridge-Signature', signature);
+
+  if (options.omitAuthorization !== true) {
+    requestBuilder.set('Authorization', `Bearer ${options.bearer ?? secret}`);
+  }
+
+  return requestBuilder.send(body);
+}
+
+function signBridgeRequest(
+  secret: string,
+  timestamp: string,
+  nonce: string,
+  method: string,
+  path: string,
+  body: string,
+): string {
+  const bodyHash = crypto.createHash('sha256').update(body).digest('hex');
+  const signaturePayload = `${timestamp}\n${nonce}\n${method}\n${path}\n${bodyHash}`;
+  const signature = crypto.createHmac('sha256', secret).update(signaturePayload).digest('hex');
+
+  return `sha256=${signature}`;
+}
+
+function createPayload(
+  eventType: BridgeEventType,
+  overrides: Record<string, unknown> = {},
+): BridgeWebhookPayload {
+  return {
+    event_id: randomUUID(),
+    event_type: eventType,
+    timestamp: Math.floor(Date.now() / 1000),
+    space_id: 'docmost-space-1',
+    page_id: 'docmost-page-1',
+    ...overrides,
+  };
+}
+
+function getResponseData(response: Response): TestResponseData {
+  const body = parseResponseBody(response);
+  if (!isRecord(body.data)) {
+    throw new Error('Expected response body to include data object');
+  }
+
+  return body.data as TestResponseData;
+}
+
+function getErrorCode(response: Response): unknown {
+  const body = parseResponseBody(response);
+  return isRecord(body.error) ? body.error.code : undefined;
+}
+
+function parseResponseBody(response: Response): Record<string, unknown> {
+  const body = response.body as unknown;
+  if (isRecord(body)) {
+    return body;
+  }
+
+  const parsed = JSON.parse(response.text) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error('Expected JSON object response body');
+  }
+
+  return parsed;
+}
+
+function requireContext(): BridgeReceiverTestContext {
+  if (context === undefined) {
+    throw new Error('Expected test context to be initialized');
+  }
+
+  return context;
+}
+
+function restoreBridgeSecrets(): void {
+  restoreEnvValue('DOCMOST_BRIDGE_SECRET', originalBridgeSecret);
+  restoreEnvValue('DOCMOST_BRIDGE_SECRET_NEXT', originalBridgeSecretNext);
+}
+
+function restoreEnvValue(name: 'DOCMOST_BRIDGE_SECRET' | 'DOCMOST_BRIDGE_SECRET_NEXT', value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+type StoredBridgeEvent = {
+  id: string;
+  event_id: string;
+  event_type: string;
+  space_id: string | null;
+  page_id: string | null;
+};
+
+class InMemoryBridgeDatabase {
+  private readonly eventsByEventId = new Map<string, StoredBridgeEvent>();
+  private pendingLookupEventId: string | undefined;
+  readonly deliveries: unknown[] = [];
+
+  insert(table: unknown): unknown {
+    if (table === bridgeEvents) {
+      return {
+        values: (value: Record<string, unknown>) => ({
+          returning: (): Promise<StoredBridgeEvent[]> => {
+            const eventId = requireString(value.event_id, 'event_id');
+            const existing = this.eventsByEventId.get(eventId);
+            if (existing !== undefined) {
+              this.pendingLookupEventId = eventId;
+              throw Object.assign(new Error('duplicate bridge event_id'), {
+                code: '23505',
+                constraint: 'bridge_events_event_id_unique',
+              });
+            }
+
+            const event: StoredBridgeEvent = {
+              id: requireString(value.id, 'id'),
+              event_id: eventId,
+              event_type: requireString(value.event_type, 'event_type'),
+              space_id: nullableString(value.space_id),
+              page_id: nullableString(value.page_id),
+            };
+            this.eventsByEventId.set(event.event_id, event);
+
+            return Promise.resolve([event]);
+          },
+        }),
+      };
+    }
+
+    if (table === webhookDeliveries) {
+      return {
+        values: (value: Record<string, unknown>): Promise<void> => {
+          this.deliveries.push(value);
+          return Promise.resolve();
+        },
+      };
+    }
+
+    throw new Error('Unexpected insert table');
+  }
+
+  select(): unknown {
+    return {
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: (): Promise<StoredBridgeEvent[]> => {
+            if (table !== bridgeEvents || this.pendingLookupEventId === undefined) {
+              return Promise.resolve([]);
+            }
+
+            const event = this.eventsByEventId.get(this.pendingLookupEventId);
+            this.pendingLookupEventId = undefined;
+            return Promise.resolve(event === undefined ? [] : [event]);
+          },
+        }),
+      }),
+    };
+  }
+
+  eventCount(eventId: string): number {
+    return this.eventsByEventId.has(eventId) ? 1 : 0;
+  }
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Expected ${fieldName} to be a string`);
+  }
+
+  return value;
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+class InMemoryBridgeRedis {
+  private readonly strings = new Map<string, { value: string; expiresAt: number }>();
+  private readonly sortedSets = new Map<string, Array<{ score: number; member: string }>>();
+
+  set(key: string, value: string, mode: 'EX', ttl: number, condition: 'NX'): Promise<'OK' | null> {
+    if (mode !== 'EX' || condition !== 'NX') {
+      return Promise.reject(new Error('Unsupported Redis SET arguments'));
+    }
+
+    this.deleteExpiredString(key);
+    if (this.strings.has(key)) {
+      return Promise.resolve(null);
+    }
+
+    this.strings.set(key, {
+      value,
+      expiresAt: Date.now() + ttl * 1000,
+    });
+    return Promise.resolve('OK');
+  }
+
+  eval(_script: string, numberOfKeys: number, ...args: Array<string | number>): Promise<[number, number]> {
+    if (numberOfKeys !== 1) {
+      return Promise.reject(new Error('Unsupported Redis EVAL key count'));
+    }
+
+    const [key, nowValue, windowMsValue, limitValue, memberValue] = args;
+    if (typeof key !== 'string' || typeof memberValue !== 'string') {
+      return Promise.reject(new Error('Invalid Redis EVAL arguments'));
+    }
+
+    const now = Number(nowValue);
+    const windowMs = Number(windowMsValue);
+    const limit = Number(limitValue);
+    const entries = this.sortedSets.get(key) ?? [];
+    const kept = entries.filter((entry) => entry.score > now - windowMs);
+    this.sortedSets.set(key, kept);
+
+    if (kept.length >= limit) {
+      return Promise.resolve([0, kept.length]);
+    }
+
+    kept.push({ score: now, member: memberValue });
+    return Promise.resolve([1, kept.length]);
+  }
+
+  private deleteExpiredString(key: string): void {
+    const entry = this.strings.get(key);
+    if (entry !== undefined && entry.expiresAt <= Date.now()) {
+      this.strings.delete(key);
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       DEFAULT_EMBEDDING_MODEL: ${DEFAULT_EMBEDDING_MODEL:-text-embedding-3-large}
       DOCMOST_BASE_URL: ${DOCMOST_BASE_URL:-http://localhost:3000}
       DOCMOST_BRIDGE_SECRET: ${DOCMOST_BRIDGE_SECRET:-dev-docmost-bridge-secret}
+      DOCMOST_BRIDGE_SECRET_NEXT: ${DOCMOST_BRIDGE_SECRET_NEXT:-}
       GRAPHIFY_PINNED_REF: ${GRAPHIFY_PINNED_REF:-58271fb5af4c0c123ddbad9c689ee1e220360be8}
     ports:
       - "127.0.0.1:8081:8080"
@@ -360,20 +361,19 @@ services:
         condition: service_healthy
 
   docmost:
-    profiles: ["phase2"]
-    build:
-      context: ./external/docmost
-      dockerfile: Dockerfile
+    profiles: ["docmost", "phase2"]
+    image: ${DOCMOST_IMAGE:-docmost/docmost:0.80.1}
     restart: unless-stopped
     environment:
       APP_URL: ${DOCMOST_BASE_URL:-http://localhost:3000}
       APP_SECRET: ${DOCMOST_APP_SECRET:-dev-docmost-app-secret-minimum-32-chars}
-      DATABASE_URL: postgresql://docmost:${DOCMOST_DB_PASSWORD:-docmost_dev}@docmost-db:5432/docmost
-      REDIS_URL: redis://docmost-redis:6379
+      DATABASE_URL: ${DOCMOST_DATABASE_URL:-postgresql://cherrygraph:${POSTGRES_PASSWORD:-cherrygraph_dev}@postgres:5432/cherrygraph}
+      REDIS_URL: ${DOCMOST_REDIS_URL:-redis://redis:6379}
+      CHERRY_API_INTERNAL_URL: ${CHERRY_API_INTERNAL_URL:-http://cherry-api:8080}
       DOCMOST_BRIDGE_SECRET: ${DOCMOST_BRIDGE_SECRET:-dev-docmost-bridge-secret}
-      DOCMOST_FORK_BUILD: ${DOCMOST_FORK_BUILD:-true}
-    ports:
-      - "3000:3000"
+      DOCMOST_BRIDGE_SECRET_NEXT: ${DOCMOST_BRIDGE_SECRET_NEXT:-}
+    expose:
+      - "3000"
     volumes:
       - docmost_storage:/app/data/storage
     healthcheck:
@@ -383,41 +383,10 @@ services:
       retries: 3
       start_period: 30s
     depends_on:
-      docmost-db:
+      postgres:
         condition: service_healthy
-      docmost-redis:
+      redis:
         condition: service_healthy
-
-  docmost-db:
-    profiles: ["phase2"]
-    image: postgres:18
-    restart: unless-stopped
-    environment:
-      POSTGRES_DB: docmost
-      POSTGRES_USER: docmost
-      POSTGRES_PASSWORD: ${DOCMOST_DB_PASSWORD:-docmost_dev}
-    volumes:
-      - docmost_db_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U docmost -d docmost"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-
-  docmost-redis:
-    profiles: ["phase2"]
-    image: redis:8-alpine
-    restart: unless-stopped
-    command: ["redis-server", "--appendonly", "yes", "--maxmemory-policy", "noeviction"]
-    volumes:
-      - docmost_redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 5s
 
   wiki-sync-worker:
     profiles: ["phase2"]
@@ -462,11 +431,10 @@ volumes:
   indexer_node_modules:
   indexer_pnpm_store:
   docmost_storage:
-  docmost_db_data:
-  docmost_redis_data:
   wiki_repo:
 
 networks:
   default:
+    name: cherry-net
   url_fetch_private:
     internal: true

--- a/docs/ops/docker-compose.skeleton.yml
+++ b/docs/ops/docker-compose.skeleton.yml
@@ -31,6 +31,7 @@ services:
       MODEL_API_KEY: ${MODEL_API_KEY}
       DOCMOST_BASE_URL: ${DOCMOST_BASE_URL}
       DOCMOST_BRIDGE_SECRET: ${DOCMOST_BRIDGE_SECRET}
+      DOCMOST_BRIDGE_SECRET_NEXT: ${DOCMOST_BRIDGE_SECRET_NEXT}
       GRAPHIFY_PINNED_REF: ${GRAPHIFY_PINNED_REF}
     ports:
       - "8081:8080"
@@ -225,22 +226,21 @@ services:
         condition: service_healthy
 
   # Phase 2 启用：Docmost Fork 开源版 + 自建 Bridge endpoint。
-  # Phase 1 不启动。启用方式：docker compose --profile phase2 up -d
+  # 默认不启动。启用方式：docker compose --profile docmost up -d docmost
   docmost:
-    profiles: ["phase2"]
-    build:
-      context: ../../external/docmost
-      dockerfile: Dockerfile
+    profiles: ["docmost", "phase2"]
+    image: ${DOCMOST_IMAGE:-docmost/docmost:0.80.1}
     restart: unless-stopped
     environment:
       APP_URL: ${DOCMOST_BASE_URL}
       APP_SECRET: ${DOCMOST_APP_SECRET}
-      DATABASE_URL: postgresql://docmost:${DOCMOST_DB_PASSWORD}@docmost-db:5432/docmost
-      REDIS_URL: redis://docmost-redis:6379
+      DATABASE_URL: ${DOCMOST_DATABASE_URL}
+      REDIS_URL: ${DOCMOST_REDIS_URL:-redis://redis:6379}
+      CHERRY_API_INTERNAL_URL: ${CHERRY_API_INTERNAL_URL:-http://cherry-api:8080}
       DOCMOST_BRIDGE_SECRET: ${DOCMOST_BRIDGE_SECRET}
-      DOCMOST_FORK_BUILD: ${DOCMOST_FORK_BUILD}
-    ports:
-      - "3000:3000"
+      DOCMOST_BRIDGE_SECRET_NEXT: ${DOCMOST_BRIDGE_SECRET_NEXT}
+    expose:
+      - "3000"
     volumes:
       - docmost_storage:/app/data/storage
     healthcheck:
@@ -250,9 +250,9 @@ services:
       retries: 3
       start_period: 30s
     depends_on:
-      docmost-db:
+      postgres:
         condition: service_healthy
-      docmost-redis:
+      redis:
         condition: service_healthy
 
   postgres:
@@ -273,43 +273,12 @@ services:
       retries: 5
       start_period: 10s
 
-  docmost-db:
-    profiles: ["phase2"]
-    image: postgres:18
-    restart: unless-stopped
-    environment:
-      POSTGRES_DB: docmost
-      POSTGRES_USER: docmost
-      POSTGRES_PASSWORD: ${DOCMOST_DB_PASSWORD}
-    volumes:
-      - docmost_db_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U docmost -d docmost"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-
   redis:
     image: redis:8
     restart: unless-stopped
     command: ["redis-server", "--appendonly", "yes"]
     volumes:
       - redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 5s
-
-  docmost-redis:
-    profiles: ["phase2"]
-    image: redis:8
-    restart: unless-stopped
-    command: ["redis-server", "--appendonly", "yes", "--maxmemory-policy", "noeviction"]
-    volumes:
-      - docmost_redis_data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -386,7 +355,9 @@ volumes:
   redis_data:
   minio_data:
   docmost_storage:
-  docmost_db_data:
-  docmost_redis_data:
   graphify_work:
   wiki_repo:
+
+networks:
+  default:
+    name: cherry-net

--- a/docs/ops/env.example
+++ b/docs/ops/env.example
@@ -72,9 +72,14 @@ EGRESS_PROXY_URL=
 # --- Docmost (Phase 2 — not used in Phase 1) ---
 DOCMOST_BASE_URL=http://localhost:3000
 DOCMOST_APP_SECRET=replace-with-long-random-secret
-DOCMOST_DB_PASSWORD=replace-with-strong-password
+DOCMOST_IMAGE=docmost/docmost:0.80.1
+DOCMOST_DATABASE_URL=postgresql://cherrygraph:replace-with-strong-password@postgres:5432/cherrygraph
+DOCMOST_REDIS_URL=redis://redis:6379
+CHERRY_API_INTERNAL_URL=http://cherry-api:8080
 DOCMOST_BRIDGE_SECRET=replace-with-bridge-shared-secret
-DOCMOST_FORK_BUILD=true
+# Optional rotation key. During rotation, Cherry API accepts signatures from
+# DOCMOST_BRIDGE_SECRET or DOCMOST_BRIDGE_SECRET_NEXT.
+DOCMOST_BRIDGE_SECRET_NEXT=
 
 # --- Claude Code Agent (Phase 3+ — not used in Phase 1) ---
 # cherry-api spawns claude CLI for Agent deep path.

--- a/docs/ops/nginx.phase2.conf.example
+++ b/docs/ops/nginx.phase2.conf.example
@@ -33,6 +33,16 @@ http {
     }
 
     # --- Cherry API ---
+    location ^~ /api/internal/bridge/ {
+      deny all;
+      return 403;
+    }
+
+    location ^~ /api/internal/docmost/events/ {
+      deny all;
+      return 403;
+    }
+
     location /api/ {
       proxy_pass http://cherry-api:8080;
       proxy_http_version 1.1;
@@ -57,6 +67,11 @@ http {
     }
 
     # --- Phase 2: Docmost 协作编辑 ---
+    location ^~ /docmost/api/internal/bridge/ {
+      deny all;
+      return 403;
+    }
+
     location /docmost/ {
       proxy_pass http://docmost:3000/;
       proxy_http_version 1.1;

--- a/docs/ops/rebase-checklist.md
+++ b/docs/ops/rebase-checklist.md
@@ -1,0 +1,12 @@
+# Stage 9 Docmost Fork Rebase Checklist
+
+Run this checklist after rebasing `external/docmost` / the `cherrygraph-bridge` branch onto a new upstream Docmost commit.
+
+| # | Verification item | Expected result |
+|---|---|---|
+| 1 | Docmost frontend CRUD works | Create, edit, move, and delete a page from the Docmost UI without API or console errors. |
+| 2 | Attachment upload works | Upload an attachment in Docmost and confirm it is downloadable from the page. |
+| 3 | Cherry Chat end-to-end sync | Save a Docmost page, wait for Bridge delivery, rebuild/refresh index if required, and confirm Cherry Chat can cite the updated wiki content. |
+| 4 | Permission changes visible | Change Cherry space permissions, push to Docmost, and confirm affected users see the updated visibility in Docmost. |
+
+Record the upstream Docmost commit, CherryWiki commit, operator, timestamp, and pass/fail notes in the release worklog before updating the submodule reference.

--- a/docs/ops/stage9-rollback.md
+++ b/docs/ops/stage9-rollback.md
@@ -1,0 +1,11 @@
+# Stage 9 Bridge Rollback Plan
+
+Use this procedure when the Docmost Bridge path causes data integrity, availability, or permission sync issues that cannot be fixed forward quickly.
+
+1. Revert the Docmost submodule or fork deployment to the last pre-Bridge commit.
+2. Set Docmost to read-only mode so users cannot create additional divergent edits during recovery.
+3. Pause write-back from Docmost to Cherry by disabling Bridge webhook delivery or clearing `DOCMOST_BRIDGE_SECRET` from the Docmost runtime.
+4. Restore service reads to the last known-good Cherry index snapshot and keep the current broken snapshot inactive.
+5. Reconcile after recovery by comparing Docmost changes, `bridge_events`, and Cherry wiki versions, then replay or manually apply only verified events.
+
+Do not re-enable write-back until HMAC validation, nonce storage, event idempotency, and permission projection have passed the contract tests again.

--- a/docs/project/26_需求追踪矩阵.md
+++ b/docs/project/26_需求追踪矩阵.md
@@ -69,14 +69,15 @@
 
 | 需求 | API | Schema | 测试 | 验收点 |
 |---|---|---|---|---|
-| Docmost 页面导入 | PUT /internal/bridge/pages/{id}/import | wiki_pages, wiki_page_versions | P2-E1 | Docmost 可编辑 |
-| Docmost 保存回写 Repo | POST /internal/docmost/events/page-saved | bridge_events, wiki_page_versions | P2-E2 | Repo 新 commit |
-| Bridge webhook 幂等 | POST /internal/docmost/events/* | bridge_events (event_id unique) | P2-E5, §4.4 | 重复不产生新版本 |
-| Bridge HMAC 校验 | — (Guard) | — | P2-E6 | 错误签名被拒 |
-| 人工区块保护 | — (merge logic) | page_block_metadata | P2-E8 | human 区块不被覆盖 |
-| 候选更新审核 | POST /api/.../proposals/{id}/accept | wiki_update_proposals | P2-E9 | 管理员可接受/拒绝 |
-| 权限映射同步 | PUT /internal/bridge/spaces/{id}/permissions | permission_versions | P2-E7 | Docmost 权限与 Cherry 一致 |
-| Docmost 同步状态 | GET /internal/bridge/spaces/{id}/sync-status | — | P2 部署验收 | status=healthy |
+| Docmost 页面导入 | PUT /api/internal/bridge/pages/{id}/import | wiki_pages, wiki_page_versions, page_block_metadata | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (page import) | Docmost 可编辑 |
+| Docmost 保存回写 Repo | POST /api/internal/docmost/events/page-saved | bridge_events, webhook_deliveries, wiki_page_versions | `apps/api/src/bridge/__tests__/bridge-receiver.test.ts`, `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (P2-E2) | Repo 新 commit |
+| Bridge webhook 幂等 | POST /api/internal/docmost/events/* | bridge_events (event_id unique), webhook_deliveries | `apps/api/src/bridge/__tests__/bridge-receiver.test.ts` (P2-E5, §4.4) | 重复不产生新版本 |
+| Bridge HMAC 校验 | Guard: /api/internal/docmost/events/*, /api/internal/bridge/* | Redis nonce store, bridge_events.nonce | `apps/api/src/bridge/__tests__/bridge-receiver.test.ts` (P2-E6) | 错误签名被拒 |
+| Bridge 快速保存去重 | Docmost EventEmitter bridge:page.saved → Cherry receiver | bridge_events, webhook_deliveries | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (P2-E10 rapid saves debounced) | 同页 2s 内仅发送最新保存事件 |
+| 人工区块保护 | 内部 merge logic | page_block_metadata | `packages/wiki-core/src/__tests__/normalization-block-markers.test.ts` (P2-E8) | human 区块不被覆盖 |
+| 候选更新审核 | POST /api/.../proposals/{id}/accept | wiki_update_proposals | `packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts` (P2-E9 前置), `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` | 管理员可接受/拒绝 |
+| 权限映射同步 | PUT /api/internal/bridge/spaces/{id}/permissions | permission_versions, space_permissions | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (P2-E7 permissions endpoint) | Docmost 权限与 Cherry 一致 |
+| Docmost 同步状态 | GET /api/internal/bridge/spaces/{id}/sync-status | bridge_events, webhook_deliveries | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (sync-status + health) | status=healthy |
 
 ## 4. Phase 3 追踪
 

--- a/docs/schemas/openapi-bridge.yaml
+++ b/docs/schemas/openapi-bridge.yaml
@@ -1,0 +1,366 @@
+openapi: 3.1.0
+info:
+  title: CherryWiki Bridge Internal API
+  version: 0.1.0
+  description: |
+    Internal Docmost-to-Cherry Bridge receiver contract.
+
+    These endpoints are only for Docker-network service-to-service traffic.
+    Public reverse proxies must deny external access to internal Bridge paths.
+
+    HMAC signature payload:
+    `X-Bridge-Timestamp + "\n" + X-Bridge-Nonce + "\n" + HTTP_METHOD + "\n" + REQUEST_PATH + "\n" + sha256(raw_body)`.
+    `X-Bridge-Signature` is `sha256=<hex hmac>` using DOCMOST_BRIDGE_SECRET.
+    During rotation, Cherry also accepts DOCMOST_BRIDGE_SECRET_NEXT.
+servers:
+  - url: /api
+    description: Cherry API global prefix
+security:
+  - bridgeBearer: []
+    bridgeHmac: []
+paths:
+  /internal/docmost/events/page-saved:
+    post:
+      operationId: receiveDocmostPageSaved
+      tags: [Bridge Receiver]
+      summary: Receive a Docmost page saved event
+      parameters:
+        - $ref: '#/components/parameters/BridgeTimestamp'
+        - $ref: '#/components/parameters/BridgeNonce'
+        - $ref: '#/components/parameters/BridgeSignature'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PageSavedEvent'
+      responses:
+        '200':
+          $ref: '#/components/responses/BridgeAccepted'
+        '401':
+          $ref: '#/components/responses/BridgeUnauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+  /internal/docmost/events/page-deleted:
+    post:
+      operationId: receiveDocmostPageDeleted
+      tags: [Bridge Receiver]
+      summary: Receive a Docmost page deleted event
+      parameters:
+        - $ref: '#/components/parameters/BridgeTimestamp'
+        - $ref: '#/components/parameters/BridgeNonce'
+        - $ref: '#/components/parameters/BridgeSignature'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PageDeletedEvent'
+      responses:
+        '200':
+          $ref: '#/components/responses/BridgeAccepted'
+        '401':
+          $ref: '#/components/responses/BridgeUnauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+  /internal/docmost/events/attachment-created:
+    post:
+      operationId: receiveDocmostAttachmentCreated
+      tags: [Bridge Receiver]
+      summary: Receive a Docmost attachment created event
+      parameters:
+        - $ref: '#/components/parameters/BridgeTimestamp'
+        - $ref: '#/components/parameters/BridgeNonce'
+        - $ref: '#/components/parameters/BridgeSignature'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttachmentCreatedEvent'
+      responses:
+        '200':
+          $ref: '#/components/responses/BridgeAccepted'
+        '401':
+          $ref: '#/components/responses/BridgeUnauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+  /internal/docmost/events/attachment-deleted:
+    post:
+      operationId: receiveDocmostAttachmentDeleted
+      tags: [Bridge Receiver]
+      summary: Receive a Docmost attachment deleted event
+      parameters:
+        - $ref: '#/components/parameters/BridgeTimestamp'
+        - $ref: '#/components/parameters/BridgeNonce'
+        - $ref: '#/components/parameters/BridgeSignature'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AttachmentDeletedEvent'
+      responses:
+        '200':
+          $ref: '#/components/responses/BridgeAccepted'
+        '401':
+          $ref: '#/components/responses/BridgeUnauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+  /internal/docmost/events/space-updated:
+    post:
+      operationId: receiveDocmostSpaceUpdated
+      tags: [Bridge Receiver]
+      summary: Receive a Docmost space updated event
+      parameters:
+        - $ref: '#/components/parameters/BridgeTimestamp'
+        - $ref: '#/components/parameters/BridgeNonce'
+        - $ref: '#/components/parameters/BridgeSignature'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpaceUpdatedEvent'
+      responses:
+        '200':
+          $ref: '#/components/responses/BridgeAccepted'
+        '401':
+          $ref: '#/components/responses/BridgeUnauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationError'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+
+components:
+  securitySchemes:
+    bridgeBearer:
+      type: http
+      scheme: bearer
+      description: Bearer token must equal DOCMOST_BRIDGE_SECRET or DOCMOST_BRIDGE_SECRET_NEXT during rotation.
+    bridgeHmac:
+      type: apiKey
+      in: header
+      name: X-Bridge-Signature
+      description: HMAC-SHA256 signature over timestamp, nonce, method, path, and raw body hash.
+
+  parameters:
+    BridgeTimestamp:
+      name: X-Bridge-Timestamp
+      in: header
+      required: true
+      schema:
+        type: string
+        pattern: '^[0-9]+$'
+      description: Unix epoch seconds. Requests outside the 5 minute freshness window are rejected.
+    BridgeNonce:
+      name: X-Bridge-Nonce
+      in: header
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 128
+      description: Unique nonce stored in Redis with a replay-prevention TTL.
+    BridgeSignature:
+      name: X-Bridge-Signature
+      in: header
+      required: true
+      schema:
+        type: string
+        pattern: '^sha256=[a-f0-9]{64}$'
+      description: Lowercase hex HMAC digest prefixed with `sha256=`.
+
+  responses:
+    BridgeAccepted:
+      description: Event accepted. Duplicate event_id values return 200 with deduplicated=true.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/WrappedBridgeAcceptedResponse'
+    BridgeUnauthorized:
+      description: Missing bearer, invalid HMAC, expired timestamp, or nonce replay.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            invalidSignature:
+              value:
+                error:
+                  code: BRIDGE_HMAC_INVALID
+                  message: Invalid Bridge HMAC signature
+                meta:
+                  request_id: req-123
+    ValidationError:
+      description: Payload schema validation failed.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    RateLimited:
+      description: Bridge receiver rate limit exceeded.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    WrappedBridgeAcceptedResponse:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          $ref: '#/components/schemas/BridgeAcceptedResponse'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    BridgeAcceptedResponse:
+      type: object
+      required: [accepted, event_id, deduplicated]
+      properties:
+        accepted:
+          type: boolean
+          const: true
+        event_id:
+          type: string
+        deduplicated:
+          type: boolean
+
+    BridgeWebhookBase:
+      type: object
+      required: [event_id, event_type, timestamp, space_id]
+      properties:
+        event_id:
+          type: string
+          maxLength: 64
+        event_type:
+          type: string
+          enum: [page.saved, page.deleted, attachment.created, attachment.deleted, space.updated]
+        timestamp:
+          type: integer
+          description: Event creation Unix epoch seconds.
+        space_id:
+          type: string
+          maxLength: 64
+      additionalProperties: true
+
+    PageSavedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BridgeWebhookBase'
+        - type: object
+          required: [page_id]
+          properties:
+            event_type:
+              const: page.saved
+            page_id:
+              type: string
+              maxLength: 64
+            content_hash:
+              type: string
+              pattern: '^[a-f0-9]{64}$'
+            title:
+              type: string
+
+    PageDeletedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BridgeWebhookBase'
+        - type: object
+          required: [page_id]
+          properties:
+            event_type:
+              const: page.deleted
+            page_id:
+              type: string
+              maxLength: 64
+
+    AttachmentCreatedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BridgeWebhookBase'
+        - type: object
+          required: [page_id, attachment_id, filename]
+          properties:
+            event_type:
+              const: attachment.created
+            page_id:
+              type: string
+              maxLength: 64
+            attachment_id:
+              type: string
+              maxLength: 64
+            filename:
+              type: string
+            download_url:
+              type: string
+              format: uri-reference
+
+    AttachmentDeletedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BridgeWebhookBase'
+        - type: object
+          required: [page_id, attachment_id]
+          properties:
+            event_type:
+              const: attachment.deleted
+            page_id:
+              type: string
+              maxLength: 64
+            attachment_id:
+              type: string
+              maxLength: 64
+
+    SpaceUpdatedEvent:
+      allOf:
+        - $ref: '#/components/schemas/BridgeWebhookBase'
+        - type: object
+          required: [change_type]
+          properties:
+            event_type:
+              const: space.updated
+            change_type:
+              type: string
+              enum: [metadata, permissions, settings, members]
+
+    ErrorResponse:
+      type: object
+      required: [error, meta]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              enum:
+                - BRIDGE_AUTH_MISSING
+                - BRIDGE_HMAC_INVALID
+                - BRIDGE_TIMESTAMP_EXPIRED
+                - BRIDGE_NONCE_REUSED
+                - RATE_LIMITED
+                - VALIDATION_ERROR
+            message:
+              type: string
+            details:
+              type: array
+              items: {}
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    Meta:
+      type: object
+      required: [request_id]
+      properties:
+        request_id:
+          type: string

--- a/docs/schemas/schema.sql
+++ b/docs/schemas/schema.sql
@@ -513,36 +513,31 @@ CREATE TABLE audit_logs (
 -- bridge_events: Cherry API 接收 Docmost webhook 的幂等记录（依赖 Docmost 集成）
 CREATE TABLE bridge_events (
   id TEXT PRIMARY KEY,
-  tenant_id TEXT NOT NULL REFERENCES tenants(id),
-  event_id TEXT NOT NULL,
-  source TEXT NOT NULL DEFAULT 'docmost',
-  event_type TEXT NOT NULL,
-  payload_json JSONB NOT NULL,
-  signature_valid BOOLEAN NOT NULL DEFAULT false,
-  deduplicated BOOLEAN NOT NULL DEFAULT false,
-  status TEXT NOT NULL DEFAULT 'received',
+  event_id VARCHAR(64) NOT NULL,
+  event_type VARCHAR(50) NOT NULL,
+  source VARCHAR(20) NOT NULL DEFAULT 'docmost',
+  space_id VARCHAR(64),
+  page_id VARCHAR(64),
+  payload JSONB NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'received',
   error_json JSONB,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  nonce VARCHAR(64),
+  received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   processed_at TIMESTAMPTZ,
-  UNIQUE (tenant_id, event_id)
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT bridge_events_event_id_unique UNIQUE (event_id)
 );
 
--- webhook_deliveries: Cherry API 向外部发送 webhook 的投递记录
+-- webhook_deliveries: Bridge webhook 投递记录（inbound/outbound）
 CREATE TABLE webhook_deliveries (
   id TEXT PRIMARY KEY,
-  tenant_id TEXT NOT NULL REFERENCES tenants(id),
-  target_url TEXT NOT NULL,
-  event_type TEXT NOT NULL,
-  payload_json JSONB NOT NULL,
-  attempt_count INT NOT NULL DEFAULT 0,
-  max_attempts INT NOT NULL DEFAULT 5,
-  status TEXT NOT NULL DEFAULT 'pending',
-  response_status INT,
-  response_body TEXT,
-  error_message TEXT,
-  next_retry_at TIMESTAMPTZ,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  delivered_at TIMESTAMPTZ
+  bridge_event_id TEXT NOT NULL REFERENCES bridge_events(id) ON DELETE CASCADE,
+  direction VARCHAR(10) NOT NULL,
+  attempt INT NOT NULL DEFAULT 1,
+  status_code INT,
+  response_time_ms INT,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- ===== Phase 3: Graph Evidence References (normalized) =====
@@ -667,10 +662,11 @@ CREATE INDEX idx_model_configs_tenant_type ON model_configs(tenant_id, model_typ
 CREATE INDEX idx_embeddings_model ON embeddings(model_config_id);
 CREATE INDEX idx_audit_logs_tenant_time ON audit_logs(tenant_id, created_at DESC);
 
--- P1 indexes
-CREATE INDEX idx_bridge_events_lookup ON bridge_events(tenant_id, event_id);
-CREATE INDEX idx_bridge_events_status ON bridge_events(status, created_at);
-CREATE INDEX idx_webhook_deliveries_status ON webhook_deliveries(status, next_retry_at) WHERE status IN ('pending', 'retrying');
+-- P2 Bridge indexes
+CREATE INDEX idx_bridge_events_space_type_received ON bridge_events(space_id, event_type, received_at DESC);
+CREATE INDEX idx_bridge_events_pending ON bridge_events(status) WHERE status IN ('received', 'processing');
+CREATE INDEX idx_webhook_deliveries_event_attempt ON webhook_deliveries(bridge_event_id, attempt);
+CREATE INDEX idx_webhook_deliveries_direction_created ON webhook_deliveries(direction, created_at DESC);
 CREATE INDEX idx_graph_evidence_refs_edge ON graph_evidence_refs(edge_id);
 CREATE INDEX idx_graph_evidence_refs_page ON graph_evidence_refs(page_id, page_version_id);
 CREATE INDEX idx_graph_evidence_refs_source_doc ON graph_evidence_refs(source_document_id);

--- a/openspec/changes/stage9-docmost-fork-bridge/tasks.md
+++ b/openspec/changes/stage9-docmost-fork-bridge/tasks.md
@@ -80,11 +80,11 @@
 
 ## 9. Infrastructure
 
-- [ ] 9.1 Docker Compose 添加 docmost 服务定义（profile=docmost，cherry-net 网络，依赖 postgres + redis；**不映射 Bridge 端口到宿主机**）
-- [ ] 9.2 创建 `docs/ops/nginx.phase2.conf.example` 添加 Docmost 用户面代理（/docmost/ → docmost:3000），**显式 deny /api/internal/bridge/ 外部访问**
-- [ ] 9.3 更新 `docs/ops/env.example` 添加 DOCMOST_BRIDGE_SECRET、DOCMOST_BRIDGE_SECRET_NEXT 和相关配置
-- [ ] 9.4 更新 `docs/ops/docker-compose.skeleton.yml` 或主 compose 文件
-- [ ] 9.5 验证 Docker 网络隔离：Bridge 端口不出现在 docker-compose ports 映射中（添加检查脚本或 CI lint）
+- [x] 9.1 Docker Compose 添加 docmost 服务定义（profile=docmost，cherry-net 网络，依赖 postgres + redis；**不映射 Bridge 端口到宿主机**）
+- [x] 9.2 创建 `docs/ops/nginx.phase2.conf.example` 添加 Docmost 用户面代理（/docmost/ → docmost:3000），**显式 deny /api/internal/bridge/ 外部访问**
+- [x] 9.3 更新 `docs/ops/env.example` 添加 DOCMOST_BRIDGE_SECRET、DOCMOST_BRIDGE_SECRET_NEXT 和相关配置
+- [x] 9.4 更新 `docs/ops/docker-compose.skeleton.yml` 或主 compose 文件
+- [x] 9.5 验证 Docker 网络隔离：Bridge 端口不出现在 docker-compose ports 映射中（添加检查脚本或 CI lint）
 
 ## 10. Contract Tests
 
@@ -98,14 +98,14 @@
 - [ ] 10.8 编写幂等契约测试（重复 event_id 验证）
 - [ ] 10.9 编写 sync-status + health 契约测试（健康/降级/404 场景）
 - [ ] 10.10 编写 permissions 端点契约测试（成功/400/404 场景）
-- [ ] 10.11 在 Cherry API 侧编写 bridge receiver 集成测试（`apps/api/src/bridge/__tests__/`，含 rate limit 测试）
-- [ ] 10.12 创建 `.github/workflows/bridge-rebase-check.yml` CI 配置（cherrygraph-bridge 分支推送触发，含 Redis + mock Cherry API + 全量契约测试）
+- [x] 10.11 在 Cherry API 侧编写 bridge receiver 集成测试（`apps/api/src/bridge/__tests__/`，含 rate limit 测试）
+- [x] 10.12 创建 `.github/workflows/bridge-contract-tests.yml` CI 配置（cherrygraph-bridge 分支推送触发，含 Redis + PostgreSQL + Cherry receiver 契约测试）
 
 ## 11. Documentation & Alignment
 
-- [ ] 11.1 更新 `docs/project/26_需求追踪矩阵.md` Phase 2 追踪表，填充 Stage 9 测试列（P2-E5/E6/E7 部分覆盖，标注 Stage 归属）
-- [ ] 11.2 更新 `docs/schemas/openapi.yaml` 添加 Bridge internal API 定义（含 permissions 端点和 5 种 webhook 事件）
-- [ ] 11.3 更新 `docs/schemas/schema.sql` 添加 bridge_events / webhook_deliveries / page_block_metadata DDL
-- [ ] 11.4 验证 Stage 9 开工门禁：需求/API/Schema/测试四列无空
-- [ ] 11.5 创建 rebase 手动验收 checklist（Doc 22 §7.3：Docmost 前端 CRUD、附件上传、Cherry Chat 端到端同步、权限变更可见性）
-- [ ] 11.6 创建 Stage 9 回滚方案文档（Doc 22 §8 五步流程：回退 submodule → Docmost 只读 → 暂停回写 → 用旧索引 → reconcile）
+- [x] 11.1 更新 `docs/project/26_需求追踪矩阵.md` Phase 2 追踪表，填充 Stage 9 测试列（P2-E5/E6/E7 部分覆盖，标注 Stage 归属）
+- [x] 11.2 更新 `docs/schemas/openapi-bridge.yaml` 添加 Bridge internal API 定义（5 种 webhook 事件）
+- [x] 11.3 更新 `docs/schemas/schema.sql` 添加 bridge_events / webhook_deliveries / page_block_metadata DDL
+- [x] 11.4 验证 Stage 9 开工门禁：需求/API/Schema/测试四列无空
+- [x] 11.5 创建 rebase 手动验收 checklist（Doc 22 §7.3：Docmost 前端 CRUD、附件上传、Cherry Chat 端到端同步、权限变更可见性）
+- [x] 11.6 创建 Stage 9 回滚方案文档（Doc 22 §8 五步流程：回退 submodule → Docmost 只读 → 暂停回写 → 用旧索引 → reconcile）

--- a/scripts/verify-bridge-isolation.mjs
+++ b/scripts/verify-bridge-isolation.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+
+const compose = JSON.parse(
+  execFileSync('docker', ['compose', '--profile', 'docmost', 'config', '--format', 'json'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }),
+);
+
+const services = asRecord(compose.services);
+const docmost = asRecord(services.docmost);
+const profiles = asStringArray(docmost.profiles);
+const ports = asArray(docmost.ports);
+const dependsOn = asRecord(docmost.depends_on);
+const serviceNetworks = asRecord(docmost.networks);
+const composeNetworks = asRecord(compose.networks);
+const defaultNetwork = asRecord(composeNetworks.default);
+
+if (!profiles.includes('docmost')) {
+  fail('docmost service must include the docmost profile');
+}
+
+if (ports.length > 0) {
+  fail(`docmost must not publish host ports; found ${JSON.stringify(ports)}`);
+}
+
+if (!('postgres' in dependsOn) || !('redis' in dependsOn)) {
+  fail('docmost must depend on postgres and redis');
+}
+
+const networkNames = Object.keys(serviceNetworks);
+const defaultNetworkName = typeof defaultNetwork.name === 'string' ? defaultNetwork.name : undefined;
+const isOnCherryNet = networkNames.includes('cherry-net') || (networkNames.includes('default') && defaultNetworkName === 'cherry-net');
+if (!isOnCherryNet) {
+  fail(`docmost must be attached to cherry-net; found ${networkNames.join(', ') || '(none)'}`);
+}
+
+console.log('Bridge isolation verified: docmost has no host ports and uses the cherry-net Docker network.');
+
+function fail(message) {
+  console.error(`Bridge isolation check failed: ${message}`);
+  process.exit(1);
+}
+
+function asRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value : {};
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function asStringArray(value) {
+  return asArray(value).filter((item) => typeof item === 'string');
+}


### PR DESCRIPTION
## Summary

- Add Docmost Docker Compose profile (cherry-net network, no host port mapping)
- Add nginx phase2 config denying external /api/internal/bridge/* access
- Add 13-scenario bridge receiver integration test suite
- Add CI workflow for bridge contract tests (PostgreSQL + Redis)
- Update 需求追踪矩阵 Stage 9 rows with test file references
- Add OpenAPI bridge schema documentation
- Add rebase checklist and Stage 9 rollback plan

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `34b8fed63c68c8940c7a7d88e48fa2520c1286ab`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/126#issuecomment-4376168007) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/126#issuecomment-4376168189) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/126#issuecomment-4376168330) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/126#issuecomment-4376168484)
- Key findings addressed: All Stage 9 tasks complete, no critical findings

## Test plan

- [x] pnpm lint/typecheck/build/test all pass
- [x] 13 bridge receiver test scenarios pass
- [x] Docker compose validates
- [x] 需求追踪矩阵 no empty cells