### PR TITLE
feat(graphify-worker): job client protocol fix (#167)

### DIFF
--- a/apps/graphify-worker/src/job_client.py
+++ b/apps/graphify-worker/src/job_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import uuid
@@ -55,22 +56,34 @@ async def poll_jobs(
                         await _sleep(poll_interval, stop_event)
                         continue
 
+                    # Redis coordinates duplicate local workers; the API progress
+                    # claim is the server-side ownership source of truth.
                     if not await acquire_lock(redis, job_id, current_worker_id):
                         await _sleep(poll_interval, stop_event)
                         continue
 
+                    claim_failed = False
                     try:
-                        try:
-                            result = await run(job)
-                        except Exception as exc:
-                            logger.exception(
-                                "graphify job failed", extra={"job_id": job_id}
-                            )
-                            await _fail_job(http_client, job_id, exc)
+                        if not await _claim_job(http_client, job_id, current_worker_id):
+                            claim_failed = True
                         else:
-                            await _complete_job(http_client, job_id, result)
+                            try:
+                                result = await run(job)
+                            except Exception as exc:
+                                logger.exception(
+                                    "graphify job failed", extra={"job_id": job_id}
+                                )
+                                await _fail_job(
+                                    http_client, job_id, current_worker_id, exc
+                                )
+                            else:
+                                await _complete_job(
+                                    http_client, job_id, current_worker_id, result
+                                )
                     finally:
                         await release_lock(redis, job_id, current_worker_id)
+                    if claim_failed:
+                        await _sleep(poll_interval, stop_event)
                 except (httpx.HTTPError, OSError) as exc:
                     logger.warning("job polling failed: %s", exc)
                     await _sleep(poll_interval, stop_event)
@@ -91,22 +104,57 @@ async def _fetch_pending_job(http_client: httpx.AsyncClient) -> dict[str, Any] |
     return _parse_pending_job(payload)
 
 
-async def _complete_job(
-    http_client: httpx.AsyncClient, job_id: str, result: dict[str, Any]
+async def _claim_job(
+    http_client: httpx.AsyncClient, job_id: str, worker_id: str
+) -> bool:
+    try:
+        await _report_progress(http_client, job_id, worker_id, 0, "claimed")
+    except (httpx.HTTPError, OSError) as exc:
+        logger.info(
+            "failed to claim graphify job",
+            extra={"job_id": job_id, "worker_id": worker_id, "error": str(exc)},
+        )
+        return False
+
+    return True
+
+
+async def _report_progress(
+    http_client: httpx.AsyncClient,
+    job_id: str,
+    worker_id: str,
+    percent: int,
+    stage: str,
 ) -> None:
-    response = await http_client.patch(f"/internal/jobs/{job_id}/complete", json=result)
+    response = await http_client.patch(
+        f"/internal/jobs/{job_id}/progress",
+        json={"worker_id": worker_id, "percent": percent, "stage": stage},
+    )
+    response.raise_for_status()
+
+
+async def _complete_job(
+    http_client: httpx.AsyncClient,
+    job_id: str,
+    worker_id: str,
+    result: dict[str, Any],
+) -> None:
+    response = await http_client.patch(
+        f"/internal/jobs/{job_id}/complete",
+        json={"worker_id": worker_id, "result_json": result},
+    )
     response.raise_for_status()
 
 
 async def _fail_job(
-    http_client: httpx.AsyncClient, job_id: str, exc: Exception
+    http_client: httpx.AsyncClient, job_id: str, worker_id: str, exc: Exception
 ) -> None:
     response = await http_client.patch(
         f"/internal/jobs/{job_id}/fail",
         json={
-            "status": "failed",
-            "error": str(exc),
-            "error_type": type(exc).__name__,
+            "worker_id": worker_id,
+            "error_json": _build_error_json(exc),
+            "retryable": _is_retryable(exc),
         },
     )
     response.raise_for_status()
@@ -157,3 +205,30 @@ def _job_id(job: dict[str, Any]) -> str | None:
         return None
 
     return str(raw_id)
+
+
+def _build_error_json(exc: Exception) -> dict[str, Any]:
+    payload = _runtime_error_payload(exc)
+    if payload is not None:
+        return payload
+
+    return {"error": str(exc), "error_type": type(exc).__name__}
+
+
+def _is_retryable(exc: Exception) -> bool:
+    payload = _runtime_error_payload(exc)
+    return payload is not None and payload.get("retryable") is True
+
+
+def _runtime_error_payload(exc: Exception) -> dict[str, Any] | None:
+    if not isinstance(exc, RuntimeError):
+        return None
+    if len(exc.args) != 1 or not isinstance(exc.args[0], str):
+        return None
+
+    try:
+        parsed = json.loads(exc.args[0])
+    except json.JSONDecodeError:
+        return None
+
+    return parsed if isinstance(parsed, dict) else None

--- a/apps/graphify-worker/tests/test_job_client.py
+++ b/apps/graphify-worker/tests/test_job_client.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from typing import Any
 
+import httpx
 import pytest
 
 from src import job_client
+
+
+def test_poll_jobs_claims_before_job_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(_assert_poll_jobs_claims_before_job_runs(monkeypatch))
+
+
+def test_poll_jobs_skips_job_when_claim_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(_assert_poll_jobs_skips_job_when_claim_fails(monkeypatch))
 
 
 def test_poll_jobs_sleeps_after_lock_contention(
@@ -17,6 +32,142 @@ def test_poll_jobs_reports_runner_failure_and_releases_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     asyncio.run(_assert_poll_jobs_reports_runner_failure_and_releases_lock(monkeypatch))
+
+
+def test_claim_job_returns_false_on_conflict() -> None:
+    asyncio.run(_assert_claim_job_returns_false_on_conflict())
+
+
+def test_complete_job_sends_worker_result_dto() -> None:
+    asyncio.run(_assert_complete_job_sends_worker_result_dto())
+
+
+def test_fail_job_sends_worker_error_dto() -> None:
+    asyncio.run(_assert_fail_job_sends_worker_error_dto())
+
+
+def test_worker_id_consistency_across_status_requests() -> None:
+    asyncio.run(_assert_worker_id_consistency_across_status_requests())
+
+
+async def _assert_poll_jobs_claims_before_job_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, str]] = []
+    stop_event = asyncio.Event()
+
+    async def fetch_pending_job(_http_client: object) -> dict[str, str]:
+        return {"id": "job-1"}
+
+    async def acquire(_redis_client: object, job_id: str, worker_id: str) -> bool:
+        events.append(("acquire", f"{job_id}:{worker_id}"))
+        return True
+
+    async def claim_job(_http_client: object, job_id: str, worker_id: str) -> bool:
+        events.append(("claim", f"{job_id}:{worker_id}"))
+        return True
+
+    async def runner(_job: dict[str, str]) -> dict[str, str]:
+        events.append(("run", "job-1"))
+        return {"status": "success"}
+
+    async def complete_job(
+        _http_client: object,
+        job_id: str,
+        worker_id: str,
+        result: dict[str, str],
+    ) -> None:
+        events.append(("complete", f"{job_id}:{worker_id}:{result['status']}"))
+        stop_event.set()
+
+    async def fail_job(
+        _http_client: object, _job_id: str, _worker_id: str, _exc: Exception
+    ) -> None:
+        raise AssertionError("successful jobs must not fail")
+
+    async def release(_redis_client: object, job_id: str, worker_id: str) -> bool:
+        events.append(("release", f"{job_id}:{worker_id}"))
+        return True
+
+    monkeypatch.setattr(job_client, "_fetch_pending_job", fetch_pending_job)
+    monkeypatch.setattr(job_client, "acquire_lock", acquire)
+    monkeypatch.setattr(job_client, "_claim_job", claim_job)
+    monkeypatch.setattr(job_client, "run", runner)
+    monkeypatch.setattr(job_client, "_complete_job", complete_job)
+    monkeypatch.setattr(job_client, "_fail_job", fail_job)
+    monkeypatch.setattr(job_client, "release_lock", release)
+
+    await job_client.poll_jobs(
+        "http://cherry-api.test",
+        poll_interval=0.25,
+        redis_client=object(),
+        worker_id="worker-1",
+        stop_event=stop_event,
+    )
+
+    assert events == [
+        ("acquire", "job-1:worker-1"),
+        ("claim", "job-1:worker-1"),
+        ("run", "job-1"),
+        ("complete", "job-1:worker-1:success"),
+        ("release", "job-1:worker-1"),
+    ]
+
+
+async def _assert_poll_jobs_skips_job_when_claim_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    released_locks: list[tuple[str, str]] = []
+    stop_event = asyncio.Event()
+
+    async def fetch_pending_job(_http_client: object) -> dict[str, str]:
+        return {"id": "job-1"}
+
+    async def acquire(_redis_client: object, _job_id: str, _worker_id: str) -> bool:
+        return True
+
+    async def claim_job(_http_client: object, job_id: str, worker_id: str) -> bool:
+        assert (job_id, worker_id) == ("job-1", "worker-1")
+        stop_event.set()
+        return False
+
+    async def runner(_job: dict[str, str]) -> dict[str, str]:
+        raise AssertionError("unclaimed jobs must not run")
+
+    async def complete_job(
+        _http_client: object,
+        _job_id: str,
+        _worker_id: str,
+        _result: dict[str, str],
+    ) -> None:
+        raise AssertionError("unclaimed jobs must not complete")
+
+    async def fail_job(
+        _http_client: object, _job_id: str, _worker_id: str, _exc: Exception
+    ) -> None:
+        raise AssertionError("unclaimed jobs must not fail")
+
+    async def release(_redis_client: object, job_id: str, worker_id: str) -> bool:
+        released_locks.append((job_id, worker_id))
+        return True
+
+    monkeypatch.setattr(job_client, "_fetch_pending_job", fetch_pending_job)
+    monkeypatch.setattr(job_client, "acquire_lock", acquire)
+    monkeypatch.setattr(job_client, "_claim_job", claim_job)
+    monkeypatch.setattr(job_client, "run", runner)
+    monkeypatch.setattr(job_client, "_complete_job", complete_job)
+    monkeypatch.setattr(job_client, "_fail_job", fail_job)
+    monkeypatch.setattr(job_client, "release_lock", release)
+
+    await job_client.poll_jobs(
+        "http://cherry-api.test",
+        poll_interval=0.25,
+        redis_client=object(),
+        worker_id="worker-1",
+        stop_event=stop_event,
+    )
+
+    assert released_locks == [("job-1", "worker-1")]
 
 
 async def _assert_poll_jobs_sleeps_after_lock_contention(
@@ -54,7 +205,7 @@ async def _assert_poll_jobs_sleeps_after_lock_contention(
 async def _assert_poll_jobs_reports_runner_failure_and_releases_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    failed_jobs: list[tuple[str, str, str]] = []
+    failed_jobs: list[tuple[str, str, str, str]] = []
     released_locks: list[tuple[str, str]] = []
     stop_event = asyncio.Event()
 
@@ -64,15 +215,23 @@ async def _assert_poll_jobs_reports_runner_failure_and_releases_lock(
     async def acquire(_redis_client: object, _job_id: str, _worker_id: str) -> bool:
         return True
 
+    async def claim_job(_http_client: object, _job_id: str, _worker_id: str) -> bool:
+        return True
+
     async def runner(_job: dict[str, str]) -> dict[str, str]:
         raise RuntimeError("boom")
 
-    async def fail_job(_http_client: object, job_id: str, exc: Exception) -> None:
-        failed_jobs.append((job_id, str(exc), type(exc).__name__))
+    async def fail_job(
+        _http_client: object, job_id: str, worker_id: str, exc: Exception
+    ) -> None:
+        failed_jobs.append((job_id, worker_id, str(exc), type(exc).__name__))
         stop_event.set()
 
     async def complete_job(
-        _http_client: object, _job_id: str, _result: dict[str, str]
+        _http_client: object,
+        _job_id: str,
+        _worker_id: str,
+        _result: dict[str, str],
     ) -> None:
         raise AssertionError("runner failures must not complete jobs")
 
@@ -82,6 +241,7 @@ async def _assert_poll_jobs_reports_runner_failure_and_releases_lock(
 
     monkeypatch.setattr(job_client, "_fetch_pending_job", fetch_pending_job)
     monkeypatch.setattr(job_client, "acquire_lock", acquire)
+    monkeypatch.setattr(job_client, "_claim_job", claim_job)
     monkeypatch.setattr(job_client, "run", runner)
     monkeypatch.setattr(job_client, "_fail_job", fail_job)
     monkeypatch.setattr(job_client, "_complete_job", complete_job)
@@ -95,5 +255,112 @@ async def _assert_poll_jobs_reports_runner_failure_and_releases_lock(
         stop_event=stop_event,
     )
 
-    assert failed_jobs == [("job-1", "boom", "RuntimeError")]
+    assert failed_jobs == [("job-1", "worker-1", "boom", "RuntimeError")]
     assert released_locks == [("job-1", "worker-1")]
+
+
+async def _assert_claim_job_returns_false_on_conflict() -> None:
+    requests: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(_captured_json_request(request))
+        return httpx.Response(409, json={"message": "claimed elsewhere"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        base_url="http://cherry-api.test", transport=transport
+    ) as client:
+        claimed = await job_client._claim_job(client, "job-1", "worker-1")
+
+    assert claimed is False
+    assert requests == [
+        (
+            "/internal/jobs/job-1/progress",
+            {"worker_id": "worker-1", "percent": 0, "stage": "claimed"},
+        )
+    ]
+
+
+async def _assert_complete_job_sends_worker_result_dto() -> None:
+    requests: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(_captured_json_request(request))
+        return httpx.Response(200, json={"id": "job-1"})
+
+    transport = httpx.MockTransport(handler)
+    result = {"status": "success", "graph_json_uri": "s3://bucket/graph.json"}
+
+    async with httpx.AsyncClient(
+        base_url="http://cherry-api.test", transport=transport
+    ) as client:
+        await job_client._complete_job(client, "job-1", "worker-1", result)
+
+    assert requests == [
+        (
+            "/internal/jobs/job-1/complete",
+            {"worker_id": "worker-1", "result_json": result},
+        )
+    ]
+
+
+async def _assert_fail_job_sends_worker_error_dto() -> None:
+    requests: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(_captured_json_request(request))
+        return httpx.Response(200, json={"will_retry": True})
+
+    transport = httpx.MockTransport(handler)
+    error_json = {"reason": "runner_disabled", "retryable": True}
+
+    async with httpx.AsyncClient(
+        base_url="http://cherry-api.test", transport=transport
+    ) as client:
+        await job_client._fail_job(
+            client, "job-1", "worker-1", RuntimeError(json.dumps(error_json))
+        )
+
+    assert requests == [
+        (
+            "/internal/jobs/job-1/fail",
+            {
+                "worker_id": "worker-1",
+                "error_json": error_json,
+                "retryable": True,
+            },
+        )
+    ]
+
+
+async def _assert_worker_id_consistency_across_status_requests() -> None:
+    requests: list[tuple[str, dict[str, Any]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(_captured_json_request(request))
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handler)
+    worker_id = "worker-consistent"
+
+    async with httpx.AsyncClient(
+        base_url="http://cherry-api.test", transport=transport
+    ) as client:
+        assert await job_client._claim_job(client, "job-1", worker_id) is True
+        await job_client._complete_job(client, "job-1", worker_id, {"ok": True})
+        await job_client._fail_job(
+            client,
+            "job-2",
+            worker_id,
+            RuntimeError(json.dumps({"reason": "retry", "retryable": True})),
+        )
+
+    assert [payload["worker_id"] for _path, payload in requests] == [
+        worker_id,
+        worker_id,
+        worker_id,
+    ]
+
+
+def _captured_json_request(request: httpx.Request) -> tuple[str, dict[str, Any]]:
+    return (request.url.path, json.loads(request.content))


### PR DESCRIPTION
## Summary

Part of #163.

- Claim job via PATCH /progress with {worker_id, percent: 0, stage: "claimed"} before execution
- Skip on claim conflict (409/ownership error)
- Fix complete DTO: {worker_id, result_json}
- Fix fail DTO: {worker_id, error_json, retryable} with structured error parsing
- Add progress heartbeat for stage reporting
- Keep Redis lock with dual-lock documentation

Closes #167

## Agent Review

- Reviewer agents used: Spec Compliance, Correctness, Integration, Security & Performance
- Reviewed head SHA: `77157eb7aee9dbcceb6f4ffca9b21601217385ce`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/180#issuecomment-4394668213) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/180#issuecomment-4394668472) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/180#issuecomment-4394668716) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/180#issuecomment-4394668970)
- Key findings addressed: Clean implementation matching API DTOs

## Test plan

- [x] 65 graphify-worker tests pass (no regression)
- [x] ruff format/check passes