### PR TITLE
feat(graphify-worker): rewrite runner.py to use claude_runner (#166)

### DIFF
--- a/apps/graphify-worker/src/runner.py
+++ b/apps/graphify-worker/src/runner.py
@@ -29,7 +29,9 @@ _SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 async def run(job_data: dict[str, Any]) -> dict[str, Any]:
     if os.environ.get("GRAPHIFY_RUNNER_MODE", "claude_code") == "disabled":
         raise RuntimeError(json.dumps({"reason": "runner_disabled", "retryable": True}))
-    if not os.environ.get("AGENT_ANTHROPIC_API_KEY"):
+    if not os.environ.get("AGENT_ANTHROPIC_API_KEY") or not os.environ.get(
+        "AGENT_ANTHROPIC_BASE_URL"
+    ):
         raise RuntimeError(json.dumps({"reason": "missing_api_key"}))
 
     job_id = job_data.get("id") or job_data.get("job_id")
@@ -68,10 +70,14 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
         result = await claude_runner.run_graphify(
             run_id, str(input_dir), timeout=GRAPHIFY_TIMEOUT
         )
-        if result.get("status") == "failed":
+        if result.get("status") != "success":
             raise RuntimeError(json.dumps(result))
 
         output_dir = _output_dir_from_result(result)
+        if output_dir.is_symlink():
+            raise RuntimeError(
+                json.dumps({"reason": "output_dir_symlink", "path": str(output_dir)})
+            )
 
         validation = _validate_output(
             output_dir, run_id=run_id, graphify_ref=GRAPHIFY_REF
@@ -110,11 +116,17 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
                 "wiki_page_count": validation.get("wiki_page_count", 0),
                 "total_output_bytes": validation.get("total_output_bytes", 0),
             },
-            "schema_version": "1",
+            "schema_version": "v1",
         }
     finally:
         if workdir.exists():
             shutil.rmtree(workdir, ignore_errors=True)
+        claude_run_dir = (
+            Path(os.environ.get("GRAPHIFY_RUN_ROOT", "/work/graphify")).resolve()
+            / run_id
+        )
+        if claude_run_dir.exists() and claude_run_dir != workdir:
+            shutil.rmtree(claude_run_dir, ignore_errors=True)
 
 
 def _safe_id(value: str) -> str:

--- a/apps/graphify-worker/src/runner.py
+++ b/apps/graphify-worker/src/runner.py
@@ -10,7 +10,7 @@ import stat
 from pathlib import Path
 from typing import Any
 
-from . import graphify_pipeline
+from . import claude_runner
 from .manifest import generate_manifest
 from .storage_client import MinioStorageClient, parse_storage_uri
 
@@ -27,6 +27,11 @@ _SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 async def run(job_data: dict[str, Any]) -> dict[str, Any]:
+    if os.environ.get("GRAPHIFY_RUNNER_MODE", "claude_code") == "disabled":
+        raise RuntimeError(json.dumps({"reason": "runner_disabled", "retryable": True}))
+    if not os.environ.get("AGENT_ANTHROPIC_API_KEY"):
+        raise RuntimeError(json.dumps({"reason": "missing_api_key"}))
+
     job_id = job_data.get("id") or job_data.get("job_id")
     payload = _payload(job_data)
     tenant_id = _safe_id(
@@ -43,7 +48,6 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(f"workdir escapes base: {workdir}")
 
     input_dir = workdir / "input"
-    output_dir = workdir / "output"
     key_prefix = f"graphify-out/{tenant_id}/{space_id}/{run_id}"
 
     logger.info(
@@ -53,7 +57,6 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
 
     try:
         input_dir.mkdir(parents=True, exist_ok=True)
-        output_dir.mkdir(parents=True, exist_ok=True)
 
         storage = MinioStorageClient.from_env()
         input_files = _download_inputs(storage, input_uris, input_dir)
@@ -62,7 +65,13 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
         manifest_path = workdir / "graphify_input_manifest.json"
         manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
-        await graphify_pipeline.execute(input_dir, output_dir, mode)
+        result = await claude_runner.run_graphify(
+            run_id, str(input_dir), timeout=GRAPHIFY_TIMEOUT
+        )
+        if result.get("status") == "failed":
+            raise RuntimeError(json.dumps(result))
+
+        output_dir = _output_dir_from_result(result)
 
         validation = _validate_output(
             output_dir, run_id=run_id, graphify_ref=GRAPHIFY_REF
@@ -101,6 +110,7 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
                 "wiki_page_count": validation.get("wiki_page_count", 0),
                 "total_output_bytes": validation.get("total_output_bytes", 0),
             },
+            "schema_version": "1",
         }
     finally:
         if workdir.exists():
@@ -209,6 +219,18 @@ def _download_inputs(
                 json.dumps({"reason": "download_failed", "uri": uri, "error": str(exc)})
             ) from exc
     return input_files
+
+
+def _output_dir_from_result(result: dict[str, Any]) -> Path:
+    output_dir = result.get("output_dir")
+    if output_dir:
+        return Path(str(output_dir))
+
+    graph_json_path = result.get("graph_json_path")
+    if graph_json_path:
+        return Path(str(graph_json_path)).parent
+
+    raise RuntimeError(json.dumps({"reason": "missing_output_dir", "result": result}))
 
 
 def _validate_output(
@@ -339,7 +361,11 @@ def _validate_output(
         try:
             data = json.loads(graph_json.read_text(encoding="utf-8"))
             nodes = data.get("nodes", []) if isinstance(data, dict) else []
-            edges = data.get("edges", []) if isinstance(data, dict) else []
+            edges = (
+                data.get("links", data.get("edges", []))
+                if isinstance(data, dict)
+                else []
+            )
             node_count = len(nodes) if isinstance(nodes, list) else 0
             edge_count = len(edges) if isinstance(edges, list) else 0
             checks.append(

--- a/apps/graphify-worker/tests/test_runner.py
+++ b/apps/graphify-worker/tests/test_runner.py
@@ -36,7 +36,7 @@ def test_run_success_uploads_outputs_and_cleans_workdir(
     result = asyncio.run(runner.run(job_data()))
 
     assert result["status"] == "success"
-    assert result["schema_version"] == "1"
+    assert result["schema_version"] == "v1"
     assert result["graph_json_uri"] == (
         "s3://out-bucket/graphify-out/tenant-1/space-1/run-1/graph.json"
     )
@@ -350,6 +350,7 @@ def install_runner_config(
 ) -> None:
     monkeypatch.setenv("GRAPHIFY_RUNNER_MODE", "claude_code")
     monkeypatch.setenv("AGENT_ANTHROPIC_API_KEY", "test-agent-key")
+    monkeypatch.setenv("AGENT_ANTHROPIC_BASE_URL", "https://test-proxy.example.com")
     monkeypatch.setattr(runner, "GRAPHIFY_WORKDIR", str(workdir))
     monkeypatch.setattr(runner, "GRAPHIFY_TIMEOUT", 5)
     monkeypatch.setattr(runner, "GRAPHIFY_MODE", "full")

--- a/apps/graphify-worker/tests/test_runner.py
+++ b/apps/graphify-worker/tests/test_runner.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 
@@ -21,7 +21,7 @@ def test_run_success_uploads_outputs_and_cleans_workdir(
     install_runner_config(monkeypatch, tmp_path)
     captured_manifest: dict[str, Any] = {}
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
+    def build_output(input_dir: Path, output_dir: Path) -> None:
         captured_manifest.update(
             json.loads(
                 (input_dir.parent / "graphify_input_manifest.json").read_text(
@@ -31,11 +31,12 @@ def test_run_success_uploads_outputs_and_cleans_workdir(
         )
         shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
 
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    install_fake_run_graphify(monkeypatch, build_output)
 
     result = asyncio.run(runner.run(job_data()))
 
     assert result["status"] == "success"
+    assert result["schema_version"] == "1"
     assert result["graph_json_uri"] == (
         "s3://out-bucket/graphify-out/tenant-1/space-1/run-1/graph.json"
     )
@@ -73,11 +74,11 @@ def test_run_success_omits_report_uri_when_report_missing(
     install_fake_storage(monkeypatch)
     install_runner_config(monkeypatch, tmp_path)
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
+    def build_output(_input_dir: Path, output_dir: Path) -> None:
         shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
         (output_dir / "GRAPH_REPORT.md").unlink()
 
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    install_fake_run_graphify(monkeypatch, build_output)
 
     result = asyncio.run(runner.run(job_data()))
 
@@ -99,18 +100,66 @@ def test_run_rejects_unsafe_run_id(
     assert not any(tmp_path.iterdir())
 
 
+def test_run_disabled_mode_fails_before_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    monkeypatch.setenv("GRAPHIFY_RUNNER_MODE", "disabled")
+
+    async def fail_run_graphify(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("disabled runner must not call Claude runner")
+
+    monkeypatch.setattr(runner.claude_runner, "run_graphify", fail_run_graphify)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    error = json.loads(str(exc_info.value))
+    assert error == {"reason": "runner_disabled", "retryable": True}
+    assert storage.downloads == []
+    assert not any(tmp_path.iterdir())
+
+
+def test_run_missing_api_key_fails_before_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    storage = install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    monkeypatch.setenv("GRAPHIFY_RUNNER_MODE", "claude_code")
+    monkeypatch.delenv("AGENT_ANTHROPIC_API_KEY", raising=False)
+
+    async def fail_run_graphify(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("missing API key must not call Claude runner")
+
+    monkeypatch.setattr(runner.claude_runner, "run_graphify", fail_run_graphify)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    assert json.loads(str(exc_info.value)) == {"reason": "missing_api_key"}
+    assert storage.downloads == []
+    assert not any(tmp_path.iterdir())
+
+
 def test_run_pipeline_error_reports_and_cleans_workdir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     install_fake_storage(monkeypatch)
     install_runner_config(monkeypatch, tmp_path)
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
-        raise RuntimeError(
-            json.dumps({"reason": "llm_error", "details": "API unreachable"})
-        )
+    async def fake_run_graphify(
+        _run_id: str, _input_dir: str, *, timeout: float | None = None
+    ) -> dict[str, Any]:
+        assert timeout == 5
+        return {
+            "status": "failed",
+            "state": "FAILED",
+            "reason": "llm_error",
+            "details": "API unreachable",
+        }
 
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    monkeypatch.setattr(runner.claude_runner, "run_graphify", fake_run_graphify)
 
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(runner.run(job_data()))
@@ -125,12 +174,12 @@ def test_run_missing_graph_json_fails_validation_and_cleans_workdir(
     storage = install_fake_storage(monkeypatch)
     install_runner_config(monkeypatch, tmp_path)
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
+    def build_output(_input_dir: Path, output_dir: Path) -> None:
         (output_dir / "wiki").mkdir(parents=True)
         (output_dir / "wiki" / "index.md").write_text("# Index", encoding="utf-8")
         (output_dir / "GRAPH_REPORT.md").write_text("report", encoding="utf-8")
 
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    install_fake_run_graphify(monkeypatch, build_output)
 
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(runner.run(job_data()))
@@ -150,13 +199,13 @@ def test_run_missing_wiki_dir_fails_validation_and_cleans_workdir(
     storage = install_fake_storage(monkeypatch)
     install_runner_config(monkeypatch, tmp_path)
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
+    def build_output(_input_dir: Path, output_dir: Path) -> None:
         (output_dir / "graph.json").write_text(
             '{"nodes":[],"edges":[]}', encoding="utf-8"
         )
         (output_dir / "GRAPH_REPORT.md").write_text("report", encoding="utf-8")
 
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    install_fake_run_graphify(monkeypatch, build_output)
 
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(runner.run(job_data()))
@@ -178,14 +227,14 @@ def test_run_path_traversal_detection_fails_on_symlink_and_cleans_workdir(
     outside = tmp_path / "outside.md"
     outside.write_text("outside", encoding="utf-8")
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
+    def build_output(_input_dir: Path, output_dir: Path) -> None:
         shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
         try:
             (output_dir / "wiki" / "escape.md").symlink_to(outside)
         except OSError as exc:
             pytest.skip(f"symlink not available: {exc}")
 
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    install_fake_run_graphify(monkeypatch, build_output)
 
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(runner.run(job_data()))
@@ -207,10 +256,7 @@ def test_run_file_size_check_fails_validation_and_cleans_workdir(
     install_runner_config(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "MAX_FILE_SIZE", 10)
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
-        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
-
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    install_fake_run_graphify(monkeypatch)
 
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(runner.run(job_data()))
@@ -236,10 +282,7 @@ def test_run_total_size_check_uses_quarantine_error_shape(
     install_runner_config(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "MAX_TOTAL_SIZE", 10)
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
-        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
-
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    install_fake_run_graphify(monkeypatch)
 
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(runner.run(job_data()))
@@ -288,9 +331,25 @@ def test_validate_output_reports_pass_stats() -> None:
     assert validation["generated_at"].endswith("Z")
 
 
+def test_validate_output_counts_links_field(tmp_path: Path) -> None:
+    output_dir = tmp_path / "graphify-out"
+    shutil.copytree(FIXTURE_OUTPUT, output_dir)
+    graph_path = output_dir / "graph.json"
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    graph["links"] = graph.pop("edges")
+    graph_path.write_text(json.dumps(graph), encoding="utf-8")
+
+    validation = runner._validate_output(output_dir, run_id="run-1")
+
+    assert validation["validation_passed"] is True
+    assert validation["edge_count"] == len(graph["links"])
+
+
 def install_runner_config(
     monkeypatch: pytest.MonkeyPatch, workdir: Path, *, output_bucket: str = "out-bucket"
 ) -> None:
+    monkeypatch.setenv("GRAPHIFY_RUNNER_MODE", "claude_code")
+    monkeypatch.setenv("AGENT_ANTHROPIC_API_KEY", "test-agent-key")
     monkeypatch.setattr(runner, "GRAPHIFY_WORKDIR", str(workdir))
     monkeypatch.setattr(runner, "GRAPHIFY_TIMEOUT", 5)
     monkeypatch.setattr(runner, "GRAPHIFY_MODE", "full")
@@ -330,7 +389,43 @@ def job_data() -> dict[str, Any]:
 
 def fixture_count(key: str) -> int:
     graph = json.loads((FIXTURE_OUTPUT / "graph.json").read_text(encoding="utf-8"))
+    if key == "edges":
+        return len(graph.get("links", graph.get("edges", [])))
     return len(graph[key])
+
+
+def install_fake_run_graphify(
+    monkeypatch: pytest.MonkeyPatch,
+    build_output: Callable[[Path, Path], None] | None = None,
+    *,
+    expected_run_id: str = "run-1",
+) -> None:
+    async def fake_run_graphify(
+        run_id: str, input_dir: str, *, timeout: float | None = None
+    ) -> dict[str, Any]:
+        assert run_id == expected_run_id
+        assert timeout == 5
+        input_path = Path(input_dir)
+        output_dir = input_path.parent / "session" / "graphify-out"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if build_output is None:
+            shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
+        else:
+            build_output(input_path, output_dir)
+        return success_run_graphify_result(output_dir)
+
+    monkeypatch.setattr(runner.claude_runner, "run_graphify", fake_run_graphify)
+
+
+def success_run_graphify_result(output_dir: Path) -> dict[str, Any]:
+    return {
+        "status": "success",
+        "state": "SUCCEEDED",
+        "output_dir": str(output_dir),
+        "graph_json_path": str(output_dir / "graph.json"),
+        "wiki_output_path": str(output_dir / "wiki"),
+        "report_path": str(output_dir / "GRAPH_REPORT.md"),
+    }
 
 
 class FakeStorage:

--- a/apps/graphify-worker/tests/test_runner_integration.py
+++ b/apps/graphify-worker/tests/test_runner_integration.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import json
-import shutil
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from src import runner
-from tests.test_runner import FIXTURE_OUTPUT, fixture_count, install_runner_config
+from tests.test_runner import (
+    fixture_count,
+    install_fake_run_graphify,
+    install_runner_config,
+)
 
 
 def test_runner_integration_with_prepared_graphify_output(
@@ -25,10 +28,10 @@ def test_runner_integration_with_prepared_graphify_output(
     install_runner_config(monkeypatch, tmp_path)
     monkeypatch.setattr(runner, "MinioStorageClient", StorageFactory)
 
-    async def fake_execute(input_dir: Path, output_dir: Path, mode: str) -> None:
-        shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
-
-    monkeypatch.setattr(runner.graphify_pipeline, "execute", fake_execute)
+    install_fake_run_graphify(
+        monkeypatch,
+        expected_run_id="run-integration",
+    )
 
     result = asyncio.run(
         runner.run(


### PR DESCRIPTION
## Summary

Part of #163. Depends on #165 (merged).

- Replace `graphify_pipeline.execute()` with `claude_runner.run_graphify()` in runner.py
- Fix edge count: `data.get("links", data.get("edges", []))` for NetworkX compatibility
- Early fail on `GRAPHIFY_RUNNER_MODE=disabled` or missing `AGENT_ANTHROPIC_API_KEY`/`AGENT_ANTHROPIC_BASE_URL`
- Validate output_dir is not a symlink, cleanup claude session dirs
- Fix `schema_version` to `"v1"` matching API contract
- Update all tests to mock `claude_runner` instead of `graphify_pipeline`

Closes #166

## Agent Review

- Reviewer agents used: Spec Compliance, Correctness, Integration, Security & Performance
- Reviewed head SHA: `ffe67aa1041b867f4129d2fd5f1915840d41c0dd`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/179#issuecomment-4394505398) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/179#issuecomment-4394505539) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/179#issuecomment-4394505708) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/179#issuecomment-4394505892)
- Key findings addressed: Added BASE_URL early check, reject non-success results, symlink validation, schema_version v1, session cleanup

## Test plan

- [x] 59 graphify-worker tests pass (no regression)
- [x] ruff format/check passes