### PR TITLE
feat(web): Phase 3 frontend — toggles, agent UI, charts, graph path, confidence (#141)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "eventsource-parser": "^3.0.8",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -8,6 +8,10 @@ import { AuthProvider, type AuthUser } from '../lib/auth.js';
 import Chat, { ChatMessageBubble, MessageInput, SessionSidebar } from '../pages/Chat.js';
 import { CHAT_INPUT_MAX_LENGTH, ChatStreamError, type ChatCitation, type ChatMessage } from '../hooks/useChatStream.js';
 
+vi.mock('echarts-for-react', () => ({
+  default: () => <div data-testid="echarts-chart">ECharts component</div>,
+}));
+
 const testUser: AuthUser = {
   id: 'user-1',
   email: 'viewer@example.com',
@@ -19,6 +23,7 @@ const testUser: AuthUser = {
 
 afterEach(() => {
   cleanup();
+  window.sessionStorage.clear();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -115,6 +120,116 @@ describe('Message input', () => {
   });
 });
 
+describe('Phase 3 chat controls and stream events', () => {
+  it('sends enable_deep_analysis when the deep analysis toggle is on', async () => {
+    const fetchState = stubChatFetch({
+      streamEvents: [{ event: 'message.completed', data: { latency_ms: 42 } }],
+    });
+
+    renderChatRoute();
+
+    fireEvent.click(await screen.findByRole('button', { name: '深度分析' }));
+    await sendChatMessage('explain the architecture');
+
+    await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({ enable_deep_analysis: true }));
+    expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({
+      message: 'explain the architecture',
+      retrieval_mode: 'wiki_only',
+    });
+  });
+
+  it('shows the database toggle only when the space database config is enabled', async () => {
+    stubChatFetch({ databaseEnabled: false });
+    renderChatRoute();
+
+    await screen.findByLabelText('Message');
+    expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument();
+
+    cleanup();
+    vi.unstubAllGlobals();
+
+    stubChatFetch({ databaseEnabled: true });
+    renderChatRoute();
+
+    expect(await screen.findByRole('button', { name: '数据库' })).toBeInTheDocument();
+  });
+
+  it('renders agent.tool_use events as a collapsed tool panel', async () => {
+    stubChatFetch({
+      streamEvents: [
+        {
+          event: 'agent.tool_use',
+          data: { id: 'tool-1', name: 'Bash', input: { command: 'cherrydb query "SELECT count(*) FROM orders"' } },
+        },
+        { event: 'message.completed', data: {} },
+      ],
+    });
+
+    renderChatRoute();
+
+    fireEvent.click(await screen.findByRole('button', { name: '深度分析' }));
+    await sendChatMessage('run a database check');
+
+    const panel = await screen.findByLabelText('Agent tool use');
+    expect(panel).toHaveProperty('tagName', 'DETAILS');
+    expect(panel).not.toHaveAttribute('open');
+    expect(screen.getByText('Bash')).toBeInTheDocument();
+    expect(screen.getAllByText(/cherrydb query/).length).toBeGreaterThan(0);
+  });
+
+  it('renders chart.data events with the ECharts component', async () => {
+    stubChatFetch({
+      streamEvents: [
+        {
+          event: 'chart.data',
+          data: {
+            type: 'cherrywiki.chart',
+            chart_type: 'bar',
+            echarts_option: { xAxis: { type: 'category' }, yAxis: {}, series: [{ type: 'bar', data: [1, 2] }] },
+          },
+        },
+        { event: 'message.completed', data: {} },
+      ],
+    });
+
+    renderChatRoute();
+    await sendChatMessage('show a chart');
+
+    expect(await screen.findByTestId('echarts-chart')).toBeInTheDocument();
+    expect(screen.getByText('bar')).toBeInTheDocument();
+  });
+
+  it('marks the assistant message complete and displays latency from message.completed', async () => {
+    stubChatFetch({
+      streamEvents: [
+        { event: 'content', data: { delta: 'Done.' } },
+        { event: 'message.completed', data: { latency_ms: 123 } },
+      ],
+    });
+
+    renderChatRoute();
+    await sendChatMessage('finish quickly');
+
+    const complete = await screen.findByLabelText('Message complete');
+    expect(complete).toHaveTextContent('完成');
+    expect(complete).toHaveTextContent('123ms');
+  });
+
+  it('sends the selected retrieval mode', async () => {
+    const fetchState = stubChatFetch({
+      streamEvents: [{ event: 'message.completed', data: {} }],
+    });
+
+    renderChatRoute();
+
+    fireEvent.change(await screen.findByLabelText('检索模式'), { target: { value: 'path_first' } });
+    expect(screen.getByText('Agent')).toBeInTheDocument();
+    await sendChatMessage('trace the path');
+
+    await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({ retrieval_mode: 'path_first' }));
+  });
+});
+
 describe('Chat error state', () => {
   it('shows the configured no-model error message', async () => {
     vi.stubGlobal(
@@ -124,6 +239,10 @@ describe('Chat error state', () => {
 
         if (path === '/api/spaces/space-1/chat/sessions' && init?.method !== 'POST') {
           return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-sessions' } }));
+        }
+
+        if (path === '/api/spaces/space-1') {
+          return Promise.resolve(jsonResponse({ data: { id: 'space-1', database_config: { enabled: false } } }));
         }
 
         if (path === '/api/chat/completions') {
@@ -186,10 +305,16 @@ function buildMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
     session_id: 'session-1',
     role: 'assistant',
     content: 'Assistant reply',
+    parts: [],
     citations: [],
     usage: null,
     created_at: '2026-05-01T10:00:00.000Z',
     status: 'complete',
+    agentPath: false,
+    agentThinking: false,
+    completedAt: null,
+    latencyMs: null,
+    firstSseLatencyMs: null,
     ...overrides,
   };
 }
@@ -215,6 +340,95 @@ function jsonResponse(body: unknown, status = 200): Response {
     status,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+type FetchCall = {
+  path: string;
+  body: unknown;
+};
+
+type StreamEvent = {
+  event: string;
+  data: unknown;
+};
+
+function stubChatFetch({
+  databaseEnabled = false,
+  streamEvents = [],
+}: {
+  databaseEnabled?: boolean;
+  streamEvents?: StreamEvent[];
+} = {}): { calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>((input, init) => {
+      const path = getRequestPath(input);
+      calls.push({ path, body: parseRequestBody(init?.body) });
+
+      if (path === '/api/spaces/space-1') {
+        return Promise.resolve(jsonResponse({ data: { id: 'space-1', database_config: { enabled: databaseEnabled } } }));
+      }
+
+      if (path === '/api/spaces/space-1/chat/sessions' && init?.method !== 'POST') {
+        return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-sessions' } }));
+      }
+
+      if (path === '/api/chat/completions') {
+        return Promise.resolve(sseResponse(streamEvents));
+      }
+
+      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+    }),
+  );
+
+  return { calls };
+}
+
+async function sendChatMessage(message: string): Promise<void> {
+  const textarea = await screen.findByLabelText('Message');
+  fireEvent.change(textarea, { target: { value: message } });
+  fireEvent.keyDown(textarea, { key: 'Enter' });
+}
+
+function getLastChatCompletionBody(calls: FetchCall[]): Record<string, unknown> {
+  const call = [...calls].reverse().find((item) => item.path === '/api/chat/completions');
+  expect(call).toBeDefined();
+  expect(call?.body).toEqual(expect.any(Object));
+  return call?.body as Record<string, unknown>;
+}
+
+function sseResponse(events: StreamEvent[]): Response {
+  const encoder = new TextEncoder();
+  const streamText = `${events
+    .map((event) => `event: ${event.event}\ndata: ${JSON.stringify(event.data)}\n\n`)
+    .join('')}data: [DONE]\n\n`;
+
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(streamText));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    },
+  );
+}
+
+function parseRequestBody(body: BodyInit | null | undefined): unknown {
+  if (typeof body !== 'string') {
+    return null;
+  }
+
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return null;
+  }
 }
 
 function getRequestPath(input: RequestInfo | URL): string {

--- a/apps/web/src/components/ChatChart.tsx
+++ b/apps/web/src/components/ChatChart.tsx
@@ -1,23 +1,52 @@
-import ReactECharts from 'echarts-for-react';
+import { lazy, Suspense } from 'react';
+
+const ReactECharts = lazy(() => import('echarts-for-react'));
 
 type ChatChartProps = {
   option: Record<string, unknown>;
   chartType: string | null;
 };
 
+const ALLOWED_SERIES_TYPES = new Set(['bar', 'line', 'pie']);
+
+function sanitizeOption(raw: Record<string, unknown>): Record<string, unknown> {
+  const safe: Record<string, unknown> = {};
+  const allowedKeys = new Set(['xAxis', 'yAxis', 'series', 'legend', 'grid', 'dataset']);
+  for (const key of Object.keys(raw)) {
+    if (allowedKeys.has(key)) {
+      safe[key] = raw[key];
+    }
+  }
+  if (Array.isArray(safe.series)) {
+    safe.series = (safe.series as Array<Record<string, unknown>>).map((s) => {
+      const { tooltip: _t, label: _l, formatter: _f, rich: _r, ...rest } = s;
+      if (typeof rest.type === 'string' && !ALLOWED_SERIES_TYPES.has(rest.type)) {
+        rest.type = 'bar';
+      }
+      return rest;
+    });
+  }
+  safe.tooltip = { show: true, confine: true };
+  safe.animation = false;
+  return safe;
+}
+
 export default function ChatChart({ option, chartType }: ChatChartProps) {
+  const sanitized = sanitizeOption(option);
   return (
     <div className="chat-chart-panel" aria-label="Chart data">
       <div className="chat-chart-header">
         <strong>图表</strong>
         {chartType !== null ? <span className="status-badge status-info">{chartType}</span> : null}
       </div>
-      <ReactECharts
-        option={option}
-        notMerge
-        lazyUpdate
-        style={{ width: '100%', height: '280px' }}
-      />
+      <Suspense fallback={<div style={{ height: '280px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>加载图表...</div>}>
+        <ReactECharts
+          option={sanitized}
+          notMerge
+          lazyUpdate
+          style={{ width: '100%', height: '280px' }}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/src/components/ChatChart.tsx
+++ b/apps/web/src/components/ChatChart.tsx
@@ -1,0 +1,23 @@
+import ReactECharts from 'echarts-for-react';
+
+type ChatChartProps = {
+  option: Record<string, unknown>;
+  chartType: string | null;
+};
+
+export default function ChatChart({ option, chartType }: ChatChartProps) {
+  return (
+    <div className="chat-chart-panel" aria-label="Chart data">
+      <div className="chat-chart-header">
+        <strong>图表</strong>
+        {chartType !== null ? <span className="status-badge status-info">{chartType}</span> : null}
+      </div>
+      <ReactECharts
+        option={option}
+        notMerge
+        lazyUpdate
+        style={{ width: '100%', height: '280px' }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/ChatChart.tsx
+++ b/apps/web/src/components/ChatChart.tsx
@@ -19,11 +19,15 @@ function sanitizeOption(raw: Record<string, unknown>): Record<string, unknown> {
   }
   if (Array.isArray(safe.series)) {
     safe.series = (safe.series as Array<Record<string, unknown>>).map((s) => {
-      const { tooltip: _t, label: _l, formatter: _f, rich: _r, ...rest } = s;
-      if (typeof rest.type === 'string' && !ALLOWED_SERIES_TYPES.has(rest.type)) {
-        rest.type = 'bar';
+      const cleaned = { ...s };
+      delete cleaned.tooltip;
+      delete cleaned.label;
+      delete cleaned.formatter;
+      delete cleaned.rich;
+      if (typeof cleaned.type === 'string' && !ALLOWED_SERIES_TYPES.has(cleaned.type)) {
+        cleaned.type = 'bar';
       }
-      return rest;
+      return cleaned;
     });
   }
   safe.tooltip = { show: true, confine: true };

--- a/apps/web/src/components/ConfidenceBadge.tsx
+++ b/apps/web/src/components/ConfidenceBadge.tsx
@@ -1,0 +1,39 @@
+export type ConfidenceLabel = string | null | undefined;
+
+export function ConfidenceBadge({ label }: { label: ConfidenceLabel }) {
+  const normalized = normalizeConfidenceLabel(label);
+
+  if (normalized === 'INFERRED') {
+    return <span className="confidence-badge confidence-inferred">推断</span>;
+  }
+
+  if (normalized === 'AMBIGUOUS') {
+    return <span className="confidence-badge confidence-ambiguous">待确认</span>;
+  }
+
+  return null;
+}
+
+export function normalizeConfidenceLabel(label: ConfidenceLabel): string | null {
+  if (typeof label !== 'string' || label.trim().length === 0) {
+    return null;
+  }
+
+  return label.trim().toUpperCase();
+}
+
+export function getConfidenceTone(score: number | null | undefined): 'high' | 'medium' | 'low' {
+  if (typeof score !== 'number' || !Number.isFinite(score)) {
+    return 'low';
+  }
+
+  if (score > 0.7) {
+    return 'high';
+  }
+
+  if (score > 0.3) {
+    return 'medium';
+  }
+
+  return 'low';
+}

--- a/apps/web/src/components/GraphPathViewer.tsx
+++ b/apps/web/src/components/GraphPathViewer.tsx
@@ -1,0 +1,86 @@
+import { ConfidenceBadge, getConfidenceTone } from './ConfidenceBadge.js';
+
+export type GraphPathNode = {
+  id: string;
+  label?: string | null;
+  node_key?: string | null;
+  stable_key?: string | null;
+  node_type?: string | null;
+};
+
+export type GraphPathEdge = {
+  id: string;
+  source_node_id: string;
+  target_node_id: string;
+  relationship?: string | null;
+  confidence_label?: string | null;
+  effective_confidence_score?: number | null;
+  confidence?: number | null;
+};
+
+export type GraphPathData = {
+  nodes: GraphPathNode[];
+  edges: GraphPathEdge[];
+  confidence?: number | null;
+  total_confidence?: number | null;
+};
+
+type GraphPathViewerProps = {
+  path: GraphPathData;
+};
+
+export default function GraphPathViewer({ path }: GraphPathViewerProps) {
+  const pathConfidence = path.total_confidence ?? path.confidence ?? null;
+  const confidenceTone = getConfidenceTone(pathConfidence);
+
+  if (path.nodes.length === 0) {
+    return <div className="graph-path-empty">No graph path data</div>;
+  }
+
+  return (
+    <div className={`graph-path-viewer confidence-${confidenceTone}`} aria-label="Graph path">
+      <div className="graph-path-meta">
+        <strong>图谱路径</strong>
+        {pathConfidence !== null ? <span>{formatConfidence(pathConfidence)}</span> : null}
+      </div>
+      <div className="graph-path-track">
+        {path.nodes.map((node, index) => {
+          const edge = path.edges[index];
+          return (
+            <div className="graph-path-step" key={`${node.id}-${index}`}>
+              <div className="graph-path-node">
+                <strong>{getNodeLabel(node)}</strong>
+                {node.node_type !== null && node.node_type !== undefined ? <span>{node.node_type}</span> : null}
+              </div>
+              {edge !== undefined ? (
+                <div className={`graph-path-edge confidence-${getConfidenceTone(getEdgeScore(edge))}`}>
+                  <span className="graph-path-edge-line" aria-hidden="true" />
+                  <span className="graph-path-edge-label">
+                    {edge.relationship ?? 'RELATED'}
+                    <ConfidenceBadge label={edge.confidence_label} />
+                  </span>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function getNodeLabel(node: GraphPathNode): string {
+  return node.label ?? node.node_key ?? node.stable_key ?? node.id;
+}
+
+function getEdgeScore(edge: GraphPathEdge): number | null {
+  return edge.effective_confidence_score ?? edge.confidence ?? null;
+}
+
+function formatConfidence(value: number): string {
+  if (value >= 0 && value <= 1) {
+    return `${Math.round(value * 100)}%`;
+  }
+
+  return value.toFixed(2);
+}

--- a/apps/web/src/hooks/useChatStream.ts
+++ b/apps/web/src/hooks/useChatStream.ts
@@ -4,6 +4,9 @@ import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateA
 export const CHAT_INPUT_MAX_LENGTH = 4000;
 
 export type ChatRole = 'user' | 'assistant';
+export type RetrievalMode = 'wiki_only' | 'graph_rag' | 'path_first' | 'community_first';
+
+export const DEFAULT_RETRIEVAL_MODE: RetrievalMode = 'wiki_only';
 
 export type ChatCitation = {
   index: number;
@@ -27,15 +30,38 @@ export type ChatUsage = {
   total_tokens: number;
 };
 
+export type ChatToolUsePart = {
+  type: 'tool_use';
+  id: string | null;
+  name: string;
+  input: unknown;
+};
+
+export type ChatChartPart = {
+  type: 'chart';
+  id: string;
+  chart_type: string | null;
+  option: Record<string, unknown>;
+  raw: Record<string, unknown>;
+};
+
+export type ChatMessagePart = ChatToolUsePart | ChatChartPart;
+
 export type ChatMessage = {
   id: string;
   session_id: string | null;
   role: ChatRole;
   content: string;
+  parts: ChatMessagePart[];
   citations: ChatCitation[];
   usage: ChatUsage | null;
   created_at: string;
   status: ChatMessageStatus;
+  agentPath: boolean;
+  agentThinking: boolean;
+  completedAt: string | null;
+  latencyMs: number | null;
+  firstSseLatencyMs: number | null;
   error?: string;
 };
 
@@ -71,8 +97,11 @@ type UseChatStreamParams = {
   onSession?: (sessionId: string) => void;
 };
 
-type SendMessageOptions = {
+export type SendMessageOptions = {
   sessionId?: string | null;
+  enableDeepAnalysis?: boolean;
+  enableDatabase?: boolean;
+  retrievalMode?: RetrievalMode;
 };
 
 export function useChatStream({ spaceId, accessToken, onSession }: UseChatStreamParams) {
@@ -83,6 +112,7 @@ export function useChatStream({ spaceId, accessToken, onSession }: UseChatStream
   const abortControllerRef = useRef<AbortController | null>(null);
   const messagesRef = useRef<ChatMessage[]>([]);
   const isStreamingRef = useRef(false);
+  const lastSendOptionsRef = useRef<Omit<SendMessageOptions, 'sessionId'> | null>(null);
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -123,11 +153,19 @@ export function useChatStream({ spaceId, accessToken, onSession }: UseChatStream
       }
 
       const requestSessionId = options.sessionId ?? sessionId;
+      const retrievalMode = options.retrievalMode ?? DEFAULT_RETRIEVAL_MODE;
+      const agentPath =
+        options.enableDeepAnalysis === true || options.enableDatabase === true || isAgentRetrievalMode(retrievalMode);
       const userMessageId = createLocalMessageId('user');
       const assistantMessageId = createLocalMessageId('assistant');
       const now = new Date().toISOString();
       const controller = new AbortController();
       abortControllerRef.current = controller;
+      lastSendOptionsRef.current = {
+        enableDeepAnalysis: options.enableDeepAnalysis === true,
+        enableDatabase: options.enableDatabase === true,
+        retrievalMode,
+      };
       isStreamingRef.current = true;
       setIsStreaming(true);
       setError(null);
@@ -138,20 +176,32 @@ export function useChatStream({ spaceId, accessToken, onSession }: UseChatStream
           session_id: requestSessionId,
           role: 'user',
           content,
+          parts: [],
           citations: [],
           usage: null,
           created_at: now,
           status: 'complete',
+          agentPath: false,
+          agentThinking: false,
+          completedAt: now,
+          latencyMs: null,
+          firstSseLatencyMs: null,
         },
         {
           id: assistantMessageId,
           session_id: requestSessionId,
           role: 'assistant',
           content: '',
+          parts: [],
           citations: [],
           usage: null,
           created_at: now,
           status: 'streaming',
+          agentPath,
+          agentThinking: agentPath,
+          completedAt: null,
+          latencyMs: null,
+          firstSseLatencyMs: null,
         },
       ]);
 
@@ -167,7 +217,10 @@ export function useChatStream({ spaceId, accessToken, onSession }: UseChatStream
           body: JSON.stringify({
             space_id: spaceId,
             message: content,
+            retrieval_mode: retrievalMode,
             ...(requestSessionId !== null && requestSessionId.length > 0 ? { session_id: requestSessionId } : {}),
+            ...(options.enableDeepAnalysis === true ? { enable_deep_analysis: true } : {}),
+            ...(options.enableDatabase === true ? { enable_database: true } : {}),
           }),
         });
 
@@ -232,7 +285,12 @@ export function useChatStream({ spaceId, accessToken, onSession }: UseChatStream
           setMessages((current) =>
             current.map((message) =>
               message.id === assistantMessageId && message.status === 'streaming'
-                ? { ...message, status: 'complete' }
+                ? {
+                    ...message,
+                    status: 'complete',
+                    agentThinking: false,
+                    completedAt: message.completedAt ?? new Date().toISOString(),
+                  }
                 : message,
             ),
           );
@@ -262,7 +320,7 @@ export function useChatStream({ spaceId, accessToken, onSession }: UseChatStream
       return;
     }
 
-    await sendMessage(lastUserMessage.content, { sessionId });
+    await sendMessage(lastUserMessage.content, { sessionId, ...(lastSendOptionsRef.current ?? {}) });
   }, [sendMessage, sessionId]);
 
   return {
@@ -285,11 +343,21 @@ export function normalizeChatMessages(rows: ChatApiMessage[]): ChatMessage[] {
       session_id: row.session_id,
       role: row.role as ChatRole,
       content: row.content,
+      parts: [],
       citations: normalizeCitationArray(row.citations_json),
       usage: null,
       created_at: row.created_at,
       status: 'complete',
+      agentPath: false,
+      agentThinking: false,
+      completedAt: null,
+      latencyMs: null,
+      firstSseLatencyMs: null,
     }));
+}
+
+export function isAgentRetrievalMode(mode: RetrievalMode): boolean {
+  return mode === 'graph_rag' || mode === 'path_first' || mode === 'community_first';
 }
 
 export function getChatErrorMessage(error: ChatStreamError | null): string | null {
@@ -354,13 +422,18 @@ function handleStreamEvent(
     return { done: false, error: null };
   }
 
-  if (eventType === 'content') {
+  if (eventType === 'content' || eventType === 'message.delta') {
     const delta = readString(data, 'delta') ?? '';
     if (delta.length > 0) {
       setMessages((current) =>
         current.map((message) =>
           message.id === assistantMessageId
-            ? { ...message, content: `${message.content}${delta}`, status: 'streaming' }
+            ? {
+                ...message,
+                content: `${message.content}${delta}`,
+                status: 'streaming',
+                agentThinking: false,
+              }
             : message,
         ),
       );
@@ -382,6 +455,49 @@ function handleStreamEvent(
       current.map((message) => (message.id === assistantMessageId ? { ...message, usage } : message)),
     );
     return { done: false, error: null };
+  }
+
+  if (eventType === 'agent.tool_use') {
+    const toolUse = normalizeToolUse(data);
+    setMessages((current) =>
+      current.map((message) =>
+        message.id === assistantMessageId ? { ...message, parts: [...message.parts, toolUse] } : message,
+      ),
+    );
+    return { done: false, error: null };
+  }
+
+  if (eventType === 'chart.data') {
+    const chart = normalizeChartPart(data);
+    setMessages((current) =>
+      current.map((message) =>
+        message.id === assistantMessageId ? { ...message, parts: [...message.parts, chart] } : message,
+      ),
+    );
+    return { done: false, error: null };
+  }
+
+  if (eventType === 'message.completed') {
+    const completedUsage = normalizeCompletedUsage(data);
+    const latencyMs = readNumber(data, 'latency_ms');
+    const firstSseLatencyMs = readNumber(data, 'first_sse_latency_ms');
+    const completedAt = new Date().toISOString();
+    setMessages((current) =>
+      current.map((message) =>
+        message.id === assistantMessageId
+          ? {
+              ...message,
+              status: 'complete',
+              agentThinking: false,
+              completedAt,
+              latencyMs,
+              firstSseLatencyMs,
+              usage: completedUsage ?? message.usage,
+            }
+          : message,
+      ),
+    );
+    return { done: true, error: null };
   }
 
   if (eventType === 'error') {
@@ -407,6 +523,7 @@ function markAssistantError(
         ? {
             ...chatMessage,
             status: 'error',
+            agentThinking: false,
             error: message,
           }
         : chatMessage,
@@ -548,14 +665,59 @@ function normalizeUsage(value: unknown): ChatUsage | null {
   const completionTokens = readNumber(value, 'completion_tokens');
   const totalTokens = readNumber(value, 'total_tokens');
 
+  const agentInputTokens = readNumber(value, 'input_tokens');
+  const agentOutputTokens = readNumber(value, 'output_tokens');
+
   if (promptTokens === null || completionTokens === null || totalTokens === null) {
-    return null;
+    if (agentInputTokens === null && agentOutputTokens === null) {
+      return null;
+    }
+
+    const normalizedPromptTokens = agentInputTokens ?? 0;
+    const normalizedCompletionTokens = agentOutputTokens ?? 0;
+    return {
+      prompt_tokens: normalizedPromptTokens,
+      completion_tokens: normalizedCompletionTokens,
+      total_tokens: normalizedPromptTokens + normalizedCompletionTokens,
+    };
   }
 
   return {
     prompt_tokens: promptTokens,
     completion_tokens: completionTokens,
     total_tokens: totalTokens,
+  };
+}
+
+function normalizeCompletedUsage(value: unknown): ChatUsage | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const nestedUsage = readRecord(value, 'usage');
+  return normalizeUsage(nestedUsage ?? value);
+}
+
+function normalizeToolUse(value: Record<string, unknown>): ChatToolUsePart {
+  return {
+    type: 'tool_use',
+    id: readString(value, 'id'),
+    name: readString(value, 'name') ?? readString(value, 'tool') ?? readString(value, 'tool_name') ?? 'Tool',
+    input: readUnknown(value, 'input') ?? readUnknown(value, 'tool_input') ?? {},
+  };
+}
+
+function normalizeChartPart(value: Record<string, unknown>): ChatChartPart {
+  const nestedData = readRecord(value, 'data');
+  const raw = nestedData ?? value;
+  const option = readRecord(raw, 'echarts_option') ?? readRecord(value, 'echarts_option') ?? raw;
+
+  return {
+    type: 'chart',
+    id: createLocalMessageId('chart'),
+    chart_type: readString(raw, 'chart_type') ?? readString(value, 'chart_type'),
+    option,
+    raw,
   };
 }
 

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -3,15 +3,24 @@ import ReactMarkdown from 'react-markdown';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
+import ChatChart from '../components/ChatChart.js';
+import { ConfidenceBadge } from '../components/ConfidenceBadge.js';
+import GraphPathViewer, { type GraphPathData, type GraphPathEdge, type GraphPathNode } from '../components/GraphPathViewer.js';
 import SpaceNav from '../components/SpaceNav.js';
 import { EmptyState, ErrorBanner, LoadingState, formatDate, getErrorMessage } from '../components/adminUi.js';
 import {
   CHAT_INPUT_MAX_LENGTH,
+  DEFAULT_RETRIEVAL_MODE,
   getChatErrorMessage,
+  isAgentRetrievalMode,
   useChatStream,
   type ChatApiSessionDetail,
   type ChatCitation,
   type ChatMessage,
+  type ChatMessagePart,
+  type ChatToolUsePart,
+  type RetrievalMode,
+  type SendMessageOptions,
 } from '../hooks/useChatStream.js';
 import { api } from '../lib/api.js';
 import { useAuth } from '../lib/auth.js';
@@ -27,7 +36,10 @@ type ChatSession = {
 type MessageInputProps = {
   disabled: boolean;
   isStreaming: boolean;
-  onSend: (message: string) => Promise<void> | void;
+  onSend: (message: string, options: ChatSettings) => Promise<void> | void;
+  settings?: ChatSettings;
+  databaseAvailable?: boolean;
+  onSettingsChange?: (settings: ChatSettings) => void;
 };
 
 type SessionSidebarProps = {
@@ -44,14 +56,40 @@ type ChatMessageBubbleProps = {
   spaceId: string;
 };
 
+type ChatSettings = {
+  enableDeepAnalysis: boolean;
+  enableDatabase: boolean;
+  retrievalMode: RetrievalMode;
+};
+
+type ChatSpaceDetail = {
+  database_config?: unknown;
+};
+
+const DEFAULT_CHAT_SETTINGS: ChatSettings = {
+  enableDeepAnalysis: false,
+  enableDatabase: false,
+  retrievalMode: DEFAULT_RETRIEVAL_MODE,
+};
+
+const RETRIEVAL_MODE_OPTIONS: { value: RetrievalMode; label: string }[] = [
+  { value: 'wiki_only', label: '自动' },
+  { value: 'graph_rag', label: '图谱优先' },
+  { value: 'path_first', label: '路径优先' },
+  { value: 'community_first', label: '社区优先' },
+];
+
 export default function Chat() {
   const { spaceId = '' } = useParams();
   const { accessToken, hasSpacePermission, isAuthenticated, user } = useAuth();
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(true);
   const [sessionsError, setSessionsError] = useState<string | null>(null);
+  const [spaceDatabaseEnabled, setSpaceDatabaseEnabled] = useState(false);
+  const [chatSettings, setChatSettings] = useState<ChatSettings>(() => loadChatSettings(spaceId));
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const sessionSwitchRef = useRef(0);
 
   const loadSessions = useCallback(
     async (background = false) => {
@@ -108,6 +146,48 @@ export default function Chat() {
   }, [loadSessions]);
 
   useEffect(() => {
+    setChatSettings(loadChatSettings(spaceId));
+  }, [spaceId]);
+
+  useEffect(() => {
+    saveChatSettings(spaceId, chatSettings);
+  }, [chatSettings, spaceId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!isAuthenticated || spaceId.length === 0) {
+      setSpaceDatabaseEnabled(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    api
+      .get<ChatSpaceDetail>(`/spaces/${encodeURIComponent(spaceId)}`)
+      .then((space) => {
+        if (!cancelled) {
+          setSpaceDatabaseEnabled(isSpaceDatabaseEnabled(space.database_config));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSpaceDatabaseEnabled(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, spaceId]);
+
+  useEffect(() => {
+    if (!spaceDatabaseEnabled && chatSettings.enableDatabase) {
+      setChatSettings((current) => ({ ...current, enableDatabase: false }));
+    }
+  }, [chatSettings.enableDatabase, spaceDatabaseEnabled]);
+
+  useEffect(() => {
     if (typeof messagesEndRef.current?.scrollIntoView === 'function') {
       messagesEndRef.current.scrollIntoView({ block: 'end' });
     }
@@ -132,8 +212,6 @@ export default function Chat() {
       </main>
     );
   }
-
-  const sessionSwitchRef = useRef(0);
 
   async function openSession(nextSessionId: string): Promise<void> {
     setSessionsError(null);
@@ -177,8 +255,15 @@ export default function Chat() {
     setIsMobileSidebarOpen(false);
   }
 
-  async function handleSend(message: string): Promise<void> {
-    await sendMessage(message, { sessionId });
+  async function handleSend(message: string, settings: ChatSettings): Promise<void> {
+    const options: SendMessageOptions = {
+      sessionId,
+      enableDeepAnalysis: settings.enableDeepAnalysis,
+      enableDatabase: spaceDatabaseEnabled && settings.enableDatabase,
+      retrievalMode: settings.retrievalMode,
+    };
+
+    await sendMessage(message, options);
     await loadSessions(true);
   }
 
@@ -260,16 +345,32 @@ export default function Chat() {
           </div>
         ) : null}
 
-        <MessageInput disabled={isStreaming} isStreaming={isStreaming} onSend={handleSend} />
+        <MessageInput
+          disabled={isStreaming}
+          isStreaming={isStreaming}
+          settings={chatSettings}
+          databaseAvailable={spaceDatabaseEnabled}
+          onSettingsChange={setChatSettings}
+          onSend={handleSend}
+        />
       </main>
     </div>
   );
 }
 
-export function MessageInput({ disabled, isStreaming, onSend }: MessageInputProps) {
+export function MessageInput({
+  disabled,
+  isStreaming,
+  onSend,
+  settings = DEFAULT_CHAT_SETTINGS,
+  databaseAvailable = false,
+  onSettingsChange,
+}: MessageInputProps) {
   const [value, setValue] = useState('');
   const trimmedLength = value.trim().length;
   const isAtLimit = value.length >= CHAT_INPUT_MAX_LENGTH;
+  const agentPathSelected =
+    settings.enableDeepAnalysis || (databaseAvailable && settings.enableDatabase) || isAgentRetrievalMode(settings.retrievalMode);
 
   async function submit(): Promise<void> {
     if (disabled || trimmedLength === 0 || value.length > CHAT_INPUT_MAX_LENGTH) {
@@ -278,7 +379,17 @@ export function MessageInput({ disabled, isStreaming, onSend }: MessageInputProp
 
     const message = value;
     setValue('');
-    await onSend(message);
+    await onSend(message, {
+      ...settings,
+      enableDatabase: databaseAvailable && settings.enableDatabase,
+    });
+  }
+
+  function updateSettings(patch: Partial<ChatSettings>): void {
+    onSettingsChange?.({
+      ...settings,
+      ...patch,
+    });
   }
 
   return (
@@ -305,6 +416,44 @@ export function MessageInput({ disabled, isStreaming, onSend }: MessageInputProp
           }
         }}
       />
+      <div className="chat-input-settings" aria-label="Chat settings">
+        <button
+          className={`chat-toggle-chip${settings.enableDeepAnalysis ? ' active' : ''}`}
+          type="button"
+          aria-pressed={settings.enableDeepAnalysis}
+          disabled={disabled}
+          onClick={() => updateSettings({ enableDeepAnalysis: !settings.enableDeepAnalysis })}
+        >
+          深度分析
+        </button>
+        {databaseAvailable ? (
+          <button
+            className={`chat-toggle-chip${settings.enableDatabase ? ' active' : ''}`}
+            type="button"
+            aria-pressed={settings.enableDatabase}
+            disabled={disabled}
+            onClick={() => updateSettings({ enableDatabase: !settings.enableDatabase })}
+          >
+            数据库
+          </button>
+        ) : null}
+        <label className="chat-retrieval-mode-label" htmlFor="chat-retrieval-mode">
+          检索模式
+          <select
+            id="chat-retrieval-mode"
+            value={settings.retrievalMode}
+            disabled={disabled}
+            onChange={(event) => updateSettings({ retrievalMode: normalizeRetrievalMode(event.target.value) })}
+          >
+            {RETRIEVAL_MODE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        {agentPathSelected ? <span className="chat-agent-path-label">Agent</span> : null}
+      </div>
       <div className="chat-input-footer">
         <span className={`chat-character-count${isAtLimit ? ' warning' : ''}`}>
           {value.length}/{CHAT_INPUT_MAX_LENGTH}
@@ -372,12 +521,18 @@ export function ChatMessageBubble({ message, spaceId }: ChatMessageBubbleProps) 
       <div className={`chat-message-bubble ${message.role}`}>
         {message.role === 'assistant' ? (
           <>
-            {message.status === 'streaming' && message.content.length === 0 ? (
+            {message.agentThinking ? (
+              <AgentThinkingIndicator />
+            ) : message.status === 'streaming' && message.content.length === 0 && message.parts.length === 0 ? (
               <TypingIndicator />
             ) : (
-              <AssistantMarkdown content={message.content} citations={message.citations} spaceId={spaceId} />
+              message.content.length > 0 ? (
+                <AssistantMarkdown content={message.content} citations={message.citations} spaceId={spaceId} />
+              ) : null
             )}
+            <ChatMessageParts parts={message.parts} />
             <CitationPanel citations={message.citations} spaceId={spaceId} />
+            <CompletionIndicator message={message} />
           </>
         ) : (
           <p className="chat-user-content">{message.content}</p>
@@ -411,10 +566,14 @@ function AssistantMarkdown({ content, citations, spaceId }: { content: string; c
           a: ({ href, children }) => {
             if (href?.startsWith('citation:') === true) {
               const index = Number(href.slice('citation:'.length));
+              const citation = Number.isFinite(index) ? citations.find((item) => item.index === index) : undefined;
               return (
-                <button className="chat-citation-ref" type="button" onClick={() => openCitation(index)}>
-                  [{Number.isFinite(index) ? index : children}]
-                </button>
+                <>
+                  <button className="chat-citation-ref" type="button" onClick={() => openCitation(index)}>
+                    [{Number.isFinite(index) ? index : children}]
+                  </button>
+                  <ConfidenceBadge label={citation !== undefined ? getCitationConfidenceLabel(citation) : null} />
+                </>
               );
             }
 
@@ -444,26 +603,137 @@ function CitationPanel({ citations, spaceId }: { citations: ChatCitation[]; spac
     <details className="chat-citations" open>
       <summary>Citations ({citations.length})</summary>
       <ol>
-        {citations.map((citation) => (
-          <li key={`${citation.index}-${citation.chunk_id || citation.wiki_page_pk}`}>
-            <button
-              className="chat-citation-card"
-              type="button"
-              onClick={() => {
-                void navigate(buildCitationPath(spaceId, citation));
-              }}
-            >
-              <span className="chat-citation-index">[{citation.index}]</span>
-              <span>
-                <strong>{citation.page_title}</strong>
-                <small>{citation.section_title ?? 'No section'}</small>
-              </span>
-              <span className="status-badge status-neutral">{formatCitationScore(citation.relevance_score)}</span>
-            </button>
-          </li>
-        ))}
+        {citations.map((citation) => {
+          const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
+          const graphPath = getCitationGraphPath(citation);
+          return (
+            <li key={`${citation.index}-${citation.chunk_id || citation.wiki_page_pk}`}>
+              <div className="chat-citation-entry">
+                <button
+                  className="chat-citation-card"
+                  type="button"
+                  onClick={() => {
+                    void navigate(buildCitationPath(spaceId, citation));
+                  }}
+                >
+                  <span className="chat-citation-index">[{citation.index}]</span>
+                  <span>
+                    <strong>{citation.page_title}</strong>
+                    <small>{citation.section_title ?? 'No section'}</small>
+                  </span>
+                  <ConfidenceBadge label={getCitationConfidenceLabel(citation)} />
+                  <span className="status-badge status-neutral">{formatCitationScore(citation.relevance_score)}</span>
+                </button>
+                {graphEdgeIds.length > 0 || graphPath !== null ? (
+                  <details className="chat-source-chain">
+                    <summary>查看图谱路径</summary>
+                    <SourceChainDetails citation={citation} graphPath={graphPath} />
+                  </details>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
       </ol>
     </details>
+  );
+}
+
+function ChatMessageParts({ parts }: { parts: ChatMessagePart[] }) {
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="chat-message-parts">
+      {parts.map((part, index) => {
+        if (part.type === 'tool_use') {
+          return <ToolUsePanel key={`${part.id ?? part.name}-${index}`} part={part} />;
+        }
+
+        return <ChatChart key={part.id} option={part.option} chartType={part.chart_type} />;
+      })}
+    </div>
+  );
+}
+
+function ToolUsePanel({ part }: { part: ChatToolUsePart }) {
+  const command = formatToolInput(part.input);
+
+  return (
+    <details className="chat-tool-use" aria-label="Agent tool use">
+      <summary>
+        <span>{part.name}</span>
+        <code>{command}</code>
+      </summary>
+      <pre>{command}</pre>
+    </details>
+  );
+}
+
+function CompletionIndicator({ message }: { message: ChatMessage }) {
+  if (message.role !== 'assistant' || message.status !== 'complete' || message.completedAt === null) {
+    return null;
+  }
+
+  return (
+    <div className="chat-completion-indicator" aria-label="Message complete">
+      <span>完成</span>
+      {message.latencyMs !== null ? <span>{formatLatency(message.latencyMs)}</span> : null}
+    </div>
+  );
+}
+
+function SourceChainDetails({ citation, graphPath }: { citation: ChatCitation; graphPath: GraphPathData | null }) {
+  const sourceDocumentIds = getCitationStringArray(citation, 'source_document_ids');
+  const graphNodeIds = getCitationStringArray(citation, 'graph_node_ids');
+  const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
+  const chainConfidence = getCitationNumber(citation, 'chain_confidence');
+
+  return (
+    <div className="chat-source-chain-body">
+      <div className="chat-source-chain-grid">
+        {sourceDocumentIds.length > 0 ? (
+          <>
+            <span>source_document_ids</span>
+            <code>{sourceDocumentIds.join(', ')}</code>
+          </>
+        ) : null}
+        {graphNodeIds.length > 0 ? (
+          <>
+            <span>graph_node_ids</span>
+            <code>{graphNodeIds.join(' -> ')}</code>
+          </>
+        ) : null}
+        {graphEdgeIds.length > 0 ? (
+          <>
+            <span>graph_edge_ids</span>
+            <code>{graphEdgeIds.join(' -> ')}</code>
+          </>
+        ) : null}
+        {chainConfidence !== null ? (
+          <>
+            <span>chain_confidence</span>
+            <code>{formatCitationScore(chainConfidence)}</code>
+          </>
+        ) : null}
+      </div>
+      <ConfidenceBadge label={getCitationConfidenceLabel(citation)} />
+      {graphPath !== null ? <GraphPathViewer path={graphPath} /> : null}
+    </div>
+  );
+}
+
+function AgentThinkingIndicator() {
+  return (
+    <div className="chat-agent-thinking" aria-label="Agent is thinking">
+      <span>Agent 思考中</span>
+      <span className="chat-thinking-dots" aria-hidden="true">
+        <i />
+        <i />
+        <i />
+      </span>
+    </div>
   );
 }
 
@@ -475,6 +745,248 @@ function TypingIndicator() {
       <span />
     </div>
   );
+}
+
+function normalizeRetrievalMode(value: string): RetrievalMode {
+  return RETRIEVAL_MODE_OPTIONS.some((option) => option.value === value) ? (value as RetrievalMode) : DEFAULT_RETRIEVAL_MODE;
+}
+
+function loadChatSettings(spaceId: string): ChatSettings {
+  if (typeof window === 'undefined' || spaceId.length === 0) {
+    return DEFAULT_CHAT_SETTINGS;
+  }
+
+  const raw = window.sessionStorage.getItem(getChatSettingsKey(spaceId));
+  if (raw === null) {
+    return DEFAULT_CHAT_SETTINGS;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      return DEFAULT_CHAT_SETTINGS;
+    }
+
+    return {
+      enableDeepAnalysis: parsed.enableDeepAnalysis === true,
+      enableDatabase: parsed.enableDatabase === true,
+      retrievalMode: typeof parsed.retrievalMode === 'string' ? normalizeRetrievalMode(parsed.retrievalMode) : DEFAULT_RETRIEVAL_MODE,
+    };
+  } catch {
+    return DEFAULT_CHAT_SETTINGS;
+  }
+}
+
+function saveChatSettings(spaceId: string, settings: ChatSettings): void {
+  if (typeof window === 'undefined' || spaceId.length === 0) {
+    return;
+  }
+
+  window.sessionStorage.setItem(getChatSettingsKey(spaceId), JSON.stringify(settings));
+}
+
+function getChatSettingsKey(spaceId: string): string {
+  return `cherry-chat-settings:${spaceId}`;
+}
+
+function isSpaceDatabaseEnabled(value: unknown): boolean {
+  return isRecord(value) && value.enabled === true;
+}
+
+function formatToolInput(input: unknown): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if (isRecord(input)) {
+    const command = readStringValue(input, 'command') ?? readStringValue(input, 'query') ?? readStringValue(input, 'input');
+    if (command !== null) {
+      return command;
+    }
+  }
+
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+}
+
+function formatLatency(milliseconds: number): string {
+  if (!Number.isFinite(milliseconds)) {
+    return '';
+  }
+
+  if (milliseconds >= 1000) {
+    return `${(milliseconds / 1000).toFixed(1)}s`;
+  }
+
+  return `${Math.max(0, Math.round(milliseconds))}ms`;
+}
+
+function getCitationConfidenceLabel(citation: ChatCitation): string | null {
+  const chain = getCitationSourceChain(citation);
+  const directLabel = readStringValue(chain, 'edge_confidence') ?? readStringValue(chain, 'confidence_label');
+  if (directLabel !== null) {
+    return directLabel;
+  }
+
+  const graphPath = getCitationGraphPath(citation);
+  return graphPath?.edges.find((edge) => edge.confidence_label !== null && edge.confidence_label !== undefined)?.confidence_label ?? null;
+}
+
+function getCitationStringArray(citation: ChatCitation, key: string): string[] {
+  const chain = getCitationSourceChain(citation);
+  const directValue = chain[key] ?? citation.source_chain_json[key];
+  return readStringArray(directValue);
+}
+
+function getCitationNumber(citation: ChatCitation, key: string): number | null {
+  const chain = getCitationSourceChain(citation);
+  return readNumberValue(chain, key) ?? readNumberValue(citation.source_chain_json, key);
+}
+
+function getCitationSourceChain(citation: ChatCitation): Record<string, unknown> {
+  return readRecordValue(citation.source_chain_json, 'source_chain') ?? citation.source_chain_json;
+}
+
+function getCitationGraphPath(citation: ChatCitation): GraphPathData | null {
+  const sourceChain = getCitationSourceChain(citation);
+  const pathRecord = readRecordValue(sourceChain, 'graph_path') ?? readRecordValue(citation.source_chain_json, 'graph_path');
+  const nodesValue =
+    readArrayValue(pathRecord, 'nodes') ??
+    readArrayValue(sourceChain, 'graph_path_nodes') ??
+    readArrayValue(citation.source_chain_json, 'graph_path_nodes');
+
+  if (nodesValue === null || nodesValue.length === 0) {
+    return null;
+  }
+
+  const nodes = nodesValue.map(normalizeGraphPathNode);
+  const edgesValue =
+    readArrayValue(pathRecord, 'edges') ??
+    readArrayValue(sourceChain, 'graph_path_edges') ??
+    readArrayValue(citation.source_chain_json, 'graph_path_edges') ??
+    [];
+  const edges = edgesValue.map((edge, index) => normalizeGraphPathEdge(edge, index, nodes));
+  const confidence =
+    readNumberValue(pathRecord, 'total_confidence') ??
+    readNumberValue(pathRecord, 'confidence') ??
+    readNumberValue(sourceChain, 'chain_confidence');
+  const graphPath: GraphPathData = { nodes, edges };
+
+  if (confidence !== null) {
+    graphPath.total_confidence = confidence;
+  }
+
+  return graphPath;
+}
+
+function normalizeGraphPathNode(value: unknown, index: number): GraphPathNode {
+  if (!isRecord(value)) {
+    return { id: `node-${index}`, label: String(value) };
+  }
+
+  const id =
+    readStringValue(value, 'id') ??
+    readStringValue(value, 'node_id') ??
+    readStringValue(value, 'node_key') ??
+    readStringValue(value, 'stable_key') ??
+    `node-${index}`;
+  const node: GraphPathNode = { id };
+  const label = readStringValue(value, 'label') ?? readStringValue(value, 'name');
+  const nodeKey = readStringValue(value, 'node_key');
+  const stableKey = readStringValue(value, 'stable_key');
+  const nodeType = readStringValue(value, 'node_type') ?? readStringValue(value, 'type');
+
+  if (label !== null) node.label = label;
+  if (nodeKey !== null) node.node_key = nodeKey;
+  if (stableKey !== null) node.stable_key = stableKey;
+  if (nodeType !== null) node.node_type = nodeType;
+
+  return node;
+}
+
+function normalizeGraphPathEdge(value: unknown, index: number, nodes: GraphPathNode[]): GraphPathEdge {
+  const sourceFallback = nodes[index]?.id ?? `source-${index}`;
+  const targetFallback = nodes[index + 1]?.id ?? `target-${index}`;
+
+  if (!isRecord(value)) {
+    return {
+      id: `edge-${index}`,
+      source_node_id: sourceFallback,
+      target_node_id: targetFallback,
+      relationship: String(value),
+    };
+  }
+
+  const edge: GraphPathEdge = {
+    id: readStringValue(value, 'id') ?? readStringValue(value, 'edge_id') ?? `edge-${index}`,
+    source_node_id: readStringValue(value, 'source_node_id') ?? readStringValue(value, 'source') ?? sourceFallback,
+    target_node_id: readStringValue(value, 'target_node_id') ?? readStringValue(value, 'target') ?? targetFallback,
+  };
+  const relationship = readStringValue(value, 'relationship') ?? readStringValue(value, 'relationship_type') ?? readStringValue(value, 'type');
+  const confidenceLabel = readStringValue(value, 'confidence_label') ?? readStringValue(value, 'edge_confidence');
+  const confidenceScore = readNumberValue(value, 'effective_confidence_score') ?? readNumberValue(value, 'confidence');
+
+  if (relationship !== null) edge.relationship = relationship;
+  if (confidenceLabel !== null) edge.confidence_label = confidenceLabel;
+  if (confidenceScore !== null) edge.effective_confidence_score = confidenceScore;
+
+  return edge;
+}
+
+function readRecordValue(record: Record<string, unknown> | null, key: string): Record<string, unknown> | null {
+  if (record === null) {
+    return null;
+  }
+
+  const value = record[key];
+  return isRecord(value) ? value : null;
+}
+
+function readArrayValue(record: Record<string, unknown> | null, key: string): unknown[] | null {
+  if (record === null) {
+    return null;
+  }
+
+  const value = record[key];
+  return Array.isArray(value) ? value : null;
+}
+
+function readStringValue(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readNumberValue(record: Record<string, unknown> | null, key: string): number | null {
+  if (record === null) {
+    return null;
+  }
+
+  const value = record[key];
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function sortSessions(sessions: ChatSession[]): ChatSession[] {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1059,6 +1059,11 @@ tbody tr:last-child td {
   vertical-align: super;
 }
 
+.chat-citation-ref + .confidence-badge {
+  margin-left: 2px;
+  vertical-align: super;
+}
+
 .chat-citations {
   margin-top: 12px;
   border-top: 1px solid var(--color-border);
@@ -1095,6 +1100,11 @@ tbody tr:last-child td {
   background: var(--color-background-hover);
 }
 
+.chat-citation-entry {
+  display: grid;
+  gap: 8px;
+}
+
 .chat-citation-card span:nth-child(2) {
   display: grid;
   flex: 1;
@@ -1123,6 +1133,94 @@ tbody tr:last-child td {
   font-weight: 800;
 }
 
+.chat-message-parts,
+.chat-source-chain-body {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.chat-tool-use,
+.chat-source-chain,
+.chat-chart-panel,
+.graph-path-viewer {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+}
+
+.chat-tool-use summary,
+.chat-source-chain summary {
+  cursor: pointer;
+  color: var(--color-text-2);
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.chat-tool-use summary {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+}
+
+.chat-tool-use summary code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text-1);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-tool-use pre {
+  margin: 0;
+  overflow-x: auto;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-1);
+  font-family: var(--font-family-mono);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  padding: 10px;
+  white-space: pre-wrap;
+}
+
+.chat-chart-panel {
+  overflow: hidden;
+  padding: 10px;
+}
+
+.chat-chart-header,
+.graph-path-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+  color: var(--color-text-2);
+  font-size: 0.86rem;
+}
+
+.chat-completion-indicator {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+  color: var(--color-text-3);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.chat-agent-thinking {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 26px;
+  color: var(--color-text-2);
+  font-weight: 800;
+}
+
+.chat-thinking-dots,
 .chat-typing-indicator {
   display: inline-flex;
   align-items: center;
@@ -1130,6 +1228,11 @@ tbody tr:last-child td {
   min-height: 24px;
 }
 
+.chat-thinking-dots i {
+  font-style: normal;
+}
+
+.chat-thinking-dots i,
 .chat-typing-indicator span {
   width: 7px;
   height: 7px;
@@ -1138,12 +1241,165 @@ tbody tr:last-child td {
   background: var(--color-text-3);
 }
 
+.chat-thinking-dots i:nth-child(2),
 .chat-typing-indicator span:nth-child(2) {
   animation-delay: 120ms;
 }
 
+.chat-thinking-dots i:nth-child(3),
 .chat-typing-indicator span:nth-child(3) {
   animation-delay: 240ms;
+}
+
+.chat-source-chain {
+  padding: 9px 10px;
+}
+
+.chat-source-chain-grid {
+  display: grid;
+  grid-template-columns: minmax(120px, auto) minmax(0, 1fr);
+  gap: 6px 10px;
+  color: var(--color-text-3);
+  font-size: 0.78rem;
+}
+
+.chat-source-chain-grid code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-1);
+}
+
+.confidence-badge {
+  display: inline-flex;
+  min-height: 20px;
+  align-items: center;
+  border-radius: var(--radius-full);
+  padding: 2px 7px;
+  font-size: 0.72rem;
+  font-weight: 900;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.confidence-inferred {
+  background: var(--color-status-degraded-bg);
+  color: var(--color-status-degraded-text);
+}
+
+.confidence-ambiguous {
+  background: var(--color-status-neutral-bg);
+  color: var(--color-status-neutral-text);
+}
+
+.graph-path-viewer {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+}
+
+.graph-path-viewer.confidence-high {
+  border-color: var(--color-success);
+}
+
+.graph-path-viewer.confidence-medium {
+  border-color: var(--color-warning);
+}
+
+.graph-path-track {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+
+.graph-path-step {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.graph-path-node {
+  display: grid;
+  min-width: 128px;
+  max-width: 190px;
+  gap: 3px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  padding: 8px 10px;
+}
+
+.graph-path-node strong,
+.graph-path-node span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-path-node span {
+  color: var(--color-text-3);
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.graph-path-edge {
+  display: inline-grid;
+  min-width: 94px;
+  gap: 4px;
+  justify-items: center;
+}
+
+.graph-path-edge-line {
+  position: relative;
+  width: 100%;
+  height: 2px;
+  background: var(--color-border-strong);
+}
+
+.graph-path-edge-line::after {
+  position: absolute;
+  right: -1px;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--color-border-strong);
+  border-bottom: 2px solid var(--color-border-strong);
+  content: '';
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.graph-path-edge.confidence-high .graph-path-edge-line,
+.graph-path-edge.confidence-high .graph-path-edge-line::after {
+  background: var(--color-success);
+  border-color: var(--color-success);
+}
+
+.graph-path-edge.confidence-medium .graph-path-edge-line,
+.graph-path-edge.confidence-medium .graph-path-edge-line::after {
+  background: var(--color-warning);
+  border-color: var(--color-warning);
+}
+
+.graph-path-edge-label {
+  display: inline-flex;
+  max-width: 140px;
+  align-items: center;
+  gap: 5px;
+  overflow: hidden;
+  color: var(--color-text-2);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graph-path-empty {
+  color: var(--color-text-3);
+  font-size: 0.82rem;
+  font-weight: 800;
 }
 
 .chat-error-bar {
@@ -1177,6 +1433,68 @@ tbody tr:last-child td {
   min-height: 86px;
   max-height: 180px;
   resize: vertical;
+}
+
+.chat-input-settings {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-toggle-chip {
+  min-height: 30px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  color: var(--color-text-2);
+  font-size: 0.82rem;
+  font-weight: 900;
+  line-height: 1;
+  padding: 6px 10px;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.chat-toggle-chip:hover:not(:disabled) {
+  border-color: var(--color-text-4);
+  color: var(--color-text-1);
+}
+
+.chat-toggle-chip.active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-mute);
+  color: var(--color-primary-hover);
+}
+
+.chat-retrieval-mode-label {
+  display: inline-flex;
+  width: auto;
+  align-items: center;
+  gap: 7px;
+  color: var(--color-text-2);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.chat-retrieval-mode-label select {
+  width: auto;
+  min-height: 30px;
+  padding: 5px 28px 5px 9px;
+}
+
+.chat-agent-path-label {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  border-radius: var(--radius-full);
+  background: var(--color-status-info-bg);
+  color: var(--color-status-info-text);
+  font-size: 0.76rem;
+  font-weight: 900;
+  padding: 3px 8px;
 }
 
 .chat-character-count,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,12 @@ importers:
 
   apps/web:
     dependencies:
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
+      echarts-for-react:
+        specifier: ^3.0.6
+        version: 3.0.6(echarts@6.0.0)(react@19.2.5)
       eventsource-parser:
         specifier: ^3.0.8
         version: 3.0.8
@@ -2914,6 +2920,15 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  echarts-for-react@3.0.6:
+    resolution: {integrity: sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==}
+    peerDependencies:
+      echarts: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+      react: ^15.0.0 || >=16.0.0
+
+  echarts@6.0.0:
+    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -4509,6 +4524,9 @@ packages:
   simple-websocket@9.1.0:
     resolution: {integrity: sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==}
 
+  size-sensor@1.0.3:
+    resolution: {integrity: sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==}
+
   slugify@1.4.7:
     resolution: {integrity: sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==}
     engines: {node: '>=8.0.0'}
@@ -4733,6 +4751,9 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
+
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -5097,6 +5118,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zrender@6.0.0:
+    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7835,6 +7859,18 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.5):
+    dependencies:
+      echarts: 6.0.0
+      fast-deep-equal: 3.1.3
+      react: 19.2.5
+      size-sensor: 1.0.3
+
+  echarts@6.0.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.0.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.344: {}
@@ -9854,6 +9890,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  size-sensor@1.0.3: {}
+
   slugify@1.4.7: {}
 
   sonic-boom@4.2.1:
@@ -10077,6 +10115,8 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@2.3.0: {}
 
   tslib@2.8.1: {}
 
@@ -10395,5 +10435,9 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zod@3.25.76: {}
+
+  zrender@6.0.0:
+    dependencies:
+      tslib: 2.3.0
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Deep analysis + database toggles, retrieval mode selector
- Agent tool_use panels, thinking indicator, message.completed
- ECharts chart rendering (sanitized, lazy-loaded)
- GraphPathViewer SVG, confidence badges, citation graph-chain

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security and Performance Reviewer
- Reviewed head SHA: `ca777b15994a6fb08a38347f8b139c3e98efa592`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/147#issuecomment-4381390211) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/147#issuecomment-4381390368) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/147#issuecomment-4381390555) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/147#issuecomment-4381390772)
- Key findings addressed: ECharts XSS sanitization, lazy-load, lint fixes

## Test plan
- [x] npm run build — pass
- [x] 50 web tests pass
- [x] ESLint clean

Closes #141