### PR TITLE
feat(sync): permission sync + integration tests + CI (#131)

### DIFF
--- a/.github/workflows/bridge-contract-tests.yml
+++ b/.github/workflows/bridge-contract-tests.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - apps/api/src/bridge/**
+      - apps/wiki-sync-worker/**
       - packages/shared/src/schema/**
       - docs/schemas/openapi-bridge.yaml
       - docker-compose.yml

--- a/.github/workflows/wiki-sync-tests.yml
+++ b/.github/workflows/wiki-sync-tests.yml
@@ -1,0 +1,28 @@
+name: Wiki Sync Tests
+
+on:
+  pull_request:
+    paths:
+      - 'apps/wiki-sync-worker/**'
+      - 'packages/wiki-core/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wiki-sync-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @cherrygraph/shared run build
+      - run: pnpm --filter @cherrygraph/wiki-core run build
+      - run: pnpm --filter @cherrygraph/wiki-sync-worker run build
+      - run: npx vitest run --config vitest.config.ts apps/wiki-sync-worker/src/__tests__/ packages/wiki-core/src/__tests__/block-merge.test.ts

--- a/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
@@ -97,6 +97,18 @@ describe('BridgeQueueService', () => {
     });
   });
 
+  it('enqueues direct permission sync jobs with tenant-space deduplication', async () => {
+    const service = createService();
+
+    await service.enqueuePermissionSyncJob({ tenantId: 'tenant-1', spaceId: 'space-1' });
+
+    expect(queueByName(BRIDGE_PERMISSION_SYNC_QUEUE).add).toHaveBeenCalledWith(
+      'permission.sync',
+      { tenantId: 'tenant-1', spaceId: 'space-1' },
+      { jobId: 'tenant-1:space-1' },
+    );
+  });
+
   it('skips enqueue when Redis is not configured', async () => {
     delete process.env.REDIS_URL;
     const warn = vi.spyOn(getApiLogger(), 'warn').mockImplementation(() => undefined);

--- a/apps/api/src/bridge/bridge-permission-hooks.ts
+++ b/apps/api/src/bridge/bridge-permission-hooks.ts
@@ -1,0 +1,14 @@
+import type { BridgeQueueService } from './bridge-queue.service.js';
+
+/**
+ * Integration point for space membership add/remove/role-change paths.
+ * Call this after the Cherry DB transaction commits so Docmost receives the
+ * latest collapsed space permission set.
+ */
+export async function enqueuePermissionSync(
+  queueService: BridgeQueueService,
+  spaceId: string,
+  tenantId: string,
+): Promise<void> {
+  await queueService.enqueuePermissionSyncJob({ spaceId, tenantId });
+}

--- a/apps/api/src/bridge/bridge-queue.service.ts
+++ b/apps/api/src/bridge/bridge-queue.service.ts
@@ -32,6 +32,11 @@ export type DocmostPushJobData = {
   tenantId: string;
 };
 
+export type PermissionSyncJobData = {
+  spaceId: string;
+  tenantId: string;
+};
+
 const DEFAULT_JOB_OPTIONS: JobsOptions = {
   attempts: 3,
   backoff: {
@@ -48,7 +53,7 @@ export class BridgeQueueService implements OnModuleDestroy {
   private readonly ownsConnection: boolean;
   private readonly disabled: boolean;
   private readonly queues: Partial<
-    Record<BridgeQueueName, Queue<BridgeQueueJobData | DocmostPushJobData>>
+    Record<BridgeQueueName, Queue<BridgeQueueJobData | DocmostPushJobData | PermissionSyncJobData>>
   >;
 
   constructor(@Optional() @Inject(REDIS_CLIENT) redis?: OptionalRedisClient) {
@@ -116,6 +121,20 @@ export class BridgeQueueService implements OnModuleDestroy {
     });
   }
 
+  async enqueuePermissionSyncJob(jobData: PermissionSyncJobData): Promise<void> {
+    if (this.disabled) {
+      getApiLogger().warn(
+        { redis_configured: false },
+        'BullMQ dispatch disabled — no Redis configured',
+      );
+      return;
+    }
+
+    await this.getQueue(BRIDGE_PERMISSION_SYNC_QUEUE).add('permission.sync', jobData, {
+      jobId: `${jobData.tenantId}:${jobData.spaceId}`,
+    });
+  }
+
   async onModuleDestroy(): Promise<void> {
     if (this.disabled) {
       return;
@@ -135,7 +154,9 @@ export class BridgeQueueService implements OnModuleDestroy {
     }
   }
 
-  private getQueue(queueName: BridgeQueueName): Queue<BridgeQueueJobData | DocmostPushJobData> {
+  private getQueue(
+    queueName: BridgeQueueName,
+  ): Queue<BridgeQueueJobData | DocmostPushJobData | PermissionSyncJobData> {
     const queue = this.queues[queueName];
     if (queue === undefined) {
       throw new Error(`Bridge queue is not initialized: ${queueName}`);

--- a/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
@@ -1,0 +1,263 @@
+import type { Job } from 'bullmq';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  audit_logs,
+  space_permissions,
+  spaces,
+} from '@cherrygraph/shared';
+
+import { reconcilePermissions } from '../reconciliation/permission-reconcile.js';
+import {
+  createPermissionSyncProcessor,
+  mapCherryRoleToDocmost,
+  type DrizzleDatabase,
+  type PermissionMember,
+  type PermissionSyncBridgeClient,
+  type PermissionSyncJobData,
+} from '../processors/permission-sync.processor.js';
+
+describe('permission-sync processor', () => {
+  it('maps Cherry roles to Docmost roles', () => {
+    expect(mapCherryRoleToDocmost('admin')).toBe('admin');
+    expect(mapCherryRoleToDocmost('owner')).toBe('admin');
+    expect(mapCherryRoleToDocmost('editor')).toBe('writer');
+    expect(mapCherryRoleToDocmost('viewer')).toBe('reader');
+    expect(mapCherryRoleToDocmost('custom')).toBe('reader');
+  });
+
+  it('pushes collapsed space permissions to Docmost', async () => {
+    const db = new PermissionSyncTestDb();
+    db.permissionRows = [
+      { userId: 'user-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
+      { userId: 'user-writer', email: 'writer@example.com', cherryRole: 'space:edit' },
+      { userId: 'user-reader', email: 'reader@example.com', cherryRole: 'space:view' },
+      { userId: 'user-writer', email: 'writer@example.com', cherryRole: 'space:view' },
+    ];
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.pushPermissions).toHaveBeenCalledWith('docmost-space-1', [
+      { userId: 'user-admin', email: 'admin@example.com', role: 'admin' },
+      { userId: 'user-reader', email: 'reader@example.com', role: 'reader' },
+      { userId: 'user-writer', email: 'writer@example.com', role: 'writer' },
+    ]);
+  });
+
+  it('skips spaces that have not been synced to Docmost', async () => {
+    const db = new PermissionSyncTestDb({
+      spaces: [createSpace({ docmost_space_id: null })],
+    });
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.pushPermissions).not.toHaveBeenCalled();
+  });
+
+  it('treats Docmost 404 as non-retryable and writes an audit event', async () => {
+    const db = new PermissionSyncTestDb();
+    const bridgeClient = createBridgeClient(
+      Object.assign(new Error('not found'), { status: 404 }),
+    );
+
+    await expect(runProcessor(db, bridgeClient)).rejects.toHaveProperty('name', 'UnrecoverableError');
+
+    expect(db.auditRows).toEqual([
+      expect.objectContaining({
+        action: 'bridge.permission_sync_failed',
+        space_id: 'space-1',
+        metadata_json: expect.objectContaining({ nonRetryable: true }),
+      }),
+    ]);
+  });
+
+  it('retries transient push failures and audits only on the final attempt', async () => {
+    const db = new PermissionSyncTestDb();
+    const bridgeClient = createBridgeClient(
+      Object.assign(new Error('upstream down'), { status: 500 }),
+    );
+
+    await expect(runProcessor(db, bridgeClient, { attemptsMade: 0 })).rejects.toThrow('upstream down');
+    expect(db.auditRows).toHaveLength(0);
+
+    await expect(runProcessor(db, bridgeClient, { attemptsMade: 2 })).rejects.toThrow('upstream down');
+    expect(db.auditRows).toEqual([
+      expect.objectContaining({
+        action: 'bridge.permission_sync_failed',
+        metadata_json: expect.objectContaining({ nonRetryable: false }),
+      }),
+    ]);
+  });
+
+  it('reconcile fixes permission drift by pushing Cherry state', async () => {
+    const db = new PermissionSyncTestDb();
+    const bridgeClient = {
+      pushPermissions: vi.fn<PermissionSyncBridgeClient['pushPermissions']>(() => Promise.resolve()),
+      getPermissions: vi.fn(() => Promise.resolve([])),
+    };
+
+    await expect(reconcilePermissions(db.asDb(), bridgeClient)).resolves.toEqual({ fixed: 1, errors: 0 });
+
+    expect(bridgeClient.pushPermissions).toHaveBeenCalledWith('docmost-space-1', [
+      { userId: 'user-admin', email: 'admin@example.com', role: 'admin' },
+    ]);
+    expect(db.auditRows.at(-1)).toMatchObject({ action: 'permission_consistency_fixed' });
+  });
+
+  it('reconcile is a no-op when permissions are already consistent', async () => {
+    const db = new PermissionSyncTestDb();
+    const bridgeClient = {
+      pushPermissions: vi.fn<PermissionSyncBridgeClient['pushPermissions']>(() => Promise.resolve()),
+      getPermissions: vi.fn(() =>
+        Promise.resolve<PermissionMember[]>([
+          { userId: 'user-admin', email: 'admin@example.com', role: 'admin' },
+        ]),
+      ),
+    };
+
+    await expect(reconcilePermissions(db.asDb(), bridgeClient)).resolves.toEqual({ fixed: 0, errors: 0 });
+
+    expect(bridgeClient.pushPermissions).not.toHaveBeenCalled();
+    expect(db.auditRows).toHaveLength(0);
+  });
+});
+
+type SpaceRow = typeof spaces.$inferSelect;
+type AuditLogInsert = typeof audit_logs.$inferInsert;
+
+class PermissionSyncTestDb {
+  spaces: SpaceRow[];
+  permissionRows: Array<{ userId: string; email: string; cherryRole: string }> = [
+    { userId: 'user-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
+  ];
+  auditRows: AuditLogInsert[] = [];
+
+  constructor(options: Partial<{ spaces: SpaceRow[] }> = {}) {
+    this.spaces = options.spaces ?? [createSpace()];
+  }
+
+  select(selection?: unknown): unknown {
+    return {
+      from: (table: unknown) => {
+        const resolveRows = (): unknown[] => {
+          if (table === spaces) {
+            if (isRecord(selection) && 'spaceId' in selection) {
+              return this.spaces
+                .filter((space) => space.docmost_space_id !== null)
+                .map((space) => ({
+                  spaceId: space.id,
+                  tenantId: space.tenant_id,
+                  docmostSpaceId: space.docmost_space_id,
+                }));
+            }
+
+            const space = this.spaces.find((row) => row.id === 'space-1');
+            return space === undefined
+              ? []
+              : [{ tenantId: space.tenant_id, docmostSpaceId: space.docmost_space_id }];
+          }
+
+          if (table === space_permissions) {
+            return this.permissionRows;
+          }
+
+          return [];
+        };
+
+        return new SelectBuilder(resolveRows);
+      },
+    };
+  }
+
+  insert(table: unknown): unknown {
+    return {
+      values: (values: unknown): Promise<void> => {
+        if (table === audit_logs) {
+          this.auditRows.push(values as AuditLogInsert);
+        }
+        return Promise.resolve();
+      },
+    };
+  }
+
+  asDb(): DrizzleDatabase {
+    return this as unknown as DrizzleDatabase;
+  }
+}
+
+class SelectBuilder {
+  constructor(private readonly resolveRows: () => unknown[]) {}
+
+  innerJoin(): this {
+    return this;
+  }
+
+  where(): this {
+    return this;
+  }
+
+  limit(limit: number): Promise<unknown[]> {
+    return Promise.resolve(this.resolveRows().slice(0, limit));
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.resolveRows()).then(onfulfilled, onrejected);
+  }
+}
+
+async function runProcessor(
+  db: PermissionSyncTestDb,
+  bridgeClient: PermissionSyncBridgeClient,
+  options: { attemptsMade?: number } = {},
+): Promise<void> {
+  const processor = createPermissionSyncProcessor({
+    db: db.asDb(),
+    bridgeClient,
+  });
+
+  await processor({
+    data: { spaceId: 'space-1', tenantId: 'tenant-1' },
+    attemptsMade: options.attemptsMade ?? 0,
+    opts: { attempts: 3 },
+  } as Job<PermissionSyncJobData>);
+}
+
+function createBridgeClient(error?: Error): PermissionSyncBridgeClient {
+  return {
+    pushPermissions: vi.fn<PermissionSyncBridgeClient['pushPermissions']>(() =>
+      error === undefined ? Promise.resolve() : Promise.reject(error),
+    ),
+  };
+}
+
+function createSpace(overrides: Partial<SpaceRow> = {}): SpaceRow {
+  return {
+    id: 'space-1',
+    tenant_id: 'tenant-1',
+    name: 'Research',
+    slug: 'research',
+    description: null,
+    status: 'active',
+    docmost_space_id: 'docmost-space-1',
+    wiki_repo_path: '/tmp/wiki',
+    active_graphify_run_id: null,
+    active_index_snapshot_id: null,
+    index_consistency_status: 'healthy',
+    permission_version: 1,
+    strict_knowledge_only: true,
+    graphify_config: {},
+    default_publish_policy: 'editor_publish',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/wiki-sync-worker/src/bridge-client.ts
+++ b/apps/wiki-sync-worker/src/bridge-client.ts
@@ -1,4 +1,5 @@
 import type { DocmostPushBridgeClient } from './processors/docmost-push.processor.js';
+import type { PermissionSyncBridgeClient } from './processors/permission-sync.processor.js';
 
 export class BridgeClientHttpError extends Error {
   constructor(
@@ -10,7 +11,10 @@ export class BridgeClientHttpError extends Error {
   }
 }
 
-export function createBridgeClient(baseUrl: string, secret: string): DocmostPushBridgeClient {
+export function createBridgeClient(
+  baseUrl: string,
+  secret: string,
+): DocmostPushBridgeClient & PermissionSyncBridgeClient {
   const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
   const headers = secret.length > 0 ? { Authorization: `Bearer ${secret}` } : {};
 
@@ -70,6 +74,45 @@ export function createBridgeClient(baseUrl: string, secret: string): DocmostPush
 
       return { markdown };
     },
+
+    async pushPermissions(docmostSpaceId, members) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/api/internal/bridge/spaces/${encodeURIComponent(docmostSpaceId)}/permissions`,
+        {
+          method: 'PUT',
+          headers: {
+            ...headers,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ members }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new BridgeClientHttpError(
+          `Bridge permissions push failed for space ${docmostSpaceId}: HTTP ${response.status}`,
+          response.status,
+        );
+      }
+    },
+
+    async getPermissions(docmostSpaceId) {
+      const response = await fetch(
+        `${normalizedBaseUrl}/api/internal/bridge/spaces/${encodeURIComponent(docmostSpaceId)}/permissions`,
+        { headers },
+      );
+
+      if (!response.ok) {
+        throw new BridgeClientHttpError(
+          `Bridge permissions fetch failed for space ${docmostSpaceId}: HTTP ${response.status}`,
+          response.status,
+        );
+      }
+
+      const payload = await response.json();
+      const rawMembers = Array.isArray(payload) ? payload : readArray(readRecord(payload).members);
+      return rawMembers.flatMap(readPermissionMember);
+    },
   };
 }
 
@@ -81,4 +124,25 @@ function readRecord(value: unknown): Record<string, unknown> {
 
 function readString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function readPermissionMember(value: unknown): Array<{ userId: string; email: string; role: 'admin' | 'writer' | 'reader' }> {
+  const record = readRecord(value);
+  const userId = readString(record.userId) ?? readString(record.user_id);
+  const email = readString(record.email);
+  const role = readPermissionRole(record.role);
+
+  if (userId === undefined || email === undefined || role === undefined) {
+    return [];
+  }
+
+  return [{ userId, email, role }];
+}
+
+function readPermissionRole(value: unknown): 'admin' | 'writer' | 'reader' | undefined {
+  return value === 'admin' || value === 'writer' || value === 'reader' ? value : undefined;
 }

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -10,6 +10,7 @@ import type { Pool as PgPool } from 'pg';
 import { createBridgeClient } from './bridge-client.js';
 import { closeHealthServer, startHealthServer } from './health.js';
 import { reconcileOnStartup, type ReconciliationDb } from './reconciliation.js';
+import { reconcilePermissions } from './reconciliation/permission-reconcile.js';
 import {
   createDocmostPushProcessor,
   type DocmostPushDeps,
@@ -19,6 +20,10 @@ import {
   createPageSyncProcessor,
   type PageSyncDeps,
 } from './processors/page-sync.processor.js';
+import {
+  createPermissionSyncProcessor,
+  type PermissionSyncDeps,
+} from './processors/permission-sync.processor.js';
 
 const WORKER_NAME = 'wiki-sync-worker';
 const PAGE_SYNC_QUEUE = 'bridge-page-sync';
@@ -59,6 +64,7 @@ type BridgeWorkerQueues = {
 
 type BridgeWorkers = {
   pageSync: BullWorker;
+  permissionSync: BullWorker;
   docmostPush: BullWorker;
 };
 
@@ -82,18 +88,27 @@ export async function bootstrap(): Promise<void> {
   await reconcileOnStartup(db as unknown as ReconciliationDb, queues);
 
   const bridgeBaseUrl = process.env.DOCMOST_BRIDGE_BASE_URL ?? process.env.DOCMOST_BASE_URL ?? 'http://localhost:3000';
-  const bridgeSecret = process.env.DOCMOST_BRIDGE_TOKEN ?? '';
+  const bridgeSecret = process.env.DOCMOST_BRIDGE_SECRET ?? process.env.DOCMOST_BRIDGE_TOKEN ?? '';
+  const bridgeClient = createBridgeClient(bridgeBaseUrl, bridgeSecret);
   const workers = createWorkers(connection, {
     pageSync: {
       db,
-      bridgeClient: createHttpBridgeClient(bridgeBaseUrl, process.env.DOCMOST_BRIDGE_TOKEN),
+      bridgeClient: createHttpBridgeClient(
+        bridgeBaseUrl,
+        process.env.DOCMOST_BRIDGE_SECRET ?? process.env.DOCMOST_BRIDGE_TOKEN,
+      ),
       wikiRepoPath: process.env.WIKI_REPO_PATH ?? process.cwd(),
     },
     docmostPush: {
       db,
-      bridgeClient: createBridgeClient(bridgeBaseUrl, bridgeSecret),
+      bridgeClient,
+    },
+    permissionSync: {
+      db,
+      bridgeClient,
     },
   });
+  const permissionReconcileTimer = startPermissionReconcileTimer(db, bridgeClient);
 
   const healthServer = await startHealthServer(
     {
@@ -105,7 +120,7 @@ export async function bootstrap(): Promise<void> {
     healthPort,
   );
 
-  const shutdown = createShutdownHandler(queues, workers, connection, pool, healthServer);
+  const shutdown = createShutdownHandler(queues, workers, connection, pool, healthServer, permissionReconcileTimer);
   process.once('SIGTERM', shutdown);
   process.once('SIGINT', shutdown);
   console.log(`${WORKER_NAME}: started`, { healthPort });
@@ -122,7 +137,7 @@ function createQueues(connection: IORedis): BridgeWorkerQueues {
 
 function createWorkers(
   connection: IORedis,
-  deps: { pageSync: PageSyncDeps; docmostPush: DocmostPushDeps },
+  deps: { pageSync: PageSyncDeps; permissionSync: PermissionSyncDeps; docmostPush: DocmostPushDeps },
 ): BridgeWorkers {
   const pageSync = new Worker(PAGE_SYNC_QUEUE, createPageSyncProcessor(deps.pageSync), {
     connection,
@@ -136,6 +151,14 @@ function createWorkers(
     connection,
     concurrency: 1,
   });
+  const permissionSync = new Worker(
+    PERMISSION_SYNC_QUEUE,
+    createPermissionSyncProcessor(deps.permissionSync),
+    {
+      connection,
+      concurrency: 1,
+    },
+  );
 
   pageSync.on('error', (error) => {
     console.error(`${WORKER_NAME}: page-sync worker error`, error);
@@ -143,8 +166,22 @@ function createWorkers(
   docmostPush.on('error', (error) => {
     console.error(`${WORKER_NAME}: docmost-push worker error`, error);
   });
+  permissionSync.on('error', (error) => {
+    console.error(`${WORKER_NAME}: permission-sync worker error`, error);
+  });
 
-  return { pageSync, docmostPush };
+  return { pageSync, permissionSync, docmostPush };
+}
+
+function startPermissionReconcileTimer(
+  db: PermissionSyncDeps['db'],
+  bridgeClient: PermissionSyncDeps['bridgeClient'],
+): ReturnType<typeof setInterval> {
+  return setInterval(() => {
+    void reconcilePermissions(db, bridgeClient).catch((error: unknown) => {
+      console.error(`${WORKER_NAME}: permission reconcile failed`, error);
+    });
+  }, 60 * 60 * 1000);
 }
 
 function parseHealthPort(value: string | undefined): number {
@@ -166,6 +203,7 @@ function createShutdownHandler(
   connection: IORedis,
   pool: PgPool,
   healthServer: Server,
+  permissionReconcileTimer: ReturnType<typeof setInterval>,
 ): () => void {
   let shuttingDown = false;
 
@@ -175,7 +213,7 @@ function createShutdownHandler(
     }
 
     shuttingDown = true;
-    void shutdown(queues, workers, connection, pool, healthServer);
+    void shutdown(queues, workers, connection, pool, healthServer, permissionReconcileTimer);
   };
 }
 
@@ -185,13 +223,15 @@ async function shutdown(
   connection: IORedis,
   pool: PgPool,
   healthServer: Server,
+  permissionReconcileTimer: ReturnType<typeof setInterval>,
 ): Promise<void> {
   let shutdownFailed = false;
   const queueList = [queues.pageSync, queues.permissionSync, queues.attachmentSync, queues.docmostPush];
-  const workerList = [workers.pageSync, workers.docmostPush];
+  const workerList = [workers.pageSync, workers.permissionSync, workers.docmostPush];
 
   try {
     console.log(`${WORKER_NAME}: shutting down`);
+    clearInterval(permissionReconcileTimer);
     const results = await Promise.allSettled([
       ...workerList.map((worker) => worker.close()),
       ...queueList.map((queue) => queue.close()),

--- a/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
@@ -1,0 +1,299 @@
+import { UnrecoverableError, type Job } from 'bullmq';
+import { and, eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { randomUUID } from 'node:crypto';
+
+import {
+  audit_logs,
+  group_members,
+  space_permissions,
+  spaces,
+  users,
+} from '@cherrygraph/shared';
+
+export type DrizzleDatabase = NodePgDatabase;
+type DatabaseClient = Pick<DrizzleDatabase, 'select' | 'insert'>;
+
+export interface PermissionSyncDeps {
+  db: DrizzleDatabase;
+  bridgeClient: PermissionSyncBridgeClient;
+}
+
+export interface PermissionSyncBridgeClient {
+  pushPermissions(docmostSpaceId: string, members: PermissionMember[]): Promise<void>;
+  getPermissions?(docmostSpaceId: string): Promise<PermissionMember[]>;
+}
+
+export interface PermissionMember {
+  userId: string;
+  email: string;
+  role: 'admin' | 'writer' | 'reader';
+}
+
+export type PermissionSyncJobData = {
+  spaceId: string;
+  tenantId?: string;
+};
+
+type SpacePermissionRow = {
+  userId: string;
+  email: string;
+  cherryRole: string;
+};
+
+type PushSpacePermissionsResult = {
+  pushed: boolean;
+  tenantId?: string;
+  docmostSpaceId?: string;
+  members: PermissionMember[];
+};
+
+export function createPermissionSyncProcessor(
+  deps: PermissionSyncDeps,
+): (job: Job<PermissionSyncJobData>) => Promise<void> {
+  return async (job) => {
+    const data = readJobData(job.data);
+
+    try {
+      await pushSpacePermissions(deps.db, deps.bridgeClient, data);
+    } catch (error) {
+      if (isHttpStatus(error, 404)) {
+        await logPermissionSyncFailure(deps.db, data, error, true);
+        throw new UnrecoverableError(
+          `Docmost space not found while syncing permissions for Cherry space ${data.spaceId}`,
+        );
+      }
+
+      if (isFinalAttempt(job)) {
+        await logPermissionSyncFailure(deps.db, data, error, false);
+      }
+
+      throw error;
+    }
+  };
+}
+
+export function mapCherryRoleToDocmost(cherryRole: string): 'admin' | 'writer' | 'reader' {
+  if (cherryRole === 'admin' || cherryRole === 'owner') return 'admin';
+  if (cherryRole === 'editor') return 'writer';
+  return 'reader';
+}
+
+export async function pushSpacePermissions(
+  db: DatabaseClient,
+  bridgeClient: PermissionSyncBridgeClient,
+  data: PermissionSyncJobData,
+): Promise<PushSpacePermissionsResult> {
+  const space = await loadPermissionSyncSpace(db, data);
+  if (space === undefined || space.docmostSpaceId === null) {
+    return { pushed: false, members: [] };
+  }
+
+  const members = await loadSpacePermissionMembers(db, {
+    spaceId: data.spaceId,
+    tenantId: space.tenantId,
+  });
+  await bridgeClient.pushPermissions(space.docmostSpaceId, members);
+
+  return {
+    pushed: true,
+    tenantId: space.tenantId,
+    docmostSpaceId: space.docmostSpaceId,
+    members,
+  };
+}
+
+export async function loadSpacePermissionMembers(
+  db: DatabaseClient,
+  data: { spaceId: string; tenantId: string },
+): Promise<PermissionMember[]> {
+  const rows = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      cherryRole: space_permissions.permission,
+    })
+    .from(space_permissions)
+    .innerJoin(
+      group_members,
+      and(
+        eq(space_permissions.tenant_id, group_members.tenant_id),
+        eq(space_permissions.group_id, group_members.group_id),
+      ),
+    )
+    .innerJoin(
+      users,
+      and(eq(group_members.tenant_id, users.tenant_id), eq(group_members.user_id, users.id)),
+    )
+    .where(
+      and(
+        eq(space_permissions.tenant_id, data.tenantId),
+        eq(space_permissions.space_id, data.spaceId),
+      ),
+    );
+
+  return collapsePermissionRows(rows);
+}
+
+export async function logPermissionAuditEvent(
+  db: DatabaseClient,
+  input: {
+    tenantId: string;
+    spaceId: string;
+    action: 'bridge.permission_sync_failed' | 'permission_consistency_fixed' | 'permission_consistency_failed';
+    metadata: Record<string, unknown>;
+  },
+): Promise<void> {
+  await db.insert(audit_logs).values({
+    id: randomUUID(),
+    tenant_id: input.tenantId,
+    actor_user_id: null,
+    action: input.action,
+    resource_type: 'space',
+    resource_id: input.spaceId,
+    space_id: input.spaceId,
+    metadata_json: input.metadata,
+  });
+}
+
+async function loadPermissionSyncSpace(
+  db: DatabaseClient,
+  data: PermissionSyncJobData,
+): Promise<{ tenantId: string; docmostSpaceId: string | null } | undefined> {
+  const where =
+    data.tenantId === undefined
+      ? eq(spaces.id, data.spaceId)
+      : and(eq(spaces.id, data.spaceId), eq(spaces.tenant_id, data.tenantId));
+  const [space] = await db
+    .select({ tenantId: spaces.tenant_id, docmostSpaceId: spaces.docmost_space_id })
+    .from(spaces)
+    .where(where)
+    .limit(1);
+
+  return space;
+}
+
+function collapsePermissionRows(rows: SpacePermissionRow[]): PermissionMember[] {
+  const membersByUserId = new Map<string, PermissionMember>();
+
+  for (const row of rows) {
+    if (row.email.length === 0) {
+      continue;
+    }
+
+    const role = mapCherryRoleToDocmost(normalizeCherryRole(row.cherryRole));
+    const existing = membersByUserId.get(row.userId);
+    if (existing !== undefined && roleRank(existing.role) >= roleRank(role)) {
+      continue;
+    }
+
+    membersByUserId.set(row.userId, {
+      userId: row.userId,
+      email: row.email,
+      role,
+    });
+  }
+
+  return [...membersByUserId.values()].sort((left, right) => left.email.localeCompare(right.email));
+}
+
+function normalizeCherryRole(permission: string): string {
+  if (permission === 'space:admin' || permission === 'admin' || permission === 'owner') {
+    return 'admin';
+  }
+
+  if (
+    permission === 'space:edit' ||
+    permission === 'wiki:publish' ||
+    permission === 'wiki:edit' ||
+    permission === 'editor'
+  ) {
+    return 'editor';
+  }
+
+  return permission;
+}
+
+function roleRank(role: PermissionMember['role']): number {
+  if (role === 'admin') {
+    return 3;
+  }
+  if (role === 'writer') {
+    return 2;
+  }
+  return 1;
+}
+
+async function logPermissionSyncFailure(
+  db: DatabaseClient,
+  data: PermissionSyncJobData,
+  error: unknown,
+  nonRetryable: boolean,
+): Promise<void> {
+  const space = await loadPermissionSyncSpace(db, data);
+  if (space === undefined) {
+    return;
+  }
+
+  await logPermissionAuditEvent(db, {
+    tenantId: space.tenantId,
+    spaceId: data.spaceId,
+    action: 'bridge.permission_sync_failed',
+    metadata: {
+      nonRetryable,
+      error: errorToJson(error),
+    },
+  });
+}
+
+function readJobData(data: unknown): PermissionSyncJobData {
+  const record = readRecord(data);
+  const spaceId = readString(record.spaceId);
+  const tenantId = readString(record.tenantId);
+
+  if (spaceId === undefined) {
+    throw new Error('permission-sync job is missing spaceId');
+  }
+
+  return tenantId === undefined ? { spaceId } : { spaceId, tenantId };
+}
+
+function isFinalAttempt(job: Job): boolean {
+  const attempts = typeof job.opts.attempts === 'number' ? job.opts.attempts : 1;
+  return job.attemptsMade + 1 >= attempts;
+}
+
+function isHttpStatus(error: unknown, status: number): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+
+  return error.status === status || error.statusCode === status;
+}
+
+function errorToJson(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      ...(isRecord(error) && typeof error.status === 'number' ? { status: error.status } : {}),
+      ...(isRecord(error) && typeof error.statusCode === 'number' ? { statusCode: error.statusCode } : {}),
+    };
+  }
+
+  return { message: String(error) };
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/wiki-sync-worker/src/reconciliation/permission-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/permission-reconcile.ts
@@ -1,0 +1,137 @@
+import { isNotNull } from 'drizzle-orm';
+
+import { spaces } from '@cherrygraph/shared';
+
+import {
+  loadSpacePermissionMembers,
+  logPermissionAuditEvent,
+  type DrizzleDatabase,
+  type PermissionMember,
+  type PermissionSyncBridgeClient,
+} from '../processors/permission-sync.processor.js';
+
+type DatabaseClient = Pick<DrizzleDatabase, 'select' | 'insert'>;
+
+export interface PermissionReconcileBridgeClient extends PermissionSyncBridgeClient {
+  getPermissions?(docmostSpaceId: string): Promise<PermissionMember[]>;
+}
+
+type ReconcileSpaceRow = {
+  spaceId: string;
+  tenantId: string;
+  docmostSpaceId: string | null;
+};
+
+export async function reconcilePermissions(
+  db: DrizzleDatabase,
+  bridgeClient: PermissionReconcileBridgeClient,
+): Promise<{ fixed: number; errors: number }> {
+  return runPermissionReconcile(db, bridgeClient, false);
+}
+
+export async function triggerFullReconcile(
+  db: DrizzleDatabase,
+  bridgeClient: PermissionReconcileBridgeClient,
+): Promise<{ fixed: number; errors: number }> {
+  return runPermissionReconcile(db, bridgeClient, true);
+}
+
+async function runPermissionReconcile(
+  db: DatabaseClient,
+  bridgeClient: PermissionReconcileBridgeClient,
+  full: boolean,
+): Promise<{ fixed: number; errors: number }> {
+  const spacesToReconcile = await loadSyncedSpaces(db);
+  let fixed = 0;
+  let errors = 0;
+
+  for (const space of spacesToReconcile) {
+    if (space.docmostSpaceId === null) {
+      continue;
+    }
+
+    try {
+      const expected = await loadSpacePermissionMembers(db, {
+        spaceId: space.spaceId,
+        tenantId: space.tenantId,
+      });
+      const actual = await bridgeClient.getPermissions?.(space.docmostSpaceId);
+      if (actual !== undefined && permissionMembersEqual(expected, actual)) {
+        continue;
+      }
+
+      await bridgeClient.pushPermissions(space.docmostSpaceId, expected);
+      fixed += 1;
+      await logPermissionAuditEvent(db, {
+        tenantId: space.tenantId,
+        spaceId: space.spaceId,
+        action: 'permission_consistency_fixed',
+        metadata: {
+          docmostSpaceId: space.docmostSpaceId,
+          expected,
+          ...(actual !== undefined ? { actual } : {}),
+          full,
+        },
+      });
+    } catch (error) {
+      errors += 1;
+      await logPermissionAuditEvent(db, {
+        tenantId: space.tenantId,
+        spaceId: space.spaceId,
+        action: 'permission_consistency_failed',
+        metadata: {
+          docmostSpaceId: space.docmostSpaceId,
+          error: errorToJson(error),
+          full,
+        },
+      });
+    }
+  }
+
+  return { fixed, errors };
+}
+
+async function loadSyncedSpaces(db: DatabaseClient): Promise<ReconcileSpaceRow[]> {
+  return db
+    .select({
+      spaceId: spaces.id,
+      tenantId: spaces.tenant_id,
+      docmostSpaceId: spaces.docmost_space_id,
+    })
+    .from(spaces)
+    .where(isNotNull(spaces.docmost_space_id));
+}
+
+function permissionMembersEqual(left: PermissionMember[], right: PermissionMember[]): boolean {
+  const normalizedLeft = normalizePermissionMembers(left);
+  const normalizedRight = normalizePermissionMembers(right);
+
+  if (normalizedLeft.length !== normalizedRight.length) {
+    return false;
+  }
+
+  return normalizedLeft.every((member, index) => {
+    const other = normalizedRight[index];
+    return (
+      other !== undefined &&
+      member.userId === other.userId &&
+      member.email === other.email &&
+      member.role === other.role
+    );
+  });
+}
+
+function normalizePermissionMembers(members: PermissionMember[]): PermissionMember[] {
+  return [...members].sort((left, right) => {
+    const userComparison = left.userId.localeCompare(right.userId);
+    return userComparison === 0 ? left.email.localeCompare(right.email) : userComparison;
+  });
+}
+
+function errorToJson(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+
+  return { message: String(error) };
+}

--- a/docs/ops/env.example
+++ b/docs/ops/env.example
@@ -81,6 +81,12 @@ DOCMOST_BRIDGE_SECRET=replace-with-bridge-shared-secret
 # DOCMOST_BRIDGE_SECRET or DOCMOST_BRIDGE_SECRET_NEXT.
 DOCMOST_BRIDGE_SECRET_NEXT=
 
+# --- wiki-sync-worker ---
+REDIS_URL=redis://localhost:6379
+DOCMOST_BASE_URL=http://localhost:3000
+DOCMOST_BRIDGE_SECRET=your-bridge-secret
+WORKER_HEALTH_PORT=9090
+
 # --- Claude Code Agent (Phase 3+ — not used in Phase 1) ---
 # cherry-api spawns claude CLI for Agent deep path.
 # 支持代理网关/替换模型 — 不必绑定 Anthropic 原生 API。详见 Doc 23 §4.8。

--- a/docs/ops/stage10-rollback.md
+++ b/docs/ops/stage10-rollback.md
@@ -1,0 +1,12 @@
+# Stage 10 Wiki Sync Rollback Plan
+
+Use this procedure when the Stage 10 wiki-sync-worker path causes permission drift, data integrity issues, or availability problems that cannot be fixed forward quickly.
+
+1. Stop `wiki-sync-worker` by scaling the service to zero or stopping the worker process.
+2. Leave Cherry API online. Cherry API continues accepting user traffic and persists Bridge events, but the wiki-sync-worker queues are no longer processed.
+3. Confirm Bridge events accumulate in Redis/BullMQ and `bridge_events` without being consumed. Do not purge queues unless a separate recovery plan has identified invalid jobs.
+4. Keep Cherry as the source of truth for permissions and wiki state while Docmost sync is paused.
+5. Re-deploy the last known-good wiki-sync-worker build, or deploy a fixed build, then start the worker again to resume processing queued Bridge events.
+6. Run the permission full reconcile trigger after the worker is healthy so Docmost permissions are overwritten from Cherry state.
+
+Do not re-enable the worker until permission sync processor tests, wiki sync integration tests, and Bridge contract tests pass against the rollback or fixed build.

--- a/docs/project/26_需求追踪矩阵.md
+++ b/docs/project/26_需求追踪矩阵.md
@@ -69,15 +69,15 @@
 
 | 需求 | API | Schema | 测试 | 验收点 |
 |---|---|---|---|---|
-| Docmost 页面导入 | PUT /api/internal/bridge/pages/{id}/import | wiki_pages, wiki_page_versions, page_block_metadata | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (page import) | Docmost 可编辑 |
-| Docmost 保存回写 Repo | POST /api/internal/docmost/events/page-saved | bridge_events, webhook_deliveries, wiki_page_versions | `apps/api/src/bridge/__tests__/bridge-receiver.test.ts`, `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (P2-E2) | Repo 新 commit |
+| Docmost 页面导入 | PUT /api/internal/bridge/pages/{id}/import | wiki_pages, wiki_page_versions, page_block_metadata | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (page import), `tests/integration/wiki-sync-integration.test.ts` (Stage 10 graphify push flow) | Docmost 可编辑 |
+| Docmost 保存回写 Repo | POST /api/internal/docmost/events/page-saved | bridge_events, webhook_deliveries, wiki_page_versions | `apps/api/src/bridge/__tests__/bridge-receiver.test.ts`, `apps/wiki-sync-worker/src/__tests__/page-sync.test.ts`, `tests/integration/wiki-sync-integration.test.ts` (Stage 10 page.saved flow) | Repo 新 commit |
 | Bridge webhook 幂等 | POST /api/internal/docmost/events/* | bridge_events (event_id unique), webhook_deliveries | `apps/api/src/bridge/__tests__/bridge-receiver.test.ts` (P2-E5, §4.4) | 重复不产生新版本 |
 | Bridge HMAC 校验 | Guard: /api/internal/docmost/events/*, /api/internal/bridge/* | Redis nonce store, bridge_events.nonce | `apps/api/src/bridge/__tests__/bridge-receiver.test.ts` (P2-E6) | 错误签名被拒 |
-| Bridge 快速保存去重 | Docmost EventEmitter bridge:page.saved → Cherry receiver | bridge_events, webhook_deliveries | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (P2-E10 rapid saves debounced) | 同页 2s 内仅发送最新保存事件 |
-| 人工区块保护 | 内部 merge logic | page_block_metadata | `packages/wiki-core/src/__tests__/normalization-block-markers.test.ts` (P2-E8) | human 区块不被覆盖 |
-| 候选更新审核 | POST /api/.../proposals/{id}/accept | wiki_update_proposals | `packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts` (P2-E9 前置), `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` | 管理员可接受/拒绝 |
-| 权限映射同步 | PUT /api/internal/bridge/spaces/{id}/permissions | permission_versions, space_permissions | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (P2-E7 permissions endpoint) | Docmost 权限与 Cherry 一致 |
-| Docmost 同步状态 | GET /api/internal/bridge/spaces/{id}/sync-status | bridge_events, webhook_deliveries | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (sync-status + health) | status=healthy |
+| Bridge 快速保存去重 | Docmost EventEmitter bridge:page.saved → Cherry receiver | bridge_events, webhook_deliveries | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (P2-E10 rapid saves debounced), `tests/integration/wiki-sync-integration.test.ts` (Stage 10 stale coalescing) | 同页 2s 内仅发送最新保存事件 |
+| 人工区块保护 | 内部 merge logic | page_block_metadata | `packages/wiki-core/src/__tests__/normalization-block-markers.test.ts` (P2-E8), `apps/wiki-sync-worker/src/__tests__/page-sync.test.ts`, `tests/integration/wiki-sync-integration.test.ts` (Stage 10 ownership transfer, marker-loss fallback) | human 区块不被覆盖 |
+| 候选更新审核 | POST /api/.../proposals/{id}/accept | wiki_update_proposals | `packages/wiki-core/src/__tests__/normalization-import-graphify-wiki.test.ts` (P2-E9 前置), `apps/wiki-sync-worker/src/__tests__/docmost-push.test.ts`, `tests/integration/wiki-sync-integration.test.ts` (Stage 10 proposal accept simplified) | 管理员可接受/拒绝 |
+| 权限映射同步 | PUT /api/internal/bridge/spaces/{id}/permissions | permission_versions, space_permissions | `apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts`, `tests/integration/wiki-sync-integration.test.ts` (Stage 10 permission sync), `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (P2-E7 permissions endpoint) | Docmost 权限与 Cherry 一致 |
+| Docmost 同步状态 | GET /api/internal/bridge/spaces/{id}/sync-status | bridge_events, webhook_deliveries | `openspec/changes/stage9-docmost-fork-bridge/specs/bridge-contract-tests/spec.md` (sync-status + health), `apps/wiki-sync-worker/src/__tests__/health.test.ts` | status=healthy |
 
 ## 4. Phase 3 追踪
 

--- a/tests/integration/wiki-sync-integration.test.ts
+++ b/tests/integration/wiki-sync-integration.test.ts
@@ -1,0 +1,712 @@
+import type { Job } from 'bullmq';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  bridgeEvents,
+  graphifyRuns,
+  pageBlockMetadata,
+  space_permissions,
+  spaces,
+  wikiPageVersions,
+  wikiPages,
+  wikiUpdateProposals,
+} from '@cherrygraph/shared';
+import { normalizeBlockHash } from '@cherrygraph/wiki-core';
+
+import {
+  createDocmostPushProcessor,
+  type DocmostPushBridgeClient,
+  type DocmostPushJobData,
+  type DrizzleDatabase as DocmostPushDb,
+} from '../../apps/wiki-sync-worker/src/processors/docmost-push.processor.js';
+import {
+  createPageSyncProcessor,
+  type BridgeClient,
+  type DrizzleDatabase as PageSyncDb,
+  type PageSyncJobData,
+} from '../../apps/wiki-sync-worker/src/processors/page-sync.processor.js';
+import {
+  createPermissionSyncProcessor,
+  type DrizzleDatabase as PermissionSyncDb,
+  type PermissionSyncBridgeClient,
+  type PermissionSyncJobData,
+} from '../../apps/wiki-sync-worker/src/processors/permission-sync.processor.js';
+
+describe('wiki sync integration flows with mocked infrastructure', () => {
+  it('processes page.saved into a new version, metadata, and synced status', async () => {
+    const db = new PageFlowDb();
+    db.metadataRows = [
+      createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nOriginal' }),
+    ];
+
+    await runPageSync(db, bridgeClientWithMarkdown(frontmatter('## Overview\nHuman edit')));
+
+    expect(db.insertedVersions).toHaveLength(1);
+    expect(db.insertedBlockMetadata).toHaveLength(1);
+    expect(db.insertedVersions[0]).toMatchObject({ source: 'docmost', version_no: 2 });
+    expect(db.pageUpdates.at(-1)).toMatchObject({ sync_status: 'synced' });
+    expect(db.bridgeEventUpdates.at(-1)).toMatchObject({ status: 'processed' });
+  });
+
+  it('pushes Graphify pages to Docmost and marks the run synced', async () => {
+    const db = new PushFlowDb({
+      pages: [createPage({ docmost_page_id: null })],
+      runVersions: [createVersion({ version_no: 1, content_markdown: frontmatter('## Overview\nNew') })],
+      metadataRows: [createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nNew' })],
+    });
+    const bridgeClient = createDocmostBridgeClient();
+
+    await runDocmostPush(db, bridgeClient);
+
+    expect(bridgeClient.importPage).toHaveBeenCalledWith(
+      'wiki.page.1',
+      expect.stringContaining('## Overview\nNew'),
+      { overwritePolicy: 'create_only' },
+    );
+    expect(db.pageUpdates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ docmost_page_id: 'docmost-created-1' }),
+        expect.objectContaining({ sync_status: 'synced' }),
+      ]),
+    );
+    expect(db.graphifyRunUpdates.at(-1)).toMatchObject({ status: 'docmost_synced' });
+  });
+
+  it('transfers ownership after a human edit and keeps human content on the next push', async () => {
+    const pageDb = new PageFlowDb();
+    pageDb.metadataRows = [
+      createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nOriginal' }),
+    ];
+
+    await runPageSync(pageDb, bridgeClientWithMarkdown(frontmatter('## Overview\nHuman edit')));
+
+    const pushedHumanMetadata = toSelectedMetadataRows(pageDb.insertedBlockMetadata);
+    expect(pushedHumanMetadata[0]).toMatchObject({ block_id: 'overview', owner: 'human' });
+
+    const pushDb = new PushFlowDb({
+      previousVersions: [
+        createVersion({
+          id: 'version-human',
+          version_no: 2,
+          content_markdown: frontmatter(['## Overview', 'Human edit', '', '## Details', 'Old graphify'].join('\n')),
+        }),
+      ],
+      runVersions: [
+        createVersion({
+          id: 'version-graphify-next',
+          version_no: 3,
+          content_markdown: frontmatter(['## Overview', 'Graphify rewrite', '', '## Details', 'New graphify'].join('\n')),
+          graphify_run_id: 'run-1',
+        }),
+      ],
+      metadataRows: [
+        ...pushedHumanMetadata.map((row) => ({
+          ...row,
+          page_version_id: 'version-graphify-next',
+        })),
+        createMetadataRow({
+          block_id: 'details',
+          owner: 'graphify',
+          content: '## Details\nNew graphify',
+          page_version_id: 'version-graphify-next',
+        }),
+      ],
+    });
+    const bridgeClient = createDocmostBridgeClient();
+
+    await runDocmostPush(pushDb, bridgeClient);
+
+    const pushedMarkdown = vi.mocked(bridgeClient.importPage).mock.calls[0]?.[1] ?? '';
+    expect(pushedMarkdown).toContain('## Overview\nHuman edit');
+    expect(pushedMarkdown).not.toContain('## Overview\nGraphify rewrite');
+  });
+
+  it('recovers ownership from sidecar metadata when exported markdown has no markers', async () => {
+    const db = new PageFlowDb();
+    db.metadataRows = [
+      createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nOriginal' }),
+    ];
+
+    await runPageSync(db, bridgeClientWithMarkdown(frontmatter('## Overview\nHuman markerless edit')));
+
+    expect(db.insertedBlockMetadata[0]).toMatchObject({
+      block_id: 'overview',
+      owner: 'human',
+      content_hash: normalizeBlockHash('## Overview\nHuman markerless edit'),
+    });
+  });
+
+  it('creates and resolves a simplified update proposal after conflict detection', async () => {
+    const db = new PushFlowDb({
+      previousVersions: [
+        createVersion({
+          id: 'previous-version',
+          version_no: 1,
+          content_markdown: frontmatter('## Details\nHuman notes'),
+        }),
+      ],
+      runVersions: [
+        createVersion({
+          version_no: 2,
+          content_markdown: frontmatter('## Details\nGraphify proposal'),
+        }),
+      ],
+      metadataRows: [
+        createMetadataRow({ block_id: 'details', owner: 'human', content: '## Details\nHuman notes' }),
+      ],
+    });
+
+    await runDocmostPush(db, createDocmostBridgeClient());
+    const proposal = db.insertedProposals[0];
+    expect(proposal).toMatchObject({ proposal_type: 'conflict', status: 'pending' });
+
+    resolveProposal(db, String(proposal?.id), 'accepted');
+
+    expect(db.insertedProposals[0]).toMatchObject({ status: 'accepted' });
+  });
+
+  it('pushes permission changes with Docmost role mapping', async () => {
+    const db = new PermissionFlowDb();
+    db.permissionRows = [
+      { userId: 'admin-user', email: 'admin@example.com', cherryRole: 'space:admin' },
+      { userId: 'editor-user', email: 'editor@example.com', cherryRole: 'space:edit' },
+      { userId: 'reader-user', email: 'reader@example.com', cherryRole: 'space:view' },
+    ];
+    const bridgeClient = {
+      pushPermissions: vi.fn<PermissionSyncBridgeClient['pushPermissions']>(() => Promise.resolve()),
+    };
+
+    const processor = createPermissionSyncProcessor({
+      db: db.asDb(),
+      bridgeClient,
+    });
+    await processor({
+      data: { spaceId: 'space-1', tenantId: 'tenant-1' },
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as Job<PermissionSyncJobData>);
+
+    expect(bridgeClient.pushPermissions).toHaveBeenCalledWith('docmost-space-1', [
+      { userId: 'admin-user', email: 'admin@example.com', role: 'admin' },
+      { userId: 'editor-user', email: 'editor@example.com', role: 'writer' },
+      { userId: 'reader-user', email: 'reader@example.com', role: 'reader' },
+    ]);
+  });
+
+  it('coalesces stale page events so only one version is created', async () => {
+    const db = new PageFlowDb();
+    db.bridgeEventRows = [
+      createBridgeEvent({ id: 'older-event', event_id: 'older', received_at: new Date('2026-05-05T10:00:00.000Z') }),
+      createBridgeEvent({ id: 'latest-event', event_id: 'latest', received_at: new Date('2026-05-05T10:01:00.000Z') }),
+    ];
+    const bridgeClient = bridgeClientWithMarkdown(frontmatter('## Overview\nLatest'));
+
+    await runPageSync(db, bridgeClient, { bridgeEventId: 'older-event', eventId: 'older' });
+    await runPageSync(db, bridgeClient, { bridgeEventId: 'latest-event', eventId: 'latest' });
+
+    expect(db.insertedVersions).toHaveLength(1);
+    expect(bridgeClient.exportPage).toHaveBeenCalledTimes(1);
+  });
+});
+
+type BridgeEventRow = typeof bridgeEvents.$inferSelect;
+type WikiPageRow = typeof wikiPages.$inferSelect;
+type WikiPageVersionRow = typeof wikiPageVersions.$inferSelect;
+type PageBlockMetadataRow = typeof pageBlockMetadata.$inferSelect;
+type WikiUpdateProposalInsert = typeof wikiUpdateProposals.$inferInsert;
+type SpaceRow = typeof spaces.$inferSelect;
+
+class PageFlowDb {
+  page: WikiPageRow | undefined = createPage();
+  currentVersion: WikiPageVersionRow | undefined = createVersion({ version_no: 1 });
+  metadataRows: PageBlockMetadataRow[] = [];
+  bridgeEventRows: BridgeEventRow[] = [createBridgeEvent()];
+  insertedVersions: Array<typeof wikiPageVersions.$inferInsert> = [];
+  insertedBlockMetadata: Array<typeof pageBlockMetadata.$inferInsert> = [];
+  bridgeEventUpdates: Array<Partial<typeof bridgeEvents.$inferInsert>> = [];
+  pageUpdates: Array<Partial<typeof wikiPages.$inferInsert>> = [];
+  activeBridgeEventId = 'bridge-event-1';
+
+  select(selection?: unknown): unknown {
+    return {
+      from: (table: unknown) => {
+        const resolveRows = (): unknown[] => {
+          if (table === bridgeEvents) {
+            if (isRecord(selection) && 'status' in selection) {
+              const event = this.bridgeEventRows.find((row) => row.id === this.activeBridgeEventId);
+              return event === undefined ? [] : [{ status: event.status }];
+            }
+
+            return this.bridgeEventRows
+              .filter((event) => event.status === 'received')
+              .sort((left, right) => right.received_at.getTime() - left.received_at.getTime());
+          }
+          if (table === wikiPages) {
+            return this.page === undefined ? [] : [{ page: this.page, spaceSlug: 'research' }];
+          }
+          if (table === wikiPageVersions) {
+            return this.currentVersion === undefined ? [] : [this.currentVersion];
+          }
+          if (table === pageBlockMetadata) {
+            return this.metadataRows;
+          }
+
+          return [];
+        };
+
+        return new SelectBuilder(resolveRows);
+      },
+    };
+  }
+
+  transaction<T>(callback: (tx: PageFlowDb) => Promise<T>): Promise<T> {
+    return callback(this);
+  }
+
+  update(table: unknown): unknown {
+    return {
+      set: (values: Record<string, unknown>) => ({
+        where: (): Promise<void> => {
+          if (table === bridgeEvents) {
+            this.bridgeEventUpdates.push(values);
+            this.applyBridgeEventUpdate(values);
+          }
+          if (table === wikiPages) {
+            this.pageUpdates.push(values);
+            if (this.page !== undefined) {
+              this.page = { ...this.page, ...values } as WikiPageRow;
+            }
+          }
+          return Promise.resolve();
+        },
+      }),
+    };
+  }
+
+  insert(table: unknown): unknown {
+    return {
+      values: (values: unknown): Promise<void> => {
+        if (table === wikiPageVersions) {
+          this.insertedVersions.push(values as typeof wikiPageVersions.$inferInsert);
+        }
+        if (table === pageBlockMetadata) {
+          this.insertedBlockMetadata.push(...(values as Array<typeof pageBlockMetadata.$inferInsert>));
+        }
+        return Promise.resolve();
+      },
+    };
+  }
+
+  asDb(): PageSyncDb {
+    return this as unknown as PageSyncDb;
+  }
+
+  private applyBridgeEventUpdate(values: Record<string, unknown>): void {
+    if (readErrorCode(values.error_json) === 'COALESCED') {
+      const latestBridgeEventId = readLatestBridgeEventId(values.error_json);
+      this.bridgeEventRows = this.bridgeEventRows.map((event) =>
+        event.id === latestBridgeEventId ? event : { ...event, status: 'processed' },
+      );
+      return;
+    }
+
+    this.bridgeEventRows = this.bridgeEventRows.map((event) =>
+      event.id === this.activeBridgeEventId ? { ...event, ...values } : event,
+    ) as BridgeEventRow[];
+  }
+}
+
+class PushFlowDb {
+  pages: WikiPageRow[];
+  runVersions: WikiPageVersionRow[];
+  previousVersions: WikiPageVersionRow[];
+  metadataRows: PageBlockMetadataRow[];
+  insertedProposals: WikiUpdateProposalInsert[] = [];
+  pageUpdates: Array<Partial<typeof wikiPages.$inferInsert>> = [];
+  graphifyRunUpdates: Array<Partial<typeof graphifyRuns.$inferInsert>> = [];
+  private wikiPageVersionSelectCount = 0;
+
+  constructor(options: Partial<{
+    pages: WikiPageRow[];
+    runVersions: WikiPageVersionRow[];
+    previousVersions: WikiPageVersionRow[];
+    metadataRows: PageBlockMetadataRow[];
+  }> = {}) {
+    this.pages = options.pages ?? [createPage()];
+    this.runVersions = options.runVersions ?? [createVersion()];
+    this.previousVersions = options.previousVersions ?? [];
+    this.metadataRows = options.metadataRows ?? [
+      createMetadataRow({ block_id: 'overview', owner: 'graphify', content: '## Overview\nNew' }),
+    ];
+  }
+
+  select(): unknown {
+    return {
+      from: (table: unknown) => {
+        const resolveRows = (): unknown[] => {
+          if (table === wikiPageVersions) {
+            if (this.wikiPageVersionSelectCount === 0) {
+              this.wikiPageVersionSelectCount += 1;
+              return this.runVersions;
+            }
+
+            this.wikiPageVersionSelectCount += 1;
+            const previous = this.previousVersions.shift();
+            return previous === undefined ? [] : [previous];
+          }
+
+          if (table === wikiPages) {
+            return this.pages;
+          }
+
+          if (table === pageBlockMetadata) {
+            return this.metadataRows;
+          }
+
+          return [];
+        };
+
+        return new SelectBuilder(resolveRows);
+      },
+    };
+  }
+
+  update(table: unknown): unknown {
+    return {
+      set: (values: Record<string, unknown>) => ({
+        where: (): Promise<void> => {
+          if (table === wikiPages) {
+            this.pageUpdates.push(values);
+            this.pages = this.pages.map((page) => ({ ...page, ...values }) as WikiPageRow);
+          }
+          if (table === graphifyRuns) {
+            this.graphifyRunUpdates.push(values);
+          }
+          return Promise.resolve();
+        },
+      }),
+    };
+  }
+
+  insert(table: unknown): unknown {
+    return {
+      values: (values: unknown): Promise<void> => {
+        if (table === wikiUpdateProposals) {
+          this.insertedProposals.push(...(Array.isArray(values) ? values : [values]) as WikiUpdateProposalInsert[]);
+        }
+        return Promise.resolve();
+      },
+    };
+  }
+
+  asDb(): DocmostPushDb {
+    return this as unknown as DocmostPushDb;
+  }
+}
+
+class PermissionFlowDb {
+  spaces: SpaceRow[] = [createSpace()];
+  permissionRows: Array<{ userId: string; email: string; cherryRole: string }> = [];
+
+  select(selection?: unknown): unknown {
+    return {
+      from: (table: unknown) => {
+        const resolveRows = (): unknown[] => {
+          if (table === spaces) {
+            if (isRecord(selection) && 'spaceId' in selection) {
+              return this.spaces.map((space) => ({
+                spaceId: space.id,
+                tenantId: space.tenant_id,
+                docmostSpaceId: space.docmost_space_id,
+              }));
+            }
+
+            const space = this.spaces[0];
+            return space === undefined
+              ? []
+              : [{ tenantId: space.tenant_id, docmostSpaceId: space.docmost_space_id }];
+          }
+          if (table === space_permissions) {
+            return this.permissionRows;
+          }
+
+          return [];
+        };
+
+        return new SelectBuilder(resolveRows);
+      },
+    };
+  }
+
+  insert(): unknown {
+    return {
+      values: (): Promise<void> => Promise.resolve(),
+    };
+  }
+
+  asDb(): PermissionSyncDb {
+    return this as unknown as PermissionSyncDb;
+  }
+}
+
+class SelectBuilder {
+  constructor(private readonly resolveRows: () => unknown[]) {}
+
+  innerJoin(): this {
+    return this;
+  }
+
+  leftJoin(): this {
+    return this;
+  }
+
+  where(): this {
+    return this;
+  }
+
+  orderBy(): this {
+    return this;
+  }
+
+  limit(limit: number): Promise<unknown[]> {
+    return Promise.resolve(this.resolveRows().slice(0, limit));
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.resolveRows()).then(onfulfilled, onrejected);
+  }
+}
+
+async function runPageSync(
+  db: PageFlowDb,
+  bridgeClient: BridgeClient,
+  overrides: Partial<PageSyncJobData> = {},
+): Promise<void> {
+  const data = {
+    bridgeEventId: 'bridge-event-1',
+    eventId: 'docmost-event-1',
+    eventType: 'page.saved',
+    pageId: 'docmost-page-1',
+    ...overrides,
+  };
+  db.activeBridgeEventId = data.bridgeEventId;
+
+  const processor = createPageSyncProcessor({
+    db: db.asDb(),
+    bridgeClient,
+    wikiRepoPath: '/tmp/wiki',
+    permissionChecker: () => true,
+  });
+
+  await processor({ data } as Job<PageSyncJobData>);
+}
+
+async function runDocmostPush(
+  db: PushFlowDb,
+  bridgeClient: DocmostPushBridgeClient,
+): Promise<void> {
+  const processor = createDocmostPushProcessor({
+    db: db.asDb(),
+    bridgeClient,
+  });
+
+  await processor({
+    data: { runId: 'run-1', spaceId: 'space-1', tenantId: 'tenant-1' },
+  } as Job<DocmostPushJobData>);
+}
+
+function bridgeClientWithMarkdown(markdown: string): BridgeClient {
+  return {
+    exportPage: vi.fn(() =>
+      Promise.resolve({
+        markdown,
+        userId: 'user-1',
+        userName: 'Ada Editor',
+        userEmail: 'ada@example.com',
+      }),
+    ),
+  };
+}
+
+function createDocmostBridgeClient(): DocmostPushBridgeClient {
+  return {
+    importPage: vi.fn<DocmostPushBridgeClient['importPage']>(() =>
+      Promise.resolve({ docmostPageId: 'docmost-created-1', contentHash: 'hash-after' }),
+    ),
+    exportPage: vi.fn<DocmostPushBridgeClient['exportPage']>(),
+  };
+}
+
+function resolveProposal(db: PushFlowDb, proposalId: string, status: 'accepted' | 'rejected'): void {
+  db.insertedProposals = db.insertedProposals.map((proposal) =>
+    proposal.id === proposalId ? { ...proposal, status, resolved_at: new Date() } : proposal,
+  );
+}
+
+function frontmatter(content: string): string {
+  return [
+    '---',
+    'page_id: wiki.page.1',
+    'space_id: space-1',
+    'title: Test Page',
+    'status: draft',
+    'source: graphify',
+    '---',
+    '',
+    content,
+  ].join('\n');
+}
+
+function createBridgeEvent(overrides: Partial<BridgeEventRow> = {}): BridgeEventRow {
+  return {
+    id: 'bridge-event-1',
+    event_id: 'docmost-event-1',
+    event_type: 'page.saved',
+    source: 'docmost',
+    space_id: 'space-1',
+    page_id: 'docmost-page-1',
+    payload: {},
+    status: 'received',
+    error_json: null,
+    nonce: null,
+    received_at: new Date('2026-05-05T12:00:00.000Z'),
+    processed_at: null,
+    created_at: new Date('2026-05-05T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createSpace(overrides: Partial<SpaceRow> = {}): SpaceRow {
+  return {
+    id: 'space-1',
+    tenant_id: 'tenant-1',
+    name: 'Research',
+    slug: 'research',
+    description: null,
+    status: 'active',
+    docmost_space_id: 'docmost-space-1',
+    wiki_repo_path: '/tmp/wiki',
+    active_graphify_run_id: null,
+    active_index_snapshot_id: null,
+    index_consistency_status: 'healthy',
+    permission_version: 1,
+    strict_knowledge_only: true,
+    graphify_config: {},
+    default_publish_policy: 'editor_publish',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createPage(overrides: Partial<WikiPageRow> = {}): WikiPageRow {
+  return {
+    id: 'wiki-pk-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    page_id: 'wiki.page.1',
+    title: 'Test Page',
+    slug: 'test-page',
+    status: 'draft',
+    current_version_id: 'version-1',
+    indexed_version_id: null,
+    sync_status: 'synced',
+    docmost_page_id: 'docmost-page-1',
+    created_by: 'user-1',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createVersion(overrides: Partial<WikiPageVersionRow> = {}): WikiPageVersionRow {
+  return {
+    id: 'version-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    wiki_page_pk: 'wiki-pk-1',
+    page_id: 'wiki.page.1',
+    version_no: 2,
+    content_markdown: frontmatter('## Overview\nNew'),
+    frontmatter_json: {
+      page_id: 'wiki.page.1',
+      space_id: 'space-1',
+      title: 'Test Page',
+      status: 'draft',
+      source: 'graphify',
+    },
+    source: 'graphify',
+    graphify_run_id: 'run-1',
+    commit_hash: 'commit-1',
+    status: 'draft',
+    created_by: 'graphify',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createMetadataRow(
+  overrides: Partial<PageBlockMetadataRow> & {
+    block_id: string;
+    owner: 'graphify' | 'human';
+    content: string;
+  },
+): PageBlockMetadataRow {
+  const { content, block_id: blockId, owner, ...rest } = overrides;
+
+  return {
+    id: `metadata-${blockId}`,
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    wiki_page_pk: 'wiki-pk-1',
+    page_version_id: 'version-1',
+    block_id: blockId,
+    owner,
+    content_hash: normalizeBlockHash(content),
+    graphify_run_id: 'run-1',
+    last_editor: null,
+    editable: owner === 'human',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...rest,
+  };
+}
+
+function toSelectedMetadataRows(
+  rows: Array<typeof pageBlockMetadata.$inferInsert>,
+): PageBlockMetadataRow[] {
+  return rows.map((row) => ({
+    id: String(row.id),
+    tenant_id: String(row.tenant_id),
+    space_id: String(row.space_id),
+    wiki_page_pk: String(row.wiki_page_pk),
+    page_version_id: String(row.page_version_id),
+    block_id: String(row.block_id),
+    owner: String(row.owner),
+    content_hash: String(row.content_hash),
+    graphify_run_id: row.graphify_run_id ?? null,
+    last_editor: row.last_editor ?? null,
+    editable: Boolean(row.editable),
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+  }));
+}
+
+function readErrorCode(value: unknown): string | undefined {
+  return value !== null && typeof value === 'object' && 'code' in value
+    ? String((value as { code: unknown }).code)
+    : undefined;
+}
+
+function readLatestBridgeEventId(value: unknown): string | undefined {
+  return value !== null && typeof value === 'object' && 'latestBridgeEventId' in value
+    ? String((value as { latestBridgeEventId: unknown }).latestBridgeEventId)
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary
- Permission sync processor：Cherry→Docmost 角色映射（admin/editor/viewer → admin/writer/reader）、404 不重试、审计日志
- Hourly reconcile：漂移检测 + 自动修复
- 集成测试：7 个 end-to-end 场景覆盖 page sync/push/ownership/marker fallback/proposals/permission/coalescing
- CI workflow：wiki-sync-tests.yml + bridge-contract-tests paths 更新
- 文档：Stage 10 rollback、env.example、需求追踪矩阵更新

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `a7f83ddad8f11e0df678581f7afc48b8150ec9fb`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/135#issuecomment-4377609989) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/135#issuecomment-4377610218) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/135#issuecomment-4377610418) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/135#issuecomment-4377610713)
- Key findings addressed: All clean — no critical/major findings

## Test plan
- [x] permission-sync.test.ts — role mapping, push success, 404 skip, reconcile drift fix
- [x] wiki-sync-integration.test.ts — 7 e2e scenarios
- [x] Full regression: 139 files, 821 tests passed

Closes #131