### PR TITLE
feat(sync): page-sync processor + block merge algorithm (#129)

### DIFF
--- a/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
@@ -56,6 +56,7 @@ describe('BridgeQueueService', () => {
 
     expect(queueByName(BRIDGE_PAGE_SYNC_QUEUE).add).toHaveBeenCalledWith('page.saved', jobData, {
       jobId: 'event-1',
+      group: { id: 'page-1' },
     });
   });
 
@@ -92,6 +93,7 @@ describe('BridgeQueueService', () => {
 
     expect(queueByName(BRIDGE_PAGE_SYNC_QUEUE).add).toHaveBeenCalledWith('page.deleted', jobData, {
       jobId: 'docmost-event-42',
+      group: { id: 'page-1' },
     });
   });
 

--- a/apps/api/src/bridge/bridge-queue.service.ts
+++ b/apps/api/src/bridge/bridge-queue.service.ts
@@ -99,7 +99,7 @@ export class BridgeQueueService implements OnModuleDestroy {
     }
 
     const queueName = resolveBridgeQueueName(eventType);
-    await this.getQueue(queueName).add(eventType, jobData, { jobId: jobData.eventId });
+    await this.getQueue(queueName).add(eventType, jobData, bridgeQueueJobOptions(eventType, jobData));
   }
 
   async enqueueDocmostPushJob(jobData: DocmostPushJobData): Promise<void> {
@@ -155,4 +155,13 @@ export function resolveBridgeQueueName(eventType: BridgeEventType): BridgeQueueN
   }
 
   return BRIDGE_ATTACHMENT_SYNC_QUEUE;
+}
+
+export function bridgeQueueJobOptions(eventType: BridgeEventType, jobData: BridgeQueueJobData): JobsOptions {
+  const options = { jobId: jobData.eventId } as JobsOptions & { group?: { id: string } };
+  if ((eventType === 'page.saved' || eventType === 'page.deleted') && jobData.pageId !== undefined) {
+    options.group = { id: jobData.pageId };
+  }
+
+  return options;
 }

--- a/apps/wiki-sync-worker/package.json
+++ b/apps/wiki-sync-worker/package.json
@@ -13,8 +13,13 @@
   },
   "dependencies": {
     "@cherrygraph/shared": "workspace:*",
+    "@cherrygraph/wiki-core": "workspace:*",
     "bullmq": "^5.76.3",
     "drizzle-orm": "^0.45.2",
-    "ioredis": "^5.10.1"
+    "ioredis": "^5.10.1",
+    "pg": "^8.20.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.20.0"
   }
 }

--- a/apps/wiki-sync-worker/src/__tests__/page-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/page-sync.test.ts
@@ -64,6 +64,41 @@ describe('page-sync processor', () => {
     });
   });
 
+  it('preserves new unmarked H2 section when markers are present', async () => {
+    const db = new PageSyncTestDb();
+    db.metadataRows = [
+      createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nOriginal', editable: false }),
+      createMetadataRow({ block_id: 'details', owner: 'human', content: '## Details\nHuman notes' }),
+    ];
+    const markdown = frontmatter(
+      [
+        '<!-- graphify:managed:start id="overview" run="gf-1" -->',
+        '## Overview',
+        'Original',
+        '<!-- graphify:managed:end -->',
+        '',
+        '## New Unmarked Section',
+        'This content was added outside markers.',
+        '',
+        '<!-- graphify:human:start id="details" run="gf-1" -->',
+        '## Details',
+        'Human notes',
+        '<!-- graphify:human:end -->',
+      ].join('\n'),
+    );
+
+    await runProcessor(db, bridgeClientWithMarkdown(markdown));
+
+    expect(db.insertedBlockMetadata).toHaveLength(3);
+    expect(blockById(db, 'new-unmarked-section')).toMatchObject({
+      owner: 'human',
+      last_editor: 'user-1',
+      editable: true,
+      content_hash: normalizeBlockHash('## New Unmarked Section\nThis content was added outside markers.'),
+    });
+    expect(db.insertedVersions[0]?.content_markdown).toContain('## New Unmarked Section');
+  });
+
   it('handles graphify-to-human, human-to-human, and new block ownership transitions', async () => {
     const db = new PageSyncTestDb();
     db.metadataRows = [
@@ -120,6 +155,18 @@ describe('page-sync processor', () => {
     expect(db.insertedVersions).toHaveLength(1);
     expect(bridgeClient.exportPage).toHaveBeenCalledTimes(1);
     expect(db.bridgeEventRows.find((event) => event.id === 'older-event')?.status).toBe('processed');
+  });
+
+  it('skips already-processed bridge event', async () => {
+    const db = new PageSyncTestDb();
+    db.bridgeEventRows = [createBridgeEvent({ status: 'processed', processed_at: new Date('2026-05-05T12:01:00.000Z') })];
+    const bridgeClient = bridgeClientWithMarkdown(frontmatter('## Overview\nSkipped'));
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.exportPage).not.toHaveBeenCalled();
+    expect(db.insertedVersions).toHaveLength(0);
+    expect(db.bridgeEventUpdates).toHaveLength(0);
   });
 
   it('marks permission denied events failed without creating a version', async () => {
@@ -188,12 +235,18 @@ class PageSyncTestDb {
   insertedBlockMetadata: Array<typeof pageBlockMetadata.$inferInsert> = [];
   bridgeEventUpdates: Array<Partial<typeof bridgeEvents.$inferInsert>> = [];
   pageUpdates: Array<Partial<typeof wikiPages.$inferInsert>> = [];
+  activeBridgeEventId = 'bridge-event-1';
 
-  select(): unknown {
+  select(selection?: unknown): unknown {
     return {
       from: (table: unknown) => {
         const resolveRows = (): unknown[] => {
           if (table === bridgeEvents) {
+            if (isRecord(selection) && 'status' in selection) {
+              const event = this.bridgeEventRows.find((row) => row.id === this.activeBridgeEventId);
+              return event === undefined ? [] : [{ status: event.status }];
+            }
+
             return this.bridgeEventRows
               .filter((event) => event.status === 'received')
               .sort((left, right) => right.received_at.getTime() - left.received_at.getTime());
@@ -214,6 +267,10 @@ class PageSyncTestDb {
         return new SelectBuilder(resolveRows);
       },
     };
+  }
+
+  transaction<T>(callback: (tx: PageSyncTestDb) => Promise<T>): Promise<T> {
+    return callback(this);
   }
 
   update(table: unknown): unknown {
@@ -264,9 +321,7 @@ class PageSyncTestDb {
     }
 
     this.bridgeEventRows = this.bridgeEventRows.map((event) =>
-      event.id === 'bridge-event-1' || event.id === 'older-event' || event.id === 'latest-event'
-        ? { ...event, ...values }
-        : event,
+      event.id === this.activeBridgeEventId ? { ...event, ...values } : event,
     ) as BridgeEventRow[];
   }
 }
@@ -304,6 +359,15 @@ async function runProcessor(
   overrides: Partial<PageSyncJobData> = {},
   permissionAllowed = true,
 ): Promise<void> {
+  const data = {
+    bridgeEventId: 'bridge-event-1',
+    eventId: 'docmost-event-1',
+    eventType: 'page.saved',
+    pageId: 'docmost-page-1',
+    ...overrides,
+  };
+  db.activeBridgeEventId = data.bridgeEventId;
+
   const processor = createPageSyncProcessor({
     db: db.asDb(),
     bridgeClient,
@@ -312,13 +376,7 @@ async function runProcessor(
   });
 
   await processor({
-    data: {
-      bridgeEventId: 'bridge-event-1',
-      eventId: 'docmost-event-1',
-      eventType: 'page.saved',
-      pageId: 'docmost-page-1',
-      ...overrides,
-    },
+    data,
   } as Job<PageSyncJobData>);
 }
 
@@ -464,4 +522,8 @@ function readLatestBridgeEventId(value: unknown): string | undefined {
   return value !== null && typeof value === 'object' && 'latestBridgeEventId' in value
     ? String((value as { latestBridgeEventId: unknown }).latestBridgeEventId)
     : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/apps/wiki-sync-worker/src/__tests__/page-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/page-sync.test.ts
@@ -1,0 +1,467 @@
+import type { Job } from 'bullmq';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  bridgeEvents,
+  pageBlockMetadata,
+  wikiPageVersions,
+  wikiPages,
+} from '@cherrygraph/shared';
+import { normalizeBlockHash } from '@cherrygraph/wiki-core';
+
+import {
+  createPageSyncProcessor,
+  type BridgeClient,
+  type DrizzleDatabase,
+  type PageSyncJobData,
+} from '../processors/page-sync.processor.js';
+
+describe('page-sync processor', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('processes page.saved through export, merge, version creation, metadata write, and synced status', async () => {
+    const db = new PageSyncTestDb();
+    db.metadataRows = [
+      createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nOriginal', editable: false }),
+      createMetadataRow({ block_id: 'details', owner: 'human', content: '## Details\nHuman notes' }),
+    ];
+    const bridgeClient = bridgeClientWithMarkdown(markedMarkdown());
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.exportPage).toHaveBeenCalledWith('docmost-page-1');
+    expect(db.insertedVersions).toHaveLength(1);
+    expect(db.insertedVersions[0]).toMatchObject({
+      wiki_page_pk: 'wiki-pk-1',
+      source: 'docmost',
+      version_no: 2,
+      created_by: 'user-1',
+    });
+    expect(db.insertedBlockMetadata).toHaveLength(2);
+    expect(db.pageUpdates.at(-1)).toMatchObject({
+      current_version_id: db.insertedVersions[0]?.id,
+      sync_status: 'synced',
+    });
+    expect(db.bridgeEventUpdates.at(-1)).toMatchObject({ status: 'processed' });
+  });
+
+  it('recovers ownership via heading fallback when markers are missing', async () => {
+    const db = new PageSyncTestDb();
+    db.metadataRows = [
+      createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nOriginal', editable: false }),
+    ];
+
+    await runProcessor(db, bridgeClientWithMarkdown(frontmatter('## Overview\nHuman edit')));
+
+    expect(db.insertedBlockMetadata[0]).toMatchObject({
+      block_id: 'overview',
+      owner: 'human',
+      content_hash: normalizeBlockHash('## Overview\nHuman edit'),
+      last_editor: 'user-1',
+      editable: true,
+    });
+  });
+
+  it('handles graphify-to-human, human-to-human, and new block ownership transitions', async () => {
+    const db = new PageSyncTestDb();
+    db.metadataRows = [
+      createMetadataRow({ block_id: 'graphify-block', owner: 'graphify', content: '## Graphify Block\nOriginal', editable: false }),
+      createMetadataRow({ block_id: 'human-block', owner: 'human', content: '## Human Block\nOriginal', last_editor: 'old-user' }),
+      createMetadataRow({ block_id: 'deleted-block', owner: 'human', content: '## Deleted Block\nRemoved' }),
+    ];
+    const markdown = frontmatter(
+      [
+        '## Graphify Block',
+        'Edited by human',
+        '',
+        '## Human Block',
+        'Updated by human',
+        '',
+        '## New Block',
+        'New content',
+      ].join('\n'),
+    );
+
+    await runProcessor(db, bridgeClientWithMarkdown(markdown));
+
+    expect(db.insertedBlockMetadata).toHaveLength(3);
+    expect(blockById(db, 'graphify-block')).toMatchObject({
+      owner: 'human',
+      last_editor: 'user-1',
+      editable: true,
+    });
+    expect(blockById(db, 'human-block')).toMatchObject({
+      owner: 'human',
+      last_editor: 'user-1',
+      editable: true,
+      content_hash: normalizeBlockHash('## Human Block\nUpdated by human'),
+    });
+    expect(blockById(db, 'new-block')).toMatchObject({
+      owner: 'human',
+      last_editor: 'user-1',
+      editable: true,
+    });
+    expect(db.insertedBlockMetadata.some((row) => row.block_id === 'deleted-block')).toBe(false);
+  });
+
+  it('coalesces stale same-page events so only the latest creates a version', async () => {
+    const db = new PageSyncTestDb();
+    db.bridgeEventRows = [
+      createBridgeEvent({ id: 'older-event', event_id: 'older', received_at: new Date('2026-05-05T11:00:00.000Z') }),
+      createBridgeEvent({ id: 'latest-event', event_id: 'latest', received_at: new Date('2026-05-05T11:01:00.000Z') }),
+    ];
+    const bridgeClient = bridgeClientWithMarkdown(frontmatter('## Overview\nLatest'));
+
+    await runProcessor(db, bridgeClient, { bridgeEventId: 'older-event', eventId: 'older' });
+    await runProcessor(db, bridgeClient, { bridgeEventId: 'latest-event', eventId: 'latest' });
+
+    expect(db.insertedVersions).toHaveLength(1);
+    expect(bridgeClient.exportPage).toHaveBeenCalledTimes(1);
+    expect(db.bridgeEventRows.find((event) => event.id === 'older-event')?.status).toBe('processed');
+  });
+
+  it('marks permission denied events failed without creating a version', async () => {
+    const db = new PageSyncTestDb();
+
+    await runProcessor(db, bridgeClientWithMarkdown(frontmatter('## Overview\nDenied')), {}, false);
+
+    expect(db.insertedVersions).toHaveLength(0);
+    expect(db.bridgeEventUpdates.at(-1)).toMatchObject({
+      status: 'failed',
+      error_json: { code: 'PERMISSION_DENIED' },
+    });
+    expect(db.pageUpdates.at(-1)).toMatchObject({ sync_status: 'sync_pending' });
+  });
+
+  it('archives mapped pages on page.deleted', async () => {
+    const db = new PageSyncTestDb();
+
+    await runProcessor(db, bridgeClientWithMarkdown(''), {
+      eventType: 'page.deleted',
+      bridgeEventId: 'delete-event',
+      eventId: 'delete',
+    });
+
+    expect(db.pageUpdates.at(-1)).toMatchObject({ status: 'archived' });
+    expect(db.bridgeEventUpdates.at(-1)).toMatchObject({ status: 'processed' });
+  });
+
+  it('marks unknown docmost_page_id events processed and skips export', async () => {
+    const db = new PageSyncTestDb();
+    db.page = undefined;
+    const bridgeClient = bridgeClientWithMarkdown(frontmatter('## Overview\nSkipped'));
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.exportPage).not.toHaveBeenCalled();
+    expect(db.insertedVersions).toHaveLength(0);
+    expect(db.bridgeEventUpdates.at(-1)).toMatchObject({ status: 'processed' });
+  });
+
+  it('repairs missing frontmatter from the DB page record', async () => {
+    const db = new PageSyncTestDb();
+
+    await runProcessor(db, bridgeClientWithMarkdown('## Overview\nNo frontmatter'));
+
+    expect(db.insertedVersions[0]?.content_markdown).toContain('page_id: wiki.page.1');
+    expect(db.insertedVersions[0]?.content_markdown).toContain('space_id: space-1');
+    expect(db.insertedVersions[0]?.frontmatter_json).toMatchObject({
+      page_id: 'wiki.page.1',
+      space_id: 'space-1',
+    });
+  });
+});
+
+type BridgeEventRow = typeof bridgeEvents.$inferSelect;
+type WikiPageRow = typeof wikiPages.$inferSelect;
+type WikiPageVersionRow = typeof wikiPageVersions.$inferSelect;
+type PageBlockMetadataRow = typeof pageBlockMetadata.$inferSelect;
+
+class PageSyncTestDb {
+  page: WikiPageRow | undefined = createPage();
+  currentVersion: WikiPageVersionRow | undefined = createVersion();
+  metadataRows: PageBlockMetadataRow[] = [];
+  bridgeEventRows: BridgeEventRow[] = [createBridgeEvent()];
+  insertedVersions: Array<typeof wikiPageVersions.$inferInsert> = [];
+  insertedBlockMetadata: Array<typeof pageBlockMetadata.$inferInsert> = [];
+  bridgeEventUpdates: Array<Partial<typeof bridgeEvents.$inferInsert>> = [];
+  pageUpdates: Array<Partial<typeof wikiPages.$inferInsert>> = [];
+
+  select(): unknown {
+    return {
+      from: (table: unknown) => {
+        const resolveRows = (): unknown[] => {
+          if (table === bridgeEvents) {
+            return this.bridgeEventRows
+              .filter((event) => event.status === 'received')
+              .sort((left, right) => right.received_at.getTime() - left.received_at.getTime());
+          }
+          if (table === wikiPages) {
+            return this.page === undefined ? [] : [{ page: this.page, spaceSlug: 'rd-platform' }];
+          }
+          if (table === wikiPageVersions) {
+            return this.currentVersion === undefined ? [] : [this.currentVersion];
+          }
+          if (table === pageBlockMetadata) {
+            return this.metadataRows;
+          }
+
+          return [];
+        };
+
+        return new SelectBuilder(resolveRows);
+      },
+    };
+  }
+
+  update(table: unknown): unknown {
+    return {
+      set: (values: Record<string, unknown>) => ({
+        where: (): Promise<void> => {
+          if (table === bridgeEvents) {
+            this.bridgeEventUpdates.push(values);
+            this.applyBridgeEventUpdate(values);
+          }
+          if (table === wikiPages) {
+            this.pageUpdates.push(values);
+            if (this.page !== undefined) {
+              this.page = { ...this.page, ...values } as WikiPageRow;
+            }
+          }
+          return Promise.resolve();
+        },
+      }),
+    };
+  }
+
+  insert(table: unknown): unknown {
+    return {
+      values: (values: unknown): Promise<void> => {
+        if (table === wikiPageVersions) {
+          this.insertedVersions.push(values as typeof wikiPageVersions.$inferInsert);
+        }
+        if (table === pageBlockMetadata) {
+          this.insertedBlockMetadata.push(...(values as Array<typeof pageBlockMetadata.$inferInsert>));
+        }
+        return Promise.resolve();
+      },
+    };
+  }
+
+  asDb(): DrizzleDatabase {
+    return this as unknown as DrizzleDatabase;
+  }
+
+  private applyBridgeEventUpdate(values: Record<string, unknown>): void {
+    if (readErrorCode(values.error_json) === 'COALESCED') {
+      const latestBridgeEventId = readLatestBridgeEventId(values.error_json);
+      this.bridgeEventRows = this.bridgeEventRows.map((event) =>
+        event.id === latestBridgeEventId ? event : { ...event, status: 'processed' },
+      );
+      return;
+    }
+
+    this.bridgeEventRows = this.bridgeEventRows.map((event) =>
+      event.id === 'bridge-event-1' || event.id === 'older-event' || event.id === 'latest-event'
+        ? { ...event, ...values }
+        : event,
+    ) as BridgeEventRow[];
+  }
+}
+
+class SelectBuilder {
+  constructor(private readonly resolveRows: () => unknown[]) {}
+
+  leftJoin(): this {
+    return this;
+  }
+
+  where(): this {
+    return this;
+  }
+
+  orderBy(): this {
+    return this;
+  }
+
+  limit(limit: number): Promise<unknown[]> {
+    return Promise.resolve(this.resolveRows().slice(0, limit));
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.resolveRows()).then(onfulfilled, onrejected);
+  }
+}
+
+async function runProcessor(
+  db: PageSyncTestDb,
+  bridgeClient: BridgeClient,
+  overrides: Partial<PageSyncJobData> = {},
+  permissionAllowed = true,
+): Promise<void> {
+  const processor = createPageSyncProcessor({
+    db: db.asDb(),
+    bridgeClient,
+    wikiRepoPath: '/tmp/wiki',
+    permissionChecker: () => permissionAllowed,
+  });
+
+  await processor({
+    data: {
+      bridgeEventId: 'bridge-event-1',
+      eventId: 'docmost-event-1',
+      eventType: 'page.saved',
+      pageId: 'docmost-page-1',
+      ...overrides,
+    },
+  } as Job<PageSyncJobData>);
+}
+
+function bridgeClientWithMarkdown(markdown: string): BridgeClient {
+  return {
+    exportPage: vi.fn(() =>
+      Promise.resolve({
+        markdown,
+        userId: 'user-1',
+        userName: 'Ada Editor',
+        userEmail: 'ada@example.com',
+      }),
+    ),
+  };
+}
+
+function markedMarkdown(): string {
+  return frontmatter(
+    [
+      '<!-- graphify:managed:start id="overview" run="gf-1" -->',
+      '## Overview',
+      'Original',
+      '<!-- graphify:managed:end -->',
+      '',
+      '<!-- graphify:human:start id="details" run="gf-1" -->',
+      '## Details',
+      'Human notes',
+      '<!-- graphify:human:end -->',
+    ].join('\n'),
+  );
+}
+
+function frontmatter(content: string): string {
+  return [
+    '---',
+    'page_id: wiki.page.1',
+    'space_id: space-1',
+    'title: Test Page',
+    'status: draft',
+    'source: graphify',
+    '---',
+    '',
+    content,
+  ].join('\n');
+}
+
+function blockById(db: PageSyncTestDb, blockId: string): typeof pageBlockMetadata.$inferInsert | undefined {
+  return db.insertedBlockMetadata.find((row) => row.block_id === blockId);
+}
+
+function createBridgeEvent(overrides: Partial<BridgeEventRow> = {}): BridgeEventRow {
+  return {
+    id: 'bridge-event-1',
+    event_id: 'docmost-event-1',
+    event_type: 'page.saved',
+    source: 'docmost',
+    space_id: 'space-1',
+    page_id: 'docmost-page-1',
+    payload: {},
+    status: 'received',
+    error_json: null,
+    nonce: null,
+    received_at: new Date('2026-05-05T12:00:00.000Z'),
+    processed_at: null,
+    created_at: new Date('2026-05-05T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createPage(overrides: Partial<WikiPageRow> = {}): WikiPageRow {
+  return {
+    id: 'wiki-pk-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    page_id: 'wiki.page.1',
+    title: 'Test Page',
+    slug: 'test-page',
+    status: 'draft',
+    current_version_id: 'version-1',
+    indexed_version_id: null,
+    sync_status: 'synced',
+    docmost_page_id: 'docmost-page-1',
+    created_by: 'user-1',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createVersion(overrides: Partial<WikiPageVersionRow> = {}): WikiPageVersionRow {
+  return {
+    id: 'version-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    wiki_page_pk: 'wiki-pk-1',
+    page_id: 'wiki.page.1',
+    version_no: 1,
+    content_markdown: frontmatter('## Overview\nOriginal'),
+    frontmatter_json: {
+      page_id: 'wiki.page.1',
+      space_id: 'space-1',
+      title: 'Test Page',
+      status: 'draft',
+      source: 'graphify',
+    },
+    source: 'graphify',
+    graphify_run_id: 'gf-1',
+    commit_hash: 'commit-1',
+    status: 'draft',
+    created_by: 'graphify',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createMetadataRow(
+  overrides: Partial<PageBlockMetadataRow> & { block_id: string; content: string },
+): PageBlockMetadataRow {
+  return {
+    id: `metadata-${overrides.block_id}`,
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    wiki_page_pk: 'wiki-pk-1',
+    page_version_id: 'version-1',
+    block_id: overrides.block_id,
+    owner: overrides.owner ?? 'human',
+    content_hash: normalizeBlockHash(overrides.content),
+    graphify_run_id: overrides.graphify_run_id ?? 'gf-1',
+    last_editor: overrides.last_editor ?? null,
+    editable: overrides.editable ?? true,
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+  };
+}
+
+function readErrorCode(value: unknown): string | undefined {
+  return value !== null && typeof value === 'object' && 'code' in value
+    ? String((value as { code: unknown }).code)
+    : undefined;
+}
+
+function readLatestBridgeEventId(value: unknown): string | undefined {
+  return value !== null && typeof value === 'object' && 'latestBridgeEventId' in value
+    ? String((value as { latestBridgeEventId: unknown }).latestBridgeEventId)
+    : undefined;
+}

--- a/apps/wiki-sync-worker/src/__tests__/reconciliation.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/reconciliation.test.ts
@@ -44,7 +44,7 @@ describe('wiki-sync-worker startup reconciliation', () => {
         spaceId: 'space-1',
         pageId: 'page-1',
       },
-      { jobId: 'docmost-1' },
+      { jobId: 'docmost-1', group: { id: 'page-1' } },
     );
     expect(queues.permissionSync.add).toHaveBeenCalledWith(
       'space.updated',

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -1,16 +1,31 @@
-import { Queue, type JobsOptions, type Queue as BullQueue } from 'bullmq';
+import { Queue, Worker, type JobsOptions, type Queue as BullQueue, type Worker as BullWorker } from 'bullmq';
+import { drizzle } from 'drizzle-orm/node-postgres';
 import { Redis } from 'ioredis';
 import type { Redis as IORedis } from 'ioredis';
 import type { Server } from 'node:http';
 import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+import type { Pool as PgPool } from 'pg';
 
 import { closeHealthServer, startHealthServer } from './health.js';
+import { reconcileOnStartup, type ReconciliationDb } from './reconciliation.js';
+import {
+  createHttpBridgeClient,
+  createPageSyncProcessor,
+  type PageSyncDeps,
+} from './processors/page-sync.processor.js';
 
 const WORKER_NAME = 'wiki-sync-worker';
 const PAGE_SYNC_QUEUE = 'bridge-page-sync';
 const PERMISSION_SYNC_QUEUE = 'bridge-permission-sync';
 const ATTACHMENT_SYNC_QUEUE = 'bridge-attachment-sync';
 const DOCMOST_PUSH_QUEUE = 'bridge-docmost-push';
+
+const PAGE_SYNC_BACKOFF = {
+  type: 'custom',
+  delay: (attemptsMade: number): number =>
+    [5_000, 30_000, 180_000][attemptsMade - 1] ?? 180_000,
+};
 
 const DEFAULT_JOB_OPTIONS: JobsOptions = {
   attempts: 3,
@@ -22,6 +37,14 @@ const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnFail: { count: 5000, age: 604_800 },
 };
 
+const PAGE_SYNC_JOB_OPTIONS: JobsOptions = {
+  ...DEFAULT_JOB_OPTIONS,
+  backoff: {
+    type: PAGE_SYNC_BACKOFF.type,
+    delay: PAGE_SYNC_BACKOFF.delay(1),
+  },
+};
+
 type BridgeWorkerQueues = {
   pageSync: BullQueue;
   permissionSync: BullQueue;
@@ -29,13 +52,37 @@ type BridgeWorkerQueues = {
   docmostPush: BullQueue;
 };
 
+type BridgeWorkers = {
+  pageSync: BullWorker;
+};
+
 export async function bootstrap(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (databaseUrl === undefined || databaseUrl.length === 0) {
+    throw new Error('DATABASE_URL is required to start wiki-sync-worker');
+  }
+
   const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
   const healthPort = parseHealthPort(process.env.WORKER_HEALTH_PORT);
+  const pool = new pg.Pool({
+    connectionString: databaseUrl,
+    connectionTimeoutMillis: 5_000,
+    idleTimeoutMillis: 30_000,
+  });
+  const db = drizzle(pool);
   const connection = new Redis(redisUrl, { maxRetriesPerRequest: null });
   const queues = createQueues(connection);
 
-  await reconcileQueuesOnStartup(queues);
+  await reconcileOnStartup(db as unknown as ReconciliationDb, queues);
+
+  const workers = createWorkers(connection, {
+    db,
+    bridgeClient: createHttpBridgeClient(
+      process.env.DOCMOST_BRIDGE_BASE_URL ?? process.env.DOCMOST_BASE_URL ?? 'http://localhost:3000',
+      process.env.DOCMOST_BRIDGE_TOKEN,
+    ),
+    wikiRepoPath: process.env.WIKI_REPO_PATH ?? process.cwd(),
+  });
 
   const healthServer = await startHealthServer(
     {
@@ -47,26 +94,36 @@ export async function bootstrap(): Promise<void> {
     healthPort,
   );
 
-  const shutdown = createShutdownHandler(queues, connection, healthServer);
+  const shutdown = createShutdownHandler(queues, workers, connection, pool, healthServer);
   process.once('SIGTERM', shutdown);
   process.once('SIGINT', shutdown);
   console.log(`${WORKER_NAME}: started`, { healthPort });
 }
 
 function createQueues(connection: IORedis): BridgeWorkerQueues {
-  const queueOptions = { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS };
-
   return {
-    pageSync: new Queue(PAGE_SYNC_QUEUE, queueOptions),
-    permissionSync: new Queue(PERMISSION_SYNC_QUEUE, queueOptions),
-    attachmentSync: new Queue(ATTACHMENT_SYNC_QUEUE, queueOptions),
-    docmostPush: new Queue(DOCMOST_PUSH_QUEUE, queueOptions),
+    pageSync: new Queue(PAGE_SYNC_QUEUE, { connection, defaultJobOptions: PAGE_SYNC_JOB_OPTIONS }),
+    permissionSync: new Queue(PERMISSION_SYNC_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
+    attachmentSync: new Queue(ATTACHMENT_SYNC_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
+    docmostPush: new Queue(DOCMOST_PUSH_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
   };
 }
 
-async function reconcileQueuesOnStartup(_queues: BridgeWorkerQueues): Promise<void> {
-  // TODO(Issue #129): create the worker DB connection and call reconcileOnStartup(db, queues).
-  console.warn('DB not connected — startup reconciliation skipped (will be wired in Issue #129)');
+function createWorkers(connection: IORedis, pageSyncDeps: PageSyncDeps): BridgeWorkers {
+  const pageSync = new Worker(PAGE_SYNC_QUEUE, createPageSyncProcessor(pageSyncDeps), {
+    connection,
+    concurrency: 3,
+    settings: {
+      backoffStrategy: (attemptsMade, type) =>
+        type === PAGE_SYNC_BACKOFF.type ? PAGE_SYNC_BACKOFF.delay(attemptsMade) : 0,
+    },
+  });
+
+  pageSync.on('error', (error) => {
+    console.error(`${WORKER_NAME}: page-sync worker error`, error);
+  });
+
+  return { pageSync };
 }
 
 function parseHealthPort(value: string | undefined): number {
@@ -84,7 +141,9 @@ function parseHealthPort(value: string | undefined): number {
 
 function createShutdownHandler(
   queues: BridgeWorkerQueues,
+  workers: BridgeWorkers,
   connection: IORedis,
+  pool: PgPool,
   healthServer: Server,
 ): () => void {
   let shuttingDown = false;
@@ -95,23 +154,28 @@ function createShutdownHandler(
     }
 
     shuttingDown = true;
-    void shutdown(queues, connection, healthServer);
+    void shutdown(queues, workers, connection, pool, healthServer);
   };
 }
 
 async function shutdown(
   queues: BridgeWorkerQueues,
+  workers: BridgeWorkers,
   connection: IORedis,
+  pool: PgPool,
   healthServer: Server,
 ): Promise<void> {
   let shutdownFailed = false;
   const queueList = [queues.pageSync, queues.permissionSync, queues.attachmentSync, queues.docmostPush];
+  const workerList = [workers.pageSync];
 
   try {
     console.log(`${WORKER_NAME}: shutting down`);
     const results = await Promise.allSettled([
+      ...workerList.map((worker) => worker.close()),
       ...queueList.map((queue) => queue.close()),
       connection.quit(),
+      pool.end(),
     ]);
 
     for (const result of results) {

--- a/apps/wiki-sync-worker/src/processors/page-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/page-sync.processor.ts
@@ -1,0 +1,547 @@
+import type { Job } from 'bullmq';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { randomUUID } from 'node:crypto';
+
+import {
+  bridgeEvents,
+  pageBlockMetadata,
+  spaces,
+  wikiPageVersions,
+  wikiPages,
+} from '@cherrygraph/shared';
+import {
+  extractMarkedBlocks,
+  generateFrontmatter,
+  matchBlocksFallback,
+  mergeBlocks,
+  parseBlockMarkers,
+  parseFrontmatter,
+  type BlockMatchResult,
+  type BlockMergeMetadataInfo,
+  type WikiFrontmatter,
+} from '@cherrygraph/wiki-core';
+
+export type DrizzleDatabase = NodePgDatabase;
+
+export interface BridgeClient {
+  exportPage(pageId: string): Promise<{
+    markdown: string;
+    userId?: string;
+    userName?: string;
+    userEmail?: string;
+  }>;
+}
+
+export interface PageSyncDeps {
+  db: DrizzleDatabase;
+  bridgeClient: BridgeClient;
+  wikiRepoPath: string;
+  permissionChecker?: (args: {
+    userId?: string;
+    spaceId: string;
+    pageId: string;
+  }) => Promise<boolean> | boolean;
+}
+
+export type PageSyncJobData = {
+  bridgeEventId: string;
+  eventId?: string;
+  eventType: string;
+  spaceId?: string;
+  pageId?: string;
+};
+
+type WikiPageRow = typeof wikiPages.$inferSelect;
+type WikiPageVersionRow = typeof wikiPageVersions.$inferSelect;
+type PageBlockMetadataRow = typeof pageBlockMetadata.$inferSelect;
+
+type PageContext = {
+  page: WikiPageRow;
+  spaceSlug: string;
+};
+
+type WritebackUser = {
+  userId?: string;
+  userName?: string;
+  userEmail?: string;
+  editId: string;
+};
+
+type FrontmatterRepairResult = {
+  frontmatter: WikiFrontmatter;
+  content: string;
+  repaired: boolean;
+};
+
+export function createPageSyncProcessor(deps: PageSyncDeps): (job: Job<PageSyncJobData>) => Promise<void> {
+  return async (job) => {
+    const data = job.data;
+
+    try {
+      if (await coalesceStalePageEvents(deps.db, data)) {
+        return;
+      }
+
+      await markBridgeEventProcessing(deps.db, data.bridgeEventId);
+
+      if (data.eventType === 'page.deleted') {
+        await processPageDeleted(deps, data);
+        return;
+      }
+
+      if (data.eventType === 'page.saved') {
+        await processPageSaved(deps, data);
+        return;
+      }
+
+      await markBridgeEventProcessed(deps.db, data.bridgeEventId);
+    } catch (error) {
+      await markBridgeEventFailed(deps.db, data.bridgeEventId, errorToJson(error));
+      await markPageSyncPending(deps.db, data.pageId);
+      throw error;
+    }
+  };
+}
+
+export function createHttpBridgeClient(baseUrl: string, token?: string): BridgeClient {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+
+  return {
+    async exportPage(pageId: string) {
+      const requestInit = token !== undefined ? { headers: { Authorization: `Bearer ${token}` } } : {};
+      const response = await fetch(
+        `${normalizedBaseUrl}/api/internal/bridge/pages/${encodeURIComponent(pageId)}/export?format=markdown`,
+        requestInit,
+      );
+
+      if (!response.ok) {
+        throw new Error(`Bridge export failed for page ${pageId}: HTTP ${response.status}`);
+      }
+
+      const payload = readRecord(await response.json());
+      const markdown = readString(payload.markdown) ?? readString(payload.content);
+      if (markdown === undefined) {
+        throw new Error(`Bridge export response for page ${pageId} did not include markdown content`);
+      }
+
+      const userId = readString(payload.userId) ?? readString(payload.user_id) ?? readString(payload.updated_by);
+      const userName = readString(payload.userName) ?? readString(payload.user_name) ?? readString(payload.updated_by_name);
+      const userEmail = readString(payload.userEmail) ?? readString(payload.user_email) ?? readString(payload.updated_by_email);
+      const result: Awaited<ReturnType<BridgeClient['exportPage']>> = { markdown };
+
+      if (userId !== undefined) {
+        result.userId = userId;
+      }
+      if (userName !== undefined) {
+        result.userName = userName;
+      }
+      if (userEmail !== undefined) {
+        result.userEmail = userEmail;
+      }
+
+      return result;
+    },
+  };
+}
+
+export async function commitToWikiRepo(
+  deps: Pick<PageSyncDeps, 'wikiRepoPath'>,
+  page: PageContext,
+  content: string,
+  user: WritebackUser,
+): Promise<{ commitHash: string | null; message: string }> {
+  const message = `[${page.spaceSlug}][human][${user.editId}] update ${page.page.slug}`;
+  console.log('wiki repo commit placeholder', {
+    wikiRepoPath: deps.wikiRepoPath,
+    pageId: page.page.page_id,
+    userId: user.userId,
+    contentBytes: Buffer.byteLength(content, 'utf8'),
+    message,
+  });
+
+  return { commitHash: null, message };
+}
+
+async function processPageSaved(deps: PageSyncDeps, data: PageSyncJobData): Promise<void> {
+  const docmostPageId = requirePageId(data);
+  const page = await findPageByDocmostPageId(deps.db, docmostPageId);
+  if (page === undefined) {
+    console.warn('page-sync: docmost_page_id not found; skipping event', {
+      docmostPageId,
+      bridgeEventId: data.bridgeEventId,
+    });
+    await markBridgeEventProcessed(deps.db, data.bridgeEventId);
+    return;
+  }
+
+  const exported = await deps.bridgeClient.exportPage(docmostPageId);
+  const user: WritebackUser = {
+    ...(exported.userId !== undefined ? { userId: exported.userId } : {}),
+    ...(exported.userName !== undefined ? { userName: exported.userName } : {}),
+    ...(exported.userEmail !== undefined ? { userEmail: exported.userEmail } : {}),
+    editId: data.eventId ?? data.bridgeEventId,
+  };
+
+  const permissionAllowed = await checkSpaceEditPermission(deps, {
+    ...(user.userId !== undefined ? { userId: user.userId } : {}),
+    spaceId: page.page.space_id,
+    pageId: page.page.page_id,
+  });
+  if (!permissionAllowed) {
+    await markBridgeEventFailed(deps.db, data.bridgeEventId, { code: 'PERMISSION_DENIED' });
+    await markPageSyncPendingByPagePk(deps.db, page.page.id);
+    return;
+  }
+
+  const currentVersion = await loadCurrentVersion(deps.db, page.page);
+  const sidecar = currentVersion === undefined ? [] : await loadPageBlockMetadata(deps.db, currentVersion.id);
+  const repaired = repairFrontmatter(exported.markdown, page.page, currentVersion);
+  if (repaired.repaired) {
+    console.warn('page-sync: repaired missing frontmatter fields', {
+      pageId: page.page.page_id,
+      docmostPageId,
+    });
+  }
+
+  const matchedBlocks = matchExportedBlocks(repaired.content, sidecar);
+  const mergeResult = mergeBlocks(matchedBlocks, user.userId, currentVersion?.graphify_run_id ?? undefined);
+  const contentMarkdown = generateFrontmatter(repaired.frontmatter, mergeResult.mergedMarkdown);
+  const versionId = randomUUID();
+  const versionNo = (currentVersion?.version_no ?? 0) + 1;
+  const commit = await commitToWikiRepo(deps, page, contentMarkdown, user);
+
+  await deps.db.insert(wikiPageVersions).values({
+    id: versionId,
+    tenant_id: page.page.tenant_id,
+    space_id: page.page.space_id,
+    wiki_page_pk: page.page.id,
+    page_id: page.page.page_id,
+    version_no: versionNo,
+    content_markdown: contentMarkdown,
+    frontmatter_json: repaired.frontmatter as unknown as Record<string, unknown>,
+    source: 'docmost',
+    graphify_run_id: currentVersion?.graphify_run_id ?? null,
+    commit_hash: commit.commitHash,
+    status: page.page.status,
+    created_by: user.userId ?? null,
+  });
+
+  await writePageBlockMetadata(deps.db, page.page, versionId, mergeResult.newMetadata);
+  await deps.db
+    .update(wikiPages)
+    .set({
+      current_version_id: versionId,
+      sync_status: 'synced',
+      updated_at: new Date(),
+    })
+    .where(eq(wikiPages.id, page.page.id));
+
+  console.log(`reindex triggered for page ${page.page.page_id}`);
+  await markBridgeEventProcessed(deps.db, data.bridgeEventId);
+}
+
+async function processPageDeleted(deps: PageSyncDeps, data: PageSyncJobData): Promise<void> {
+  const docmostPageId = requirePageId(data);
+  const page = await findPageByDocmostPageId(deps.db, docmostPageId);
+  if (page === undefined) {
+    console.warn('page-sync: docmost_page_id not found for delete; skipping event', {
+      docmostPageId,
+      bridgeEventId: data.bridgeEventId,
+    });
+    await markBridgeEventProcessed(deps.db, data.bridgeEventId);
+    return;
+  }
+
+  await deps.db
+    .update(wikiPages)
+    .set({ status: 'archived', updated_at: new Date() })
+    .where(eq(wikiPages.id, page.page.id));
+  console.log(`reindex triggered for page ${page.page.page_id}`);
+  await markBridgeEventProcessed(deps.db, data.bridgeEventId);
+}
+
+function matchExportedBlocks(markdown: string, sidecar: BlockMergeMetadataInfo[]): BlockMatchResult[] {
+  const markers = parseBlockMarkers(markdown);
+  if (markers.length === 0 || markers.length < sidecar.length) {
+    return matchBlocksFallback(markdown, sidecar);
+  }
+
+  const contentByBlockId = extractMarkedBlocks(markdown);
+  const metadataByBlockId = new Map(sidecar.map((metadata) => [metadata.blockId, metadata]));
+  const results: BlockMatchResult[] = [];
+
+  for (const marker of markers) {
+    const content = contentByBlockId.get(marker.blockId);
+    if (content === undefined) {
+      continue;
+    }
+
+    const matchedMetadata = metadataByBlockId.get(marker.blockId);
+    results.push(
+      matchedMetadata === undefined
+        ? {
+            blockId: marker.blockId,
+            content,
+            matchType: 'new',
+          }
+        : {
+            blockId: marker.blockId,
+            content,
+            matchedMetadata,
+            matchType: 'marker',
+          },
+    );
+  }
+
+  return results;
+}
+
+function repairFrontmatter(
+  markdown: string,
+  page: WikiPageRow,
+  currentVersion: WikiPageVersionRow | undefined,
+): FrontmatterRepairResult {
+  const parsed = parseFrontmatter(markdown);
+  const exportedFrontmatter = readRecord(parsed.frontmatter);
+  const existingFrontmatter = readRecord(currentVersion?.frontmatter_json);
+  const frontmatter: Record<string, unknown> = {
+    ...existingFrontmatter,
+    ...exportedFrontmatter,
+  };
+  let repaired = false;
+
+  if (readString(exportedFrontmatter.page_id) === undefined) {
+    frontmatter.page_id = readString(existingFrontmatter.page_id) ?? page.page_id;
+    repaired = true;
+  }
+  if (readString(exportedFrontmatter.space_id) === undefined) {
+    frontmatter.space_id = readString(existingFrontmatter.space_id) ?? page.space_id;
+    repaired = true;
+  }
+  if (readString(frontmatter.title) === undefined) {
+    frontmatter.title = page.title;
+    repaired = true;
+  }
+  if (readString(frontmatter.status) === undefined) {
+    frontmatter.status = page.status;
+    repaired = true;
+  }
+  if (readString(frontmatter.source) === undefined) {
+    frontmatter.source = 'docmost';
+    repaired = true;
+  }
+  frontmatter.version = (currentVersion?.version_no ?? 0) + 1;
+
+  return {
+    frontmatter: frontmatter as unknown as WikiFrontmatter,
+    content: parsed.content,
+    repaired,
+  };
+}
+
+async function coalesceStalePageEvents(db: DrizzleDatabase, data: PageSyncJobData): Promise<boolean> {
+  if (data.pageId === undefined) {
+    return false;
+  }
+
+  const receivedEvents = await db
+    .select()
+    .from(bridgeEvents)
+    .where(and(eq(bridgeEvents.page_id, data.pageId), eq(bridgeEvents.status, 'received')))
+    .orderBy(desc(bridgeEvents.received_at), desc(bridgeEvents.id))
+    .limit(50);
+
+  if (receivedEvents.length <= 1) {
+    return false;
+  }
+
+  const [latest, ...olderEvents] = receivedEvents;
+  if (latest === undefined) {
+    return false;
+  }
+
+  const olderIds = olderEvents.map((event) => event.id);
+  await db
+    .update(bridgeEvents)
+    .set({
+      status: 'processed',
+      processed_at: new Date(),
+      error_json: { code: 'COALESCED', latestBridgeEventId: latest.id },
+    })
+    .where(inArray(bridgeEvents.id, olderIds));
+
+  return olderIds.includes(data.bridgeEventId);
+}
+
+async function findPageByDocmostPageId(
+  db: DrizzleDatabase,
+  docmostPageId: string,
+): Promise<PageContext | undefined> {
+  const [row] = await db
+    .select({ page: wikiPages, spaceSlug: spaces.slug })
+    .from(wikiPages)
+    .leftJoin(spaces, eq(wikiPages.space_id, spaces.id))
+    .where(eq(wikiPages.docmost_page_id, docmostPageId))
+    .limit(1);
+
+  if (row === undefined) {
+    return undefined;
+  }
+
+  return {
+    page: row.page,
+    spaceSlug: row.spaceSlug ?? row.page.space_id,
+  };
+}
+
+async function loadCurrentVersion(
+  db: DrizzleDatabase,
+  page: WikiPageRow,
+): Promise<WikiPageVersionRow | undefined> {
+  if (page.current_version_id !== null) {
+    const [version] = await db
+      .select()
+      .from(wikiPageVersions)
+      .where(eq(wikiPageVersions.id, page.current_version_id))
+      .limit(1);
+    return version;
+  }
+
+  const [version] = await db
+    .select()
+    .from(wikiPageVersions)
+    .where(eq(wikiPageVersions.wiki_page_pk, page.id))
+    .orderBy(desc(wikiPageVersions.version_no))
+    .limit(1);
+  return version;
+}
+
+async function loadPageBlockMetadata(
+  db: DrizzleDatabase,
+  pageVersionId: string,
+): Promise<BlockMergeMetadataInfo[]> {
+  const rows = await db
+    .select()
+    .from(pageBlockMetadata)
+    .where(eq(pageBlockMetadata.page_version_id, pageVersionId));
+
+  return rows.map(toBlockMetadataInfo);
+}
+
+async function writePageBlockMetadata(
+  db: DrizzleDatabase,
+  page: WikiPageRow,
+  versionId: string,
+  metadata: BlockMergeMetadataInfo[],
+): Promise<void> {
+  if (metadata.length === 0) {
+    return;
+  }
+
+  await db.insert(pageBlockMetadata).values(
+    metadata.map((block) => ({
+      id: randomUUID(),
+      tenant_id: page.tenant_id,
+      space_id: page.space_id,
+      wiki_page_pk: page.id,
+      page_version_id: versionId,
+      block_id: block.blockId,
+      owner: block.owner,
+      content_hash: block.contentHash,
+      graphify_run_id: block.graphifyRunId ?? null,
+      last_editor: block.lastEditor ?? null,
+      editable: block.editable,
+    })),
+  );
+}
+
+function toBlockMetadataInfo(row: PageBlockMetadataRow): BlockMergeMetadataInfo {
+  return {
+    blockId: row.block_id,
+    owner: row.owner === 'human' ? 'human' : 'graphify',
+    contentHash: row.content_hash,
+    ...(row.graphify_run_id !== null ? { graphifyRunId: row.graphify_run_id } : {}),
+    ...(row.last_editor !== null ? { lastEditor: row.last_editor } : {}),
+    editable: row.editable,
+  };
+}
+
+async function checkSpaceEditPermission(
+  deps: PageSyncDeps,
+  args: { userId?: string; spaceId: string; pageId: string },
+): Promise<boolean> {
+  return deps.permissionChecker?.(args) ?? true;
+}
+
+async function markBridgeEventProcessing(db: DrizzleDatabase, bridgeEventId: string): Promise<void> {
+  await db.update(bridgeEvents).set({ status: 'processing' }).where(eq(bridgeEvents.id, bridgeEventId));
+}
+
+async function markBridgeEventProcessed(db: DrizzleDatabase, bridgeEventId: string): Promise<void> {
+  await db
+    .update(bridgeEvents)
+    .set({ status: 'processed', processed_at: new Date() })
+    .where(eq(bridgeEvents.id, bridgeEventId));
+}
+
+async function markBridgeEventFailed(
+  db: DrizzleDatabase,
+  bridgeEventId: string,
+  errorJson: Record<string, unknown>,
+): Promise<void> {
+  await db
+    .update(bridgeEvents)
+    .set({ status: 'failed', error_json: errorJson })
+    .where(eq(bridgeEvents.id, bridgeEventId));
+}
+
+async function markPageSyncPending(db: DrizzleDatabase, docmostPageId: string | undefined): Promise<void> {
+  if (docmostPageId === undefined) {
+    return;
+  }
+
+  await db
+    .update(wikiPages)
+    .set({ sync_status: 'sync_pending', updated_at: new Date() })
+    .where(eq(wikiPages.docmost_page_id, docmostPageId));
+}
+
+async function markPageSyncPendingByPagePk(db: DrizzleDatabase, pagePk: string): Promise<void> {
+  await db
+    .update(wikiPages)
+    .set({ sync_status: 'sync_pending', updated_at: new Date() })
+    .where(eq(wikiPages.id, pagePk));
+}
+
+function requirePageId(data: PageSyncJobData): string {
+  if (data.pageId === undefined || data.pageId.length === 0) {
+    throw new Error(`page-sync job ${data.bridgeEventId} is missing pageId`);
+  }
+
+  return data.pageId;
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function errorToJson(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      code: error.name || 'ERROR',
+      message: error.message,
+    };
+  }
+
+  return {
+    code: 'ERROR',
+    message: String(error),
+  };
+}

--- a/apps/wiki-sync-worker/src/processors/page-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/page-sync.processor.ts
@@ -11,10 +11,12 @@ import {
   wikiPages,
 } from '@cherrygraph/shared';
 import {
+  extractH2Blocks,
   extractMarkedBlocks,
   generateFrontmatter,
   matchBlocksFallback,
   mergeBlocks,
+  normalizeBlockContent,
   parseBlockMarkers,
   parseFrontmatter,
   type BlockMatchResult,
@@ -23,6 +25,7 @@ import {
 } from '@cherrygraph/wiki-core';
 
 export type DrizzleDatabase = NodePgDatabase;
+type DatabaseClient = Pick<DrizzleDatabase, 'select' | 'insert' | 'update'>;
 
 export interface BridgeClient {
   exportPage(pageId: string): Promise<{
@@ -55,6 +58,7 @@ export type PageSyncJobData = {
 type WikiPageRow = typeof wikiPages.$inferSelect;
 type WikiPageVersionRow = typeof wikiPageVersions.$inferSelect;
 type PageBlockMetadataRow = typeof pageBlockMetadata.$inferSelect;
+type BridgeEventRow = typeof bridgeEvents.$inferSelect;
 
 type PageContext = {
   page: WikiPageRow;
@@ -74,11 +78,27 @@ type FrontmatterRepairResult = {
   repaired: boolean;
 };
 
+type MarkedBlockRange = {
+  blockId: string;
+  start: number;
+  end: number;
+  content: string;
+};
+
+type PositionedBlockMatchResult = BlockMatchResult & {
+  start: number;
+};
+
 export function createPageSyncProcessor(deps: PageSyncDeps): (job: Job<PageSyncJobData>) => Promise<void> {
   return async (job) => {
     const data = job.data;
 
     try {
+      const bridgeEventStatus = await loadBridgeEventStatus(deps.db, data.bridgeEventId);
+      if (bridgeEventStatus === 'processed' || bridgeEventStatus === 'failed') {
+        return;
+      }
+
       if (await coalesceStalePageEvents(deps.db, data)) {
         return;
       }
@@ -195,7 +215,8 @@ async function processPageSaved(deps: PageSyncDeps, data: PageSyncJobData): Prom
   }
 
   const currentVersion = await loadCurrentVersion(deps.db, page.page);
-  const sidecar = currentVersion === undefined ? [] : await loadPageBlockMetadata(deps.db, currentVersion.id);
+  const rawSidecar = currentVersion === undefined ? [] : await loadPageBlockMetadata(deps.db, currentVersion.id);
+  const sidecar = enrichSidecarWithNormalizedContent(rawSidecar, currentVersion);
   const repaired = repairFrontmatter(exported.markdown, page.page, currentVersion);
   if (repaired.repaired) {
     console.warn('page-sync: repaired missing frontmatter fields', {
@@ -211,34 +232,36 @@ async function processPageSaved(deps: PageSyncDeps, data: PageSyncJobData): Prom
   const versionNo = (currentVersion?.version_no ?? 0) + 1;
   const commit = await commitToWikiRepo(deps, page, contentMarkdown, user);
 
-  await deps.db.insert(wikiPageVersions).values({
-    id: versionId,
-    tenant_id: page.page.tenant_id,
-    space_id: page.page.space_id,
-    wiki_page_pk: page.page.id,
-    page_id: page.page.page_id,
-    version_no: versionNo,
-    content_markdown: contentMarkdown,
-    frontmatter_json: repaired.frontmatter as unknown as Record<string, unknown>,
-    source: 'docmost',
-    graphify_run_id: currentVersion?.graphify_run_id ?? null,
-    commit_hash: commit.commitHash,
-    status: page.page.status,
-    created_by: user.userId ?? null,
+  await deps.db.transaction(async (tx) => {
+    await tx.insert(wikiPageVersions).values({
+      id: versionId,
+      tenant_id: page.page.tenant_id,
+      space_id: page.page.space_id,
+      wiki_page_pk: page.page.id,
+      page_id: page.page.page_id,
+      version_no: versionNo,
+      content_markdown: contentMarkdown,
+      frontmatter_json: repaired.frontmatter as unknown as Record<string, unknown>,
+      source: 'docmost',
+      graphify_run_id: currentVersion?.graphify_run_id ?? null,
+      commit_hash: commit.commitHash,
+      status: page.page.status,
+      created_by: user.userId ?? null,
+    });
+
+    await writePageBlockMetadata(tx, page.page, versionId, mergeResult.newMetadata);
+    await tx
+      .update(wikiPages)
+      .set({
+        current_version_id: versionId,
+        sync_status: 'synced',
+        updated_at: new Date(),
+      })
+      .where(eq(wikiPages.id, page.page.id));
+    await markBridgeEventProcessed(tx, data.bridgeEventId);
   });
 
-  await writePageBlockMetadata(deps.db, page.page, versionId, mergeResult.newMetadata);
-  await deps.db
-    .update(wikiPages)
-    .set({
-      current_version_id: versionId,
-      sync_status: 'synced',
-      updated_at: new Date(),
-    })
-    .where(eq(wikiPages.id, page.page.id));
-
   console.log(`reindex triggered for page ${page.page.page_id}`);
-  await markBridgeEventProcessed(deps.db, data.bridgeEventId);
 }
 
 async function processPageDeleted(deps: PageSyncDeps, data: PageSyncJobData): Promise<void> {
@@ -268,33 +291,152 @@ function matchExportedBlocks(markdown: string, sidecar: BlockMergeMetadataInfo[]
   }
 
   const contentByBlockId = extractMarkedBlocks(markdown);
+  const markedRanges = extractMarkedBlockRanges(markdown);
   const metadataByBlockId = new Map(sidecar.map((metadata) => [metadata.blockId, metadata]));
-  const results: BlockMatchResult[] = [];
+  const results: PositionedBlockMatchResult[] = [];
+  const usedBlockIds = new Set<string>();
 
-  for (const marker of markers) {
-    const content = contentByBlockId.get(marker.blockId);
-    if (content === undefined) {
+  for (const markedRange of markedRanges) {
+    const content = contentByBlockId.get(markedRange.blockId) ?? markedRange.content.trim();
+
+    const matchedMetadata = metadataByBlockId.get(markedRange.blockId);
+    usedBlockIds.add(markedRange.blockId);
+    if (matchedMetadata === undefined) {
+      results.push({
+        blockId: markedRange.blockId,
+        content,
+        matchType: 'new',
+        start: markedRange.start,
+      });
       continue;
     }
 
-    const matchedMetadata = metadataByBlockId.get(marker.blockId);
-    results.push(
-      matchedMetadata === undefined
-        ? {
-            blockId: marker.blockId,
-            content,
-            matchType: 'new',
-          }
-        : {
-            blockId: marker.blockId,
-            content,
-            matchedMetadata,
-            matchType: 'marker',
-          },
-    );
+    results.push({
+      blockId: markedRange.blockId,
+      content,
+      matchedMetadata,
+      matchType: 'marker',
+      start: markedRange.start,
+    });
   }
 
-  return results;
+  for (const block of extractUnmarkedH2Blocks(markdown, markedRanges)) {
+    const blockId = reserveBlockId(block.blockId, usedBlockIds);
+    results.push({
+      blockId,
+      content: block.content,
+      matchType: 'new',
+      start: block.start,
+    });
+  }
+
+  return results
+    .sort((left, right) => left.start - right.start)
+    .map(({ start: _start, ...result }) => result);
+}
+
+function extractMarkedBlockRanges(markdown: string): MarkedBlockRange[] {
+  const ranges: MarkedBlockRange[] = [];
+  const pattern =
+    /<!--\s*(?:(?:graphify):(?:managed|human)|(?:human):curated):start\s+id="([^"]+)"(?:\s+run="[^"]*")?\s*-->([\s\S]*?)<!--\s*(?:(?:graphify):(?:managed|human)|(?:human):curated):end\s*-->/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(markdown)) !== null) {
+    const blockId = match[1];
+    const content = match[2];
+    if (blockId === undefined || content === undefined) {
+      continue;
+    }
+
+    ranges.push({
+      blockId,
+      start: match.index,
+      end: match.index + match[0].length,
+      content,
+    });
+  }
+
+  return ranges;
+}
+
+function extractUnmarkedH2Blocks(
+  markdown: string,
+  markedRanges: MarkedBlockRange[],
+): Array<{ blockId: string; start: number; end: number; content: string }> {
+  const sortedRanges = [...markedRanges].sort((left, right) => left.start - right.start);
+  const blocks: Array<{ blockId: string; start: number; end: number; content: string }> = [];
+
+  for (const block of extractH2Blocks(markdown)) {
+    if (isOffsetInRanges(block.start, sortedRanges)) {
+      continue;
+    }
+
+    const contentRanges = subtractMarkedRanges({ start: block.start, end: block.end }, sortedRanges);
+    const content = contentRanges.map((range) => markdown.slice(range.start, range.end)).join('').trimEnd();
+    if (content.length === 0) {
+      continue;
+    }
+
+    blocks.push({
+      blockId: block.blockId,
+      start: block.start,
+      end: contentRanges.at(-1)?.end ?? block.end,
+      content,
+    });
+  }
+
+  return blocks;
+}
+
+function isOffsetInRanges(offset: number, ranges: MarkedBlockRange[]): boolean {
+  return ranges.some((range) => range.start <= offset && offset < range.end);
+}
+
+function subtractMarkedRanges(
+  range: { start: number; end: number },
+  markedRanges: MarkedBlockRange[],
+): Array<{ start: number; end: number }> {
+  const ranges: Array<{ start: number; end: number }> = [];
+  let cursor = range.start;
+
+  for (const markedRange of markedRanges) {
+    if (markedRange.end <= cursor) {
+      continue;
+    }
+    if (markedRange.start >= range.end) {
+      break;
+    }
+
+    if (markedRange.start > cursor) {
+      ranges.push({ start: cursor, end: Math.min(markedRange.start, range.end) });
+    }
+    cursor = Math.max(cursor, markedRange.end);
+    if (cursor >= range.end) {
+      break;
+    }
+  }
+
+  if (cursor < range.end) {
+    ranges.push({ start: cursor, end: range.end });
+  }
+
+  return ranges;
+}
+
+function reserveBlockId(blockId: string, usedBlockIds: Set<string>): string {
+  if (!usedBlockIds.has(blockId)) {
+    usedBlockIds.add(blockId);
+    return blockId;
+  }
+
+  let suffix = 2;
+  let candidate = `${blockId}-${suffix}`;
+  while (usedBlockIds.has(candidate)) {
+    suffix += 1;
+    candidate = `${blockId}-${suffix}`;
+  }
+  usedBlockIds.add(candidate);
+  return candidate;
 }
 
 function repairFrontmatter(
@@ -340,7 +482,20 @@ function repairFrontmatter(
   };
 }
 
-async function coalesceStalePageEvents(db: DrizzleDatabase, data: PageSyncJobData): Promise<boolean> {
+async function loadBridgeEventStatus(
+  db: DatabaseClient,
+  bridgeEventId: string,
+): Promise<BridgeEventRow['status'] | undefined> {
+  const [event] = await db
+    .select({ status: bridgeEvents.status })
+    .from(bridgeEvents)
+    .where(eq(bridgeEvents.id, bridgeEventId))
+    .limit(1);
+
+  return event?.status;
+}
+
+async function coalesceStalePageEvents(db: DatabaseClient, data: PageSyncJobData): Promise<boolean> {
   if (data.pageId === undefined) {
     return false;
   }
@@ -375,7 +530,7 @@ async function coalesceStalePageEvents(db: DrizzleDatabase, data: PageSyncJobDat
 }
 
 async function findPageByDocmostPageId(
-  db: DrizzleDatabase,
+  db: DatabaseClient,
   docmostPageId: string,
 ): Promise<PageContext | undefined> {
   const [row] = await db
@@ -396,7 +551,7 @@ async function findPageByDocmostPageId(
 }
 
 async function loadCurrentVersion(
-  db: DrizzleDatabase,
+  db: DatabaseClient,
   page: WikiPageRow,
 ): Promise<WikiPageVersionRow | undefined> {
   if (page.current_version_id !== null) {
@@ -418,7 +573,7 @@ async function loadCurrentVersion(
 }
 
 async function loadPageBlockMetadata(
-  db: DrizzleDatabase,
+  db: DatabaseClient,
   pageVersionId: string,
 ): Promise<BlockMergeMetadataInfo[]> {
   const rows = await db
@@ -429,8 +584,43 @@ async function loadPageBlockMetadata(
   return rows.map(toBlockMetadataInfo);
 }
 
+function enrichSidecarWithNormalizedContent(
+  sidecar: BlockMergeMetadataInfo[],
+  currentVersion: WikiPageVersionRow | undefined,
+): BlockMergeMetadataInfo[] {
+  if (currentVersion === undefined || sidecar.length === 0) {
+    return sidecar;
+  }
+
+  const body = parseFrontmatter(currentVersion.content_markdown).content;
+  const contentByBlockId = extractExistingBlockContent(body);
+
+  return sidecar.map((metadata) => {
+    const content = contentByBlockId.get(metadata.blockId);
+    if (content === undefined) {
+      return metadata;
+    }
+
+    return {
+      ...metadata,
+      normalizedContent: normalizeBlockContent(content),
+    };
+  });
+}
+
+function extractExistingBlockContent(markdown: string): Map<string, string> {
+  const contentByBlockId = new Map(extractMarkedBlocks(markdown));
+  for (const block of extractH2Blocks(markdown)) {
+    if (!contentByBlockId.has(block.blockId)) {
+      contentByBlockId.set(block.blockId, block.content);
+    }
+  }
+
+  return contentByBlockId;
+}
+
 async function writePageBlockMetadata(
-  db: DrizzleDatabase,
+  db: DatabaseClient,
   page: WikiPageRow,
   versionId: string,
   metadata: BlockMergeMetadataInfo[],
@@ -474,11 +664,11 @@ async function checkSpaceEditPermission(
   return deps.permissionChecker?.(args) ?? true;
 }
 
-async function markBridgeEventProcessing(db: DrizzleDatabase, bridgeEventId: string): Promise<void> {
+async function markBridgeEventProcessing(db: DatabaseClient, bridgeEventId: string): Promise<void> {
   await db.update(bridgeEvents).set({ status: 'processing' }).where(eq(bridgeEvents.id, bridgeEventId));
 }
 
-async function markBridgeEventProcessed(db: DrizzleDatabase, bridgeEventId: string): Promise<void> {
+async function markBridgeEventProcessed(db: DatabaseClient, bridgeEventId: string): Promise<void> {
   await db
     .update(bridgeEvents)
     .set({ status: 'processed', processed_at: new Date() })
@@ -486,17 +676,17 @@ async function markBridgeEventProcessed(db: DrizzleDatabase, bridgeEventId: stri
 }
 
 async function markBridgeEventFailed(
-  db: DrizzleDatabase,
+  db: DatabaseClient,
   bridgeEventId: string,
   errorJson: Record<string, unknown>,
 ): Promise<void> {
   await db
     .update(bridgeEvents)
-    .set({ status: 'failed', error_json: errorJson })
+    .set({ status: 'failed', error_json: errorJson, processed_at: new Date() })
     .where(eq(bridgeEvents.id, bridgeEventId));
 }
 
-async function markPageSyncPending(db: DrizzleDatabase, docmostPageId: string | undefined): Promise<void> {
+async function markPageSyncPending(db: DatabaseClient, docmostPageId: string | undefined): Promise<void> {
   if (docmostPageId === undefined) {
     return;
   }
@@ -507,7 +697,7 @@ async function markPageSyncPending(db: DrizzleDatabase, docmostPageId: string | 
     .where(eq(wikiPages.docmost_page_id, docmostPageId));
 }
 
-async function markPageSyncPendingByPagePk(db: DrizzleDatabase, pagePk: string): Promise<void> {
+async function markPageSyncPendingByPagePk(db: DatabaseClient, pagePk: string): Promise<void> {
   await db
     .update(wikiPages)
     .set({ sync_status: 'sync_pending', updated_at: new Date() })

--- a/apps/wiki-sync-worker/src/reconciliation.ts
+++ b/apps/wiki-sync-worker/src/reconciliation.ts
@@ -10,7 +10,11 @@ export type BridgeSyncJobData = {
 };
 
 export type ReconciliationQueue = {
-  add: (name: string, data: BridgeSyncJobData, opts: { jobId: string }) => Promise<unknown>;
+  add: (
+    name: string,
+    data: BridgeSyncJobData,
+    opts: { jobId: string; group?: { id: string } },
+  ) => Promise<unknown>;
 };
 
 export type ReconciliationQueues = {
@@ -89,7 +93,12 @@ async function enqueueBridgeEvent(
     return;
   }
 
-  await queue.add(event.event_type, toJobData(event), { jobId: event.event_id });
+  const jobData = toJobData(event);
+  await queue.add(
+    event.event_type,
+    jobData,
+    bridgeSyncJobOptions(event.event_type as BridgeEventType, event.event_id, jobData),
+  );
 }
 
 function queueForEventType(
@@ -119,4 +128,16 @@ function toJobData(event: BridgeEventRow): BridgeSyncJobData {
     ...(event.space_id !== null ? { spaceId: event.space_id } : {}),
     ...(event.page_id !== null ? { pageId: event.page_id } : {}),
   };
+}
+
+function bridgeSyncJobOptions(
+  eventType: BridgeEventType,
+  eventId: string,
+  data: BridgeSyncJobData,
+): { jobId: string; group?: { id: string } } {
+  if ((eventType === 'page.saved' || eventType === 'page.deleted') && data.pageId !== undefined) {
+    return { jobId: eventId, group: { id: data.pageId } };
+  }
+
+  return { jobId: eventId };
 }

--- a/apps/wiki-sync-worker/tsconfig.json
+++ b/apps/wiki-sync-worker/tsconfig.json
@@ -12,6 +12,9 @@
   "references": [
     {
       "path": "../../packages/shared"
+    },
+    {
+      "path": "../../packages/wiki-core"
     }
   ]
 }

--- a/packages/shared/src/schema/validation.ts
+++ b/packages/shared/src/schema/validation.ts
@@ -262,7 +262,7 @@ export const updateSourceDocumentSchema = z
   .partial();
 
 export const wikiPageStatusSchema = z.enum(['draft', 'published', 'archived']);
-export const wikiVersionSourceSchema = z.enum(['graphify', 'human', 'import', 'rollback']);
+export const wikiVersionSourceSchema = z.enum(['graphify', 'human', 'import', 'rollback', 'docmost']);
 
 export const insertWikiPageSchema = z.object({
   id: optionalIdSchema.optional(),

--- a/packages/wiki-core/src/__tests__/block-merge.test.ts
+++ b/packages/wiki-core/src/__tests__/block-merge.test.ts
@@ -7,6 +7,7 @@ import {
   type BlockMetadataInfo,
   matchBlocksFallback,
   mergeBlocks,
+  normalizeBlockContent,
   normalizeBlockHash,
 } from '../normalization/block-merge.js';
 
@@ -55,14 +56,23 @@ describe('block merge', () => {
       ]);
     });
 
-    it('falls back to fuzzy content-hash matching when the heading changed', () => {
-      const content = '## Renamed\nOriginal content';
-      const hash = normalizeBlockHash(content);
+    it('falls back to fuzzy content matching when the heading changed', () => {
+      const previousContent = [
+        '## Original Title',
+        'This section describes the page sync worker and its retry behavior.',
+        'Bridge events are exported, merged into wiki markdown, and written as a new version.',
+      ].join('\n');
+      const content = [
+        '## Renamed Title',
+        'This section describes the page sync worker and its retry behavior.',
+        'Bridge events are exported, merged into wiki markdown, and written as a new version.',
+      ].join('\n');
       const sidecar = [
-        {
-          ...metadata({ blockId: 'original-title', content: '## Original Title\nOriginal content' }),
-          contentHash: `${hash.slice(0, -1)}${hash.endsWith('a') ? 'b' : 'a'}`,
-        },
+        metadata({
+          blockId: 'original-title',
+          content: previousContent,
+          normalizedContent: previousContent,
+        }),
       ];
 
       const [result] = matchBlocksFallback(content, sidecar);
@@ -185,6 +195,7 @@ function metadata(overrides: {
   blockId: string;
   owner?: 'graphify' | 'human';
   content: string;
+  normalizedContent?: string;
   graphifyRunId?: string;
   lastEditor?: string;
   editable?: boolean;
@@ -193,6 +204,7 @@ function metadata(overrides: {
     blockId: overrides.blockId,
     owner: overrides.owner ?? 'human',
     contentHash: normalizeBlockHash(overrides.content),
+    normalizedContent: normalizeBlockContent(overrides.normalizedContent ?? overrides.content),
     ...(overrides.graphifyRunId !== undefined ? { graphifyRunId: overrides.graphifyRunId } : {}),
     ...(overrides.lastEditor !== undefined ? { lastEditor: overrides.lastEditor } : {}),
     editable: overrides.editable ?? true,

--- a/packages/wiki-core/src/__tests__/block-merge.test.ts
+++ b/packages/wiki-core/src/__tests__/block-merge.test.ts
@@ -1,0 +1,213 @@
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  type BlockMatchResult,
+  type BlockMetadataInfo,
+  matchBlocksFallback,
+  mergeBlocks,
+  normalizeBlockHash,
+} from '../normalization/block-merge.js';
+
+describe('block merge', () => {
+  describe('normalizeBlockHash', () => {
+    it('normalizes trailing whitespace and CRLF line endings', () => {
+      const left = '## Overview\r\nAlpha   \r\nBeta\t\r\n';
+      const right = '## Overview\nAlpha\nBeta';
+
+      expect(normalizeBlockHash(left)).toBe(normalizeBlockHash(right));
+    });
+
+    it('excludes graphify marker lines from the hash', () => {
+      const marked = [
+        '<!-- graphify:managed:start id="overview" run="gf-1" -->',
+        '## Overview',
+        'Alpha',
+        '<!-- graphify:managed:end -->',
+      ].join('\n');
+      const unmarked = '## Overview\nAlpha';
+
+      expect(normalizeBlockHash(marked)).toBe(normalizeBlockHash(unmarked));
+    });
+
+    it('returns deterministic SHA-256 hex output', () => {
+      const content = '## Overview\nAlpha';
+
+      expect(normalizeBlockHash(content)).toBe(
+        createHash('sha256').update(content).digest('hex'),
+      );
+      expect(normalizeBlockHash(content)).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
+
+  describe('matchBlocksFallback', () => {
+    it('matches blocks by H2 heading-derived block ID', () => {
+      const markdown = '## Overview\nHuman edit\n\n## Details\nMore';
+      const sidecar = [
+        metadata({ blockId: 'overview', content: '## Overview\nOriginal' }),
+        metadata({ blockId: 'details', content: '## Details\nMore' }),
+      ];
+
+      expect(matchBlocksFallback(markdown, sidecar)).toMatchObject([
+        { blockId: 'overview', matchType: 'heading', matchedMetadata: sidecar[0] },
+        { blockId: 'details', matchType: 'heading', matchedMetadata: sidecar[1] },
+      ]);
+    });
+
+    it('falls back to fuzzy content-hash matching when the heading changed', () => {
+      const content = '## Renamed\nOriginal content';
+      const hash = normalizeBlockHash(content);
+      const sidecar = [
+        {
+          ...metadata({ blockId: 'original-title', content: '## Original Title\nOriginal content' }),
+          contentHash: `${hash.slice(0, -1)}${hash.endsWith('a') ? 'b' : 'a'}`,
+        },
+      ];
+
+      const [result] = matchBlocksFallback(content, sidecar);
+
+      expect(result).toMatchObject({
+        blockId: 'original-title',
+        matchType: 'hash',
+        matchedMetadata: sidecar[0],
+      });
+    });
+
+    it('marks unmatched markdown blocks as new and omits deleted sidecar blocks', () => {
+      const markdown = '## New Section\nDraft';
+      const sidecar = [metadata({ blockId: 'deleted-section', content: '## Deleted Section\nGone' })];
+
+      const results = matchBlocksFallback(markdown, sidecar);
+
+      expect(results).toEqual([
+        {
+          blockId: 'new-section',
+          content: '## New Section\nDraft',
+          matchType: 'new',
+        },
+      ]);
+      expect(results.some((result) => result.blockId === 'deleted-section')).toBe(false);
+    });
+  });
+
+  describe('mergeBlocks', () => {
+    it('transfers graphify ownership to human when content changes', () => {
+      const existing = metadata({
+        blockId: 'overview',
+        owner: 'graphify',
+        content: '## Overview\nGraphify content',
+        graphifyRunId: 'gf-1',
+        editable: false,
+      });
+      const result = mergeBlocks(
+        [matched({ blockId: 'overview', content: '## Overview\nHuman edit', matchedMetadata: existing })],
+        'user-1',
+      );
+
+      expect(result.newMetadata[0]).toMatchObject({
+        blockId: 'overview',
+        owner: 'human',
+        lastEditor: 'user-1',
+        graphifyRunId: 'gf-1',
+        editable: true,
+        contentHash: normalizeBlockHash('## Overview\nHuman edit'),
+      });
+      expect(result.proposals).toEqual([]);
+    });
+
+    it('keeps unchanged graphify blocks as-is', () => {
+      const existing = metadata({
+        blockId: 'overview',
+        owner: 'graphify',
+        content: '## Overview\nGraphify content',
+        editable: false,
+      });
+      const result = mergeBlocks([
+        matched({ blockId: 'overview', content: '## Overview\nGraphify content', matchedMetadata: existing }),
+      ]);
+
+      expect(result.newMetadata[0]).toEqual(existing);
+    });
+
+    it('updates human-owned block hash and editor when content changes', () => {
+      const existing = metadata({
+        blockId: 'notes',
+        owner: 'human',
+        content: '## Notes\nOriginal',
+        lastEditor: 'user-old',
+      });
+      const result = mergeBlocks(
+        [matched({ blockId: 'notes', content: '## Notes\nUpdated', matchedMetadata: existing })],
+        'user-new',
+      );
+
+      expect(result.newMetadata[0]).toMatchObject({
+        blockId: 'notes',
+        owner: 'human',
+        lastEditor: 'user-new',
+        editable: true,
+        contentHash: normalizeBlockHash('## Notes\nUpdated'),
+      });
+    });
+
+    it('creates human-owned metadata for new blocks and concatenates content', () => {
+      const result = mergeBlocks(
+        [
+          { blockId: 'first', content: '## First\nA', matchType: 'new' },
+          { blockId: 'second', content: '## Second\nB', matchType: 'new' },
+        ],
+        'user-1',
+      );
+
+      expect(result.mergedMarkdown).toBe('## First\nA\n\n## Second\nB');
+      expect(result.newMetadata).toEqual([
+        {
+          blockId: 'first',
+          owner: 'human',
+          contentHash: normalizeBlockHash('## First\nA'),
+          lastEditor: 'user-1',
+          editable: true,
+        },
+        {
+          blockId: 'second',
+          owner: 'human',
+          contentHash: normalizeBlockHash('## Second\nB'),
+          lastEditor: 'user-1',
+          editable: true,
+        },
+      ]);
+    });
+  });
+});
+
+function metadata(overrides: {
+  blockId: string;
+  owner?: 'graphify' | 'human';
+  content: string;
+  graphifyRunId?: string;
+  lastEditor?: string;
+  editable?: boolean;
+}): BlockMetadataInfo {
+  return {
+    blockId: overrides.blockId,
+    owner: overrides.owner ?? 'human',
+    contentHash: normalizeBlockHash(overrides.content),
+    ...(overrides.graphifyRunId !== undefined ? { graphifyRunId: overrides.graphifyRunId } : {}),
+    ...(overrides.lastEditor !== undefined ? { lastEditor: overrides.lastEditor } : {}),
+    editable: overrides.editable ?? true,
+  };
+}
+
+function matched(args: {
+  blockId: string;
+  content: string;
+  matchedMetadata: BlockMetadataInfo;
+}): BlockMatchResult {
+  return {
+    blockId: args.blockId,
+    content: args.content,
+    matchedMetadata: args.matchedMetadata,
+    matchType: 'heading',
+  };
+}

--- a/packages/wiki-core/src/index.ts
+++ b/packages/wiki-core/src/index.ts
@@ -14,6 +14,7 @@ export * from './normalization/block-markers.js';
 export {
   matchBlocksFallback,
   mergeBlocks,
+  normalizeBlockContent,
   normalizeBlockHash,
   type BlockMatchResult,
   type BlockMetadataInfo as BlockMergeMetadataInfo,

--- a/packages/wiki-core/src/index.ts
+++ b/packages/wiki-core/src/index.ts
@@ -11,4 +11,12 @@ export * from './normalization/safe-filename.js';
 export * from './normalization/identify-page-type.js';
 export * from './normalization/sanitize-markdown.js';
 export * from './normalization/block-markers.js';
+export {
+  matchBlocksFallback,
+  mergeBlocks,
+  normalizeBlockHash,
+  type BlockMatchResult,
+  type BlockMetadataInfo as BlockMergeMetadataInfo,
+  type MergeResult,
+} from './normalization/block-merge.js';
 export * from './normalization/import-graphify-wiki.js';

--- a/packages/wiki-core/src/normalization/block-merge.ts
+++ b/packages/wiki-core/src/normalization/block-merge.ts
@@ -6,6 +6,7 @@ export interface BlockMetadataInfo {
   blockId: string;
   owner: 'graphify' | 'human';
   contentHash: string;
+  normalizedContent?: string;
   graphifyRunId?: string;
   lastEditor?: string;
   editable: boolean;
@@ -29,18 +30,20 @@ export interface MergeResult {
 }
 
 const markerLinePattern = /^\s*<!--\s*graphify:(?:managed|human):[^>]*-->\s*$/;
-const fuzzyHashThreshold = 0.8;
+const fuzzyContentThreshold = 0.8;
 
-export function normalizeBlockHash(content: string): string {
-  const normalized = content
+export function normalizeBlockContent(content: string): string {
+  return content
     .replace(/\r\n?/g, '\n')
     .split('\n')
     .filter((line) => !markerLinePattern.test(line))
     .map((line) => line.trimEnd())
     .join('\n')
     .trimEnd();
+}
 
-  return createHash('sha256').update(normalized).digest('hex');
+export function normalizeBlockHash(content: string): string {
+  return createHash('sha256').update(normalizeBlockContent(content)).digest('hex');
 }
 
 export function matchBlocksFallback(
@@ -66,14 +69,14 @@ export function matchBlocksFallback(
       };
     }
 
-    const contentHash = normalizeBlockHash(block.content);
-    const hashMatch = findBestHashMatch(contentHash, sidecar, matchedSidecarIds);
-    if (hashMatch !== undefined) {
-      matchedSidecarIds.add(hashMatch.blockId);
+    const normalizedContent = normalizeBlockContent(block.content);
+    const contentMatch = findBestContentMatch(normalizedContent, sidecar, matchedSidecarIds);
+    if (contentMatch !== undefined) {
+      matchedSidecarIds.add(contentMatch.blockId);
       return {
-        blockId: hashMatch.blockId,
+        blockId: contentMatch.blockId,
         content: block.content,
-        matchedMetadata: hashMatch,
+        matchedMetadata: contentMatch,
         matchType: 'hash',
       };
     }
@@ -145,20 +148,24 @@ function readH2Heading(content: string): string | undefined {
   return match?.[1]?.trim().replace(/\s+#*$/, '');
 }
 
-function findBestHashMatch(
-  contentHash: string,
+function findBestContentMatch(
+  normalizedContent: string,
   sidecar: BlockMetadataInfo[],
   matchedSidecarIds: Set<string>,
 ): BlockMetadataInfo | undefined {
   let bestMatch: BlockMetadataInfo | undefined;
-  let bestScore = fuzzyHashThreshold;
+  let bestScore = fuzzyContentThreshold;
 
   for (const metadata of sidecar) {
     if (matchedSidecarIds.has(metadata.blockId)) {
       continue;
     }
 
-    const score = characterOverlap(contentHash, metadata.contentHash);
+    if (metadata.normalizedContent === undefined) {
+      continue;
+    }
+
+    const score = characterJaccardSimilarity(normalizedContent, metadata.normalizedContent);
     if (score > bestScore) {
       bestScore = score;
       bestMatch = metadata;
@@ -168,7 +175,7 @@ function findBestHashMatch(
   return bestMatch;
 }
 
-function characterOverlap(left: string, right: string): number {
+function characterJaccardSimilarity(left: string, right: string): number {
   if (left.length === 0 && right.length === 0) {
     return 1;
   }
@@ -190,5 +197,5 @@ function characterOverlap(left: string, right: string): number {
     }
   }
 
-  return overlap / Math.max(left.length, right.length);
+  return overlap / (left.length + right.length - overlap);
 }

--- a/packages/wiki-core/src/normalization/block-merge.ts
+++ b/packages/wiki-core/src/normalization/block-merge.ts
@@ -1,0 +1,194 @@
+import { createHash } from 'node:crypto';
+
+import { blockIdFromHeading, extractH2Blocks } from './block-markers.js';
+
+export interface BlockMetadataInfo {
+  blockId: string;
+  owner: 'graphify' | 'human';
+  contentHash: string;
+  graphifyRunId?: string;
+  lastEditor?: string;
+  editable: boolean;
+}
+
+export interface BlockMatchResult {
+  blockId: string;
+  content: string;
+  matchedMetadata?: BlockMetadataInfo;
+  matchType: 'marker' | 'heading' | 'hash' | 'new';
+}
+
+export interface MergeResult {
+  mergedMarkdown: string;
+  newMetadata: BlockMetadataInfo[];
+  proposals: Array<{
+    blockId: string;
+    proposalType: 'conflict';
+    diffJson: { humanContent: string; graphifyContent: string };
+  }>;
+}
+
+const markerLinePattern = /^\s*<!--\s*graphify:(?:managed|human):[^>]*-->\s*$/;
+const fuzzyHashThreshold = 0.8;
+
+export function normalizeBlockHash(content: string): string {
+  const normalized = content
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .filter((line) => !markerLinePattern.test(line))
+    .map((line) => line.trimEnd())
+    .join('\n')
+    .trimEnd();
+
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+export function matchBlocksFallback(
+  markdown: string,
+  sidecar: BlockMetadataInfo[],
+): BlockMatchResult[] {
+  const sidecarByBlockId = new Map(sidecar.map((metadata) => [metadata.blockId, metadata]));
+  const matchedSidecarIds = new Set<string>();
+  const blocks = extractH2Blocks(markdown);
+
+  return blocks.map((block, index) => {
+    const heading = readH2Heading(block.content);
+    const headingBlockId = heading ? blockIdFromHeading(heading, index) : block.blockId;
+    const headingMatch = sidecarByBlockId.get(headingBlockId) ?? sidecarByBlockId.get(block.blockId);
+
+    if (headingMatch !== undefined && !matchedSidecarIds.has(headingMatch.blockId)) {
+      matchedSidecarIds.add(headingMatch.blockId);
+      return {
+        blockId: headingMatch.blockId,
+        content: block.content,
+        matchedMetadata: headingMatch,
+        matchType: 'heading',
+      };
+    }
+
+    const contentHash = normalizeBlockHash(block.content);
+    const hashMatch = findBestHashMatch(contentHash, sidecar, matchedSidecarIds);
+    if (hashMatch !== undefined) {
+      matchedSidecarIds.add(hashMatch.blockId);
+      return {
+        blockId: hashMatch.blockId,
+        content: block.content,
+        matchedMetadata: hashMatch,
+        matchType: 'hash',
+      };
+    }
+
+    return {
+      blockId: block.blockId,
+      content: block.content,
+      matchType: 'new',
+    };
+  });
+}
+
+export function mergeBlocks(
+  matchedBlocks: BlockMatchResult[],
+  userId?: string,
+  runId?: string,
+): MergeResult {
+  const newMetadata = matchedBlocks.map((block) => {
+    const contentHash = normalizeBlockHash(block.content);
+    const existing = block.matchedMetadata;
+
+    if (existing === undefined || block.matchType === 'new') {
+      return {
+        blockId: block.blockId,
+        owner: 'human' as const,
+        contentHash,
+        ...(userId !== undefined ? { lastEditor: userId } : {}),
+        editable: true,
+      };
+    }
+
+    if (existing.owner === 'graphify') {
+      if (contentHash === existing.contentHash) {
+        return { ...existing };
+      }
+
+      const graphifyRunId = existing.graphifyRunId ?? runId;
+      return {
+        ...existing,
+        owner: 'human' as const,
+        contentHash,
+        ...(graphifyRunId !== undefined ? { graphifyRunId } : {}),
+        ...(userId !== undefined ? { lastEditor: userId } : {}),
+        editable: true,
+      };
+    }
+
+    if (contentHash === existing.contentHash) {
+      return { ...existing };
+    }
+
+    return {
+      ...existing,
+      contentHash,
+      ...(userId !== undefined ? { lastEditor: userId } : {}),
+      editable: true,
+    };
+  });
+
+  return {
+    mergedMarkdown: matchedBlocks.map((block) => block.content.trimEnd()).join('\n\n').trimEnd(),
+    newMetadata,
+    proposals: [],
+  };
+}
+
+function readH2Heading(content: string): string | undefined {
+  const match = /^##(?!#)[ \t]+(.+?)\s*#*\s*$/m.exec(content);
+  return match?.[1]?.trim().replace(/\s+#*$/, '');
+}
+
+function findBestHashMatch(
+  contentHash: string,
+  sidecar: BlockMetadataInfo[],
+  matchedSidecarIds: Set<string>,
+): BlockMetadataInfo | undefined {
+  let bestMatch: BlockMetadataInfo | undefined;
+  let bestScore = fuzzyHashThreshold;
+
+  for (const metadata of sidecar) {
+    if (matchedSidecarIds.has(metadata.blockId)) {
+      continue;
+    }
+
+    const score = characterOverlap(contentHash, metadata.contentHash);
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = metadata;
+    }
+  }
+
+  return bestMatch;
+}
+
+function characterOverlap(left: string, right: string): number {
+  if (left.length === 0 && right.length === 0) {
+    return 1;
+  }
+  if (left.length === 0 || right.length === 0) {
+    return 0;
+  }
+
+  const counts = new Map<string, number>();
+  for (const char of left) {
+    counts.set(char, (counts.get(char) ?? 0) + 1);
+  }
+
+  let overlap = 0;
+  for (const char of right) {
+    const count = counts.get(char) ?? 0;
+    if (count > 0) {
+      overlap += 1;
+      counts.set(char, count - 1);
+    }
+  }
+
+  return overlap / Math.max(left.length, right.length);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       '@cherrygraph/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@cherrygraph/wiki-core':
+        specifier: workspace:*
+        version: link:../../packages/wiki-core
       bullmq:
         specifier: ^5.76.3
         version: 5.76.3
@@ -266,6 +269,13 @@ importers:
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
 
   packages/ai-core:
     dependencies:


### PR DESCRIPTION
## Summary
- Block merge 算法（wiki-core）：`normalizeBlockHash` SHA-256 哈希、`matchBlocksFallback` heading+content Jaccard 双轨匹配、`mergeBlocks` ownership 转换
- Page-sync processor：完整 page.saved 回写链路（bridge event 状态流转 → docmost_page_id 查找 → frontmatter 修复 → block merge → 事务性 version 创建 → metadata 写入 → sync_status 更新）
- Stale event coalescing + duplicate event skip + per-page group option
- `wikiVersionSourceSchema` 新增 `docmost` 值

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `668e5fe66ee853ea2505778ab0e6c12a1e6319c8`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/133#issuecomment-4377209285) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/133#issuecomment-4377209428) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/133#issuecomment-4377209555) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/133#issuecomment-4377209701)
- Key findings addressed: Fixed marker-mode content loss for unmarked H2 sections, wrapped DB writes in transaction, changed fuzzy matching from SHA-256 hex to content-level Jaccard similarity, added duplicate event skip guard, added processed_at to failed events

## Test plan
- [x] `block-merge.test.ts` — hash normalization, heading/content-based fallback matching, merge ownership transitions
- [x] `page-sync.test.ts` — complete flow, marker-loss fallback, ownership transitions, coalescing, permission denied, page.deleted, docmost_page_id not found, frontmatter repair, unmarked H2 preservation, already-processed event skip
- [x] Full regression: 135 files, 791 tests passed
- [x] All 4 packages build successfully

Closes #129