### PR TITLE
feat(sync): docmost-push processor + proposal workflow API (#130)

### DIFF
--- a/apps/api/src/admin/__tests__/proposal.controller.test.ts
+++ b/apps/api/src/admin/__tests__/proposal.controller.test.ts
@@ -50,18 +50,17 @@ describe('ProposalController', () => {
     });
   });
 
-  it('accepts a pending proposal and clears sync status when no pending proposals remain', async () => {
+  it('accepts a pending proposal without clearing sync status (content replacement deferred)', async () => {
     const db = new ScriptedProposalDb();
     db.queueSelect([createProposal()]);
     db.queueUpdateReturning(createProposal({ status: 'accepted', resolved_at: new Date('2026-05-05T13:00:00.000Z') }));
-    db.queueSelect([]);
     const { controller } = createController(db);
 
     const result = await controller.resolveProposal('proposal-1', { action: 'accept' });
 
     expect(result.status).toBe('accepted');
     expect(db.proposalUpdates[0]).toMatchObject({ status: 'accepted' });
-    expect(db.pageUpdates[0]).toMatchObject({ sync_status: 'synced' });
+    expect(db.pageUpdates).toHaveLength(0);
   });
 
   it('rejects a pending proposal and clears sync status when no pending proposals remain', async () => {

--- a/apps/api/src/admin/__tests__/proposal.controller.test.ts
+++ b/apps/api/src/admin/__tests__/proposal.controller.test.ts
@@ -1,0 +1,262 @@
+import { HttpException } from '@nestjs/common';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { describe, expect, it } from 'vitest';
+
+import { wikiPages, wikiUpdateProposals } from '@cherrygraph/shared';
+
+import { ProposalController } from '../proposals/proposal.controller.js';
+import { ProposalService } from '../proposals/proposal.service.js';
+
+describe('ProposalController', () => {
+  it('lists proposals with pagination', async () => {
+    const db = new ScriptedProposalDb();
+    db.queueSelect([createProposal({ id: 'proposal-2' }), createProposal({ id: 'proposal-1' })]);
+    db.queueSelect([{ total: 2 }]);
+    const { controller } = createController(db);
+
+    const result = await controller.listProposals({ page: '2', limit: '20' });
+
+    expect(result).toMatchObject({
+      total: 2,
+      page: 2,
+      limit: 20,
+    });
+    expect(result.data.map((proposal) => proposal.id)).toEqual(['proposal-2', 'proposal-1']);
+    expect(db.offsets).toEqual([20]);
+  });
+
+  it('filters proposals by status', async () => {
+    const db = new ScriptedProposalDb();
+    db.queueSelect([createProposal({ status: 'accepted' })]);
+    db.queueSelect([{ total: 1 }]);
+    const { controller } = createController(db);
+
+    const result = await controller.listProposals({ status: 'accepted' });
+
+    expect(result.total).toBe(1);
+    expect(result.data[0]?.status).toBe('accepted');
+  });
+
+  it('returns proposal detail with diff_json', async () => {
+    const db = new ScriptedProposalDb();
+    db.queueSelect([createProposal({ diff_json: { blockId: 'overview', humanContent: 'Human', graphifyContent: 'Graphify' } })]);
+    const { controller } = createController(db);
+
+    const result = await controller.getProposal('proposal-1');
+
+    expect(result).toMatchObject({
+      id: 'proposal-1',
+      diff_json: { blockId: 'overview', humanContent: 'Human', graphifyContent: 'Graphify' },
+    });
+  });
+
+  it('accepts a pending proposal and clears sync status when no pending proposals remain', async () => {
+    const db = new ScriptedProposalDb();
+    db.queueSelect([createProposal()]);
+    db.queueUpdateReturning(createProposal({ status: 'accepted', resolved_at: new Date('2026-05-05T13:00:00.000Z') }));
+    db.queueSelect([]);
+    const { controller } = createController(db);
+
+    const result = await controller.resolveProposal('proposal-1', { action: 'accept' });
+
+    expect(result.status).toBe('accepted');
+    expect(db.proposalUpdates[0]).toMatchObject({ status: 'accepted' });
+    expect(db.pageUpdates[0]).toMatchObject({ sync_status: 'synced' });
+  });
+
+  it('rejects a pending proposal and clears sync status when no pending proposals remain', async () => {
+    const db = new ScriptedProposalDb();
+    db.queueSelect([createProposal()]);
+    db.queueUpdateReturning(createProposal({ status: 'rejected', resolved_at: new Date('2026-05-05T13:00:00.000Z') }));
+    db.queueSelect([]);
+    const { controller } = createController(db);
+
+    const result = await controller.resolveProposal('proposal-1', { action: 'reject' });
+
+    expect(result.status).toBe('rejected');
+    expect(db.proposalUpdates[0]).toMatchObject({ status: 'rejected' });
+    expect(db.pageUpdates[0]).toMatchObject({ sync_status: 'synced' });
+  });
+
+  it('returns 409 when resolving an already-resolved proposal', async () => {
+    const db = new ScriptedProposalDb();
+    db.queueSelect([createProposal({ status: 'accepted' })]);
+    const { controller } = createController(db);
+
+    const err = await getRejectedHttpException(controller.resolveProposal('proposal-1', { action: 'reject' }));
+
+    expect(err.getStatus()).toBe(409);
+    expect(err.getResponse()).toMatchObject({ code: 'PROPOSAL_ALREADY_RESOLVED' });
+    expect(db.proposalUpdates).toHaveLength(0);
+  });
+
+  it('returns 404 when proposal is not found', async () => {
+    const db = new ScriptedProposalDb();
+    db.queueSelect([]);
+    const { controller } = createController(db);
+
+    const err = await getRejectedHttpException(controller.getProposal('missing-proposal'));
+
+    expect(err.getStatus()).toBe(404);
+  });
+});
+
+type ProposalRow = typeof wikiUpdateProposals.$inferSelect;
+
+class ScriptedProposalDb {
+  readonly selectResults: unknown[][] = [];
+  readonly updateReturningResults: unknown[][] = [];
+  readonly proposalUpdates: Array<Partial<typeof wikiUpdateProposals.$inferInsert>> = [];
+  readonly pageUpdates: Array<Partial<typeof wikiPages.$inferInsert>> = [];
+  readonly offsets: number[] = [];
+
+  asDrizzle(): NodePgDatabase {
+    return this as unknown as NodePgDatabase;
+  }
+
+  queueSelect(result: unknown[]): void {
+    this.selectResults.push(result);
+  }
+
+  queueUpdateReturning(row: unknown): void {
+    this.updateReturningResults.push([row]);
+  }
+
+  select(): ScriptedSelectBuilder {
+    return new ScriptedSelectBuilder(this, this.selectResults.shift() ?? []);
+  }
+
+  update(table: unknown): ScriptedUpdateBuilder {
+    return new ScriptedUpdateBuilder(this, table);
+  }
+}
+
+class ScriptedSelectBuilder implements PromiseLike<unknown[]> {
+  constructor(
+    private readonly db: ScriptedProposalDb,
+    private readonly result: unknown[],
+  ) {}
+
+  from(): this {
+    return this;
+  }
+
+  where(): this {
+    return this;
+  }
+
+  orderBy(): this {
+    return this;
+  }
+
+  limit(): this {
+    return this;
+  }
+
+  offset(offset: number): Promise<unknown[]> {
+    this.db.offsets.push(offset);
+    return Promise.resolve(this.result);
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.result).then(onfulfilled ?? undefined, onrejected ?? undefined);
+  }
+}
+
+class ScriptedUpdateBuilder {
+  constructor(
+    private readonly db: ScriptedProposalDb,
+    private readonly table: unknown,
+  ) {}
+
+  set(values: Record<string, unknown>): { where: () => ScriptedUpdateWhereBuilder } {
+    return {
+      where: () => new ScriptedUpdateWhereBuilder(this.db, this.table, values),
+    };
+  }
+}
+
+class ScriptedUpdateWhereBuilder implements PromiseLike<void> {
+  private applied = false;
+
+  constructor(
+    private readonly db: ScriptedProposalDb,
+    private readonly table: unknown,
+    private readonly values: Record<string, unknown>,
+  ) {}
+
+  returning(): Promise<unknown[]> {
+    this.applyUpdate();
+    return Promise.resolve(this.db.updateReturningResults.shift() ?? []);
+  }
+
+  then<TResult1 = void, TResult2 = never>(
+    onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    this.applyUpdate();
+    return Promise.resolve(undefined).then(onfulfilled ?? undefined, onrejected ?? undefined);
+  }
+
+  private applyUpdate(): void {
+    if (this.applied) {
+      return;
+    }
+    this.applied = true;
+
+    if (this.table === wikiUpdateProposals) {
+      this.db.proposalUpdates.push(this.values);
+    }
+    if (this.table === wikiPages) {
+      this.db.pageUpdates.push(this.values);
+    }
+  }
+}
+
+function createController(db: ScriptedProposalDb): {
+  controller: ProposalController;
+  service: ProposalService;
+} {
+  const service = new ProposalService(db.asDrizzle());
+
+  return {
+    controller: new ProposalController(service),
+    service,
+  };
+}
+
+function createProposal(overrides: Partial<ProposalRow> = {}): ProposalRow {
+  return {
+    id: 'proposal-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    wiki_page_pk: 'wiki-pk-1',
+    graphify_run_id: 'run-1',
+    proposal_type: 'conflict',
+    status: 'pending',
+    diff_json: {
+      blockId: 'overview',
+      humanContent: '## Overview\nHuman',
+      graphifyContent: '## Overview\nGraphify',
+    },
+    created_at: new Date('2026-05-05T12:00:00.000Z'),
+    resolved_at: null,
+    ...overrides,
+  };
+}
+
+async function getRejectedHttpException(promise: Promise<unknown>): Promise<HttpException> {
+  try {
+    await promise;
+  } catch (err) {
+    if (err instanceof HttpException) {
+      return err;
+    }
+    throw err;
+  }
+
+  throw new Error('Expected promise to reject');
+}

--- a/apps/api/src/admin/proposals/proposal.controller.ts
+++ b/apps/api/src/admin/proposals/proposal.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { Permissions } from '@cherrygraph/auth-core';
+
+import {
+  ProposalService,
+  type ListProposalsResponse,
+  type ProposalDetail,
+  type ProposalListQuery,
+  type ResolveProposalAction,
+} from './proposal.service.js';
+
+@Permissions('admin')
+@Controller('admin/proposals')
+export class ProposalController {
+  constructor(private readonly proposalService: ProposalService) {}
+
+  @Get()
+  async listProposals(@Query() query: ProposalListQuery): Promise<ListProposalsResponse> {
+    return this.proposalService.listProposals(query);
+  }
+
+  @Get(':id')
+  async getProposal(@Param('id') id: string): Promise<ProposalDetail> {
+    return this.proposalService.getProposal(id);
+  }
+
+  @Post(':id/resolve')
+  async resolveProposal(
+    @Param('id') id: string,
+    @Body() body: { action?: ResolveProposalAction },
+  ): Promise<ProposalDetail> {
+    return this.proposalService.resolveProposal(id, body?.action);
+  }
+}

--- a/apps/api/src/admin/proposals/proposal.module.ts
+++ b/apps/api/src/admin/proposals/proposal.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { ProposalController } from './proposal.controller.js';
+import { ProposalService } from './proposal.service.js';
+
+@Module({
+  controllers: [ProposalController],
+  providers: [ProposalService],
+})
+export class ProposalModule {}

--- a/apps/api/src/admin/proposals/proposal.service.ts
+++ b/apps/api/src/admin/proposals/proposal.service.ts
@@ -104,9 +104,9 @@ export class ProposalService {
         { proposal_id: id, wiki_page_pk: updated.wiki_page_pk },
         'proposal accepted, content replacement deferred',
       );
+    } else {
+      await this.markPageSyncedWhenNoPending(updated);
     }
-
-    await this.markPageSyncedWhenNoPending(updated);
     return toProposalDetail(updated);
   }
 

--- a/apps/api/src/admin/proposals/proposal.service.ts
+++ b/apps/api/src/admin/proposals/proposal.service.ts
@@ -1,0 +1,204 @@
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { ErrorCode, wikiPages, wikiUpdateProposals } from '@cherrygraph/shared';
+import { and, count, desc, eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { getApiLogger } from '../../common/logger/logger.module.js';
+import { DRIZZLE } from '../../database/drizzle.constants.js';
+
+type ProposalRow = typeof wikiUpdateProposals.$inferSelect;
+type ProposalStatus = 'pending' | 'accepted' | 'rejected';
+
+export type ResolveProposalAction = 'accept' | 'reject';
+
+export type ProposalSummary = {
+  id: string;
+  proposal_type: string;
+  status: string;
+  created_at: Date;
+  wiki_page_pk: string | null;
+  space_id: string;
+};
+
+export type ProposalDetail = ProposalSummary & {
+  tenant_id: string;
+  graphify_run_id: string | null;
+  diff_json: unknown;
+  resolved_at: Date | null;
+};
+
+export type ListProposalsResponse = {
+  data: ProposalSummary[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type ProposalListQuery = {
+  status?: string;
+  page?: string | number;
+  limit?: string | number;
+};
+
+@Injectable()
+export class ProposalService {
+  constructor(@Inject(DRIZZLE) private readonly db: NodePgDatabase) {}
+
+  async listProposals(query: ProposalListQuery = {}): Promise<ListProposalsResponse> {
+    const page = normalizePositiveInt(query.page, 1);
+    const limit = normalizePositiveInt(query.limit, 20, 100);
+    const status = normalizeOptionalStatus(query.status);
+    const where = status === undefined ? undefined : eq(wikiUpdateProposals.status, status);
+    const rows = await this.db
+      .select({
+        id: wikiUpdateProposals.id,
+        proposal_type: wikiUpdateProposals.proposal_type,
+        status: wikiUpdateProposals.status,
+        created_at: wikiUpdateProposals.created_at,
+        wiki_page_pk: wikiUpdateProposals.wiki_page_pk,
+        space_id: wikiUpdateProposals.space_id,
+      })
+      .from(wikiUpdateProposals)
+      .where(where)
+      .orderBy(desc(wikiUpdateProposals.created_at))
+      .limit(limit)
+      .offset((page - 1) * limit);
+    const [countRow] = await this.db
+      .select({ total: count() })
+      .from(wikiUpdateProposals)
+      .where(where);
+
+    return {
+      data: rows,
+      total: Number(countRow?.total ?? 0),
+      page,
+      limit,
+    };
+  }
+
+  async getProposal(id: string): Promise<ProposalDetail> {
+    return toProposalDetail(await this.requireProposal(id));
+  }
+
+  async resolveProposal(id: string, action: ResolveProposalAction | undefined): Promise<ProposalDetail> {
+    const normalizedAction = normalizeResolveAction(action);
+    const proposal = await this.requireProposal(id);
+    if (proposal.status !== 'pending') {
+      throwApiError('PROPOSAL_ALREADY_RESOLVED', 'Proposal is already resolved', HttpStatus.CONFLICT);
+    }
+
+    const status = normalizedAction === 'accept' ? 'accepted' : 'rejected';
+    const resolvedAt = new Date();
+    const [updated] = await this.db
+      .update(wikiUpdateProposals)
+      .set({ status, resolved_at: resolvedAt })
+      .where(eq(wikiUpdateProposals.id, id))
+      .returning();
+
+    if (updated === undefined) {
+      throwApiError(ErrorCode.NOT_FOUND, 'Proposal not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (normalizedAction === 'accept') {
+      getApiLogger().info(
+        { proposal_id: id, wiki_page_pk: updated.wiki_page_pk },
+        'proposal accepted, content replacement deferred',
+      );
+    }
+
+    await this.markPageSyncedWhenNoPending(updated);
+    return toProposalDetail(updated);
+  }
+
+  private async requireProposal(id: string): Promise<ProposalRow> {
+    const [proposal] = await this.db
+      .select()
+      .from(wikiUpdateProposals)
+      .where(eq(wikiUpdateProposals.id, id))
+      .limit(1);
+
+    if (proposal === undefined) {
+      throwApiError(ErrorCode.NOT_FOUND, 'Proposal not found', HttpStatus.NOT_FOUND);
+    }
+
+    return proposal;
+  }
+
+  private async markPageSyncedWhenNoPending(proposal: ProposalRow): Promise<void> {
+    if (proposal.wiki_page_pk === null) {
+      return;
+    }
+
+    const [pending] = await this.db
+      .select({ id: wikiUpdateProposals.id })
+      .from(wikiUpdateProposals)
+      .where(
+        and(
+          eq(wikiUpdateProposals.wiki_page_pk, proposal.wiki_page_pk),
+          eq(wikiUpdateProposals.status, 'pending'),
+        ),
+      )
+      .limit(1);
+
+    if (pending !== undefined) {
+      return;
+    }
+
+    await this.db
+      .update(wikiPages)
+      .set({ sync_status: 'synced', updated_at: new Date() })
+      .where(eq(wikiPages.id, proposal.wiki_page_pk));
+  }
+}
+
+function toProposalDetail(row: ProposalRow): ProposalDetail {
+  return {
+    id: row.id,
+    tenant_id: row.tenant_id,
+    space_id: row.space_id,
+    wiki_page_pk: row.wiki_page_pk,
+    graphify_run_id: row.graphify_run_id,
+    proposal_type: row.proposal_type,
+    status: row.status,
+    diff_json: row.diff_json,
+    created_at: row.created_at,
+    resolved_at: row.resolved_at,
+  };
+}
+
+function normalizePositiveInt(value: string | number | undefined, fallback: number, max = Number.POSITIVE_INFINITY): number {
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  const parsed = typeof value === 'number' ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return Math.min(parsed, max);
+}
+
+function normalizeOptionalStatus(status: string | undefined): ProposalStatus | undefined {
+  if (status === undefined || status.trim().length === 0) {
+    return undefined;
+  }
+
+  if (status === 'pending' || status === 'accepted' || status === 'rejected') {
+    return status;
+  }
+
+  throwApiError('INVALID_PROPOSAL_STATUS', `Invalid proposal status: ${status}`, HttpStatus.BAD_REQUEST);
+}
+
+function normalizeResolveAction(action: ResolveProposalAction | undefined): ResolveProposalAction {
+  if (action === 'accept' || action === 'reject') {
+    return action;
+  }
+
+  throwApiError('INVALID_PROPOSAL_ACTION', 'Action must be accept or reject', HttpStatus.BAD_REQUEST);
+}
+
+function throwApiError(code: ErrorCode | string, message: string, status: HttpStatus): never {
+  throw new HttpException({ code, message }, status);
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { RequestContextMiddleware } from './common/middleware/request-context.mi
 import { RedisModule } from './common/redis/redis.module.js';
 import { AdminHealthModule } from './admin/admin-health.module.js';
 import { AdminIndexModule } from './admin/admin-index.module.js';
+import { ProposalModule } from './admin/proposals/proposal.module.js';
 import { AuditModule } from './audit/audit.module.js';
 import { AuthModule } from './auth/auth.module.js';
 import { BridgeModule } from './bridge/bridge.module.js';
@@ -45,6 +46,7 @@ import { WikiModule } from './wiki/wiki.module.js';
     HealthModule,
     AdminHealthModule,
     AdminIndexModule,
+    ProposalModule,
   ],
 })
 export class AppModule implements NestModule {

--- a/apps/wiki-sync-worker/src/__tests__/docmost-push.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/docmost-push.test.ts
@@ -1,0 +1,427 @@
+import type { Job } from 'bullmq';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  graphifyRuns,
+  pageBlockMetadata,
+  wikiPageVersions,
+  wikiPages,
+  wikiUpdateProposals,
+} from '@cherrygraph/shared';
+import { normalizeBlockHash } from '@cherrygraph/wiki-core';
+
+import {
+  createDocmostPushProcessor,
+  type DocmostPushBridgeClient,
+  type DocmostPushJobData,
+  type DrizzleDatabase,
+} from '../processors/docmost-push.processor.js';
+
+describe('docmost-push processor', () => {
+  it('pushes a new page and writes back docmost_page_id', async () => {
+    const db = new DocmostPushTestDb({
+      pages: [createPage({ docmost_page_id: null })],
+      runVersions: [createVersion({ version_no: 1, content_markdown: frontmatter('## Overview\nNew content') })],
+      metadataRows: [createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nNew content' })],
+    });
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.importPage).toHaveBeenCalledWith(
+      'wiki.page.1',
+      expect.stringContaining('<!-- graphify:managed:start id="overview" run="run-1" -->'),
+      { overwritePolicy: 'create_only' },
+    );
+    expect(db.pageUpdates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ docmost_page_id: 'docmost-created-1' }),
+        expect.objectContaining({ sync_status: 'synced' }),
+      ]),
+    );
+    expect(db.graphifyRunUpdates.at(-1)).toMatchObject({ status: 'docmost_synced' });
+  });
+
+  it('updates an existing page with optimistic expected hash', async () => {
+    const db = new DocmostPushTestDb({
+      previousVersions: [createVersion({ id: 'previous-version', version_no: 1, content_markdown: frontmatter('## Overview\nOld') })],
+      runVersions: [createVersion({ version_no: 2, content_markdown: frontmatter('## Overview\nNew') })],
+      metadataRows: [createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nNew' })],
+    });
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.importPage).toHaveBeenCalledWith(
+      'docmost-page-1',
+      expect.stringContaining('## Overview\nNew'),
+      expect.objectContaining({ overwritePolicy: 'update', expectedHash: expect.stringMatching(/^sha256:/) }),
+    );
+  });
+
+  it('retries once after optimistic lock conflict', async () => {
+    const db = new DocmostPushTestDb({
+      previousVersions: [createVersion({ id: 'previous-version', version_no: 1, content_markdown: frontmatter('## Overview\nOld') })],
+      runVersions: [createVersion({ version_no: 2, content_markdown: frontmatter('## Overview\nNew') })],
+      metadataRows: [createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nNew' })],
+    });
+    const conflict = Object.assign(new Error('conflict'), { status: 409 });
+    const importPage = vi
+      .fn<DocmostPushBridgeClient['importPage']>()
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce({ docmostPageId: 'docmost-page-1', contentHash: 'hash-after' });
+    const bridgeClient: DocmostPushBridgeClient = {
+      importPage,
+      exportPage: vi.fn<DocmostPushBridgeClient['exportPage']>(() =>
+        Promise.resolve({ markdown: frontmatter('## Overview\nHuman edit during race') }),
+      ),
+    };
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.exportPage).toHaveBeenCalledWith('docmost-page-1');
+    expect(bridgeClient.importPage).toHaveBeenCalledTimes(2);
+    expect(bridgeClient.importPage).toHaveBeenNthCalledWith(
+      2,
+      'docmost-page-1',
+      expect.stringContaining('## Overview\nHuman edit during race'),
+      expect.objectContaining({ overwritePolicy: 'update', expectedHash: expect.stringMatching(/^sha256:/) }),
+    );
+  });
+
+  it('preserves human blocks while updating graphify blocks', async () => {
+    const db = new DocmostPushTestDb({
+      previousVersions: [
+        createVersion({
+          id: 'previous-version',
+          version_no: 1,
+          content_markdown: frontmatter(['## Overview', 'Old', '', '## Details', 'Human notes'].join('\n')),
+        }),
+      ],
+      runVersions: [
+        createVersion({
+          version_no: 2,
+          content_markdown: frontmatter(['## Overview', 'New graphify', '', '## Details', 'Graphify rewrite'].join('\n')),
+        }),
+      ],
+      metadataRows: [
+        createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nNew graphify' }),
+        createMetadataRow({ block_id: 'details', owner: 'human', content: '## Details\nHuman notes' }),
+      ],
+    });
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    const pushedMarkdown = vi.mocked(bridgeClient.importPage).mock.calls[0]?.[1] ?? '';
+    expect(pushedMarkdown).toContain('<!-- graphify:human:start id="details" run="run-1" -->');
+    expect(pushedMarkdown).toContain('## Details\nHuman notes');
+    expect(pushedMarkdown).not.toContain('## Details\nGraphify rewrite');
+    expect(db.insertedProposals).toHaveLength(1);
+    expect(db.pageUpdates).toEqual(expect.arrayContaining([expect.objectContaining({ sync_status: 'conflict_required' })]));
+  });
+
+  it('creates a conflict proposal for a human-owned block', async () => {
+    const db = new DocmostPushTestDb({
+      previousVersions: [createVersion({ id: 'previous-version', version_no: 1, content_markdown: frontmatter('## Details\nHuman notes') })],
+      runVersions: [createVersion({ version_no: 2, content_markdown: frontmatter('## Details\nGraphify rewrite') })],
+      metadataRows: [createMetadataRow({ block_id: 'details', owner: 'human', content: '## Details\nHuman notes' })],
+    });
+
+    await runProcessor(db, createBridgeClient());
+
+    expect(db.insertedProposals).toHaveLength(1);
+    expect(db.insertedProposals[0]).toMatchObject({
+      proposal_type: 'conflict',
+      status: 'pending',
+      diff_json: {
+        blockId: 'details',
+        humanContent: '## Details\nHuman notes',
+        graphifyContent: '## Details\nGraphify rewrite',
+      },
+    });
+  });
+
+  it('creates one proposal per conflicting human block', async () => {
+    const db = new DocmostPushTestDb({
+      previousVersions: [
+        createVersion({
+          id: 'previous-version',
+          version_no: 1,
+          content_markdown: frontmatter(['## One', 'Human one', '', '## Two', 'Human two'].join('\n')),
+        }),
+      ],
+      runVersions: [
+        createVersion({
+          version_no: 2,
+          content_markdown: frontmatter(['## One', 'Graphify one', '', '## Two', 'Graphify two'].join('\n')),
+        }),
+      ],
+      metadataRows: [
+        createMetadataRow({ block_id: 'one', owner: 'human', content: '## One\nHuman one' }),
+        createMetadataRow({ block_id: 'two', owner: 'human', content: '## Two\nHuman two' }),
+      ],
+    });
+
+    await runProcessor(db, createBridgeClient());
+
+    expect(db.insertedProposals).toHaveLength(2);
+    expect(db.insertedProposals.map((proposal) => readBlockId(proposal.diff_json))).toEqual(['one', 'two']);
+  });
+
+  it('skips unchanged existing pages', async () => {
+    const unchanged = frontmatter('## Overview\nSame content');
+    const db = new DocmostPushTestDb({
+      previousVersions: [createVersion({ id: 'previous-version', version_no: 1, content_markdown: unchanged })],
+      runVersions: [createVersion({ version_no: 2, content_markdown: unchanged })],
+      metadataRows: [createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nSame content' })],
+    });
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.importPage).not.toHaveBeenCalled();
+    expect(db.graphifyRunUpdates.at(-1)).toMatchObject({ status: 'docmost_synced' });
+  });
+
+  it('marks run failed and page sync pending when a page push fails', async () => {
+    const db = new DocmostPushTestDb({
+      previousVersions: [createVersion({ id: 'previous-version', version_no: 1, content_markdown: frontmatter('## Overview\nOld') })],
+      runVersions: [createVersion({ version_no: 2, content_markdown: frontmatter('## Overview\nNew') })],
+      metadataRows: [createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nNew' })],
+    });
+    const bridgeClient: DocmostPushBridgeClient = {
+      importPage: vi.fn<DocmostPushBridgeClient['importPage']>(() => Promise.reject(Object.assign(new Error('down'), { status: 500 }))),
+      exportPage: vi.fn<DocmostPushBridgeClient['exportPage']>(),
+    };
+
+    await runProcessor(db, bridgeClient);
+
+    expect(db.pageUpdates).toEqual(expect.arrayContaining([expect.objectContaining({ sync_status: 'sync_pending' })]));
+    expect(db.graphifyRunUpdates.at(-1)).toMatchObject({ status: 'docmost_sync_failed' });
+  });
+});
+
+type WikiPageRow = typeof wikiPages.$inferSelect;
+type WikiPageVersionRow = typeof wikiPageVersions.$inferSelect;
+type PageBlockMetadataRow = typeof pageBlockMetadata.$inferSelect;
+
+class DocmostPushTestDb {
+  pages: WikiPageRow[];
+  runVersions: WikiPageVersionRow[];
+  previousVersions: WikiPageVersionRow[];
+  metadataRows: PageBlockMetadataRow[];
+  insertedProposals: Array<typeof wikiUpdateProposals.$inferInsert> = [];
+  pageUpdates: Array<Partial<typeof wikiPages.$inferInsert>> = [];
+  graphifyRunUpdates: Array<Partial<typeof graphifyRuns.$inferInsert>> = [];
+  private wikiPageVersionSelectCount = 0;
+
+  constructor(options: Partial<{
+    pages: WikiPageRow[];
+    runVersions: WikiPageVersionRow[];
+    previousVersions: WikiPageVersionRow[];
+    metadataRows: PageBlockMetadataRow[];
+  }> = {}) {
+    this.pages = options.pages ?? [createPage()];
+    this.runVersions = options.runVersions ?? [createVersion()];
+    this.previousVersions = options.previousVersions ?? [];
+    this.metadataRows = options.metadataRows ?? [
+      createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nNew content' }),
+    ];
+  }
+
+  select(): unknown {
+    return {
+      from: (table: unknown) => {
+        const resolveRows = (): unknown[] => {
+          if (table === wikiPageVersions) {
+            if (this.wikiPageVersionSelectCount === 0) {
+              this.wikiPageVersionSelectCount += 1;
+              return this.runVersions;
+            }
+
+            this.wikiPageVersionSelectCount += 1;
+            const previous = this.previousVersions.shift();
+            return previous === undefined ? [] : [previous];
+          }
+
+          if (table === wikiPages) {
+            return this.pages;
+          }
+
+          if (table === pageBlockMetadata) {
+            return this.metadataRows;
+          }
+
+          return [];
+        };
+
+        return new SelectBuilder(resolveRows);
+      },
+    };
+  }
+
+  update(table: unknown): unknown {
+    return {
+      set: (values: Record<string, unknown>) => ({
+        where: (): Promise<void> => {
+          if (table === wikiPages) {
+            this.pageUpdates.push(values);
+            this.pages = this.pages.map((page) => ({ ...page, ...values }) as WikiPageRow);
+          }
+          if (table === graphifyRuns) {
+            this.graphifyRunUpdates.push(values);
+          }
+          return Promise.resolve();
+        },
+      }),
+    };
+  }
+
+  insert(table: unknown): unknown {
+    return {
+      values: (values: unknown): Promise<void> => {
+        if (table === wikiUpdateProposals) {
+          this.insertedProposals.push(...(Array.isArray(values) ? values : [values]) as Array<typeof wikiUpdateProposals.$inferInsert>);
+        }
+        return Promise.resolve();
+      },
+    };
+  }
+
+  asDb(): DrizzleDatabase {
+    return this as unknown as DrizzleDatabase;
+  }
+}
+
+class SelectBuilder {
+  constructor(private readonly resolveRows: () => unknown[]) {}
+
+  where(): this {
+    return this;
+  }
+
+  orderBy(): this {
+    return this;
+  }
+
+  limit(limit: number): Promise<unknown[]> {
+    return Promise.resolve(this.resolveRows().slice(0, limit));
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.resolveRows()).then(onfulfilled, onrejected);
+  }
+}
+
+async function runProcessor(
+  db: DocmostPushTestDb,
+  bridgeClient: DocmostPushBridgeClient,
+): Promise<void> {
+  const processor = createDocmostPushProcessor({
+    db: db.asDb(),
+    bridgeClient,
+  });
+
+  await processor({
+    data: {
+      runId: 'run-1',
+      spaceId: 'space-1',
+      tenantId: 'tenant-1',
+    },
+  } as Job<DocmostPushJobData>);
+}
+
+function createBridgeClient(): DocmostPushBridgeClient {
+  return {
+    importPage: vi.fn<DocmostPushBridgeClient['importPage']>(() =>
+      Promise.resolve({ docmostPageId: 'docmost-created-1', contentHash: 'hash-after' }),
+    ),
+    exportPage: vi.fn<DocmostPushBridgeClient['exportPage']>(),
+  };
+}
+
+function frontmatter(content: string): string {
+  return ['---', 'page_id: wiki.page.1', 'space_id: space-1', 'title: Test Page', 'status: draft', '---', '', content].join('\n');
+}
+
+function createPage(overrides: Partial<WikiPageRow> = {}): WikiPageRow {
+  return {
+    id: 'wiki-pk-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    page_id: 'wiki.page.1',
+    title: 'Test Page',
+    slug: 'test-page',
+    status: 'draft',
+    current_version_id: 'version-2',
+    indexed_version_id: null,
+    sync_status: 'synced',
+    docmost_page_id: 'docmost-page-1',
+    created_by: 'graphify',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createVersion(overrides: Partial<WikiPageVersionRow> = {}): WikiPageVersionRow {
+  return {
+    id: 'version-2',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    wiki_page_pk: 'wiki-pk-1',
+    page_id: 'wiki.page.1',
+    version_no: 2,
+    content_markdown: frontmatter('## Overview\nNew content'),
+    frontmatter_json: {
+      page_id: 'wiki.page.1',
+      space_id: 'space-1',
+      title: 'Test Page',
+      status: 'draft',
+    },
+    source: 'graphify',
+    graphify_run_id: 'run-1',
+    commit_hash: 'commit-2',
+    status: 'draft',
+    created_by: 'graphify',
+    created_at: new Date('2026-05-05T11:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createMetadataRow(
+  overrides: Partial<PageBlockMetadataRow> & {
+    block_id: string;
+    owner: 'graphify' | 'human';
+    content: string;
+  },
+): PageBlockMetadataRow {
+  const { content: _content, block_id: blockId, owner, ...rest } = overrides;
+
+  return {
+    id: `metadata-${blockId}`,
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    wiki_page_pk: 'wiki-pk-1',
+    page_version_id: 'version-2',
+    block_id: blockId,
+    owner,
+    content_hash: normalizeBlockHash(_content),
+    graphify_run_id: 'run-1',
+    last_editor: null,
+    editable: owner === 'human',
+    created_at: new Date('2026-05-05T11:00:00.000Z'),
+    updated_at: new Date('2026-05-05T11:00:00.000Z'),
+    ...rest,
+  };
+}
+
+function readBlockId(value: unknown): string | undefined {
+  return value !== null && typeof value === 'object' && 'blockId' in value
+    ? String((value as { blockId: unknown }).blockId)
+    : undefined;
+}

--- a/apps/wiki-sync-worker/src/__tests__/docmost-push.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/docmost-push.test.ts
@@ -55,7 +55,7 @@ describe('docmost-push processor', () => {
     expect(bridgeClient.importPage).toHaveBeenCalledWith(
       'docmost-page-1',
       expect.stringContaining('## Overview\nNew'),
-      expect.objectContaining({ overwritePolicy: 'update', expectedHash: expect.stringMatching(/^sha256:/) }),
+      expect.objectContaining({ overwritePolicy: 'update', expectedHash: expect.stringMatching(/^[a-f0-9]{64}$/) }),
     );
   });
 
@@ -85,7 +85,7 @@ describe('docmost-push processor', () => {
       2,
       'docmost-page-1',
       expect.stringContaining('## Overview\nHuman edit during race'),
-      expect.objectContaining({ overwritePolicy: 'update', expectedHash: expect.stringMatching(/^sha256:/) }),
+      expect.objectContaining({ overwritePolicy: 'update', expectedHash: expect.stringMatching(/^[a-f0-9]{64}$/) }),
     );
   });
 

--- a/apps/wiki-sync-worker/src/bridge-client.ts
+++ b/apps/wiki-sync-worker/src/bridge-client.ts
@@ -1,0 +1,84 @@
+import type { DocmostPushBridgeClient } from './processors/docmost-push.processor.js';
+
+export class BridgeClientHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'BridgeClientHttpError';
+  }
+}
+
+export function createBridgeClient(baseUrl: string, secret: string): DocmostPushBridgeClient {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+  const headers = secret.length > 0 ? { Authorization: `Bearer ${secret}` } : {};
+
+  return {
+    async importPage(pageId, markdown, opts) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/api/internal/bridge/pages/${encodeURIComponent(pageId)}/import`,
+        {
+          method: 'PUT',
+          headers: {
+            ...headers,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            markdown,
+            overwrite_policy: opts.overwritePolicy,
+            ...(opts.expectedHash !== undefined ? { expected_hash: opts.expectedHash } : {}),
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new BridgeClientHttpError(
+          `Bridge import failed for page ${pageId}: HTTP ${response.status}`,
+          response.status,
+        );
+      }
+
+      const payload = readRecord(await response.json());
+      const docmostPageId = readString(payload.docmostPageId) ?? readString(payload.docmost_page_id) ?? readString(payload.page_id);
+      const contentHash = readString(payload.contentHash) ?? readString(payload.content_hash);
+      if (docmostPageId === undefined || contentHash === undefined) {
+        throw new Error(`Bridge import response for page ${pageId} did not include docmostPageId and contentHash`);
+      }
+
+      return { docmostPageId, contentHash };
+    },
+
+    async exportPage(pageId) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/api/internal/bridge/pages/${encodeURIComponent(pageId)}/export?format=markdown`,
+        { headers },
+      );
+
+      if (!response.ok) {
+        throw new BridgeClientHttpError(
+          `Bridge export failed for page ${pageId}: HTTP ${response.status}`,
+          response.status,
+        );
+      }
+
+      const payload = readRecord(await response.json());
+      const markdown = readString(payload.markdown) ?? readString(payload.content);
+      if (markdown === undefined) {
+        throw new Error(`Bridge export response for page ${pageId} did not include markdown content`);
+      }
+
+      return { markdown };
+    },
+  };
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -7,8 +7,13 @@ import { fileURLToPath } from 'node:url';
 import pg from 'pg';
 import type { Pool as PgPool } from 'pg';
 
+import { createBridgeClient } from './bridge-client.js';
 import { closeHealthServer, startHealthServer } from './health.js';
 import { reconcileOnStartup, type ReconciliationDb } from './reconciliation.js';
+import {
+  createDocmostPushProcessor,
+  type DocmostPushDeps,
+} from './processors/docmost-push.processor.js';
 import {
   createHttpBridgeClient,
   createPageSyncProcessor,
@@ -54,6 +59,7 @@ type BridgeWorkerQueues = {
 
 type BridgeWorkers = {
   pageSync: BullWorker;
+  docmostPush: BullWorker;
 };
 
 export async function bootstrap(): Promise<void> {
@@ -75,13 +81,18 @@ export async function bootstrap(): Promise<void> {
 
   await reconcileOnStartup(db as unknown as ReconciliationDb, queues);
 
+  const bridgeBaseUrl = process.env.DOCMOST_BRIDGE_BASE_URL ?? process.env.DOCMOST_BASE_URL ?? 'http://localhost:3000';
+  const bridgeSecret = process.env.DOCMOST_BRIDGE_TOKEN ?? '';
   const workers = createWorkers(connection, {
-    db,
-    bridgeClient: createHttpBridgeClient(
-      process.env.DOCMOST_BRIDGE_BASE_URL ?? process.env.DOCMOST_BASE_URL ?? 'http://localhost:3000',
-      process.env.DOCMOST_BRIDGE_TOKEN,
-    ),
-    wikiRepoPath: process.env.WIKI_REPO_PATH ?? process.cwd(),
+    pageSync: {
+      db,
+      bridgeClient: createHttpBridgeClient(bridgeBaseUrl, process.env.DOCMOST_BRIDGE_TOKEN),
+      wikiRepoPath: process.env.WIKI_REPO_PATH ?? process.cwd(),
+    },
+    docmostPush: {
+      db,
+      bridgeClient: createBridgeClient(bridgeBaseUrl, bridgeSecret),
+    },
   });
 
   const healthServer = await startHealthServer(
@@ -109,8 +120,11 @@ function createQueues(connection: IORedis): BridgeWorkerQueues {
   };
 }
 
-function createWorkers(connection: IORedis, pageSyncDeps: PageSyncDeps): BridgeWorkers {
-  const pageSync = new Worker(PAGE_SYNC_QUEUE, createPageSyncProcessor(pageSyncDeps), {
+function createWorkers(
+  connection: IORedis,
+  deps: { pageSync: PageSyncDeps; docmostPush: DocmostPushDeps },
+): BridgeWorkers {
+  const pageSync = new Worker(PAGE_SYNC_QUEUE, createPageSyncProcessor(deps.pageSync), {
     connection,
     concurrency: 3,
     settings: {
@@ -118,12 +132,19 @@ function createWorkers(connection: IORedis, pageSyncDeps: PageSyncDeps): BridgeW
         type === PAGE_SYNC_BACKOFF.type ? PAGE_SYNC_BACKOFF.delay(attemptsMade) : 0,
     },
   });
+  const docmostPush = new Worker(DOCMOST_PUSH_QUEUE, createDocmostPushProcessor(deps.docmostPush), {
+    connection,
+    concurrency: 1,
+  });
 
   pageSync.on('error', (error) => {
     console.error(`${WORKER_NAME}: page-sync worker error`, error);
   });
+  docmostPush.on('error', (error) => {
+    console.error(`${WORKER_NAME}: docmost-push worker error`, error);
+  });
 
-  return { pageSync };
+  return { pageSync, docmostPush };
 }
 
 function parseHealthPort(value: string | undefined): number {
@@ -167,7 +188,7 @@ async function shutdown(
 ): Promise<void> {
   let shutdownFailed = false;
   const queueList = [queues.pageSync, queues.permissionSync, queues.attachmentSync, queues.docmostPush];
-  const workerList = [workers.pageSync];
+  const workerList = [workers.pageSync, workers.docmostPush];
 
   try {
     console.log(`${WORKER_NAME}: shutting down`);

--- a/apps/wiki-sync-worker/src/processors/docmost-push.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/docmost-push.processor.ts
@@ -1,0 +1,456 @@
+import type { Job } from 'bullmq';
+import { and, desc, eq, inArray, lt } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { createHash, randomUUID } from 'node:crypto';
+
+import {
+  graphifyRuns,
+  pageBlockMetadata,
+  wikiPageVersions,
+  wikiPages,
+  wikiUpdateProposals,
+} from '@cherrygraph/shared';
+import {
+  extractH2Blocks,
+  extractMarkedBlocks,
+  generateFrontmatter,
+  matchBlocksFallback,
+  mergeBlocks,
+  normalizeBlockContent,
+  normalizeBlockHash,
+  parseFrontmatter,
+  wrapGraphifyBlock,
+  wrapHumanBlock,
+  type BlockMergeMetadataInfo,
+  type WikiFrontmatter,
+} from '@cherrygraph/wiki-core';
+
+export type DrizzleDatabase = NodePgDatabase;
+type DatabaseClient = Pick<DrizzleDatabase, 'select' | 'insert' | 'update'>;
+
+export interface DocmostPushDeps {
+  db: DrizzleDatabase;
+  bridgeClient: DocmostPushBridgeClient;
+}
+
+export interface DocmostPushBridgeClient {
+  importPage(
+    pageId: string,
+    markdown: string,
+    opts: { overwritePolicy: 'create_only' | 'update'; expectedHash?: string },
+  ): Promise<{ docmostPageId: string; contentHash: string }>;
+  exportPage(pageId: string): Promise<{ markdown: string }>;
+}
+
+export type DocmostPushJobData = {
+  runId: string;
+  spaceId: string;
+  tenantId: string;
+};
+
+type WikiPageRow = typeof wikiPages.$inferSelect;
+type WikiPageVersionRow = typeof wikiPageVersions.$inferSelect;
+type PageBlockMetadataRow = typeof pageBlockMetadata.$inferSelect;
+
+type PagePushInput = {
+  page: WikiPageRow;
+  version: WikiPageVersionRow;
+  metadata: BlockMergeMetadataInfo[];
+  previousVersion?: WikiPageVersionRow;
+};
+
+type ConflictProposal = {
+  blockId: string;
+  humanContent: string;
+  graphifyContent: string;
+};
+
+type BuildPushMarkdownResult = {
+  markdown: string;
+  proposals: ConflictProposal[];
+};
+
+export function createDocmostPushProcessor(
+  deps: DocmostPushDeps,
+): (job: Job) => Promise<void> {
+  return async (job) => {
+    const data = readJobData(job.data);
+    const pages = await loadGraphifyRunPages(deps.db, data);
+    let failed = false;
+
+    for (const pageInput of pages) {
+      try {
+        await pushPage(deps, data.runId, pageInput);
+      } catch (error) {
+        failed = true;
+        await markPageSyncPending(deps.db, pageInput.page.id);
+        console.error('docmost-push: page push failed', {
+          runId: data.runId,
+          pageId: pageInput.page.page_id,
+          error,
+        });
+      }
+    }
+
+    await updateRunStatus(deps.db, data.runId, failed ? 'docmost_sync_failed' : 'docmost_synced');
+  };
+}
+
+async function loadGraphifyRunPages(
+  db: DatabaseClient,
+  data: DocmostPushJobData,
+): Promise<PagePushInput[]> {
+  const versions = await db
+    .select()
+    .from(wikiPageVersions)
+    .where(
+      and(
+        eq(wikiPageVersions.graphify_run_id, data.runId),
+        eq(wikiPageVersions.space_id, data.spaceId),
+        eq(wikiPageVersions.tenant_id, data.tenantId),
+      ),
+    )
+    .orderBy(desc(wikiPageVersions.version_no));
+
+  if (versions.length === 0) {
+    return [];
+  }
+
+  const versionIds = versions.map((version) => version.id);
+  const metadataRows = await db
+    .select()
+    .from(pageBlockMetadata)
+    .where(inArray(pageBlockMetadata.page_version_id, versionIds));
+  const pageIds = Array.from(new Set(versions.map((version) => version.wiki_page_pk)));
+  const pages = await db
+    .select()
+    .from(wikiPages)
+    .where(
+      and(
+        eq(wikiPages.tenant_id, data.tenantId),
+        eq(wikiPages.space_id, data.spaceId),
+        inArray(wikiPages.id, pageIds),
+      ),
+    );
+
+  const pagesById = new Map(pages.map((page) => [page.id, page]));
+  const metadataByVersionId = groupMetadataByVersionId(metadataRows);
+  const inputs: PagePushInput[] = [];
+
+  for (const version of versions) {
+    const page = pagesById.get(version.wiki_page_pk);
+    if (page === undefined) {
+      continue;
+    }
+
+    const previousVersion = await loadPreviousVersion(db, page.id, version.version_no);
+    inputs.push({
+      page,
+      version,
+      metadata: (metadataByVersionId.get(version.id) ?? []).map(toBlockMetadataInfo),
+      ...(previousVersion !== undefined ? { previousVersion } : {}),
+    });
+  }
+
+  return inputs;
+}
+
+async function pushPage(deps: DocmostPushDeps, runId: string, input: PagePushInput): Promise<void> {
+  const firstBuild = buildPushMarkdown(input.version.content_markdown, input.metadata, {
+    runId,
+    humanContentByBlock: extractExistingBlockContent(input.previousVersion?.content_markdown),
+  });
+  let proposalCount = firstBuild.proposals.length;
+
+  await persistConflictProposals(deps.db, input.page, runId, firstBuild.proposals);
+  if (firstBuild.proposals.length > 0) {
+    await markPageConflictRequired(deps.db, input.page.id);
+  }
+
+  if (
+    input.page.docmost_page_id !== null &&
+    input.previousVersion !== undefined &&
+    contentSemanticHash(input.previousVersion.content_markdown) === contentSemanticHash(firstBuild.markdown)
+  ) {
+    return;
+  }
+
+  const targetPageId = input.page.docmost_page_id ?? input.page.page_id;
+  const expectedHash = input.page.docmost_page_id === null
+    ? undefined
+    : contentHash(input.previousVersion?.content_markdown ?? input.version.content_markdown);
+
+  try {
+    await importPageAndWriteback(deps, input.page, targetPageId, firstBuild.markdown, expectedHash);
+  } catch (error) {
+    if (!isHttpStatus(error, 409)) {
+      throw error;
+    }
+
+    if (input.page.docmost_page_id === null) {
+      throw error;
+    }
+
+    proposalCount += await retryAfterOptimisticConflict(deps, runId, input, input.page.docmost_page_id);
+  }
+
+  if (proposalCount === 0) {
+    await markPageSynced(deps.db, input.page.id);
+  }
+}
+
+async function importPageAndWriteback(
+  deps: DocmostPushDeps,
+  page: WikiPageRow,
+  targetPageId: string,
+  markdown: string,
+  expectedHash: string | undefined,
+): Promise<void> {
+  const overwritePolicy = page.docmost_page_id === null ? 'create_only' : 'update';
+  const result = await deps.bridgeClient.importPage(
+    targetPageId,
+    markdown,
+    expectedHash === undefined ? { overwritePolicy } : { overwritePolicy, expectedHash },
+  );
+
+  if (page.docmost_page_id === null) {
+    await deps.db
+      .update(wikiPages)
+      .set({ docmost_page_id: result.docmostPageId, updated_at: new Date() })
+      .where(eq(wikiPages.id, page.id));
+    page.docmost_page_id = result.docmostPageId;
+  }
+}
+
+async function retryAfterOptimisticConflict(
+  deps: DocmostPushDeps,
+  runId: string,
+  input: PagePushInput,
+  docmostPageId: string,
+): Promise<number> {
+  const exported = await deps.bridgeClient.exportPage(docmostPageId);
+  const exportedBody = parseFrontmatter(exported.markdown).content;
+  const merged = mergeBlocks(matchBlocksFallback(exportedBody, input.metadata), undefined, runId);
+  const retryMetadata = merged.newMetadata.length > 0 ? merged.newMetadata : input.metadata;
+  const retryBuild = buildPushMarkdown(input.version.content_markdown, retryMetadata, {
+    runId,
+    humanContentByBlock: extractExistingBlockContent(merged.mergedMarkdown),
+  });
+
+  await persistConflictProposals(deps.db, input.page, runId, retryBuild.proposals);
+  if (retryBuild.proposals.length > 0) {
+    await markPageConflictRequired(deps.db, input.page.id);
+  }
+
+  await deps.bridgeClient.importPage(docmostPageId, retryBuild.markdown, {
+    overwritePolicy: 'update',
+    expectedHash: contentHash(exported.markdown),
+  });
+  return retryBuild.proposals.length;
+}
+
+function buildPushMarkdown(
+  contentMarkdown: string,
+  metadata: BlockMergeMetadataInfo[],
+  options: { runId: string; humanContentByBlock: Map<string, string> },
+): BuildPushMarkdownResult {
+  const parsed = parseFrontmatter(contentMarkdown);
+  const body = parsed.content;
+  const blocks = extractH2Blocks(body);
+  if (blocks.length === 0) {
+    return { markdown: contentMarkdown, proposals: [] };
+  }
+
+  const metadataByBlockId = new Map(metadata.map((block) => [block.blockId, block]));
+  const incomingContentByBlock = extractExistingBlockContent(body);
+  const proposals: ConflictProposal[] = [];
+  let mergedBody = body.slice(0, blocks[0]?.start ?? 0);
+
+  for (const block of blocks) {
+    const blockId = block.blockId;
+    const blockMetadata = metadataByBlockId.get(blockId);
+    const graphifyContent = incomingContentByBlock.get(blockId) ?? block.content;
+
+    if (blockMetadata?.owner === 'human') {
+      const humanContent = options.humanContentByBlock.get(blockId) ?? graphifyContent;
+      if (
+        normalizeBlockContent(graphifyContent) !== normalizeBlockContent(humanContent) ||
+        normalizeBlockHash(graphifyContent) !== blockMetadata.contentHash
+      ) {
+        proposals.push({ blockId, humanContent, graphifyContent });
+      }
+      mergedBody += wrapHumanBlock(humanContent, blockId, options.runId);
+      continue;
+    }
+
+    mergedBody += wrapGraphifyBlock(graphifyContent, blockId, options.runId);
+  }
+
+  const frontmatter = readRecord(parsed.frontmatter);
+  if (Object.keys(frontmatter).length === 0) {
+    return { markdown: mergedBody.trimEnd(), proposals };
+  }
+
+  return {
+    markdown: generateFrontmatter(frontmatter as unknown as WikiFrontmatter, mergedBody.trimEnd()),
+    proposals,
+  };
+}
+
+async function persistConflictProposals(
+  db: DatabaseClient,
+  page: WikiPageRow,
+  runId: string,
+  proposals: ConflictProposal[],
+): Promise<void> {
+  if (proposals.length === 0) {
+    return;
+  }
+
+  await db.insert(wikiUpdateProposals).values(
+    proposals.map((proposal) => ({
+      id: randomUUID(),
+      tenant_id: page.tenant_id,
+      space_id: page.space_id,
+      wiki_page_pk: page.id,
+      graphify_run_id: runId,
+      proposal_type: 'conflict',
+      status: 'pending',
+      diff_json: {
+        blockId: proposal.blockId,
+        humanContent: proposal.humanContent,
+        graphifyContent: proposal.graphifyContent,
+      },
+    })),
+  );
+}
+
+async function loadPreviousVersion(
+  db: DatabaseClient,
+  pagePk: string,
+  versionNo: number,
+): Promise<WikiPageVersionRow | undefined> {
+  const [version] = await db
+    .select()
+    .from(wikiPageVersions)
+    .where(and(eq(wikiPageVersions.wiki_page_pk, pagePk), lt(wikiPageVersions.version_no, versionNo)))
+    .orderBy(desc(wikiPageVersions.version_no))
+    .limit(1);
+
+  return version;
+}
+
+function groupMetadataByVersionId(
+  rows: PageBlockMetadataRow[],
+): Map<string, PageBlockMetadataRow[]> {
+  const grouped = new Map<string, PageBlockMetadataRow[]>();
+
+  for (const row of rows) {
+    const existing = grouped.get(row.page_version_id) ?? [];
+    existing.push(row);
+    grouped.set(row.page_version_id, existing);
+  }
+
+  return grouped;
+}
+
+function toBlockMetadataInfo(row: PageBlockMetadataRow): BlockMergeMetadataInfo {
+  return {
+    blockId: row.block_id,
+    owner: row.owner === 'human' ? 'human' : 'graphify',
+    contentHash: row.content_hash,
+    ...(row.graphify_run_id !== null ? { graphifyRunId: row.graphify_run_id } : {}),
+    ...(row.last_editor !== null ? { lastEditor: row.last_editor } : {}),
+    editable: row.editable,
+  };
+}
+
+function extractExistingBlockContent(contentMarkdown: string | undefined): Map<string, string> {
+  if (contentMarkdown === undefined) {
+    return new Map();
+  }
+
+  const body = parseFrontmatter(contentMarkdown).content;
+  const contentByBlockId = new Map(extractMarkedBlocks(body));
+  for (const block of extractH2Blocks(body)) {
+    if (!contentByBlockId.has(block.blockId)) {
+      contentByBlockId.set(block.blockId, block.content);
+    }
+  }
+
+  return contentByBlockId;
+}
+
+async function markPageConflictRequired(db: DatabaseClient, pagePk: string): Promise<void> {
+  await db
+    .update(wikiPages)
+    .set({ sync_status: 'conflict_required', updated_at: new Date() })
+    .where(eq(wikiPages.id, pagePk));
+}
+
+async function markPageSynced(db: DatabaseClient, pagePk: string): Promise<void> {
+  await db
+    .update(wikiPages)
+    .set({ sync_status: 'synced', updated_at: new Date() })
+    .where(eq(wikiPages.id, pagePk));
+}
+
+async function markPageSyncPending(db: DatabaseClient, pagePk: string): Promise<void> {
+  await db
+    .update(wikiPages)
+    .set({ sync_status: 'sync_pending', updated_at: new Date() })
+    .where(eq(wikiPages.id, pagePk));
+}
+
+async function updateRunStatus(
+  db: DatabaseClient,
+  runId: string,
+  status: 'docmost_synced' | 'docmost_sync_failed',
+): Promise<void> {
+  await db.update(graphifyRuns).set({ status }).where(eq(graphifyRuns.id, runId));
+}
+
+function contentHash(markdown: string): string {
+  return `sha256:${createHash('sha256').update(markdown).digest('hex')}`;
+}
+
+function contentSemanticHash(markdown: string): string {
+  return createHash('sha256')
+    .update(normalizeBlockContent(parseFrontmatter(markdown).content))
+    .digest('hex');
+}
+
+function isHttpStatus(error: unknown, status: number): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+
+  return error.status === status || error.statusCode === status;
+}
+
+function readJobData(data: unknown): DocmostPushJobData {
+  const record = readRecord(data);
+  const runId = readString(record.runId);
+  const spaceId = readString(record.spaceId);
+  const tenantId = readString(record.tenantId);
+
+  if (runId === undefined || spaceId === undefined || tenantId === undefined) {
+    throw new Error('docmost-push job is missing runId, spaceId, or tenantId');
+  }
+
+  return { runId, spaceId, tenantId };
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/wiki-sync-worker/src/processors/docmost-push.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/docmost-push.processor.ts
@@ -411,7 +411,7 @@ async function updateRunStatus(
 }
 
 function contentHash(markdown: string): string {
-  return `sha256:${createHash('sha256').update(markdown).digest('hex')}`;
+  return createHash('sha256').update(markdown).digest('hex');
 }
 
 function contentSemanticHash(markdown: string): string {


### PR DESCRIPTION
## Summary
- Docmost-push processor：Graphify 完成后推送页面到 Docmost，含 human block 保护、conflict→proposal 创建、乐观锁 409 重试、run status 更新
- Proposal API：admin CRUD（list/detail/accept/reject），含 409 防护
- Bridge client placeholder：fetch-based HTTP 客户端

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `3a2fb7504f07c1448d179f5b3097635328d6d3d4`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/134#issuecomment-4377438650) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/134#issuecomment-4377438833) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/134#issuecomment-4377439097) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/134#issuecomment-4377439280)
- Key findings addressed: Fixed expected_hash format (raw hex, no sha256: prefix), proposal accept preserves conflict_required status

## Test plan
- [x] docmost-push.test.ts — push flow, human block protection, conflict proposals, unchanged skip, run status
- [x] proposal.controller.test.ts — list/detail/accept/reject/409/404
- [x] Full regression: 137 files, 806 tests passed

Closes #130