### PR TITLE
feat(graphify-worker): Claude Code Runner core implementation (#165)

### DIFF
--- a/apps/graphify-worker/src/claude_runner.py
+++ b/apps/graphify-worker/src/claude_runner.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.resources
 import json
+import logging
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -50,6 +53,7 @@ _WAITING_FOR_INPUT_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
+_LOGGER = logging.getLogger(__name__)
 
 
 class RunState(str, Enum):
@@ -94,6 +98,12 @@ def prepare_run_dirs(run_id: str) -> RunDirs:
     input_dir = session_dir / "input"
     home_dir = session_dir / ".home"
     config_dir = home_dir / ".claude"
+
+    if session_dir.exists() or session_dir.is_symlink():
+        if session_dir.is_symlink() or session_dir.is_file():
+            session_dir.unlink()
+        else:
+            shutil.rmtree(session_dir)
 
     input_dir.mkdir(parents=True, exist_ok=True)
     config_dir.mkdir(parents=True, exist_ok=True)
@@ -146,38 +156,49 @@ def build_claude_env(
         "ANTHROPIC_BASE_URL": os.environ.get("AGENT_ANTHROPIC_BASE_URL", ""),
         "ANTHROPIC_MODEL": model,
         "ANTHROPIC_DEFAULT_MODEL": model,
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": model,
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": model,
     }
 
 
 def install_skill(config_dir: Path | str) -> Path:
     config_path = Path(config_dir)
     skill_dst = config_path / "skills" / "graphify" / "SKILL.md"
-    skill_dst.parent.mkdir(parents=True, exist_ok=True)
-
-    skill_src = _find_graphify_skill()
-    if skill_src is not None:
-        shutil.copy2(skill_src, skill_dst)
-        (skill_dst.parent / ".graphify_version").write_text(
-            "local", encoding="utf-8"
-        )
-        return skill_dst
-
     env = {
         "HOME": str(config_path.parent),
         "CLAUDE_CONFIG_DIR": str(config_path),
         "PATH": os.environ.get("PATH", ""),
         "LANG": os.environ.get("LANG", "C.UTF-8"),
     }
-    subprocess.run(
-        ["graphify", "install"],
-        check=True,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    if not skill_dst.exists():
-        raise RuntimeError(f"graphify install did not create {skill_dst}")
+
+    try:
+        subprocess.run(
+            ["graphify", "install"],
+            check=True,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if skill_dst.exists():
+            return skill_dst
+    except (OSError, subprocess.CalledProcessError) as install_error:
+        fallback_reason = install_error
+    else:
+        fallback_reason = RuntimeError(f"graphify install did not create {skill_dst}")
+
+    skill_dst.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        skill_src = _find_graphify_skill()
+    except RuntimeError as lookup_error:
+        raise RuntimeError(
+            "Unable to install graphify skill via `graphify install` or local copy: "
+            f"{lookup_error}"
+        ) from fallback_reason
+
+    shutil.copy2(skill_src, skill_dst)
+    (skill_dst.parent / ".graphify_version").write_text("local", encoding="utf-8")
     return skill_dst
 
 
@@ -196,7 +217,7 @@ def spawn_claude(
         args,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
         cwd=str(session_dir),
         env=build_claude_env(config_path.parent, config_path),
         text=True,
@@ -275,7 +296,20 @@ def assistant_waiting_for_input(text: str) -> bool:
 
 def preflight_check(input_dir: Path | str) -> dict[str, Any]:
     input_path = Path(input_dir)
-    if not input_path.is_dir():
+    try:
+        input_stat = input_path.lstat()
+    except OSError:
+        return {
+            "ok": False,
+            "reason": "input_missing",
+            "file_count": 0,
+            "total_words": 0,
+        }
+
+    if stat.S_ISLNK(input_stat.st_mode):
+        return _symlink_rejected_result(input_path)
+
+    if not stat.S_ISDIR(input_stat.st_mode):
         return {
             "ok": False,
             "reason": "input_missing",
@@ -286,7 +320,17 @@ def preflight_check(input_dir: Path | str) -> dict[str, Any]:
     max_files = _env_int("GRAPHIFY_MAX_INPUT_FILES", DEFAULT_MAX_INPUT_FILES)
     max_words = _env_int("GRAPHIFY_MAX_INPUT_WORDS", DEFAULT_MAX_INPUT_WORDS)
 
-    files = sorted(path for path in input_path.rglob("*") if path.is_file())
+    files: list[Path] = []
+    for path in sorted(input_path.rglob("*")):
+        try:
+            path_stat = path.lstat()
+        except OSError:
+            continue
+        if stat.S_ISLNK(path_stat.st_mode):
+            return _symlink_rejected_result(path)
+        if stat.S_ISREG(path_stat.st_mode):
+            files.append(path)
+
     file_count = len(files)
     if file_count > max_files:
         return {
@@ -315,7 +359,23 @@ def preflight_check(input_dir: Path | str) -> dict[str, Any]:
 
 
 def output_complete(session_dir: Path | str) -> bool:
-    return (Path(session_dir) / "graphify-out" / "graph.json").is_file()
+    output_dir = Path(session_dir) / "graphify-out"
+    graph_json = output_dir / "graph.json"
+    try:
+        if not graph_json.is_file() or graph_json.stat().st_size == 0:
+            return False
+    except OSError:
+        return False
+
+    wiki_dir = output_dir / "wiki"
+    if not wiki_dir.is_dir():
+        return False
+    if not any(path.is_file() for path in wiki_dir.glob("*.md")):
+        return False
+
+    if not (output_dir / "GRAPH_REPORT.md").is_file():
+        _LOGGER.warning("GRAPH_REPORT.md missing from graphify output")
+    return True
 
 
 def resolve_idle_state(
@@ -361,12 +421,12 @@ async def run_graphify(
     run_id: str, input_dir: Path | str, *, timeout: float | None = None
 ) -> dict[str, Any]:
     if os.environ.get("GRAPHIFY_RUNNER_MODE", "claude_code") == "disabled":
-        return {"reason": "runner_disabled", "retryable": True}
+        return {"status": "failed", "state": RunState.FAILED.value, "reason": "runner_disabled", "retryable": True}
 
     if not os.environ.get("AGENT_ANTHROPIC_API_KEY") or not os.environ.get(
         "AGENT_ANTHROPIC_BASE_URL"
     ):
-        return {"reason": "missing_api_key"}
+        return {"status": "failed", "state": RunState.FAILED.value, "reason": "missing_api_key", "retryable": False}
 
     preflight = preflight_check(input_dir)
     if not preflight.get("ok"):
@@ -376,14 +436,19 @@ async def run_graphify(
     _copy_inputs(Path(input_dir), dirs.input_dir)
     install_skill(dirs.config_dir)
     settings_path = generate_settings(dirs.config_dir)
-    proc = spawn_claude(dirs.session_dir, dirs.config_dir, settings_path)
-    write_user_message(proc, FIRST_GRAPHIFY_MESSAGE)
 
     timeout_seconds = timeout
     if timeout_seconds is None:
         timeout_seconds = _env_int("GRAPHIFY_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS)
 
-    return await _run_stream_loop(proc, dirs.session_dir, float(timeout_seconds))
+    proc: subprocess.Popen[str] | None = None
+    try:
+        proc = spawn_claude(dirs.session_dir, dirs.config_dir, settings_path)
+        write_user_message(proc, FIRST_GRAPHIFY_MESSAGE)
+        return await _run_stream_loop(proc, dirs.session_dir, float(timeout_seconds))
+    finally:
+        if proc is not None:
+            await _cleanup_process(proc)
 
 
 async def _run_stream_loop(
@@ -500,6 +565,37 @@ async def _terminate_for_timeout(proc: subprocess.Popen[str]) -> dict[str, Any]:
     }
 
 
+async def _cleanup_process(proc: subprocess.Popen[str]) -> None:
+    _close_stdin(proc)
+    if _process_exited(proc):
+        return
+
+    _request_terminate(proc)
+    try:
+        await _wait_for_process_exit(proc, 5)
+    except TimeoutError:
+        _request_kill(proc)
+        try:
+            await _wait_for_process_exit(proc, 5)
+        except TimeoutError:
+            _LOGGER.warning("Claude process %s did not exit after SIGKILL", proc.pid)
+
+
+def _close_stdin(proc: subprocess.Popen[str]) -> None:
+    stdin = getattr(proc, "stdin", None)
+    if stdin is None:
+        return
+    try:
+        stdin.close()
+    except OSError:
+        pass
+
+
+def _process_exited(proc: subprocess.Popen[str]) -> bool:
+    poll = getattr(proc, "poll", None)
+    return poll is not None and poll() is not None
+
+
 async def _wait_for_process_exit(
     proc: subprocess.Popen[str], timeout: float
 ) -> int | None:
@@ -533,10 +629,19 @@ def _read_stdout_line(proc: subprocess.Popen[str]) -> str:
 
 
 def _copy_inputs(src_dir: Path, dst_dir: Path) -> None:
+    src_stat = src_dir.lstat()
+    if stat.S_ISLNK(src_stat.st_mode):
+        raise ValueError(f"Refusing to copy symlinked input directory: {src_dir}")
     if src_dir.resolve() == dst_dir.resolve():
         return
     for src in src_dir.rglob("*"):
-        if not src.is_file():
+        try:
+            src_stat = src.lstat()
+        except OSError:
+            continue
+        if stat.S_ISLNK(src_stat.st_mode):
+            raise ValueError(f"Refusing to copy symlinked input path: {src}")
+        if not stat.S_ISREG(src_stat.st_mode):
             continue
         rel = src.relative_to(src_dir)
         dst = dst_dir / rel
@@ -620,27 +725,53 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _symlink_rejected_result(path: Path) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "reason": "input_symlink_rejected",
+        "path": str(path),
+    }
+
+
 def _run_root() -> Path:
     return Path(os.environ.get("GRAPHIFY_RUN_ROOT", str(GRAPHIFY_RUN_ROOT)))
 
 
-def _find_graphify_skill() -> Path | None:
+def _find_graphify_skill() -> Path:
     env_path = os.environ.get("GRAPHIFY_SKILL_PATH")
     candidates: list[Path] = []
     if env_path:
         candidates.append(Path(env_path))
 
-    repo_root = Path(__file__).resolve().parents[3]
-    candidates.append(repo_root / "external" / "graphify" / "graphify" / "skill.md")
+    try:
+        resource = importlib.resources.files("graphify").joinpath("skill.md")
+        if resource.is_file():
+            with importlib.resources.as_file(resource) as resource_path:
+                candidates.append(resource_path)
+    except Exception:
+        pass
 
     try:
         import graphify  # type: ignore[import-not-found]
-
         candidates.append(Path(graphify.__file__).resolve().parent / "skill.md")
     except Exception:
         pass
 
+    try:
+        repo_root = Path(__file__).resolve().parents[3]
+    except IndexError:
+        repo_root = None
+    if repo_root is not None:
+        candidates.append(
+            repo_root / "external" / "graphify" / "graphify" / "skill.md"
+        )
+
     for candidate in candidates:
         if candidate.is_file():
             return candidate
-    return None
+
+    checked = ", ".join(str(candidate) for candidate in candidates) or "no candidates"
+    raise RuntimeError(
+        "Unable to locate graphify skill.md. Checked installed graphify package, "
+        f"repo checkout, and GRAPHIFY_SKILL_PATH. Candidates: {checked}"
+    )

--- a/apps/graphify-worker/src/claude_runner.py
+++ b/apps/graphify-worker/src/claude_runner.py
@@ -421,12 +421,22 @@ async def run_graphify(
     run_id: str, input_dir: Path | str, *, timeout: float | None = None
 ) -> dict[str, Any]:
     if os.environ.get("GRAPHIFY_RUNNER_MODE", "claude_code") == "disabled":
-        return {"status": "failed", "state": RunState.FAILED.value, "reason": "runner_disabled", "retryable": True}
+        return {
+            "status": "failed",
+            "state": RunState.FAILED.value,
+            "reason": "runner_disabled",
+            "retryable": True,
+        }
 
     if not os.environ.get("AGENT_ANTHROPIC_API_KEY") or not os.environ.get(
         "AGENT_ANTHROPIC_BASE_URL"
     ):
-        return {"status": "failed", "state": RunState.FAILED.value, "reason": "missing_api_key", "retryable": False}
+        return {
+            "status": "failed",
+            "state": RunState.FAILED.value,
+            "reason": "missing_api_key",
+            "retryable": False,
+        }
 
     preflight = preflight_check(input_dir)
     if not preflight.get("ok"):
@@ -753,6 +763,7 @@ def _find_graphify_skill() -> Path:
 
     try:
         import graphify  # type: ignore[import-not-found]
+
         candidates.append(Path(graphify.__file__).resolve().parent / "skill.md")
     except Exception:
         pass
@@ -762,9 +773,7 @@ def _find_graphify_skill() -> Path:
     except IndexError:
         repo_root = None
     if repo_root is not None:
-        candidates.append(
-            repo_root / "external" / "graphify" / "graphify" / "skill.md"
-        )
+        candidates.append(repo_root / "external" / "graphify" / "graphify" / "skill.md")
 
     for candidate in candidates:
         if candidate.is_file():

--- a/apps/graphify-worker/src/claude_runner.py
+++ b/apps/graphify-worker/src/claude_runner.py
@@ -1,0 +1,646 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, TypedDict
+
+
+SUBAGENT_TOOL_NAME = "Agent"
+ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", SUBAGENT_TOOL_NAME]
+CLAUDE_SPAWN_ARGS = [
+    "claude",
+    "--bare",
+    "-p",
+    "--input-format",
+    "stream-json",
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--permission-mode",
+    "bypassPermissions",
+]
+
+FIRST_GRAPHIFY_MESSAGE = (
+    "/graphify ./input --wiki\n\n"
+    "Worker mode: run autonomously. Do not ask questions. If the input is too "
+    "large or ambiguous, stop with a clear failure reason."
+)
+
+GRAPHIFY_RUN_ROOT = Path(os.environ.get("GRAPHIFY_RUN_ROOT", "/work/graphify"))
+DEFAULT_TIMEOUT_SECONDS = 3600
+DEFAULT_MAX_INPUT_FILES = 150
+DEFAULT_MAX_INPUT_WORDS = 1_500_000
+_SAFE_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_WAITING_FOR_INPUT_RE = re.compile(
+    r"("
+    r"\bplease\s+(choose|select|confirm|provide|clarify)\b|"
+    r"\bwhich\s+(files?|directory|option|one)\b|"
+    r"\bwould\s+you\s+like\b|"
+    r"\bdo\s+you\s+want\b|"
+    r"\bwaiting\s+for\s+(user\s+)?input\b|"
+    r"\bneed\s+(your|user)\s+(input|selection|clarification)\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+class RunState(str, Enum):
+    STARTING = "STARTING"
+    RUNNING = "RUNNING"
+    IDLE = "IDLE"
+    FINISHING = "FINISHING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
+class StreamEvent(TypedDict, total=False):
+    type: str
+    session_id: str | None
+    text: str
+    tool_uses: list[dict[str, Any]]
+    waiting_for_input: bool
+    is_error: bool
+    message: str
+    raw: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RunDirs:
+    run_dir: Path
+    session_dir: Path
+    input_dir: Path
+    home_dir: Path
+    config_dir: Path
+
+
+def prepare_run_dirs(run_id: str) -> RunDirs:
+    if not _SAFE_RUN_ID_RE.match(run_id):
+        raise ValueError(f"Invalid run_id for path use: {run_id!r}")
+
+    base = _run_root().resolve()
+    run_dir = (base / run_id).resolve()
+    if not run_dir.is_relative_to(base):
+        raise ValueError(f"run_dir escapes base: {run_dir}")
+
+    session_dir = run_dir / "session"
+    input_dir = session_dir / "input"
+    home_dir = session_dir / ".home"
+    config_dir = home_dir / ".claude"
+
+    input_dir.mkdir(parents=True, exist_ok=True)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return RunDirs(
+        run_dir=run_dir,
+        session_dir=session_dir,
+        input_dir=input_dir,
+        home_dir=home_dir,
+        config_dir=config_dir,
+    )
+
+
+def generate_settings(config_dir: Path | str) -> Path:
+    config_path = Path(config_dir)
+    config_path.mkdir(parents=True, exist_ok=True)
+    settings_path = config_path / "settings.json"
+    settings = {
+        "permissions": {
+            "allow": list(ALLOWED_TOOLS),
+            "deny": [],
+            "defaultMode": "bypassPermissions",
+        },
+        "allowedTools": list(ALLOWED_TOOLS),
+        "dangerouslySkipPermissions": True,
+        "disableAllHooks": True,
+    }
+    settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+    return settings_path
+
+
+def build_claude_env(
+    home_dir: Path | str | None = None, config_dir: Path | str | None = None
+) -> dict[str, str]:
+    home = str(home_dir or os.environ.get("HOME", ""))
+    claude_config = str(
+        config_dir
+        or os.environ.get("CLAUDE_CONFIG_DIR")
+        or (Path(home) / ".claude" if home else "")
+    )
+    model = os.environ.get("AGENT_ANTHROPIC_MODEL", "deepseek-v4-flash")
+
+    return {
+        "HOME": home,
+        "CLAUDE_CONFIG_DIR": claude_config,
+        "PATH": os.environ.get("PATH", ""),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "TMPDIR": os.environ.get("TMPDIR", tempfile.gettempdir()),
+        "DISABLE_AUTOUPDATER": "1",
+        "ANTHROPIC_API_KEY": os.environ.get("AGENT_ANTHROPIC_API_KEY", ""),
+        "ANTHROPIC_BASE_URL": os.environ.get("AGENT_ANTHROPIC_BASE_URL", ""),
+        "ANTHROPIC_MODEL": model,
+        "ANTHROPIC_DEFAULT_MODEL": model,
+    }
+
+
+def install_skill(config_dir: Path | str) -> Path:
+    config_path = Path(config_dir)
+    skill_dst = config_path / "skills" / "graphify" / "SKILL.md"
+    skill_dst.parent.mkdir(parents=True, exist_ok=True)
+
+    skill_src = _find_graphify_skill()
+    if skill_src is not None:
+        shutil.copy2(skill_src, skill_dst)
+        (skill_dst.parent / ".graphify_version").write_text(
+            "local", encoding="utf-8"
+        )
+        return skill_dst
+
+    env = {
+        "HOME": str(config_path.parent),
+        "CLAUDE_CONFIG_DIR": str(config_path),
+        "PATH": os.environ.get("PATH", ""),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+    }
+    subprocess.run(
+        ["graphify", "install"],
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if not skill_dst.exists():
+        raise RuntimeError(f"graphify install did not create {skill_dst}")
+    return skill_dst
+
+
+def spawn_claude(
+    session_dir: Path | str, config_dir: Path | str, settings_path: Path | str
+) -> subprocess.Popen[str]:
+    config_path = Path(config_dir)
+    args = [
+        *CLAUDE_SPAWN_ARGS,
+        "--settings",
+        str(settings_path),
+        "--tools",
+        ",".join(ALLOWED_TOOLS),
+    ]
+    return subprocess.Popen(
+        args,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(session_dir),
+        env=build_claude_env(config_path.parent, config_path),
+        text=True,
+        bufsize=1,
+    )
+
+
+def write_user_message(proc: subprocess.Popen[str], text: str) -> None:
+    if proc.stdin is None:
+        raise RuntimeError("Claude process stdin is not available")
+
+    payload = {"type": "user", "message": {"role": "user", "content": text}}
+    line = json.dumps(payload, separators=(",", ":")) + "\n"
+    try:
+        proc.stdin.write(line)
+    except TypeError:
+        proc.stdin.write(line.encode("utf-8"))  # type: ignore[arg-type]
+    proc.stdin.flush()
+
+
+def parse_stream_event(line: str | bytes) -> StreamEvent | None:
+    if isinstance(line, bytes):
+        line = line.decode("utf-8", errors="replace")
+    line = line.strip()
+    if not line:
+        return None
+
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    event_type = payload.get("type")
+    if event_type == "system":
+        return {
+            "type": "system",
+            "session_id": _optional_str(payload.get("session_id")),
+            "raw": payload,
+        }
+
+    if event_type == "assistant":
+        text, tool_uses = _assistant_content(payload)
+        return {
+            "type": "assistant",
+            "text": text,
+            "tool_uses": tool_uses,
+            "waiting_for_input": assistant_waiting_for_input(text),
+            "raw": payload,
+        }
+
+    if event_type == "result":
+        is_error = _result_is_error(payload)
+        return {
+            "type": "result",
+            "is_error": is_error,
+            "message": _result_message(payload),
+            "raw": payload,
+        }
+
+    if event_type == "error":
+        return {
+            "type": "error",
+            "message": _stringify_error(payload.get("error") or payload.get("message")),
+            "raw": payload,
+        }
+
+    return None
+
+
+def assistant_waiting_for_input(text: str) -> bool:
+    return bool(_WAITING_FOR_INPUT_RE.search(text))
+
+
+def preflight_check(input_dir: Path | str) -> dict[str, Any]:
+    input_path = Path(input_dir)
+    if not input_path.is_dir():
+        return {
+            "ok": False,
+            "reason": "input_missing",
+            "file_count": 0,
+            "total_words": 0,
+        }
+
+    max_files = _env_int("GRAPHIFY_MAX_INPUT_FILES", DEFAULT_MAX_INPUT_FILES)
+    max_words = _env_int("GRAPHIFY_MAX_INPUT_WORDS", DEFAULT_MAX_INPUT_WORDS)
+
+    files = sorted(path for path in input_path.rglob("*") if path.is_file())
+    file_count = len(files)
+    if file_count > max_files:
+        return {
+            "ok": False,
+            "reason": "input_too_large",
+            "file_count": file_count,
+            "total_words": 0,
+        }
+
+    total_words = 0
+    for path in files:
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore")
+            total_words += len(content.split())
+        except OSError:
+            continue
+        if total_words > max_words:
+            return {
+                "ok": False,
+                "reason": "input_too_large",
+                "file_count": file_count,
+                "total_words": total_words,
+            }
+
+    return {"ok": True, "file_count": file_count, "total_words": total_words}
+
+
+def output_complete(session_dir: Path | str) -> bool:
+    return (Path(session_dir) / "graphify-out" / "graph.json").is_file()
+
+
+def resolve_idle_state(
+    session_dir: Path | str,
+    *,
+    assistant_waiting_for_input: bool,
+    proc: subprocess.Popen[str] | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    if output_complete(session_dir):
+        _request_terminate(proc)
+        output_dir = Path(session_dir) / "graphify-out"
+        return {
+            "status": "success",
+            "state": RunState.SUCCEEDED.value,
+            "session_id": session_id,
+            "output_dir": str(output_dir),
+            "graph_json_path": str(output_dir / "graph.json"),
+            "wiki_output_path": str(output_dir / "wiki"),
+            "report_path": str(output_dir / "GRAPH_REPORT.md"),
+        }
+
+    _request_terminate(proc)
+    if assistant_waiting_for_input:
+        return {
+            "status": "failed",
+            "state": RunState.FAILED.value,
+            "reason": "requires_interaction",
+            "retryable": False,
+            "session_id": session_id,
+        }
+
+    return {
+        "status": "failed",
+        "state": RunState.FAILED.value,
+        "reason": "empty_output",
+        "retryable": False,
+        "session_id": session_id,
+    }
+
+
+async def run_graphify(
+    run_id: str, input_dir: Path | str, *, timeout: float | None = None
+) -> dict[str, Any]:
+    if os.environ.get("GRAPHIFY_RUNNER_MODE", "claude_code") == "disabled":
+        return {"reason": "runner_disabled", "retryable": True}
+
+    if not os.environ.get("AGENT_ANTHROPIC_API_KEY") or not os.environ.get(
+        "AGENT_ANTHROPIC_BASE_URL"
+    ):
+        return {"reason": "missing_api_key"}
+
+    preflight = preflight_check(input_dir)
+    if not preflight.get("ok"):
+        return preflight
+
+    dirs = prepare_run_dirs(run_id)
+    _copy_inputs(Path(input_dir), dirs.input_dir)
+    install_skill(dirs.config_dir)
+    settings_path = generate_settings(dirs.config_dir)
+    proc = spawn_claude(dirs.session_dir, dirs.config_dir, settings_path)
+    write_user_message(proc, FIRST_GRAPHIFY_MESSAGE)
+
+    timeout_seconds = timeout
+    if timeout_seconds is None:
+        timeout_seconds = _env_int("GRAPHIFY_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS)
+
+    return await _run_stream_loop(proc, dirs.session_dir, float(timeout_seconds))
+
+
+async def _run_stream_loop(
+    proc: subprocess.Popen[str], session_dir: Path, timeout_seconds: float
+) -> dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    state = RunState.STARTING
+    session_id: str | None = None
+    waiting_for_input = False
+
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return await _terminate_for_timeout(proc)
+
+        try:
+            line = await asyncio.wait_for(
+                asyncio.to_thread(_read_stdout_line, proc),
+                timeout=remaining,
+            )
+        except TimeoutError:
+            return await _terminate_for_timeout(proc)
+
+        if line == "":
+            if output_complete(session_dir):
+                return resolve_idle_state(
+                    session_dir,
+                    assistant_waiting_for_input=False,
+                    proc=proc,
+                    session_id=session_id,
+                )
+            return {
+                "status": "failed",
+                "state": RunState.FAILED.value,
+                "reason": "claude_exited",
+                "retryable": True,
+                "session_id": session_id,
+            }
+
+        event = parse_stream_event(line)
+        if event is None:
+            continue
+
+        if event["type"] == "system":
+            session_id = event.get("session_id")
+            state = RunState.RUNNING
+            continue
+
+        if event["type"] == "assistant":
+            state = RunState.RUNNING
+            waiting_for_input = waiting_for_input or bool(
+                event.get("waiting_for_input")
+            )
+            continue
+
+        if event["type"] == "error":
+            _request_terminate(proc)
+            await _wait_for_process_exit(proc, 10)
+            return {
+                "status": "failed",
+                "state": RunState.FAILED.value,
+                "reason": "claude_error",
+                "message": event.get("message", ""),
+                "retryable": True,
+                "session_id": session_id,
+            }
+
+        if event["type"] == "result":
+            if event.get("is_error"):
+                _request_terminate(proc)
+                await _wait_for_process_exit(proc, 10)
+                return {
+                    "status": "failed",
+                    "state": RunState.FAILED.value,
+                    "reason": "claude_result_error",
+                    "message": event.get("message", ""),
+                    "retryable": True,
+                    "session_id": session_id,
+                }
+
+            state = RunState.IDLE
+            result = resolve_idle_state(
+                session_dir,
+                assistant_waiting_for_input=waiting_for_input,
+                proc=proc,
+                session_id=session_id,
+            )
+            await _wait_for_process_exit(proc, 10)
+            return result
+
+        if state == RunState.FAILED:
+            return {
+                "status": "failed",
+                "state": RunState.FAILED.value,
+                "reason": "unknown",
+                "retryable": True,
+                "session_id": session_id,
+            }
+
+
+async def _terminate_for_timeout(proc: subprocess.Popen[str]) -> dict[str, Any]:
+    _request_terminate(proc)
+    try:
+        await _wait_for_process_exit(proc, 10)
+    except TimeoutError:
+        _request_kill(proc)
+        await _wait_for_process_exit(proc, 10)
+    return {
+        "status": "failed",
+        "state": RunState.FAILED.value,
+        "reason": "timeout",
+        "retryable": True,
+    }
+
+
+async def _wait_for_process_exit(
+    proc: subprocess.Popen[str], timeout: float
+) -> int | None:
+    wait = getattr(proc, "wait", None)
+    if wait is None:
+        return None
+    return await asyncio.wait_for(asyncio.to_thread(wait), timeout=timeout)
+
+
+def _request_terminate(proc: subprocess.Popen[str] | None) -> None:
+    if proc is None:
+        return
+    poll = getattr(proc, "poll", None)
+    if poll is not None and poll() is not None:
+        return
+    terminate = getattr(proc, "terminate", None)
+    if terminate is not None:
+        terminate()
+
+
+def _request_kill(proc: subprocess.Popen[str]) -> None:
+    kill = getattr(proc, "kill", None)
+    if kill is not None:
+        kill()
+
+
+def _read_stdout_line(proc: subprocess.Popen[str]) -> str:
+    if proc.stdout is None:
+        return ""
+    return proc.stdout.readline()
+
+
+def _copy_inputs(src_dir: Path, dst_dir: Path) -> None:
+    if src_dir.resolve() == dst_dir.resolve():
+        return
+    for src in src_dir.rglob("*"):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(src_dir)
+        dst = dst_dir / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+
+def _assistant_content(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
+    message = payload.get("message") if isinstance(payload.get("message"), dict) else {}
+    content = message.get("content", payload.get("content", []))
+    texts: list[str] = []
+    tool_uses: list[dict[str, Any]] = []
+
+    if isinstance(payload.get("text"), str):
+        texts.append(payload["text"])
+    if isinstance(content, str):
+        texts.append(content)
+    elif isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type == "text" and isinstance(item.get("text"), str):
+                texts.append(item["text"])
+            elif item_type in {"tool_use", "toolUse"}:
+                tool_uses.append(item)
+
+    return "\n".join(texts), tool_uses
+
+
+def _result_is_error(payload: dict[str, Any]) -> bool:
+    result = payload.get("result")
+    if isinstance(result, dict) and "is_error" in result:
+        return bool(result["is_error"])
+    if "is_error" in payload:
+        return bool(payload["is_error"])
+
+    subtype = _optional_str(payload.get("subtype"))
+    if subtype is None and isinstance(result, dict):
+        subtype = _optional_str(result.get("subtype"))
+    if subtype is None:
+        return False
+    subtype = subtype.lower()
+    return subtype.startswith("error") or subtype in {"failed", "failure"}
+
+
+def _result_message(payload: dict[str, Any]) -> str:
+    result = payload.get("result")
+    if isinstance(result, dict):
+        for key in ("message", "error", "error_message"):
+            if result.get(key):
+                return _stringify_error(result[key])
+    for key in ("message", "error", "error_message"):
+        if payload.get(key):
+            return _stringify_error(payload[key])
+    if isinstance(result, str):
+        return result
+    return ""
+
+
+def _stringify_error(error: Any) -> str:
+    if error is None:
+        return ""
+    if isinstance(error, str):
+        return error
+    if isinstance(error, dict):
+        message = error.get("message") or error.get("error")
+        if message:
+            return str(message)
+    return json.dumps(error, sort_keys=True)
+
+
+def _optional_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def _run_root() -> Path:
+    return Path(os.environ.get("GRAPHIFY_RUN_ROOT", str(GRAPHIFY_RUN_ROOT)))
+
+
+def _find_graphify_skill() -> Path | None:
+    env_path = os.environ.get("GRAPHIFY_SKILL_PATH")
+    candidates: list[Path] = []
+    if env_path:
+        candidates.append(Path(env_path))
+
+    repo_root = Path(__file__).resolve().parents[3]
+    candidates.append(repo_root / "external" / "graphify" / "graphify" / "skill.md")
+
+    try:
+        import graphify  # type: ignore[import-not-found]
+
+        candidates.append(Path(graphify.__file__).resolve().parent / "skill.md")
+    except Exception:
+        pass
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None

--- a/apps/graphify-worker/tests/test_claude_runner.py
+++ b/apps/graphify-worker/tests/test_claude_runner.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src import claude_runner
+
+
+def test_generate_settings_does_not_contain_api_key_strings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_ANTHROPIC_API_KEY", "secret-api-key")
+    monkeypatch.setenv("DATABASE_URL", "postgres://secret-db")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "secret-minio")
+    monkeypatch.setenv("WORKER_API_KEY", "secret-worker")
+
+    settings_path = claude_runner.generate_settings(tmp_path / ".claude")
+
+    content = settings_path.read_text(encoding="utf-8")
+    assert "secret-api-key" not in content
+    assert "secret-db" not in content
+    assert "secret-minio" not in content
+    assert "secret-worker" not in content
+
+
+def test_build_claude_env_uses_allowlist_and_maps_agent_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "home" / ".claude"))
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("LANG", "C.UTF-8")
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "tmp"))
+    monkeypatch.setenv("AGENT_ANTHROPIC_API_KEY", "agent-key")
+    monkeypatch.setenv("AGENT_ANTHROPIC_BASE_URL", "https://agent.test")
+    monkeypatch.setenv("AGENT_ANTHROPIC_MODEL", "deepseek-v4-flash")
+    monkeypatch.setenv("DATABASE_URL", "postgres://db")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "minio-access")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "minio-secret")
+    monkeypatch.setenv("WORKER_API_KEY", "worker-secret")
+
+    env = claude_runner.build_claude_env()
+
+    assert env["ANTHROPIC_API_KEY"] == "agent-key"
+    assert env["ANTHROPIC_BASE_URL"] == "https://agent.test"
+    assert env["ANTHROPIC_MODEL"] == "deepseek-v4-flash"
+    assert env["ANTHROPIC_DEFAULT_MODEL"] == "deepseek-v4-flash"
+    assert "DATABASE_URL" not in env
+    assert "WORKER_API_KEY" not in env
+    assert not any(key.startswith("MINIO_") for key in env)
+    assert set(env) == {
+        "HOME",
+        "CLAUDE_CONFIG_DIR",
+        "PATH",
+        "LANG",
+        "TMPDIR",
+        "DISABLE_AUTOUPDATER",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_DEFAULT_MODEL",
+    }
+
+
+def test_install_skill_creates_skill_md_at_config_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_skill = tmp_path / "source" / "skill.md"
+    source_skill.parent.mkdir()
+    source_skill.write_text("# graphify\n", encoding="utf-8")
+    monkeypatch.setenv("GRAPHIFY_SKILL_PATH", str(source_skill))
+
+    skill_path = claude_runner.install_skill(tmp_path / ".claude")
+
+    assert skill_path == tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md"
+    assert skill_path.read_text(encoding="utf-8") == "# graphify\n"
+
+
+def test_spawn_claude_uses_required_stream_json_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePopen:
+        def __init__(self, args: list[str], **kwargs: Any) -> None:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(claude_runner.subprocess, "Popen", FakePopen)
+
+    claude_runner.spawn_claude(
+        tmp_path / "session", tmp_path / ".claude", tmp_path / ".claude/settings.json"
+    )
+
+    args = captured["args"]
+    assert args[:1] == ["claude"]
+    assert "--bare" in args
+    assert "-p" in args
+    assert _arg_value(args, "--input-format") == "stream-json"
+    assert _arg_value(args, "--output-format") == "stream-json"
+    assert _arg_value(args, "--permission-mode") == "bypassPermissions"
+    assert captured["kwargs"]["stdin"] is claude_runner.subprocess.PIPE
+    assert captured["kwargs"]["stdout"] is claude_runner.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] is claude_runner.subprocess.PIPE
+    assert captured["kwargs"]["cwd"] == str(tmp_path / "session")
+
+
+def test_write_user_message_outputs_stream_json_user_line() -> None:
+    proc = FakeProc()
+
+    claude_runner.write_user_message(proc, "hello")
+
+    payload = json.loads(proc.stdin.getvalue())
+    assert payload == {
+        "type": "user",
+        "message": {"role": "user", "content": "hello"},
+    }
+
+
+def test_parse_stream_event_parses_system() -> None:
+    event = claude_runner.parse_stream_event(
+        '{"type":"system","session_id":"session-1"}'
+    )
+
+    assert event == {
+        "type": "system",
+        "session_id": "session-1",
+        "raw": {"type": "system", "session_id": "session-1"},
+    }
+
+
+def test_parse_stream_event_parses_assistant_text_and_tool_use() -> None:
+    line = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Working"},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                ],
+            },
+        }
+    )
+
+    event = claude_runner.parse_stream_event(line)
+
+    assert event is not None
+    assert event["type"] == "assistant"
+    assert event["text"] == "Working"
+    assert event["tool_uses"][0]["name"] == "Bash"
+
+
+def test_parse_stream_event_parses_result_success() -> None:
+    event = claude_runner.parse_stream_event(
+        '{"type":"result","result":{"is_error":false}}'
+    )
+
+    assert event is not None
+    assert event["type"] == "result"
+    assert event["is_error"] is False
+
+
+def test_parse_stream_event_parses_result_error() -> None:
+    event = claude_runner.parse_stream_event(
+        '{"type":"result","result":{"is_error":true,"error":"bad"}}'
+    )
+
+    assert event is not None
+    assert event["type"] == "result"
+    assert event["is_error"] is True
+    assert event["message"] == "bad"
+
+
+def test_parse_stream_event_parses_error_event() -> None:
+    event = claude_runner.parse_stream_event(
+        '{"type":"error","error":{"message":"boom"}}'
+    )
+
+    assert event is not None
+    assert event["type"] == "error"
+    assert event["message"] == "boom"
+    assert claude_runner.parse_stream_event("not json") is None
+
+
+def test_idle_with_complete_output_succeeds_and_terminates(tmp_path: Path) -> None:
+    proc = FakeProc()
+    output_dir = tmp_path / "graphify-out"
+    output_dir.mkdir()
+    (output_dir / "graph.json").write_text('{"nodes":[],"links":[]}', encoding="utf-8")
+
+    result = claude_runner.resolve_idle_state(
+        tmp_path, assistant_waiting_for_input=False, proc=proc
+    )
+
+    assert result["state"] == "SUCCEEDED"
+    assert result["status"] == "success"
+    assert result["graph_json_path"] == str(output_dir / "graph.json")
+    assert proc.terminated is True
+
+
+def test_idle_with_missing_output_and_waiting_fails_requires_interaction(
+    tmp_path: Path,
+) -> None:
+    proc = FakeProc()
+
+    result = claude_runner.resolve_idle_state(
+        tmp_path, assistant_waiting_for_input=True, proc=proc
+    )
+
+    assert result["state"] == "FAILED"
+    assert result["reason"] == "requires_interaction"
+    assert result["retryable"] is False
+    assert proc.terminated is True
+
+
+def test_timeout_sends_sigterm_after_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_dir = _input_dir(tmp_path)
+    fake_proc = FakeProc(stdout=BlockingStdout())
+    _enable_runner(monkeypatch, tmp_path)
+
+    def fake_popen(*_args: Any, **_kwargs: Any) -> FakeProc:
+        return fake_proc
+
+    monkeypatch.setattr(claude_runner.subprocess, "Popen", fake_popen)
+
+    result = asyncio.run(claude_runner.run_graphify("run-1", input_dir, timeout=0.01))
+
+    assert result["reason"] == "timeout"
+    assert fake_proc.terminated is True
+    assert fake_proc.killed is False
+
+
+def test_preflight_151_files_fails_input_too_large(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GRAPHIFY_MAX_INPUT_FILES", raising=False)
+    monkeypatch.delenv("GRAPHIFY_MAX_INPUT_WORDS", raising=False)
+    for index in range(151):
+        (tmp_path / f"{index}.md").write_text("word", encoding="utf-8")
+
+    result = claude_runner.preflight_check(tmp_path)
+
+    assert result["reason"] == "input_too_large"
+    assert result["file_count"] == 151
+
+
+def test_preflight_1500001_words_fails_input_too_large(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GRAPHIFY_MAX_INPUT_FILES", raising=False)
+    monkeypatch.delenv("GRAPHIFY_MAX_INPUT_WORDS", raising=False)
+    (tmp_path / "large.md").write_text("w " * 1_500_001, encoding="utf-8")
+
+    result = claude_runner.preflight_check(tmp_path)
+
+    assert result["reason"] == "input_too_large"
+    assert result["total_words"] == 1_500_001
+
+
+def test_preflight_within_limits_returns_ok(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text("one two", encoding="utf-8")
+    (tmp_path / "b.md").write_text("three", encoding="utf-8")
+
+    result = claude_runner.preflight_check(tmp_path)
+
+    assert result == {"ok": True, "file_count": 2, "total_words": 3}
+
+
+def test_run_graphify_within_preflight_limits_proceeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_dir = _input_dir(tmp_path)
+    fake_proc = FakeProc(
+        stdout=LineStdout(
+            [
+                '{"type":"system","session_id":"session-1"}\n',
+                '{"type":"result","result":{"is_error":false}}\n',
+            ]
+        )
+    )
+    spawned: list[Path] = []
+    _enable_runner(monkeypatch, tmp_path)
+
+    def fake_spawn(
+        session_dir: Path, _config_dir: Path, _settings_path: Path
+    ) -> FakeProc:
+        spawned.append(session_dir)
+        output_dir = session_dir / "graphify-out"
+        output_dir.mkdir()
+        (output_dir / "graph.json").write_text(
+            '{"nodes":[],"links":[]}', encoding="utf-8"
+        )
+        return fake_proc
+
+    monkeypatch.setattr(claude_runner, "spawn_claude", fake_spawn)
+
+    result = asyncio.run(claude_runner.run_graphify("run-1", input_dir, timeout=1))
+
+    assert result["status"] == "success"
+    assert result["session_id"] == "session-1"
+    assert spawned == [tmp_path / "work" / "run-1" / "session"]
+    assert "/graphify ./input --wiki" in fake_proc.stdin.getvalue()
+
+
+def test_runner_disabled_returns_immediate_retryable_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GRAPHIFY_RUNNER_MODE", "disabled")
+
+    def fail_spawn(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("disabled runner must not spawn Claude")
+
+    monkeypatch.setattr(claude_runner, "spawn_claude", fail_spawn)
+
+    result = asyncio.run(claude_runner.run_graphify("run-1", tmp_path))
+
+    assert result == {"reason": "runner_disabled", "retryable": True}
+
+
+def test_missing_api_key_returns_immediate_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GRAPHIFY_RUNNER_MODE", "claude_code")
+    monkeypatch.delenv("AGENT_ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("AGENT_ANTHROPIC_BASE_URL", "https://agent.test")
+
+    def fail_spawn(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("missing API key must not spawn Claude")
+
+    monkeypatch.setattr(claude_runner, "spawn_claude", fail_spawn)
+
+    result = asyncio.run(claude_runner.run_graphify("run-1", tmp_path))
+
+    assert result == {"reason": "missing_api_key"}
+
+
+def test_subagent_tool_name_is_agent() -> None:
+    assert claude_runner.SUBAGENT_TOOL_NAME == "Agent"
+
+
+def test_settings_and_spawn_tool_lists_are_consistent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakePopen:
+        def __init__(self, args: list[str], **kwargs: Any) -> None:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(claude_runner.subprocess, "Popen", FakePopen)
+    settings_path = claude_runner.generate_settings(tmp_path / ".claude")
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+
+    claude_runner.spawn_claude(
+        tmp_path / "session", tmp_path / ".claude", settings_path
+    )
+
+    spawn_tools = _arg_value(captured["args"], "--tools").split(",")
+    assert settings["permissions"]["allow"] == spawn_tools
+    assert settings["allowedTools"] == spawn_tools
+    assert spawn_tools == claude_runner.ALLOWED_TOOLS
+
+
+def _arg_value(args: list[str], name: str) -> str:
+    index = args.index(name)
+    return args[index + 1]
+
+
+def _input_dir(tmp_path: Path) -> Path:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    (input_dir / "doc.md").write_text("hello world", encoding="utf-8")
+    return input_dir
+
+
+def _enable_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("GRAPHIFY_RUNNER_MODE", "claude_code")
+    monkeypatch.setenv("AGENT_ANTHROPIC_API_KEY", "agent-key")
+    monkeypatch.setenv("AGENT_ANTHROPIC_BASE_URL", "https://agent.test")
+    monkeypatch.setattr(claude_runner, "GRAPHIFY_RUN_ROOT", tmp_path / "work")
+    monkeypatch.delenv("GRAPHIFY_RUN_ROOT", raising=False)
+
+
+class LineStdout:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    def readline(self) -> str:
+        if not self._lines:
+            return ""
+        return self._lines.pop(0)
+
+
+class BlockingStdout:
+    def readline(self) -> str:
+        time.sleep(0.2)
+        return ""
+
+
+class FakeProc:
+    def __init__(self, stdout: Any | None = None) -> None:
+        self.stdin = io.StringIO()
+        self.stdout = stdout or LineStdout([])
+        self.stderr = io.StringIO()
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return 0 if self.terminated or self.killed else None
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def wait(self) -> int:
+        return 0

--- a/apps/graphify-worker/tests/test_claude_runner.py
+++ b/apps/graphify-worker/tests/test_claude_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,9 @@ def test_build_claude_env_uses_allowlist_and_maps_agent_env(
     assert env["ANTHROPIC_BASE_URL"] == "https://agent.test"
     assert env["ANTHROPIC_MODEL"] == "deepseek-v4-flash"
     assert env["ANTHROPIC_DEFAULT_MODEL"] == "deepseek-v4-flash"
+    assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "deepseek-v4-flash"
+    assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "deepseek-v4-flash"
+    assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "deepseek-v4-flash"
     assert "DATABASE_URL" not in env
     assert "WORKER_API_KEY" not in env
     assert not any(key.startswith("MINIO_") for key in env)
@@ -65,6 +69,9 @@ def test_build_claude_env_uses_allowlist_and_maps_agent_env(
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_MODEL",
         "ANTHROPIC_DEFAULT_MODEL",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
     }
 
 
@@ -75,11 +82,54 @@ def test_install_skill_creates_skill_md_at_config_path(
     source_skill.parent.mkdir()
     source_skill.write_text("# graphify\n", encoding="utf-8")
     monkeypatch.setenv("GRAPHIFY_SKILL_PATH", str(source_skill))
+    monkeypatch.setattr(claude_runner.subprocess, "run", _raise_graphify_missing)
 
     skill_path = claude_runner.install_skill(tmp_path / ".claude")
 
     assert skill_path == tmp_path / ".claude" / "skills" / "graphify" / "SKILL.md"
     assert skill_path.read_text(encoding="utf-8") == "# graphify\n"
+
+
+def test_install_skill_prefers_graphify_install_with_claude_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+    config_dir = tmp_path / ".claude"
+
+    def fake_run(args: list[str], **kwargs: Any) -> None:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        skill_path = config_dir / "skills" / "graphify" / "SKILL.md"
+        skill_path.parent.mkdir(parents=True, exist_ok=True)
+        skill_path.write_text("# graphify cli\n", encoding="utf-8")
+
+    monkeypatch.setattr(claude_runner.subprocess, "run", fake_run)
+
+    skill_path = claude_runner.install_skill(config_dir)
+
+    assert captured["args"] == ["graphify", "install"]
+    assert captured["kwargs"]["env"]["CLAUDE_CONFIG_DIR"] == str(config_dir)
+    assert skill_path.read_text(encoding="utf-8") == "# graphify cli\n"
+
+
+def test_install_skill_uses_installed_package_with_shallow_module_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_root = tmp_path / "site-packages"
+    graphify_pkg = package_root / "graphify"
+    graphify_pkg.mkdir(parents=True)
+    (graphify_pkg / "__init__.py").write_text("", encoding="utf-8")
+    (graphify_pkg / "skill.md").write_text("# installed graphify\n", encoding="utf-8")
+
+    monkeypatch.syspath_prepend(str(package_root))
+    monkeypatch.delitem(sys.modules, "graphify", raising=False)
+    monkeypatch.delenv("GRAPHIFY_SKILL_PATH", raising=False)
+    monkeypatch.setattr(claude_runner, "__file__", "/app/src/claude_runner.py")
+    monkeypatch.setattr(claude_runner.subprocess, "run", _raise_graphify_missing)
+
+    skill_path = claude_runner.install_skill(tmp_path / ".claude")
+
+    assert skill_path.read_text(encoding="utf-8") == "# installed graphify\n"
 
 
 def test_spawn_claude_uses_required_stream_json_args(
@@ -107,7 +157,7 @@ def test_spawn_claude_uses_required_stream_json_args(
     assert _arg_value(args, "--permission-mode") == "bypassPermissions"
     assert captured["kwargs"]["stdin"] is claude_runner.subprocess.PIPE
     assert captured["kwargs"]["stdout"] is claude_runner.subprocess.PIPE
-    assert captured["kwargs"]["stderr"] is claude_runner.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] is claude_runner.subprocess.DEVNULL
     assert captured["kwargs"]["cwd"] == str(tmp_path / "session")
 
 
@@ -194,6 +244,9 @@ def test_idle_with_complete_output_succeeds_and_terminates(tmp_path: Path) -> No
     output_dir = tmp_path / "graphify-out"
     output_dir.mkdir()
     (output_dir / "graph.json").write_text('{"nodes":[],"links":[]}', encoding="utf-8")
+    wiki_dir = output_dir / "wiki"
+    wiki_dir.mkdir()
+    (wiki_dir / "index.md").write_text("# Index\n", encoding="utf-8")
 
     result = claude_runner.resolve_idle_state(
         tmp_path, assistant_waiting_for_input=False, proc=proc
@@ -203,6 +256,14 @@ def test_idle_with_complete_output_succeeds_and_terminates(tmp_path: Path) -> No
     assert result["status"] == "success"
     assert result["graph_json_path"] == str(output_dir / "graph.json")
     assert proc.terminated is True
+
+
+def test_output_complete_requires_wiki_markdown(tmp_path: Path) -> None:
+    output_dir = tmp_path / "graphify-out"
+    output_dir.mkdir()
+    (output_dir / "graph.json").write_text('{"nodes":[],"links":[]}', encoding="utf-8")
+
+    assert claude_runner.output_complete(tmp_path) is False
 
 
 def test_idle_with_missing_output_and_waiting_fails_requires_interaction(
@@ -275,6 +336,40 @@ def test_preflight_within_limits_returns_ok(tmp_path: Path) -> None:
     assert result == {"ok": True, "file_count": 2, "total_words": 3}
 
 
+def test_preflight_rejects_symlinked_input_files(tmp_path: Path) -> None:
+    target = tmp_path / "outside.md"
+    target.write_text("secret", encoding="utf-8")
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    try:
+        (input_dir / "linked.md").symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    result = claude_runner.preflight_check(input_dir)
+
+    assert result["ok"] is False
+    assert result["reason"] == "input_symlink_rejected"
+    assert result["path"] == str(input_dir / "linked.md")
+
+
+def test_prepare_run_dirs_clears_existing_session_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(claude_runner, "GRAPHIFY_RUN_ROOT", tmp_path / "work")
+    monkeypatch.delenv("GRAPHIFY_RUN_ROOT", raising=False)
+    stale_file = tmp_path / "work" / "run-1" / "session" / "graphify-out" / "graph.json"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("stale", encoding="utf-8")
+
+    dirs = claude_runner.prepare_run_dirs("run-1")
+
+    assert dirs.session_dir == tmp_path / "work" / "run-1" / "session"
+    assert not stale_file.exists()
+    assert dirs.input_dir.is_dir()
+    assert dirs.config_dir.is_dir()
+
+
 def test_run_graphify_within_preflight_limits_proceeds(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -299,6 +394,9 @@ def test_run_graphify_within_preflight_limits_proceeds(
         (output_dir / "graph.json").write_text(
             '{"nodes":[],"links":[]}', encoding="utf-8"
         )
+        wiki_dir = output_dir / "wiki"
+        wiki_dir.mkdir()
+        (wiki_dir / "index.md").write_text("# Index\n", encoding="utf-8")
         return fake_proc
 
     monkeypatch.setattr(claude_runner, "spawn_claude", fake_spawn)
@@ -323,7 +421,10 @@ def test_runner_disabled_returns_immediate_retryable_failure(
 
     result = asyncio.run(claude_runner.run_graphify("run-1", tmp_path))
 
-    assert result == {"reason": "runner_disabled", "retryable": True}
+    assert result["reason"] == "runner_disabled"
+    assert result["retryable"] is True
+    assert result["status"] == "failed"
+    assert result["state"] == "FAILED"
 
 
 def test_missing_api_key_returns_immediate_failure(
@@ -340,7 +441,9 @@ def test_missing_api_key_returns_immediate_failure(
 
     result = asyncio.run(claude_runner.run_graphify("run-1", tmp_path))
 
-    assert result == {"reason": "missing_api_key"}
+    assert result["reason"] == "missing_api_key"
+    assert result["status"] == "failed"
+    assert result["state"] == "FAILED"
 
 
 def test_subagent_tool_name_is_agent() -> None:
@@ -376,6 +479,10 @@ def _arg_value(args: list[str], name: str) -> str:
     return args[index + 1]
 
 
+def _raise_graphify_missing(*_args: Any, **_kwargs: Any) -> None:
+    raise FileNotFoundError("graphify")
+
+
 def _input_dir(tmp_path: Path) -> Path:
     input_dir = tmp_path / "input"
     input_dir.mkdir()
@@ -389,6 +496,14 @@ def _enable_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("AGENT_ANTHROPIC_BASE_URL", "https://agent.test")
     monkeypatch.setattr(claude_runner, "GRAPHIFY_RUN_ROOT", tmp_path / "work")
     monkeypatch.delenv("GRAPHIFY_RUN_ROOT", raising=False)
+
+    def fake_install_skill(config_dir: Path | str) -> Path:
+        skill_path = Path(config_dir) / "skills" / "graphify" / "SKILL.md"
+        skill_path.parent.mkdir(parents=True, exist_ok=True)
+        skill_path.write_text("# graphify\n", encoding="utf-8")
+        return skill_path
+
+    monkeypatch.setattr(claude_runner, "install_skill", fake_install_skill)
 
 
 class LineStdout:
@@ -409,7 +524,7 @@ class BlockingStdout:
 
 class FakeProc:
     def __init__(self, stdout: Any | None = None) -> None:
-        self.stdin = io.StringIO()
+        self.stdin = InspectableStringIO()
         self.stdout = stdout or LineStdout([])
         self.stderr = io.StringIO()
         self.terminated = False
@@ -426,3 +541,8 @@ class FakeProc:
 
     def wait(self) -> int:
         return 0
+
+
+class InspectableStringIO(io.StringIO):
+    def close(self) -> None:
+        pass


### PR DESCRIPTION
## Summary

Part of #163. Depends on #164 (merged).

- New `apps/graphify-worker/src/claude_runner.py` (700+ lines): Claude Code process manager for executing `/graphify` skill via stream-json bidirectional protocol
- New `apps/graphify-worker/tests/test_claude_runner.py` (460+ lines): 26 unit tests covering all spec scenarios
- Key components: isolated dirs, settings generation (no secrets), env allowlist (with ANTHROPIC_DEFAULT_*_MODEL), skill installation (Docker-resilient), spawn args, stream-json parser, multi-turn state machine, timeout/SIGKILL, input preflight (symlink rejection), process cleanup

Closes #165

## Agent Review

- Reviewer agents used: Spec Compliance, Correctness, Integration, Security & Performance
- Reviewed head SHA: `87c110d1c16659b02558f344717cbd2b90d9c4ab`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/178#issuecomment-4394397984) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/178#issuecomment-4394398103) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/178#issuecomment-4394398197) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/178#issuecomment-4394398324)
- Key findings addressed: Fixed install_skill Docker path resilience, added ANTHROPIC_DEFAULT_*_MODEL env vars, expanded output_complete to check wiki/*.md, redirected stderr to DEVNULL, added try/finally cleanup, rejected symlinks in preflight, consistent return envelope with status/state/retryable

## Test plan

- [x] 26 unit tests pass (`pytest test_claude_runner.py`)
- [x] 56 total graphify-worker tests pass (no regression)
- [x] ruff format check passes
- [ ] Smoke test: `--bare -p --input-format stream-json` on pinned Claude Code version