### PR TITLE
feat(sync): schema fixes + wiki-sync-worker scaffold + BullMQ event dispatch (#128)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^11.1.19",
     "@nestjs/platform-fastify": "^11.1.19",
     "@nestjs/schedule": "^6.1.3",
+    "bullmq": "^5.76.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "drizzle-orm": "^0.45.2",

--- a/apps/api/src/bridge/__tests__/bridge-event-dispatch.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-event-dispatch.test.ts
@@ -1,4 +1,9 @@
-import { bridgeEvents, type BridgeEventType, type BridgeWebhookPayload } from '@cherrygraph/shared';
+import {
+  bridgeEvents,
+  type BridgeEventStatus,
+  type BridgeEventType,
+  type BridgeWebhookPayload,
+} from '@cherrygraph/shared';
 import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -23,7 +28,21 @@ describe('BridgeEventService queue dispatch', () => {
     });
   });
 
-  it('does not enqueue another job for a deduplicated event', async () => {
+  it('does not enqueue another job for a deduplicated event that is already processed', async () => {
+    const db = new InMemoryBridgeDatabase();
+    const queue = createBridgeQueueMock();
+    const service = new BridgeEventService(db.asDb() as never, queue);
+    const eventId = randomUUID();
+
+    await service.receiveEvent(createPayload('page.saved', { event_id: eventId }));
+    db.setEventStatus(eventId, 'processed');
+    const result = await service.receiveEvent(createPayload('page.saved', { event_id: eventId }));
+
+    expect(result.deduplicated).toBe(true);
+    expect(queue.enqueueBridgeJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-enqueues on duplicate if event is not yet processed', async () => {
     const db = new InMemoryBridgeDatabase();
     const queue = createBridgeQueueMock();
     const service = new BridgeEventService(db.asDb() as never, queue);
@@ -33,7 +52,14 @@ describe('BridgeEventService queue dispatch', () => {
     const result = await service.receiveEvent(createPayload('page.saved', { event_id: eventId }));
 
     expect(result.deduplicated).toBe(true);
-    expect(queue.enqueueBridgeJob).toHaveBeenCalledTimes(1);
+    expect(queue.enqueueBridgeJob).toHaveBeenCalledTimes(2);
+    expect(queue.enqueueBridgeJob).toHaveBeenLastCalledWith('page.saved', {
+      bridgeEventId: expect.any(String),
+      eventId,
+      eventType: 'page.saved',
+      spaceId: 'space-1',
+      pageId: 'page-1',
+    });
   });
 });
 
@@ -43,6 +69,7 @@ type StoredBridgeEvent = {
   event_type: string;
   space_id: string | null;
   page_id: string | null;
+  status: BridgeEventStatus;
 };
 
 class InMemoryBridgeDatabase {
@@ -73,6 +100,7 @@ class InMemoryBridgeDatabase {
             event_type: requireString(value.event_type, 'event_type'),
             space_id: nullableString(value.space_id),
             page_id: nullableString(value.page_id),
+            status: requireBridgeEventStatus(value.status),
           };
           this.eventsByEventId.set(event.event_id, event);
 
@@ -102,6 +130,15 @@ class InMemoryBridgeDatabase {
 
   asDb(): unknown {
     return this;
+  }
+
+  setEventStatus(eventId: string, status: BridgeEventStatus): void {
+    const event = this.eventsByEventId.get(eventId);
+    if (event === undefined) {
+      throw new Error(`Expected event ${eventId} to exist`);
+    }
+
+    this.eventsByEventId.set(eventId, { ...event, status });
   }
 }
 
@@ -135,4 +172,17 @@ function requireString(value: unknown, fieldName: string): string {
 
 function nullableString(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
+}
+
+function requireBridgeEventStatus(value: unknown): BridgeEventStatus {
+  if (
+    value === 'received' ||
+    value === 'processing' ||
+    value === 'processed' ||
+    value === 'failed'
+  ) {
+    return value;
+  }
+
+  throw new Error('Expected bridge event status');
 }

--- a/apps/api/src/bridge/__tests__/bridge-event-dispatch.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-event-dispatch.test.ts
@@ -13,24 +13,25 @@ import type { BridgeQueueService } from '../bridge-queue.service.js';
 describe('BridgeEventService queue dispatch', () => {
   it('enqueues a BullMQ job after a bridge event is persisted', async () => {
     const db = new InMemoryBridgeDatabase();
-    const queue = createBridgeQueueMock();
+    const enqueueSpy = vi.fn(() => Promise.resolve());
+    const queue = createBridgeQueueMock(enqueueSpy);
     const service = new BridgeEventService(db.asDb() as never, queue);
     const payload = createPayload('page.saved');
 
     await service.receiveEvent(payload);
 
-    expect(queue.enqueueBridgeJob).toHaveBeenCalledWith('page.saved', {
-      bridgeEventId: expect.any(String),
+    expect(enqueueSpy).toHaveBeenCalledWith('page.saved', expect.objectContaining({
       eventId: payload.event_id,
       eventType: 'page.saved',
       spaceId: 'space-1',
       pageId: 'page-1',
-    });
+    }));
   });
 
   it('does not enqueue another job for a deduplicated event that is already processed', async () => {
     const db = new InMemoryBridgeDatabase();
-    const queue = createBridgeQueueMock();
+    const enqueueSpy = vi.fn(() => Promise.resolve());
+    const queue = createBridgeQueueMock(enqueueSpy);
     const service = new BridgeEventService(db.asDb() as never, queue);
     const eventId = randomUUID();
 
@@ -39,12 +40,13 @@ describe('BridgeEventService queue dispatch', () => {
     const result = await service.receiveEvent(createPayload('page.saved', { event_id: eventId }));
 
     expect(result.deduplicated).toBe(true);
-    expect(queue.enqueueBridgeJob).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
   });
 
   it('re-enqueues on duplicate if event is not yet processed', async () => {
     const db = new InMemoryBridgeDatabase();
-    const queue = createBridgeQueueMock();
+    const enqueueSpy = vi.fn(() => Promise.resolve());
+    const queue = createBridgeQueueMock(enqueueSpy);
     const service = new BridgeEventService(db.asDb() as never, queue);
     const eventId = randomUUID();
 
@@ -52,14 +54,13 @@ describe('BridgeEventService queue dispatch', () => {
     const result = await service.receiveEvent(createPayload('page.saved', { event_id: eventId }));
 
     expect(result.deduplicated).toBe(true);
-    expect(queue.enqueueBridgeJob).toHaveBeenCalledTimes(2);
-    expect(queue.enqueueBridgeJob).toHaveBeenLastCalledWith('page.saved', {
-      bridgeEventId: expect.any(String),
+    expect(enqueueSpy).toHaveBeenCalledTimes(2);
+    expect(enqueueSpy).toHaveBeenLastCalledWith('page.saved', expect.objectContaining({
       eventId,
       eventType: 'page.saved',
       spaceId: 'space-1',
       pageId: 'page-1',
-    });
+    }));
   });
 });
 
@@ -142,9 +143,9 @@ class InMemoryBridgeDatabase {
   }
 }
 
-function createBridgeQueueMock(): BridgeQueueService {
+function createBridgeQueueMock(enqueueSpy: ReturnType<typeof vi.fn>): BridgeQueueService {
   return {
-    enqueueBridgeJob: vi.fn(() => Promise.resolve()),
+    enqueueBridgeJob: enqueueSpy,
   } as unknown as BridgeQueueService;
 }
 

--- a/apps/api/src/bridge/__tests__/bridge-event-dispatch.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-event-dispatch.test.ts
@@ -1,0 +1,138 @@
+import { bridgeEvents, type BridgeEventType, type BridgeWebhookPayload } from '@cherrygraph/shared';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BridgeEventService } from '../bridge-event.service.js';
+import type { BridgeQueueService } from '../bridge-queue.service.js';
+
+describe('BridgeEventService queue dispatch', () => {
+  it('enqueues a BullMQ job after a bridge event is persisted', async () => {
+    const db = new InMemoryBridgeDatabase();
+    const queue = createBridgeQueueMock();
+    const service = new BridgeEventService(db.asDb() as never, queue);
+    const payload = createPayload('page.saved');
+
+    await service.receiveEvent(payload);
+
+    expect(queue.enqueueBridgeJob).toHaveBeenCalledWith('page.saved', {
+      bridgeEventId: expect.any(String),
+      eventId: payload.event_id,
+      eventType: 'page.saved',
+      spaceId: 'space-1',
+      pageId: 'page-1',
+    });
+  });
+
+  it('does not enqueue another job for a deduplicated event', async () => {
+    const db = new InMemoryBridgeDatabase();
+    const queue = createBridgeQueueMock();
+    const service = new BridgeEventService(db.asDb() as never, queue);
+    const eventId = randomUUID();
+
+    await service.receiveEvent(createPayload('page.saved', { event_id: eventId }));
+    const result = await service.receiveEvent(createPayload('page.saved', { event_id: eventId }));
+
+    expect(result.deduplicated).toBe(true);
+    expect(queue.enqueueBridgeJob).toHaveBeenCalledTimes(1);
+  });
+});
+
+type StoredBridgeEvent = {
+  id: string;
+  event_id: string;
+  event_type: string;
+  space_id: string | null;
+  page_id: string | null;
+};
+
+class InMemoryBridgeDatabase {
+  private readonly eventsByEventId = new Map<string, StoredBridgeEvent>();
+  private pendingLookupEventId: string | undefined;
+
+  insert(table: unknown): unknown {
+    if (table !== bridgeEvents) {
+      throw new Error('Unexpected insert table');
+    }
+
+    return {
+      values: (value: Record<string, unknown>) => ({
+        returning: (): Promise<StoredBridgeEvent[]> => {
+          const eventId = requireString(value.event_id, 'event_id');
+          const existing = this.eventsByEventId.get(eventId);
+          if (existing !== undefined) {
+            this.pendingLookupEventId = eventId;
+            throw Object.assign(new Error('duplicate bridge event_id'), {
+              code: '23505',
+              constraint: 'bridge_events_event_id_unique',
+            });
+          }
+
+          const event = {
+            id: requireString(value.id, 'id'),
+            event_id: eventId,
+            event_type: requireString(value.event_type, 'event_type'),
+            space_id: nullableString(value.space_id),
+            page_id: nullableString(value.page_id),
+          };
+          this.eventsByEventId.set(event.event_id, event);
+
+          return Promise.resolve([event]);
+        },
+      }),
+    };
+  }
+
+  select(): unknown {
+    return {
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: (): Promise<StoredBridgeEvent[]> => {
+            if (table !== bridgeEvents || this.pendingLookupEventId === undefined) {
+              return Promise.resolve([]);
+            }
+
+            const event = this.eventsByEventId.get(this.pendingLookupEventId);
+            this.pendingLookupEventId = undefined;
+            return Promise.resolve(event === undefined ? [] : [event]);
+          },
+        }),
+      }),
+    };
+  }
+
+  asDb(): unknown {
+    return this;
+  }
+}
+
+function createBridgeQueueMock(): BridgeQueueService {
+  return {
+    enqueueBridgeJob: vi.fn(() => Promise.resolve()),
+  } as unknown as BridgeQueueService;
+}
+
+function createPayload(
+  eventType: BridgeEventType,
+  overrides: Partial<BridgeWebhookPayload> = {},
+): BridgeWebhookPayload {
+  return {
+    event_id: randomUUID(),
+    event_type: eventType,
+    timestamp: Math.floor(Date.now() / 1000),
+    space_id: 'space-1',
+    page_id: 'page-1',
+    ...overrides,
+  };
+}
+
+function requireString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Expected ${fieldName} to be a string`);
+  }
+
+  return value;
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}

--- a/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
@@ -1,0 +1,119 @@
+import type { BridgeEventType } from '@cherrygraph/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BRIDGE_ATTACHMENT_SYNC_QUEUE,
+  BRIDGE_PAGE_SYNC_QUEUE,
+  BRIDGE_PERMISSION_SYNC_QUEUE,
+  BridgeQueueService,
+} from '../bridge-queue.service.js';
+
+type QueueMock = {
+  name: string;
+  add: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+const queueMockState = vi.hoisted(() => {
+  const state = {
+    instances: [] as QueueMock[],
+  };
+
+  return {
+    state,
+    Queue: vi.fn(function Queue(name: string) {
+      const queue = {
+        name,
+        add: vi.fn(() => Promise.resolve()),
+        close: vi.fn(() => Promise.resolve()),
+      };
+      state.instances.push(queue);
+      return queue;
+    }),
+  };
+});
+
+vi.mock('bullmq', () => ({
+  Queue: queueMockState.Queue,
+}));
+
+describe('BridgeQueueService', () => {
+  afterEach(() => {
+    queueMockState.state.instances.length = 0;
+    queueMockState.Queue.mockClear();
+  });
+
+  it('routes page.saved events to bridge:page-sync', async () => {
+    const service = createService();
+    const jobData = createJobData('page.saved');
+
+    await service.enqueueBridgeJob('page.saved', jobData);
+
+    expect(queueByName(BRIDGE_PAGE_SYNC_QUEUE).add).toHaveBeenCalledWith('page.saved', jobData, {
+      jobId: 'event-1',
+    });
+  });
+
+  it('routes space.updated events to bridge:permission-sync', async () => {
+    const service = createService();
+    const jobData = createJobData('space.updated');
+
+    await service.enqueueBridgeJob('space.updated', jobData);
+
+    expect(queueByName(BRIDGE_PERMISSION_SYNC_QUEUE).add).toHaveBeenCalledWith('space.updated', jobData, {
+      jobId: 'event-1',
+    });
+  });
+
+  it.each(['attachment.created', 'attachment.deleted'] as const)(
+    'routes %s events to bridge:attachment-sync',
+    async (eventType) => {
+      const service = createService();
+      const jobData = createJobData(eventType);
+
+      await service.enqueueBridgeJob(eventType, jobData);
+
+      expect(queueByName(BRIDGE_ATTACHMENT_SYNC_QUEUE).add).toHaveBeenCalledWith(eventType, jobData, {
+        jobId: 'event-1',
+      });
+    },
+  );
+
+  it('uses event_id as the BullMQ jobId for deduplication', async () => {
+    const service = createService();
+    const jobData = createJobData('page.deleted', { eventId: 'docmost-event-42' });
+
+    await service.enqueueBridgeJob('page.deleted', jobData);
+
+    expect(queueByName(BRIDGE_PAGE_SYNC_QUEUE).add).toHaveBeenCalledWith('page.deleted', jobData, {
+      jobId: 'docmost-event-42',
+    });
+  });
+});
+
+function createService(): BridgeQueueService {
+  return new BridgeQueueService({} as never);
+}
+
+function createJobData(
+  eventType: BridgeEventType,
+  overrides: Partial<Parameters<BridgeQueueService['enqueueBridgeJob']>[1]> = {},
+): Parameters<BridgeQueueService['enqueueBridgeJob']>[1] {
+  return {
+    bridgeEventId: 'bridge-event-1',
+    eventId: 'event-1',
+    eventType,
+    spaceId: 'space-1',
+    pageId: 'page-1',
+    ...overrides,
+  };
+}
+
+function queueByName(name: string): QueueMock {
+  const queue = queueMockState.state.instances.find((instance) => instance.name === name);
+  if (queue === undefined) {
+    throw new Error(`Queue ${name} was not created`);
+  }
+
+  return queue;
+}

--- a/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
@@ -48,7 +48,7 @@ describe('BridgeQueueService', () => {
     vi.restoreAllMocks();
   });
 
-  it('routes page.saved events to bridge:page-sync', async () => {
+  it('routes page.saved events to bridge-page-sync', async () => {
     const service = createService();
     const jobData = createJobData('page.saved');
 
@@ -59,7 +59,7 @@ describe('BridgeQueueService', () => {
     });
   });
 
-  it('routes space.updated events to bridge:permission-sync', async () => {
+  it('routes space.updated events to bridge-permission-sync', async () => {
     const service = createService();
     const jobData = createJobData('space.updated');
 
@@ -71,7 +71,7 @@ describe('BridgeQueueService', () => {
   });
 
   it.each(['attachment.created', 'attachment.deleted'] as const)(
-    'routes %s events to bridge:attachment-sync',
+    'routes %s events to bridge-attachment-sync',
     async (eventType) => {
       const service = createService();
       const jobData = createJobData(eventType);

--- a/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
@@ -1,6 +1,7 @@
 import type { BridgeEventType } from '@cherrygraph/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { getApiLogger } from '../../common/logger/logger.module.js';
 import {
   BRIDGE_ATTACHMENT_SYNC_QUEUE,
   BRIDGE_PAGE_SYNC_QUEUE,
@@ -38,9 +39,13 @@ vi.mock('bullmq', () => ({
 }));
 
 describe('BridgeQueueService', () => {
+  const originalRedisUrl = process.env.REDIS_URL;
+
   afterEach(() => {
     queueMockState.state.instances.length = 0;
     queueMockState.Queue.mockClear();
+    restoreRedisUrl(originalRedisUrl);
+    vi.restoreAllMocks();
   });
 
   it('routes page.saved events to bridge:page-sync', async () => {
@@ -89,6 +94,21 @@ describe('BridgeQueueService', () => {
       jobId: 'docmost-event-42',
     });
   });
+
+  it('skips enqueue when Redis is not configured', async () => {
+    delete process.env.REDIS_URL;
+    const warn = vi.spyOn(getApiLogger(), 'warn').mockImplementation(() => undefined);
+    const service = new BridgeQueueService();
+    const jobData = createJobData('page.saved');
+
+    await service.enqueueBridgeJob('page.saved', jobData);
+
+    expect(queueMockState.Queue).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      { redis_configured: false },
+      'BullMQ dispatch disabled — no Redis configured',
+    );
+  });
 });
 
 function createService(): BridgeQueueService {
@@ -116,4 +136,13 @@ function queueByName(name: string): QueueMock {
   }
 
   return queue;
+}
+
+function restoreRedisUrl(value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env.REDIS_URL;
+    return;
+  }
+
+  process.env.REDIS_URL = value;
 }

--- a/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
@@ -6,6 +6,7 @@ import {
   ErrorCode,
   bridgeEvents,
   webhookDeliveries,
+  type BridgeEventStatus,
   type BridgeEventType,
   type BridgeWebhookPayload,
 } from '@cherrygraph/shared';
@@ -309,6 +310,7 @@ type StoredBridgeEvent = {
   event_type: string;
   space_id: string | null;
   page_id: string | null;
+  status: BridgeEventStatus;
 };
 
 class InMemoryBridgeDatabase {
@@ -337,6 +339,7 @@ class InMemoryBridgeDatabase {
               event_type: requireString(value.event_type, 'event_type'),
               space_id: nullableString(value.space_id),
               page_id: nullableString(value.page_id),
+              status: requireBridgeEventStatus(value.status),
             };
             this.eventsByEventId.set(event.event_id, event);
 
@@ -391,6 +394,14 @@ function requireString(value: unknown, fieldName: string): string {
 
 function nullableString(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
+}
+
+function requireBridgeEventStatus(value: unknown): BridgeEventStatus {
+  if (value === 'received' || value === 'processing' || value === 'processed' || value === 'failed') {
+    return value;
+  }
+
+  throw new Error('Expected bridge event status');
 }
 
 class InMemoryBridgeRedis {

--- a/apps/api/src/bridge/bridge-event.service.ts
+++ b/apps/api/src/bridge/bridge-event.service.ts
@@ -3,6 +3,7 @@ import { bridgeEvents, type BridgeEventType, type BridgeWebhookPayload, webhookD
 import { eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 
+import { getApiLogger } from '../common/logger/logger.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import type { DrizzleDatabase } from '../database/drizzle.module.js';
 import { BridgeQueueService } from './bridge-queue.service.js';
@@ -34,6 +35,7 @@ type BridgeEventRow = {
   event_type: string;
   space_id: string | null;
   page_id: string | null;
+  status: string;
 };
 
 @Injectable()
@@ -71,13 +73,21 @@ export class BridgeEventService {
           event_type: bridgeEvents.event_type,
           space_id: bridgeEvents.space_id,
           page_id: bridgeEvents.page_id,
+          status: bridgeEvents.status,
         });
 
       if (event === undefined) {
         throw new Error('Failed to persist bridge event');
       }
 
-      await this.bridgeQueueService?.enqueueBridgeJob(event.event_type as BridgeEventType, toBridgeQueueJobData(event));
+      try {
+        await this.bridgeQueueService?.enqueueBridgeJob(event.event_type as BridgeEventType, toBridgeQueueJobData(event));
+      } catch (enqueueError) {
+        getApiLogger().error(
+          { err: enqueueError, event_id: event.event_id, bridge_event_id: event.id },
+          'Failed to enqueue bridge event after persist — reconciliation will recover',
+        );
+      }
 
       return toReceiveResult(event, false);
     } catch (err) {
@@ -88,6 +98,20 @@ export class BridgeEventService {
       const event = await this.findEventByEventId(payload.event_id);
       if (event === undefined) {
         throw err;
+      }
+
+      if (event.status !== 'processed') {
+        try {
+          await this.bridgeQueueService?.enqueueBridgeJob(
+            event.event_type as BridgeEventType,
+            toBridgeQueueJobData(event),
+          );
+        } catch (enqueueError) {
+          getApiLogger().error(
+            { err: enqueueError, event_id: event.event_id, bridge_event_id: event.id },
+            'Failed to re-enqueue deduplicated bridge event',
+          );
+        }
       }
 
       return toReceiveResult(event, true);
@@ -114,6 +138,7 @@ export class BridgeEventService {
         event_type: bridgeEvents.event_type,
         space_id: bridgeEvents.space_id,
         page_id: bridgeEvents.page_id,
+        status: bridgeEvents.status,
       })
       .from(bridgeEvents)
       .where(eq(bridgeEvents.event_id, eventId))

--- a/apps/api/src/bridge/bridge-event.service.ts
+++ b/apps/api/src/bridge/bridge-event.service.ts
@@ -1,10 +1,11 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 import { bridgeEvents, type BridgeEventType, type BridgeWebhookPayload, webhookDeliveries } from '@cherrygraph/shared';
 import { eq } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import type { DrizzleDatabase } from '../database/drizzle.module.js';
+import { BridgeQueueService } from './bridge-queue.service.js';
 
 export type ReceiveBridgeEventMetadata = {
   nonce?: string | undefined;
@@ -37,7 +38,10 @@ type BridgeEventRow = {
 
 @Injectable()
 export class BridgeEventService {
-  constructor(@Inject(DRIZZLE) private readonly db: DrizzleDatabase) {}
+  constructor(
+    @Inject(DRIZZLE) private readonly db: DrizzleDatabase,
+    @Optional() private readonly bridgeQueueService?: BridgeQueueService,
+  ) {}
 
   async receiveEvent(
     payload: BridgeWebhookPayload,
@@ -72,6 +76,8 @@ export class BridgeEventService {
       if (event === undefined) {
         throw new Error('Failed to persist bridge event');
       }
+
+      await this.bridgeQueueService?.enqueueBridgeJob(event.event_type as BridgeEventType, toBridgeQueueJobData(event));
 
       return toReceiveResult(event, false);
     } catch (err) {
@@ -126,6 +132,22 @@ function toReceiveResult(event: BridgeEventRow, deduplicated: boolean): ReceiveB
     bridge_event_id: event.id,
     ...(event.space_id !== null ? { space_id: event.space_id } : {}),
     ...(event.page_id !== null ? { page_id: event.page_id } : {}),
+  };
+}
+
+function toBridgeQueueJobData(event: BridgeEventRow): {
+  bridgeEventId: string;
+  eventId: string;
+  eventType: BridgeEventType;
+  spaceId?: string;
+  pageId?: string;
+} {
+  return {
+    bridgeEventId: event.id,
+    eventId: event.event_id,
+    eventType: event.event_type as BridgeEventType,
+    ...(event.space_id !== null ? { spaceId: event.space_id } : {}),
+    ...(event.page_id !== null ? { pageId: event.page_id } : {}),
   };
 }
 

--- a/apps/api/src/bridge/bridge-queue.service.ts
+++ b/apps/api/src/bridge/bridge-queue.service.ts
@@ -7,10 +7,10 @@ import type { BridgeEventType } from '@cherrygraph/shared';
 import { getApiLogger } from '../common/logger/logger.module.js';
 import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
 
-export const BRIDGE_PAGE_SYNC_QUEUE = 'bridge:page-sync';
-export const BRIDGE_PERMISSION_SYNC_QUEUE = 'bridge:permission-sync';
-export const BRIDGE_ATTACHMENT_SYNC_QUEUE = 'bridge:attachment-sync';
-export const BRIDGE_DOCMOST_PUSH_QUEUE = 'bridge:docmost-push';
+export const BRIDGE_PAGE_SYNC_QUEUE = 'bridge-page-sync';
+export const BRIDGE_PERMISSION_SYNC_QUEUE = 'bridge-permission-sync';
+export const BRIDGE_ATTACHMENT_SYNC_QUEUE = 'bridge-attachment-sync';
+export const BRIDGE_DOCMOST_PUSH_QUEUE = 'bridge-docmost-push';
 
 export type BridgeQueueName =
   | typeof BRIDGE_PAGE_SYNC_QUEUE

--- a/apps/api/src/bridge/bridge-queue.service.ts
+++ b/apps/api/src/bridge/bridge-queue.service.ts
@@ -4,6 +4,7 @@ import { Redis, type Redis as IORedis } from 'ioredis';
 
 import type { BridgeEventType } from '@cherrygraph/shared';
 
+import { getApiLogger } from '../common/logger/logger.module.js';
 import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
 
 export const BRIDGE_PAGE_SYNC_QUEUE = 'bridge:page-sync';
@@ -37,51 +38,92 @@ const DEFAULT_JOB_OPTIONS: JobsOptions = {
     type: 'exponential',
     delay: 5_000,
   },
+  removeOnComplete: { count: 1000, age: 86_400 },
+  removeOnFail: { count: 5000, age: 604_800 },
 };
 
 @Injectable()
 export class BridgeQueueService implements OnModuleDestroy {
-  private readonly connection: IORedis;
+  private readonly connection?: IORedis;
   private readonly ownsConnection: boolean;
-  private readonly queues: Record<BridgeQueueName, Queue<BridgeQueueJobData | DocmostPushJobData>>;
+  private readonly disabled: boolean;
+  private readonly queues: Partial<
+    Record<BridgeQueueName, Queue<BridgeQueueJobData | DocmostPushJobData>>
+  >;
 
   constructor(@Optional() @Inject(REDIS_CLIENT) redis?: OptionalRedisClient) {
-    this.connection = redis ?? new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
-      lazyConnect: true,
-      maxRetriesPerRequest: null,
-    });
-    this.ownsConnection = redis === undefined;
+    const redisUrl = process.env.REDIS_URL;
+    if (redis == null && (redisUrl === undefined || redisUrl.length === 0)) {
+      this.disabled = true;
+      this.ownsConnection = false;
+      this.queues = {};
+      return;
+    }
+
+    this.disabled = false;
+    const connection =
+      redis ??
+      new Redis(redisUrl as string, {
+        lazyConnect: true,
+        maxRetriesPerRequest: null,
+      });
+    this.connection = connection;
+    this.ownsConnection = redis == null;
     this.queues = {
       [BRIDGE_PAGE_SYNC_QUEUE]: new Queue(BRIDGE_PAGE_SYNC_QUEUE, {
-        connection: this.connection,
+        connection,
         defaultJobOptions: DEFAULT_JOB_OPTIONS,
       }),
       [BRIDGE_PERMISSION_SYNC_QUEUE]: new Queue(BRIDGE_PERMISSION_SYNC_QUEUE, {
-        connection: this.connection,
+        connection,
         defaultJobOptions: DEFAULT_JOB_OPTIONS,
       }),
       [BRIDGE_ATTACHMENT_SYNC_QUEUE]: new Queue(BRIDGE_ATTACHMENT_SYNC_QUEUE, {
-        connection: this.connection,
+        connection,
         defaultJobOptions: DEFAULT_JOB_OPTIONS,
       }),
       [BRIDGE_DOCMOST_PUSH_QUEUE]: new Queue(BRIDGE_DOCMOST_PUSH_QUEUE, {
-        connection: this.connection,
+        connection,
         defaultJobOptions: DEFAULT_JOB_OPTIONS,
       }),
     };
   }
 
   async enqueueBridgeJob(eventType: BridgeEventType, jobData: BridgeQueueJobData): Promise<void> {
+    if (this.disabled) {
+      getApiLogger().warn(
+        { redis_configured: false },
+        'BullMQ dispatch disabled — no Redis configured',
+      );
+      return;
+    }
+
     const queueName = resolveBridgeQueueName(eventType);
-    await this.queues[queueName].add(eventType, jobData, { jobId: jobData.eventId });
+    await this.getQueue(queueName).add(eventType, jobData, { jobId: jobData.eventId });
   }
 
   async enqueueDocmostPushJob(jobData: DocmostPushJobData): Promise<void> {
-    await this.queues[BRIDGE_DOCMOST_PUSH_QUEUE].add('docmost.push', jobData, { jobId: jobData.runId });
+    if (this.disabled) {
+      getApiLogger().warn(
+        { redis_configured: false },
+        'BullMQ dispatch disabled — no Redis configured',
+      );
+      return;
+    }
+
+    await this.getQueue(BRIDGE_DOCMOST_PUSH_QUEUE).add('docmost.push', jobData, {
+      jobId: jobData.runId,
+    });
   }
 
   async onModuleDestroy(): Promise<void> {
-    const results = await Promise.allSettled(Object.values(this.queues).map((queue) => queue.close()));
+    if (this.disabled) {
+      return;
+    }
+
+    const results = await Promise.allSettled(
+      Object.values(this.queues).map((queue) => queue.close()),
+    );
     for (const result of results) {
       if (result.status === 'rejected') {
         throw result.reason;
@@ -89,8 +131,17 @@ export class BridgeQueueService implements OnModuleDestroy {
     }
 
     if (this.ownsConnection) {
-      this.connection.disconnect();
+      this.connection?.disconnect();
     }
+  }
+
+  private getQueue(queueName: BridgeQueueName): Queue<BridgeQueueJobData | DocmostPushJobData> {
+    const queue = this.queues[queueName];
+    if (queue === undefined) {
+      throw new Error(`Bridge queue is not initialized: ${queueName}`);
+    }
+
+    return queue;
   }
 }
 

--- a/apps/api/src/bridge/bridge-queue.service.ts
+++ b/apps/api/src/bridge/bridge-queue.service.ts
@@ -1,0 +1,107 @@
+import { Inject, Injectable, Optional, type OnModuleDestroy } from '@nestjs/common';
+import { Queue, type JobsOptions } from 'bullmq';
+import { Redis, type Redis as IORedis } from 'ioredis';
+
+import type { BridgeEventType } from '@cherrygraph/shared';
+
+import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
+
+export const BRIDGE_PAGE_SYNC_QUEUE = 'bridge:page-sync';
+export const BRIDGE_PERMISSION_SYNC_QUEUE = 'bridge:permission-sync';
+export const BRIDGE_ATTACHMENT_SYNC_QUEUE = 'bridge:attachment-sync';
+export const BRIDGE_DOCMOST_PUSH_QUEUE = 'bridge:docmost-push';
+
+export type BridgeQueueName =
+  | typeof BRIDGE_PAGE_SYNC_QUEUE
+  | typeof BRIDGE_PERMISSION_SYNC_QUEUE
+  | typeof BRIDGE_ATTACHMENT_SYNC_QUEUE
+  | typeof BRIDGE_DOCMOST_PUSH_QUEUE;
+
+export type BridgeQueueJobData = {
+  bridgeEventId: string;
+  eventId: string;
+  eventType: BridgeEventType;
+  spaceId?: string;
+  pageId?: string;
+};
+
+export type DocmostPushJobData = {
+  runId: string;
+  spaceId: string;
+  tenantId: string;
+};
+
+const DEFAULT_JOB_OPTIONS: JobsOptions = {
+  attempts: 3,
+  backoff: {
+    type: 'exponential',
+    delay: 5_000,
+  },
+};
+
+@Injectable()
+export class BridgeQueueService implements OnModuleDestroy {
+  private readonly connection: IORedis;
+  private readonly ownsConnection: boolean;
+  private readonly queues: Record<BridgeQueueName, Queue<BridgeQueueJobData | DocmostPushJobData>>;
+
+  constructor(@Optional() @Inject(REDIS_CLIENT) redis?: OptionalRedisClient) {
+    this.connection = redis ?? new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
+      lazyConnect: true,
+      maxRetriesPerRequest: null,
+    });
+    this.ownsConnection = redis === undefined;
+    this.queues = {
+      [BRIDGE_PAGE_SYNC_QUEUE]: new Queue(BRIDGE_PAGE_SYNC_QUEUE, {
+        connection: this.connection,
+        defaultJobOptions: DEFAULT_JOB_OPTIONS,
+      }),
+      [BRIDGE_PERMISSION_SYNC_QUEUE]: new Queue(BRIDGE_PERMISSION_SYNC_QUEUE, {
+        connection: this.connection,
+        defaultJobOptions: DEFAULT_JOB_OPTIONS,
+      }),
+      [BRIDGE_ATTACHMENT_SYNC_QUEUE]: new Queue(BRIDGE_ATTACHMENT_SYNC_QUEUE, {
+        connection: this.connection,
+        defaultJobOptions: DEFAULT_JOB_OPTIONS,
+      }),
+      [BRIDGE_DOCMOST_PUSH_QUEUE]: new Queue(BRIDGE_DOCMOST_PUSH_QUEUE, {
+        connection: this.connection,
+        defaultJobOptions: DEFAULT_JOB_OPTIONS,
+      }),
+    };
+  }
+
+  async enqueueBridgeJob(eventType: BridgeEventType, jobData: BridgeQueueJobData): Promise<void> {
+    const queueName = resolveBridgeQueueName(eventType);
+    await this.queues[queueName].add(eventType, jobData, { jobId: jobData.eventId });
+  }
+
+  async enqueueDocmostPushJob(jobData: DocmostPushJobData): Promise<void> {
+    await this.queues[BRIDGE_DOCMOST_PUSH_QUEUE].add('docmost.push', jobData, { jobId: jobData.runId });
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    const results = await Promise.allSettled(Object.values(this.queues).map((queue) => queue.close()));
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        throw result.reason;
+      }
+    }
+
+    if (this.ownsConnection) {
+      this.connection.disconnect();
+    }
+  }
+}
+
+export function resolveBridgeQueueName(eventType: BridgeEventType): BridgeQueueName {
+  if (eventType === 'page.saved' || eventType === 'page.deleted') {
+    return BRIDGE_PAGE_SYNC_QUEUE;
+  }
+
+  if (eventType === 'space.updated') {
+    return BRIDGE_PERMISSION_SYNC_QUEUE;
+  }
+
+  return BRIDGE_ATTACHMENT_SYNC_QUEUE;
+}

--- a/apps/api/src/bridge/bridge.module.ts
+++ b/apps/api/src/bridge/bridge.module.ts
@@ -4,11 +4,13 @@ import { AuditModule } from '../audit/audit.module.js';
 import { BridgeAuthGuard } from './bridge-auth.guard.js';
 import { BridgeEventController } from './bridge-event.controller.js';
 import { BridgeEventService } from './bridge-event.service.js';
+import { BridgeQueueService } from './bridge-queue.service.js';
 import { BridgeRateLimitGuard } from './bridge-rate-limit.guard.js';
 
 @Module({
   imports: [AuditModule],
   controllers: [BridgeEventController],
-  providers: [BridgeAuthGuard, BridgeRateLimitGuard, BridgeEventService],
+  providers: [BridgeAuthGuard, BridgeRateLimitGuard, BridgeEventService, BridgeQueueService],
+  exports: [BridgeQueueService],
 })
 export class BridgeModule {}

--- a/apps/api/src/internal/__tests__/graphify-docmost-push.test.ts
+++ b/apps/api/src/internal/__tests__/graphify-docmost-push.test.ts
@@ -12,6 +12,7 @@ import { graphifyRuns } from '@cherrygraph/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { BridgeQueueService } from '../../bridge/bridge-queue.service.js';
+import { getApiLogger } from '../../common/logger/logger.module.js';
 import { InternalJobsService } from '../internal-jobs.service.js';
 
 describe('Graphify completion docmost push dispatch', () => {
@@ -29,7 +30,7 @@ describe('Graphify completion docmost push dispatch', () => {
     });
   });
 
-  it('transitions the run from succeeded to docmost_syncing before enqueue', async () => {
+  it('transitions the run from succeeded to docmost_syncing after enqueue', async () => {
     const context = await runGraphifyCompletion();
 
     expect(context.db.updates).toEqual([
@@ -40,7 +41,30 @@ describe('Graphify completion docmost push dispatch', () => {
         },
       },
     ]);
+    expect(context.db.operations).toEqual(['enqueue', 'update:docmost_syncing']);
     expect(context.bridgeQueue.enqueueDocmostPushJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets docmost_sync_failed when enqueue fails', async () => {
+    const error = new Error('redis unavailable');
+    const errorSpy = vi.spyOn(getApiLogger(), 'error').mockImplementation(() => undefined);
+    const context = await runGraphifyCompletion({
+      enqueueDocmostPushJob: () => Promise.reject(error),
+    });
+
+    expect(context.db.updates).toEqual([
+      {
+        table: graphifyRuns,
+        values: {
+          status: 'docmost_sync_failed',
+        },
+      },
+    ]);
+    expect(context.db.operations).toEqual(['enqueue', 'update:docmost_sync_failed']);
+    expect(errorSpy).toHaveBeenCalledWith(
+      { err: error, job_id: 'graphify-job-1', run_id: 'run-1' },
+      'Failed to enqueue Docmost sync job after Graphify completion',
+    );
   });
 });
 
@@ -49,14 +73,21 @@ type RunContext = {
   bridgeQueue: BridgeQueueService;
 };
 
-async function runGraphifyCompletion(): Promise<RunContext> {
+type RunOptions = {
+  enqueueDocmostPushJob?: () => Promise<void>;
+};
+
+async function runGraphifyCompletion(options: RunOptions = {}): Promise<RunContext> {
   const db = new GraphifyDocmostDb();
   const redis = createRedisMock();
   const graphifyService = {
     handleRunCompletion: vi.fn(() => Promise.resolve({ status: 'succeeded', space_id: 'space-1' })),
   };
   const bridgeQueue = {
-    enqueueDocmostPushJob: vi.fn(() => Promise.resolve()),
+    enqueueDocmostPushJob: vi.fn(() => {
+      db.operations.push('enqueue');
+      return options.enqueueDocmostPushJob?.() ?? Promise.resolve();
+    }),
   } as unknown as BridgeQueueService;
   const service = new InternalJobsService(
     db.asDb() as never,
@@ -116,6 +147,7 @@ async function runGraphifyCompletion(): Promise<RunContext> {
 
 class GraphifyDocmostDb {
   readonly updates: Array<{ table: unknown; values: Record<string, unknown> }> = [];
+  readonly operations: string[] = [];
 
   async transaction<T>(callback: (tx: unknown) => Promise<T>): Promise<T> {
     return callback(this);
@@ -130,6 +162,7 @@ class GraphifyDocmostDb {
       set: (values) => ({
         where: () => {
           this.updates.push({ table, values });
+          this.operations.push(`update:${String(values.status)}`);
           return Promise.resolve();
         },
       }),

--- a/apps/api/src/internal/__tests__/graphify-docmost-push.test.ts
+++ b/apps/api/src/internal/__tests__/graphify-docmost-push.test.ts
@@ -23,7 +23,7 @@ describe('Graphify completion docmost push dispatch', () => {
   it('enqueues a docmost-push job when Graphify completion succeeds', async () => {
     const context = await runGraphifyCompletion();
 
-    expect(context.bridgeQueue.enqueueDocmostPushJob).toHaveBeenCalledWith({
+    expect(context.enqueueSpy).toHaveBeenCalledWith({
       runId: 'run-1',
       spaceId: 'space-1',
       tenantId: 'tenant-1',
@@ -42,7 +42,7 @@ describe('Graphify completion docmost push dispatch', () => {
       },
     ]);
     expect(context.db.operations).toEqual(['enqueue', 'update:docmost_syncing']);
-    expect(context.bridgeQueue.enqueueDocmostPushJob).toHaveBeenCalledTimes(1);
+    expect(context.enqueueSpy).toHaveBeenCalledTimes(1);
   });
 
   it('sets docmost_sync_failed when enqueue fails', async () => {
@@ -71,6 +71,7 @@ describe('Graphify completion docmost push dispatch', () => {
 type RunContext = {
   db: GraphifyDocmostDb;
   bridgeQueue: BridgeQueueService;
+  enqueueSpy: ReturnType<typeof vi.fn>;
 };
 
 type RunOptions = {
@@ -83,11 +84,12 @@ async function runGraphifyCompletion(options: RunOptions = {}): Promise<RunConte
   const graphifyService = {
     handleRunCompletion: vi.fn(() => Promise.resolve({ status: 'succeeded', space_id: 'space-1' })),
   };
+  const enqueueSpy = vi.fn(() => {
+    db.operations.push('enqueue');
+    return options.enqueueDocmostPushJob?.() ?? Promise.resolve();
+  });
   const bridgeQueue = {
-    enqueueDocmostPushJob: vi.fn(() => {
-      db.operations.push('enqueue');
-      return options.enqueueDocmostPushJob?.() ?? Promise.resolve();
-    }),
+    enqueueDocmostPushJob: enqueueSpy,
   } as unknown as BridgeQueueService;
   const service = new InternalJobsService(
     db.asDb() as never,
@@ -142,7 +144,7 @@ async function runGraphifyCompletion(options: RunOptions = {}): Promise<RunConte
     result_json: { graph_json_uri: 's3://bucket/graph.json' },
   });
 
-  return { db, bridgeQueue };
+  return { db, bridgeQueue, enqueueSpy };
 }
 
 class GraphifyDocmostDb {

--- a/apps/api/src/internal/__tests__/graphify-docmost-push.test.ts
+++ b/apps/api/src/internal/__tests__/graphify-docmost-push.test.ts
@@ -1,0 +1,203 @@
+import {
+  JobEventRepository,
+  JobRepository,
+  JobStateMachine,
+  JobStatus,
+  QueueFactory,
+  QUEUE_INDEXING,
+  RedisJobLock,
+  type JobRow,
+} from '@cherrygraph/job-core';
+import { graphifyRuns } from '@cherrygraph/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { BridgeQueueService } from '../../bridge/bridge-queue.service.js';
+import { InternalJobsService } from '../internal-jobs.service.js';
+
+describe('Graphify completion docmost push dispatch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('enqueues a docmost-push job when Graphify completion succeeds', async () => {
+    const context = await runGraphifyCompletion();
+
+    expect(context.bridgeQueue.enqueueDocmostPushJob).toHaveBeenCalledWith({
+      runId: 'run-1',
+      spaceId: 'space-1',
+      tenantId: 'tenant-1',
+    });
+  });
+
+  it('transitions the run from succeeded to docmost_syncing before enqueue', async () => {
+    const context = await runGraphifyCompletion();
+
+    expect(context.db.updates).toEqual([
+      {
+        table: graphifyRuns,
+        values: {
+          status: 'docmost_syncing',
+        },
+      },
+    ]);
+    expect(context.bridgeQueue.enqueueDocmostPushJob).toHaveBeenCalledTimes(1);
+  });
+});
+
+type RunContext = {
+  db: GraphifyDocmostDb;
+  bridgeQueue: BridgeQueueService;
+};
+
+async function runGraphifyCompletion(): Promise<RunContext> {
+  const db = new GraphifyDocmostDb();
+  const redis = createRedisMock();
+  const graphifyService = {
+    handleRunCompletion: vi.fn(() => Promise.resolve({ status: 'succeeded', space_id: 'space-1' })),
+  };
+  const bridgeQueue = {
+    enqueueDocmostPushJob: vi.fn(() => Promise.resolve()),
+  } as unknown as BridgeQueueService;
+  const service = new InternalJobsService(
+    db.asDb() as never,
+    redis.asClient() as never,
+    undefined,
+    undefined,
+    graphifyService as never,
+    bridgeQueue,
+  );
+  const runningJob = createJobRow({
+    id: 'graphify-job-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    type: 'graphify',
+    status: JobStatus.RUNNING,
+    locked_by: 'worker-1',
+    locked_at: new Date('2026-05-05T11:55:00.000Z'),
+    started_at: new Date('2026-05-05T11:55:00.000Z'),
+    payload_json: { run_id: 'run-1' },
+  });
+  const completedJob = createJobRow({
+    ...runningJob,
+    status: JobStatus.SUCCEEDED,
+    locked_by: null,
+    locked_at: null,
+    result_json: { graph_json_uri: 's3://bucket/graph.json' },
+    completed_at: new Date('2026-05-05T12:00:00.000Z'),
+  });
+  const queue = {
+    add: vi.fn(() => Promise.resolve()),
+    close: vi.fn(() => Promise.resolve()),
+  };
+
+  vi.spyOn(JobRepository, 'findById').mockResolvedValue(runningJob);
+  vi.spyOn(RedisJobLock, 'renew').mockResolvedValue(true);
+  vi.spyOn(JobStateMachine, 'transition').mockResolvedValue(completedJob);
+  vi.spyOn(JobEventRepository, 'create').mockResolvedValue({} as Awaited<ReturnType<typeof JobEventRepository.create>>);
+  vi.spyOn(RedisJobLock, 'release').mockResolvedValue(true);
+  vi.spyOn(JobRepository, 'create').mockResolvedValue(
+    createJobRow({
+      id: 'index-job-1',
+      tenant_id: 'tenant-1',
+      space_id: 'space-1',
+      queue_name: QUEUE_INDEXING,
+      type: 'reindex',
+    }),
+  );
+  vi.spyOn(QueueFactory, 'createQueue').mockReturnValue(queue as never);
+
+  await service.reportComplete('graphify-job-1', {
+    worker_id: 'worker-1',
+    result_json: { graph_json_uri: 's3://bucket/graph.json' },
+  });
+
+  return { db, bridgeQueue };
+}
+
+class GraphifyDocmostDb {
+  readonly updates: Array<{ table: unknown; values: Record<string, unknown> }> = [];
+
+  async transaction<T>(callback: (tx: unknown) => Promise<T>): Promise<T> {
+    return callback(this);
+  }
+
+  update(table: unknown): {
+    set: (values: Record<string, unknown>) => {
+      where: () => Promise<void>;
+    };
+  } {
+    return {
+      set: (values) => ({
+        where: () => {
+          this.updates.push({ table, values });
+          return Promise.resolve();
+        },
+      }),
+    };
+  }
+
+  asDb(): unknown {
+    return this;
+  }
+}
+
+class RedisMemoryStore {
+  readonly values = new Map<string, string>();
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  set(key: string, value: string): Promise<'OK'> {
+    this.values.set(key, value);
+    return Promise.resolve('OK');
+  }
+
+  eval(): Promise<number> {
+    return Promise.resolve(1);
+  }
+
+  asClient(): {
+    get: (key: string) => Promise<string | null>;
+    set: (key: string, value: string, ...args: Array<string | number>) => Promise<string | null>;
+    eval: (script: string, numKeys: number, ...args: Array<string | number>) => Promise<number>;
+  } {
+    return {
+      get: this.get.bind(this),
+      set: async (key: string, value: string): Promise<string | null> => this.set(key, value),
+      eval: this.eval.bind(this),
+    };
+  }
+}
+
+function createRedisMock(): RedisMemoryStore {
+  return new RedisMemoryStore();
+}
+
+function createJobRow(overrides: Partial<JobRow> = {}): JobRow {
+  return {
+    id: 'job-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    queue_name: 'graphify',
+    type: 'graphify',
+    priority: 100,
+    status: JobStatus.PENDING,
+    attempt_count: 0,
+    max_attempts: 3,
+    timeout_seconds: 600,
+    locked_by: null,
+    locked_at: null,
+    next_run_at: null,
+    cancel_requested_at: null,
+    payload_json: { run_id: 'run-1' },
+    result_json: null,
+    error_json: null,
+    idempotency_key: null,
+    created_by: 'user-1',
+    created_at: new Date('2026-05-05T11:50:00.000Z'),
+    started_at: null,
+    completed_at: null,
+    ...overrides,
+  };
+}

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -688,15 +688,36 @@ export class InternalJobsService {
       }
 
       if (this.bridgeQueueService !== undefined) {
-        await this.db
-          .update(graphifyRuns)
-          .set({ status: 'docmost_syncing' })
-          .where(and(eq(graphifyRuns.id, runId), eq(graphifyRuns.status, 'succeeded')));
-        await this.bridgeQueueService.enqueueDocmostPushJob({
-          runId,
-          spaceId: completedRun.space_id,
-          tenantId: job.tenant_id,
-        });
+        try {
+          await this.bridgeQueueService.enqueueDocmostPushJob({
+            runId,
+            spaceId: completedRun.space_id,
+            tenantId: job.tenant_id,
+          });
+        } catch (err) {
+          getApiLogger().error(
+            { err, job_id: job.id, run_id: runId },
+            'Failed to enqueue Docmost sync job after Graphify completion',
+          );
+
+          await this.db
+            .update(graphifyRuns)
+            .set({ status: 'docmost_sync_failed' })
+            .where(and(eq(graphifyRuns.id, runId), eq(graphifyRuns.status, 'succeeded')));
+          return;
+        }
+
+        try {
+          await this.db
+            .update(graphifyRuns)
+            .set({ status: 'docmost_syncing' })
+            .where(and(eq(graphifyRuns.id, runId), eq(graphifyRuns.status, 'succeeded')));
+        } catch (statusErr) {
+          getApiLogger().error(
+            { err: statusErr, job_id: job.id, run_id: runId },
+            'Failed to update run status to docmost_syncing after enqueue — push job is queued but status is stale',
+          );
+        }
       }
     } catch (err) {
       getApiLogger().error(

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -13,11 +13,12 @@ import {
   jobs,
   type JobRow,
 } from '@cherrygraph/job-core';
-import { ErrorCode } from '@cherrygraph/shared';
+import { ErrorCode, graphifyRuns } from '@cherrygraph/shared';
 import { and, eq, inArray, isNotNull } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
 import { AuditService } from '../audit/audit.service.js';
+import { BridgeQueueService } from '../bridge/bridge-queue.service.js';
 import { getApiLogger } from '../common/logger/logger.module.js';
 import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
@@ -58,6 +59,7 @@ export class InternalJobsService {
     @Optional() private readonly uploadsService?: UploadsService,
     @Optional() private readonly auditService?: AuditService,
     @Optional() private readonly graphifyService?: GraphifyService,
+    @Optional() private readonly bridgeQueueService?: BridgeQueueService,
   ) {}
 
   async pollPendingJobs(type: string, limit: number): Promise<JobDto[]> {
@@ -683,6 +685,18 @@ export class InternalJobsService {
         await queue.add('reindex', { jobId: indexJob.id });
       } finally {
         await queue.close();
+      }
+
+      if (this.bridgeQueueService !== undefined) {
+        await this.db
+          .update(graphifyRuns)
+          .set({ status: 'docmost_syncing' })
+          .where(and(eq(graphifyRuns.id, runId), eq(graphifyRuns.status, 'succeeded')));
+        await this.bridgeQueueService.enqueueDocmostPushJob({
+          runId,
+          spaceId: completedRun.space_id,
+          tenantId: job.tenant_id,
+        });
       }
     } catch (err) {
       getApiLogger().error(

--- a/apps/api/src/internal/internal.module.ts
+++ b/apps/api/src/internal/internal.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 
 import { AuditModule } from '../audit/audit.module.js';
+import { BridgeModule } from '../bridge/bridge.module.js';
 import { GraphifyModule } from '../graphify/graphify.module.js';
 import { UploadsModule } from '../uploads/uploads.module.js';
 import { InternalJobsController } from './internal-jobs.controller.js';
@@ -10,7 +11,7 @@ import { InternalWorkersController } from './internal-workers.controller.js';
 import { WorkerApiKeyGuard } from './worker-api-key.guard.js';
 
 @Module({
-  imports: [ScheduleModule.forRoot(), UploadsModule, AuditModule, GraphifyModule],
+  imports: [ScheduleModule.forRoot(), UploadsModule, AuditModule, GraphifyModule, BridgeModule],
   controllers: [InternalJobsController, InternalWorkersController],
   providers: [InternalJobsService, WorkerApiKeyGuard],
 })

--- a/apps/wiki-sync-worker/package.json
+++ b/apps/wiki-sync-worker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@cherrygraph/wiki-sync-worker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
+  "scripts": {
+    "dev": "node --import tsx src/main.ts",
+    "build": "tsc -b",
+    "start": "node dist/main.js",
+    "test": "vitest run --config ../../vitest.config.ts"
+  },
+  "dependencies": {
+    "@cherrygraph/shared": "workspace:*",
+    "bullmq": "^5.76.3",
+    "drizzle-orm": "^0.45.2",
+    "ioredis": "^5.10.1"
+  }
+}

--- a/apps/wiki-sync-worker/src/__tests__/health.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/health.test.ts
@@ -11,6 +11,7 @@ describe('wiki-sync-worker health server', () => {
       {
         'page-sync': { getWaitingCount: vi.fn(() => Promise.resolve(2)) },
         'permission-sync': { getWaitingCount: vi.fn(() => Promise.resolve(1)) },
+        'attachment-sync': { getWaitingCount: vi.fn(() => Promise.resolve(4)) },
         'docmost-push': { getWaitingCount: vi.fn(() => Promise.resolve(3)) },
       },
       0,
@@ -29,6 +30,7 @@ describe('wiki-sync-worker health server', () => {
         queues: {
           'page-sync': 2,
           'permission-sync': 1,
+          'attachment-sync': 4,
           'docmost-push': 3,
         },
       });

--- a/apps/wiki-sync-worker/src/__tests__/health.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/health.test.ts
@@ -1,0 +1,70 @@
+import { get } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { closeHealthServer, startHealthServer, type WikiSyncHealthPayload } from '../health.js';
+
+describe('wiki-sync-worker health server', () => {
+  it('returns queue pending counts', async () => {
+    const server = await startHealthServer(
+      {
+        'page-sync': { getWaitingCount: vi.fn(() => Promise.resolve(2)) },
+        'permission-sync': { getWaitingCount: vi.fn(() => Promise.resolve(1)) },
+        'docmost-push': { getWaitingCount: vi.fn(() => Promise.resolve(3)) },
+      },
+      0,
+    );
+
+    try {
+      const address = server.address();
+      if (!isAddressInfo(address)) {
+        throw new Error('Expected the test server to bind a TCP port');
+      }
+
+      const response = await requestJson(address.port);
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual({
+        status: 'ok',
+        queues: {
+          'page-sync': 2,
+          'permission-sync': 1,
+          'docmost-push': 3,
+        },
+      });
+    } finally {
+      await closeHealthServer(server);
+    }
+  });
+});
+
+type HealthResponse = {
+  statusCode: number;
+  body: WikiSyncHealthPayload;
+};
+
+function requestJson(port: number): Promise<HealthResponse> {
+  return new Promise((resolve, reject) => {
+    const request = get({ host: '127.0.0.1', port, path: '/health' }, (response) => {
+      response.setEncoding('utf8');
+      let data = '';
+
+      response.on('data', (chunk: string) => {
+        data += chunk;
+      });
+
+      response.on('end', () => {
+        const parsed = JSON.parse(data) as WikiSyncHealthPayload;
+        resolve({ statusCode: response.statusCode ?? 0, body: parsed });
+      });
+    });
+
+    request.on('error', reject);
+  });
+}
+
+function isAddressInfo(address: ReturnType<ServerAddress>): address is AddressInfo {
+  return typeof address === 'object' && address !== null;
+}
+
+type ServerAddress = typeof import('node:http').Server.prototype.address;

--- a/apps/wiki-sync-worker/src/__tests__/reconciliation.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/reconciliation.test.ts
@@ -71,12 +71,33 @@ class TestReconciliationDb {
 
   select(): {
     from: () => {
-      where: () => Promise<BridgeEventRow[]>;
+      where: () => {
+        orderBy: () => {
+          limit: (limit: number) => {
+            offset: (offset: number) => Promise<BridgeEventRow[]>;
+          };
+        };
+      };
     };
   } {
     return {
       from: () => ({
-        where: () => Promise.resolve(this.rows),
+        where: () => ({
+          orderBy: () => ({
+            limit: (limit) => ({
+              offset: (offset) =>
+                Promise.resolve(
+                  this.rows
+                    .filter(
+                      (row) =>
+                        row.status === 'received' ||
+                        row.received_at < new Date('2026-05-05T11:55:00.000Z'),
+                    )
+                    .slice(offset, offset + limit),
+                ),
+            }),
+          }),
+        }),
       }),
     };
   }

--- a/apps/wiki-sync-worker/src/__tests__/reconciliation.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/reconciliation.test.ts
@@ -1,0 +1,135 @@
+import { bridgeEvents } from '@cherrygraph/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { reconcileOnStartup, type ReconciliationDb, type ReconciliationQueue } from '../reconciliation.js';
+
+describe('wiki-sync-worker startup reconciliation', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('re-enqueues received events and stale processing events', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-05T12:00:00.000Z'));
+
+    const db = new TestReconciliationDb([
+      createBridgeEvent({ id: 'event-1', event_id: 'docmost-1', event_type: 'page.saved', status: 'received' }),
+      createBridgeEvent({
+        id: 'event-2',
+        event_id: 'docmost-2',
+        event_type: 'space.updated',
+        status: 'processing',
+        received_at: new Date('2026-05-05T11:54:00.000Z'),
+      }),
+      createBridgeEvent({
+        id: 'event-3',
+        event_id: 'docmost-3',
+        event_type: 'attachment.created',
+        status: 'processing',
+        received_at: new Date('2026-05-05T11:59:00.000Z'),
+      }),
+    ]);
+    const queues = createQueues();
+
+    const enqueued = await reconcileOnStartup(db.asDb(), queues);
+
+    expect(enqueued).toBe(2);
+    expect(db.updated).toEqual([{ status: 'received' }]);
+    expect(queues.pageSync.add).toHaveBeenCalledWith(
+      'page.saved',
+      {
+        bridgeEventId: 'event-1',
+        eventId: 'docmost-1',
+        eventType: 'page.saved',
+        spaceId: 'space-1',
+        pageId: 'page-1',
+      },
+      { jobId: 'docmost-1' },
+    );
+    expect(queues.permissionSync.add).toHaveBeenCalledWith(
+      'space.updated',
+      {
+        bridgeEventId: 'event-2',
+        eventId: 'docmost-2',
+        eventType: 'space.updated',
+        spaceId: 'space-1',
+        pageId: 'page-1',
+      },
+      { jobId: 'docmost-2' },
+    );
+    expect(queues.attachmentSync.add).not.toHaveBeenCalled();
+    expect(queues.docmostPush.add).not.toHaveBeenCalled();
+  });
+});
+
+type BridgeEventRow = typeof bridgeEvents.$inferSelect;
+
+class TestReconciliationDb {
+  readonly updated: Array<Partial<typeof bridgeEvents.$inferInsert>> = [];
+
+  constructor(private readonly rows: BridgeEventRow[]) {}
+
+  select(): {
+    from: () => {
+      where: () => Promise<BridgeEventRow[]>;
+    };
+  } {
+    return {
+      from: () => ({
+        where: () => Promise.resolve(this.rows),
+      }),
+    };
+  }
+
+  update(): {
+    set: (values: Partial<typeof bridgeEvents.$inferInsert>) => {
+      where: () => Promise<void>;
+    };
+  } {
+    return {
+      set: (values) => ({
+        where: () => {
+          this.updated.push(values);
+          return Promise.resolve();
+        },
+      }),
+    };
+  }
+
+  asDb(): ReconciliationDb {
+    return this as unknown as ReconciliationDb;
+  }
+}
+
+function createQueues(): {
+  pageSync: ReconciliationQueue & { add: ReturnType<typeof vi.fn> };
+  permissionSync: ReconciliationQueue & { add: ReturnType<typeof vi.fn> };
+  attachmentSync: ReconciliationQueue & { add: ReturnType<typeof vi.fn> };
+  docmostPush: ReconciliationQueue & { add: ReturnType<typeof vi.fn> };
+} {
+  return {
+    pageSync: { add: vi.fn(() => Promise.resolve()) },
+    permissionSync: { add: vi.fn(() => Promise.resolve()) },
+    attachmentSync: { add: vi.fn(() => Promise.resolve()) },
+    docmostPush: { add: vi.fn(() => Promise.resolve()) },
+  };
+}
+
+function createBridgeEvent(overrides: Partial<BridgeEventRow>): BridgeEventRow {
+  return {
+    id: 'event-1',
+    event_id: 'docmost-event-1',
+    event_type: 'page.saved',
+    source: 'docmost',
+    space_id: 'space-1',
+    page_id: 'page-1',
+    payload: {},
+    status: 'received',
+    error_json: null,
+    nonce: null,
+    received_at: new Date('2026-05-05T11:58:00.000Z'),
+    processed_at: null,
+    created_at: new Date('2026-05-05T11:58:00.000Z'),
+    ...overrides,
+  };
+}

--- a/apps/wiki-sync-worker/src/health.ts
+++ b/apps/wiki-sync-worker/src/health.ts
@@ -7,6 +7,7 @@ export type PendingQueue = {
 export type WikiSyncHealthQueues = {
   'page-sync': PendingQueue;
   'permission-sync': PendingQueue;
+  'attachment-sync': PendingQueue;
   'docmost-push': PendingQueue;
 };
 
@@ -15,6 +16,7 @@ export type WikiSyncHealthPayload = {
   queues: {
     'page-sync': number;
     'permission-sync': number;
+    'attachment-sync': number;
     'docmost-push': number;
   };
 };
@@ -40,9 +42,10 @@ export function createHealthServer(queues: WikiSyncHealthQueues): Server {
 }
 
 export async function buildHealthPayload(queues: WikiSyncHealthQueues): Promise<WikiSyncHealthPayload> {
-  const [pageSync, permissionSync, docmostPush] = await Promise.all([
+  const [pageSync, permissionSync, attachmentSync, docmostPush] = await Promise.all([
     queues['page-sync'].getWaitingCount(),
     queues['permission-sync'].getWaitingCount(),
+    queues['attachment-sync'].getWaitingCount(),
     queues['docmost-push'].getWaitingCount(),
   ]);
 
@@ -51,6 +54,7 @@ export async function buildHealthPayload(queues: WikiSyncHealthQueues): Promise<
     queues: {
       'page-sync': pageSync,
       'permission-sync': permissionSync,
+      'attachment-sync': attachmentSync,
       'docmost-push': docmostPush,
     },
   };

--- a/apps/wiki-sync-worker/src/health.ts
+++ b/apps/wiki-sync-worker/src/health.ts
@@ -1,0 +1,86 @@
+import { createServer, type Server } from 'node:http';
+
+export type PendingQueue = {
+  getWaitingCount: () => Promise<number>;
+};
+
+export type WikiSyncHealthQueues = {
+  'page-sync': PendingQueue;
+  'permission-sync': PendingQueue;
+  'docmost-push': PendingQueue;
+};
+
+export type WikiSyncHealthPayload = {
+  status: 'ok';
+  queues: {
+    'page-sync': number;
+    'permission-sync': number;
+    'docmost-push': number;
+  };
+};
+
+export function createHealthServer(queues: WikiSyncHealthQueues): Server {
+  return createServer((request, response) => {
+    if (request.method !== 'GET' || request.url !== '/health') {
+      response.writeHead(404, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: 'not_found' }));
+      return;
+    }
+
+    void buildHealthPayload(queues)
+      .then((payload) => {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify(payload));
+      })
+      .catch((error: unknown) => {
+        response.writeHead(503, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ status: 'error', error: String(error) }));
+      });
+  });
+}
+
+export async function buildHealthPayload(queues: WikiSyncHealthQueues): Promise<WikiSyncHealthPayload> {
+  const [pageSync, permissionSync, docmostPush] = await Promise.all([
+    queues['page-sync'].getWaitingCount(),
+    queues['permission-sync'].getWaitingCount(),
+    queues['docmost-push'].getWaitingCount(),
+  ]);
+
+  return {
+    status: 'ok',
+    queues: {
+      'page-sync': pageSync,
+      'permission-sync': permissionSync,
+      'docmost-push': docmostPush,
+    },
+  };
+}
+
+export function startHealthServer(queues: WikiSyncHealthQueues, port: number): Promise<Server> {
+  const server = createHealthServer(queues);
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, () => {
+      server.off('error', reject);
+      resolve(server);
+    });
+  });
+}
+
+export function closeHealthServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error === undefined) {
+        resolve();
+        return;
+      }
+
+      reject(error);
+    });
+  });
+}

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -1,0 +1,159 @@
+import { Queue, Worker, type JobsOptions, type Queue as BullQueue, type Worker as BullWorker } from 'bullmq';
+import { Redis } from 'ioredis';
+import type { Redis as IORedis } from 'ioredis';
+import type { Server } from 'node:http';
+import { fileURLToPath } from 'node:url';
+
+import { closeHealthServer, startHealthServer } from './health.js';
+
+const WORKER_NAME = 'wiki-sync-worker';
+const PAGE_SYNC_QUEUE = 'bridge:page-sync';
+const PERMISSION_SYNC_QUEUE = 'bridge:permission-sync';
+const ATTACHMENT_SYNC_QUEUE = 'bridge:attachment-sync';
+const DOCMOST_PUSH_QUEUE = 'bridge:docmost-push';
+
+const DEFAULT_JOB_OPTIONS: JobsOptions = {
+  attempts: 3,
+  backoff: {
+    type: 'exponential',
+    delay: 5_000,
+  },
+};
+
+type BridgeWorkerQueues = {
+  pageSync: BullQueue;
+  permissionSync: BullQueue;
+  attachmentSync: BullQueue;
+  docmostPush: BullQueue;
+};
+
+export async function bootstrap(): Promise<void> {
+  const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
+  const healthPort = parseHealthPort(process.env.WORKER_HEALTH_PORT);
+  const connection = new Redis(redisUrl, { maxRetriesPerRequest: null });
+  const queues = createQueues(connection);
+  const workers = createWorkers(connection);
+  const healthServer = await startHealthServer(
+    {
+      'page-sync': queues.pageSync,
+      'permission-sync': queues.permissionSync,
+      'docmost-push': queues.docmostPush,
+    },
+    healthPort,
+  );
+
+  for (const worker of workers) {
+    worker.on('error', (error) => {
+      console.error(`${WORKER_NAME}: worker error`, error);
+    });
+  }
+
+  const shutdown = createShutdownHandler(workers, queues, connection, healthServer);
+  process.once('SIGTERM', shutdown);
+  process.once('SIGINT', shutdown);
+  console.log(`${WORKER_NAME}: started`, { healthPort });
+}
+
+function createQueues(connection: IORedis): BridgeWorkerQueues {
+  const queueOptions = { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS };
+
+  return {
+    pageSync: new Queue(PAGE_SYNC_QUEUE, queueOptions),
+    permissionSync: new Queue(PERMISSION_SYNC_QUEUE, queueOptions),
+    attachmentSync: new Queue(ATTACHMENT_SYNC_QUEUE, queueOptions),
+    docmostPush: new Queue(DOCMOST_PUSH_QUEUE, queueOptions),
+  };
+}
+
+function createWorkers(connection: IORedis): BullWorker[] {
+  const processor = async (): Promise<void> => {};
+
+  return [
+    new Worker(PAGE_SYNC_QUEUE, processor, { connection, concurrency: 3 }),
+    new Worker(PERMISSION_SYNC_QUEUE, processor, { connection }),
+    new Worker(ATTACHMENT_SYNC_QUEUE, processor, { connection }),
+    new Worker(DOCMOST_PUSH_QUEUE, processor, { connection }),
+  ];
+}
+
+function parseHealthPort(value: string | undefined): number {
+  if (value === undefined || value.trim() === '') {
+    return 9090;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65_535) {
+    throw new Error(`Invalid WORKER_HEALTH_PORT value: ${value}`);
+  }
+
+  return parsed;
+}
+
+function createShutdownHandler(
+  workers: BullWorker[],
+  queues: BridgeWorkerQueues,
+  connection: IORedis,
+  healthServer: Server,
+): () => void {
+  let shuttingDown = false;
+
+  return () => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    void shutdown(workers, queues, connection, healthServer);
+  };
+}
+
+async function shutdown(
+  workers: BullWorker[],
+  queues: BridgeWorkerQueues,
+  connection: IORedis,
+  healthServer: Server,
+): Promise<void> {
+  let shutdownFailed = false;
+  const queueList = [queues.pageSync, queues.permissionSync, queues.attachmentSync, queues.docmostPush];
+
+  try {
+    console.log(`${WORKER_NAME}: shutting down`);
+    const results = await Promise.allSettled([
+      ...workers.map((worker) => worker.close()),
+      ...queueList.map((queue) => queue.close()),
+      connection.quit(),
+    ]);
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        shutdownFailed = true;
+        console.error(`${WORKER_NAME}: shutdown step failed`, result.reason);
+      }
+    }
+  } catch (error) {
+    shutdownFailed = true;
+    console.error(`${WORKER_NAME}: shutdown failed`, error);
+  } finally {
+    try {
+      await closeHealthServer(healthServer);
+    } catch (error) {
+      shutdownFailed = true;
+      console.error(`${WORKER_NAME}: health server shutdown failed`, error);
+    }
+  }
+
+  if (shutdownFailed) {
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`${WORKER_NAME}: stopped`);
+}
+
+function isEntrypoint(): boolean {
+  return process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+}
+
+if (isEntrypoint()) {
+  await bootstrap();
+}

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -7,10 +7,10 @@ import { fileURLToPath } from 'node:url';
 import { closeHealthServer, startHealthServer } from './health.js';
 
 const WORKER_NAME = 'wiki-sync-worker';
-const PAGE_SYNC_QUEUE = 'bridge:page-sync';
-const PERMISSION_SYNC_QUEUE = 'bridge:permission-sync';
-const ATTACHMENT_SYNC_QUEUE = 'bridge:attachment-sync';
-const DOCMOST_PUSH_QUEUE = 'bridge:docmost-push';
+const PAGE_SYNC_QUEUE = 'bridge-page-sync';
+const PERMISSION_SYNC_QUEUE = 'bridge-permission-sync';
+const ATTACHMENT_SYNC_QUEUE = 'bridge-attachment-sync';
+const DOCMOST_PUSH_QUEUE = 'bridge-docmost-push';
 
 const DEFAULT_JOB_OPTIONS: JobsOptions = {
   attempts: 3,

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -1,4 +1,4 @@
-import { Queue, Worker, type JobsOptions, type Queue as BullQueue, type Worker as BullWorker } from 'bullmq';
+import { Queue, type JobsOptions, type Queue as BullQueue } from 'bullmq';
 import { Redis } from 'ioredis';
 import type { Redis as IORedis } from 'ioredis';
 import type { Server } from 'node:http';
@@ -18,6 +18,8 @@ const DEFAULT_JOB_OPTIONS: JobsOptions = {
     type: 'exponential',
     delay: 5_000,
   },
+  removeOnComplete: { count: 1000, age: 86_400 },
+  removeOnFail: { count: 5000, age: 604_800 },
 };
 
 type BridgeWorkerQueues = {
@@ -32,23 +34,20 @@ export async function bootstrap(): Promise<void> {
   const healthPort = parseHealthPort(process.env.WORKER_HEALTH_PORT);
   const connection = new Redis(redisUrl, { maxRetriesPerRequest: null });
   const queues = createQueues(connection);
-  const workers = createWorkers(connection);
+
+  await reconcileQueuesOnStartup(queues);
+
   const healthServer = await startHealthServer(
     {
       'page-sync': queues.pageSync,
       'permission-sync': queues.permissionSync,
+      'attachment-sync': queues.attachmentSync,
       'docmost-push': queues.docmostPush,
     },
     healthPort,
   );
 
-  for (const worker of workers) {
-    worker.on('error', (error) => {
-      console.error(`${WORKER_NAME}: worker error`, error);
-    });
-  }
-
-  const shutdown = createShutdownHandler(workers, queues, connection, healthServer);
+  const shutdown = createShutdownHandler(queues, connection, healthServer);
   process.once('SIGTERM', shutdown);
   process.once('SIGINT', shutdown);
   console.log(`${WORKER_NAME}: started`, { healthPort });
@@ -65,15 +64,9 @@ function createQueues(connection: IORedis): BridgeWorkerQueues {
   };
 }
 
-function createWorkers(connection: IORedis): BullWorker[] {
-  const processor = async (): Promise<void> => {};
-
-  return [
-    new Worker(PAGE_SYNC_QUEUE, processor, { connection, concurrency: 3 }),
-    new Worker(PERMISSION_SYNC_QUEUE, processor, { connection }),
-    new Worker(ATTACHMENT_SYNC_QUEUE, processor, { connection }),
-    new Worker(DOCMOST_PUSH_QUEUE, processor, { connection }),
-  ];
+async function reconcileQueuesOnStartup(_queues: BridgeWorkerQueues): Promise<void> {
+  // TODO(Issue #129): create the worker DB connection and call reconcileOnStartup(db, queues).
+  console.warn('DB not connected — startup reconciliation skipped (will be wired in Issue #129)');
 }
 
 function parseHealthPort(value: string | undefined): number {
@@ -90,7 +83,6 @@ function parseHealthPort(value: string | undefined): number {
 }
 
 function createShutdownHandler(
-  workers: BullWorker[],
   queues: BridgeWorkerQueues,
   connection: IORedis,
   healthServer: Server,
@@ -103,12 +95,11 @@ function createShutdownHandler(
     }
 
     shuttingDown = true;
-    void shutdown(workers, queues, connection, healthServer);
+    void shutdown(queues, connection, healthServer);
   };
 }
 
 async function shutdown(
-  workers: BullWorker[],
   queues: BridgeWorkerQueues,
   connection: IORedis,
   healthServer: Server,
@@ -119,7 +110,6 @@ async function shutdown(
   try {
     console.log(`${WORKER_NAME}: shutting down`);
     const results = await Promise.allSettled([
-      ...workers.map((worker) => worker.close()),
       ...queueList.map((queue) => queue.close()),
       connection.quit(),
     ]);

--- a/apps/wiki-sync-worker/src/reconciliation.ts
+++ b/apps/wiki-sync-worker/src/reconciliation.ts
@@ -1,0 +1,102 @@
+import { bridgeEvents, type BridgeEventType } from '@cherrygraph/shared';
+import { and, eq, inArray, lt } from 'drizzle-orm';
+
+export type BridgeSyncJobData = {
+  bridgeEventId: string;
+  eventId: string;
+  eventType: string;
+  spaceId?: string;
+  pageId?: string;
+};
+
+export type ReconciliationQueue = {
+  add: (name: string, data: BridgeSyncJobData, opts: { jobId: string }) => Promise<unknown>;
+};
+
+export type ReconciliationQueues = {
+  pageSync: ReconciliationQueue;
+  permissionSync: ReconciliationQueue;
+  attachmentSync: ReconciliationQueue;
+  docmostPush: ReconciliationQueue;
+};
+
+type BridgeEventRow = typeof bridgeEvents.$inferSelect;
+type BridgeEventInsert = typeof bridgeEvents.$inferInsert;
+
+export type ReconciliationDb = {
+  select: () => {
+    from: (table: typeof bridgeEvents) => {
+      where: (condition: unknown) => Promise<BridgeEventRow[]>;
+    };
+  };
+  update: (table: typeof bridgeEvents) => {
+    set: (values: Partial<BridgeEventInsert>) => {
+      where: (condition: unknown) => Promise<unknown>;
+    };
+  };
+};
+
+const STUCK_PROCESSING_MS = 5 * 60 * 1000;
+
+export async function reconcileOnStartup(db: ReconciliationDb, queues: ReconciliationQueues): Promise<number> {
+  const staleThreshold = new Date(Date.now() - STUCK_PROCESSING_MS);
+  const events = await db
+    .select()
+    .from(bridgeEvents)
+    .where(inArray(bridgeEvents.status, ['received', 'processing']));
+  const eventsToEnqueue = events.filter(
+    (event) => event.status === 'received' || isStaleProcessingEvent(event, staleThreshold),
+  );
+
+  if (eventsToEnqueue.some((event) => event.status === 'processing')) {
+    await db
+      .update(bridgeEvents)
+      .set({ status: 'received' })
+      .where(and(eq(bridgeEvents.status, 'processing'), lt(bridgeEvents.received_at, staleThreshold)));
+  }
+
+  await Promise.all(eventsToEnqueue.map((event) => enqueueBridgeEvent(event, queues)));
+  return eventsToEnqueue.length;
+}
+
+async function enqueueBridgeEvent(event: BridgeEventRow, queues: ReconciliationQueues): Promise<void> {
+  const queue = queueForEventType(event.event_type as BridgeEventType, queues);
+  if (queue === undefined) {
+    return;
+  }
+
+  await queue.add(event.event_type, toJobData(event), { jobId: event.event_id });
+}
+
+function queueForEventType(
+  eventType: BridgeEventType,
+  queues: ReconciliationQueues,
+): ReconciliationQueue | undefined {
+  if (eventType === 'page.saved' || eventType === 'page.deleted') {
+    return queues.pageSync;
+  }
+
+  if (eventType === 'space.updated') {
+    return queues.permissionSync;
+  }
+
+  if (eventType.startsWith('attachment.')) {
+    return queues.attachmentSync;
+  }
+
+  return undefined;
+}
+
+function toJobData(event: BridgeEventRow): BridgeSyncJobData {
+  return {
+    bridgeEventId: event.id,
+    eventId: event.event_id,
+    eventType: event.event_type,
+    ...(event.space_id !== null ? { spaceId: event.space_id } : {}),
+    ...(event.page_id !== null ? { pageId: event.page_id } : {}),
+  };
+}
+
+function isStaleProcessingEvent(event: BridgeEventRow, staleThreshold: Date): boolean {
+  return event.status === 'processing' && event.received_at < staleThreshold;
+}

--- a/apps/wiki-sync-worker/src/reconciliation.ts
+++ b/apps/wiki-sync-worker/src/reconciliation.ts
@@ -1,5 +1,5 @@
 import { bridgeEvents, type BridgeEventType } from '@cherrygraph/shared';
-import { and, eq, inArray, lt } from 'drizzle-orm';
+import { and, asc, eq, lt } from 'drizzle-orm';
 
 export type BridgeSyncJobData = {
   bridgeEventId: string;
@@ -26,7 +26,13 @@ type BridgeEventInsert = typeof bridgeEvents.$inferInsert;
 export type ReconciliationDb = {
   select: () => {
     from: (table: typeof bridgeEvents) => {
-      where: (condition: unknown) => Promise<BridgeEventRow[]>;
+      where: (condition: unknown) => {
+        orderBy: (...columns: unknown[]) => {
+          limit: (limit: number) => {
+            offset: (offset: number) => Promise<BridgeEventRow[]>;
+          };
+        };
+      };
     };
   };
   update: (table: typeof bridgeEvents) => {
@@ -37,29 +43,47 @@ export type ReconciliationDb = {
 };
 
 const STUCK_PROCESSING_MS = 5 * 60 * 1000;
+const RECONCILIATION_BATCH_SIZE = 50;
 
-export async function reconcileOnStartup(db: ReconciliationDb, queues: ReconciliationQueues): Promise<number> {
+export async function reconcileOnStartup(
+  db: ReconciliationDb,
+  queues: ReconciliationQueues,
+): Promise<number> {
   const staleThreshold = new Date(Date.now() - STUCK_PROCESSING_MS);
-  const events = await db
-    .select()
-    .from(bridgeEvents)
-    .where(inArray(bridgeEvents.status, ['received', 'processing']));
-  const eventsToEnqueue = events.filter(
-    (event) => event.status === 'received' || isStaleProcessingEvent(event, staleThreshold),
-  );
+  await db
+    .update(bridgeEvents)
+    .set({ status: 'received' })
+    .where(
+      and(eq(bridgeEvents.status, 'processing'), lt(bridgeEvents.received_at, staleThreshold)),
+    );
 
-  if (eventsToEnqueue.some((event) => event.status === 'processing')) {
-    await db
-      .update(bridgeEvents)
-      .set({ status: 'received' })
-      .where(and(eq(bridgeEvents.status, 'processing'), lt(bridgeEvents.received_at, staleThreshold)));
+  let enqueued = 0;
+  let offset = 0;
+
+  while (true) {
+    const events = await db
+      .select()
+      .from(bridgeEvents)
+      .where(eq(bridgeEvents.status, 'received'))
+      .orderBy(asc(bridgeEvents.received_at), asc(bridgeEvents.id))
+      .limit(RECONCILIATION_BATCH_SIZE)
+      .offset(offset);
+
+    const results = await Promise.allSettled(events.map((event) => enqueueBridgeEvent(event, queues)));
+    enqueued += results.filter((r) => r.status === 'fulfilled').length;
+
+    if (events.length < RECONCILIATION_BATCH_SIZE) {
+      return enqueued;
+    }
+
+    offset += RECONCILIATION_BATCH_SIZE;
   }
-
-  await Promise.all(eventsToEnqueue.map((event) => enqueueBridgeEvent(event, queues)));
-  return eventsToEnqueue.length;
 }
 
-async function enqueueBridgeEvent(event: BridgeEventRow, queues: ReconciliationQueues): Promise<void> {
+async function enqueueBridgeEvent(
+  event: BridgeEventRow,
+  queues: ReconciliationQueues,
+): Promise<void> {
   const queue = queueForEventType(event.event_type as BridgeEventType, queues);
   if (queue === undefined) {
     return;
@@ -95,8 +119,4 @@ function toJobData(event: BridgeEventRow): BridgeSyncJobData {
     ...(event.space_id !== null ? { spaceId: event.space_id } : {}),
     ...(event.page_id !== null ? { pageId: event.page_id } : {}),
   };
-}
-
-function isStaleProcessingEvent(event: BridgeEventRow, staleThreshold: Date): boolean {
-  return event.status === 'processing' && event.received_at < staleThreshold;
 }

--- a/apps/wiki-sync-worker/tsconfig.json
+++ b/apps/wiki-sync-worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "emitDecoratorMetadata": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    {
+      "path": "../../packages/shared"
+    }
+  ]
+}

--- a/packages/shared/src/schema/__tests__/validation-sync-status.test.ts
+++ b/packages/shared/src/schema/__tests__/validation-sync-status.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  graphifyRunStatusSchema,
+  insertWikiPageSchema,
+  proposalTypeSchema,
+  syncStatusSchema,
+} from '../validation.js';
+
+describe('sync status validation', () => {
+  it.each(['synced', 'sync_pending', 'conflict_required'] as const)(
+    'accepts %s as a wiki page sync status',
+    (status) => {
+      expect(syncStatusSchema.safeParse(status).success).toBe(true);
+    },
+  );
+
+  it('rejects invalid sync status values', () => {
+    expect(syncStatusSchema.safeParse('pending').success).toBe(false);
+    expect(syncStatusSchema.safeParse('graphify_suggestion').success).toBe(false);
+  });
+
+  it('round-trips wiki page sync fields through insertWikiPageSchema', () => {
+    const parsed = insertWikiPageSchema.parse({
+      tenant_id: 'tenant-1',
+      space_id: 'space-1',
+      page_id: 'space-1.index.root',
+      title: 'Index',
+      slug: 'index',
+      sync_status: 'sync_pending',
+      docmost_page_id: 'docmost-page-1',
+    });
+
+    expect(parsed).toMatchObject({
+      sync_status: 'sync_pending',
+      docmost_page_id: 'docmost-page-1',
+    });
+  });
+});
+
+describe('proposal type validation', () => {
+  it('accepts conflict proposals and rejects the old graphify_suggestion value', () => {
+    expect(proposalTypeSchema.safeParse('conflict').success).toBe(true);
+    expect(proposalTypeSchema.safeParse('graphify_suggestion').success).toBe(false);
+  });
+});
+
+describe('graphify run status validation', () => {
+  it.each(['docmost_syncing', 'docmost_synced', 'docmost_sync_failed'] as const)(
+    'accepts %s as a graphify run status',
+    (status) => {
+      expect(graphifyRunStatusSchema.safeParse(status).success).toBe(true);
+    },
+  );
+});

--- a/packages/shared/src/schema/validation.ts
+++ b/packages/shared/src/schema/validation.ts
@@ -273,7 +273,7 @@ export const insertWikiPageSchema = z.object({
   slug: nonEmptyString.max(500),
   status: wikiPageStatusSchema.default('draft'),
   sync_status: syncStatusSchema.default('synced'),
-  docmost_page_id: z.string().max(200).nullable().optional(),
+  docmost_page_id: nonEmptyString.max(200).nullable().optional(),
   created_by: optionalIdSchema.nullable().optional(),
 });
 

--- a/packages/shared/src/schema/validation.ts
+++ b/packages/shared/src/schema/validation.ts
@@ -36,7 +36,16 @@ export const sourceDocumentStatusSchema = z.enum([
 ]);
 export const sourceDocumentProcessingStrategySchema = z.enum(['immediate', 'stash', 'archive_only']);
 export const graphifyRunModeSchema = z.enum(['full', 'update', 'incremental']);
-export const graphifyRunStatusSchema = z.enum(['pending', 'running', 'succeeded', 'failed', 'cancelled']);
+export const graphifyRunStatusSchema = z.enum([
+  'pending',
+  'running',
+  'succeeded',
+  'failed',
+  'cancelled',
+  'docmost_syncing',
+  'docmost_synced',
+  'docmost_sync_failed',
+]);
 export const graphifyTriggerTypeSchema = z.enum(['manual', 'scheduled', 'auto']);
 export const confidenceLabelSchema = z.enum(['EXTRACTED', 'INFERRED', 'AMBIGUOUS']);
 export const blockOwnerSchema = z.enum(['graphify', 'human', 'locked']);
@@ -44,6 +53,7 @@ export const proposalTypeSchema = z.enum(['conflict', 'deprecation', 'new_page']
 export const proposalStatusSchema = z.enum(['pending', 'accepted', 'rejected']);
 export const indexSnapshotStatusSchema = z.enum(['building', 'ready', 'activated', 'superseded']);
 export const chunkIndexStatusSchema = z4.enum(['pending', 'indexed']);
+export const syncStatusSchema = z.enum(['synced', 'sync_pending', 'conflict_required']);
 
 const nonEmptyString = z.string().trim().min(1);
 const idSchema = nonEmptyString.max(200);
@@ -262,6 +272,8 @@ export const insertWikiPageSchema = z.object({
   title: nonEmptyString.max(500),
   slug: nonEmptyString.max(500),
   status: wikiPageStatusSchema.default('draft'),
+  sync_status: syncStatusSchema.default('synced'),
+  docmost_page_id: z.string().max(200).nullable().optional(),
   created_by: optionalIdSchema.nullable().optional(),
 });
 
@@ -445,6 +457,7 @@ export type InsertSourceDocumentInput = z.infer<typeof insertSourceDocumentSchem
 export type UpdateSourceDocumentInput = z.infer<typeof updateSourceDocumentSchema>;
 export type WikiPageStatus = z.infer<typeof wikiPageStatusSchema>;
 export type WikiVersionSource = z.infer<typeof wikiVersionSourceSchema>;
+export type SyncStatus = z.infer<typeof syncStatusSchema>;
 export type InsertWikiPageInput = z.infer<typeof insertWikiPageSchema>;
 export type InsertWikiPageVersionInput = z.infer<typeof insertWikiPageVersionSchema>;
 export type PublishRequestInput = z.infer<typeof publishRequestSchema>;

--- a/packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts
+++ b/packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts
@@ -177,7 +177,7 @@ describe('importGraphifyWiki', () => {
     expect(result.proposalsCreated[0]).toMatchObject({
       pageId: authPage.pageId,
       blockId: 'key-components',
-      proposalType: 'graphify_suggestion',
+      proposalType: 'conflict',
     });
     expect(result.proposalsCreated[0]?.diffJson.graphifyContent).toContain('JWT tokens serve');
   });

--- a/packages/wiki-core/src/normalization/import-graphify-wiki.ts
+++ b/packages/wiki-core/src/normalization/import-graphify-wiki.ts
@@ -70,7 +70,7 @@ export interface WikiPageImport {
 export interface ProposalInfo {
   pageId: string;
   blockId: string;
-  proposalType: 'graphify_suggestion';
+  proposalType: 'conflict';
   diffJson: { humanContent: string; graphifyContent: string };
 }
 
@@ -276,7 +276,7 @@ function buildContentWithBlockOwnership(args: {
         proposalsCreated.push({
           pageId: args.pageId,
           blockId: block.blockId,
-          proposalType: 'graphify_suggestion',
+          proposalType: 'conflict',
           diffJson: {
             humanContent: preservedContent,
             graphifyContent: block.content,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@nestjs/schedule':
         specifier: ^6.1.3
         version: 6.1.3(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+      bullmq:
+        specifier: ^5.76.3
+        version: 5.76.3
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -248,6 +251,21 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.21.0))
+
+  apps/wiki-sync-worker:
+    dependencies:
+      '@cherrygraph/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      bullmq:
+        specifier: ^5.76.3
+        version: 5.76.3
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.20.0)
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
 
   packages/ai-core:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     },
     {
       "path": "./apps/indexer-worker"
+    },
+    {
+      "path": "./apps/wiki-sync-worker"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Schema 一致性修复：`syncStatusSchema`、`graphifyRunStatusSchema` 增加 docmost 状态、`proposalType` 从 `graphify_suggestion` 修正为 `conflict`
- 新增 `apps/wiki-sync-worker` 包：BullMQ 四队列定义（bridge-page-sync/bridge-permission-sync/bridge-attachment-sync/bridge-docmost-push）、health endpoint、startup reconciliation
- Cherry API 事件分发：`BridgeQueueService` 在 bridge event 持久化后 enqueue 到对应队列，Graphify completion 触发 docmost-push job

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `92b41601daadeb053968bdb420654941c8bcc9c6`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/132#issuecomment-4376971102) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/132#issuecomment-4376971241) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/132#issuecomment-4376971397) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/132#issuecomment-4376971528)
- Key findings addressed: Removed no-op BullMQ workers to prevent job loss, added enqueue resilience on primary and dedup paths, fixed docmost_syncing atomicity, renamed queue names to remove BullMQ-illegal colons, added Redis-disabled guard, job retention, batched reconciliation, resolved ESLint unbound-method errors

## Test plan
- [x] `validation-sync-status.test.ts` — 9 tests covering syncStatus/proposalType/graphifyRunStatus schemas
- [x] `health.test.ts` + `reconciliation.test.ts` — wiki-sync-worker unit tests
- [x] `bridge-queue.service.test.ts` — 6 tests for queue routing, dedup, and Redis guard
- [x] `bridge-event-dispatch.test.ts` — 3 tests for event→queue integration including dedup re-enqueue
- [x] `graphify-docmost-push.test.ts` — 3 tests for Graphify completion dispatch and failure handling
- [x] Regression: `bridge-receiver.test.ts` (24 tests), `internal-jobs.service.test.ts` (24 tests)
- [x] Regression: `wiki-core` (74 tests including updated proposal type assertion)
- [x] Full suite: 133 files, 771 tests passed
- [x] All 4 packages build successfully (shared, wiki-core, api, wiki-sync-worker)

Closes #128