### PR TITLE
feat(api): upload handoff creates Graphify run with input_uris (#168)

### DIFF
--- a/apps/api/src/uploads/__tests__/uploads.service.test.ts
+++ b/apps/api/src/uploads/__tests__/uploads.service.test.ts
@@ -1,6 +1,5 @@
 import { JobRepository, type JobCreateInput, type JobRow } from '@cherrygraph/job-core';
-import type { SourceDocumentStatus } from '@cherrygraph/shared';
-import { ErrorCode } from '@cherrygraph/shared';
+import { ErrorCode, graphifyRuns, type SourceDocumentStatus } from '@cherrygraph/shared';
 import { createHash } from 'node:crypto';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -449,8 +448,8 @@ describe('UploadsService', () => {
     expect(storage.deleteQuarantineFile).toHaveBeenCalledTimes(1);
   });
 
-  it('creates one graphify job for a parsed immediate batch and marks documents pending', async () => {
-    const { service, sourceDocuments, jobs } = createServiceContext();
+  it('creates one graphify run and job for a parsed immediate batch and marks documents pending', async () => {
+    const { service, db, sourceDocuments, jobs } = createServiceContext();
     for (let index = 0; index < 5; index += 1) {
       sourceDocuments.seed(
         createSourceDocumentRow({
@@ -459,6 +458,10 @@ describe('UploadsService', () => {
           metadata_json: {
             batch_id: 'batch-1',
             processing_strategy: 'immediate',
+            ...(index === 0 ? { parsed_uri: 's3://parsed/source-1.md' } : {}),
+            ...(index === 1 ? { parsed_md_uri: 's3://parsed/source-2.md' } : {}),
+            ...(index === 2 ? { parsed_markdown_uri: 's3://parsed/source-3.md' } : {}),
+            ...(index === 3 ? { parsed_uri: 's3://parsed/source-4.md' } : {}),
           },
         }),
       );
@@ -469,11 +472,36 @@ describe('UploadsService', () => {
     }
 
     expect(jobs.created.filter((job) => job.type === 'graphify')).toHaveLength(1);
+    expect(db.inserts[0]?.table).toBe(graphifyRuns);
+    const runInsert = asRecord(db.inserts[0]?.value);
+    expect(runInsert.id).toEqual(expect.any(String));
+    const runId = runInsert.id as string;
+    expect(runInsert).toMatchObject({
+      tenant_id: TEST_TENANT_ID,
+      space_id: TEST_SPACE_ID,
+      trigger_type: 'upload',
+      mode: 'standard',
+      status: 'pending',
+      stats_json: {
+        input_scope: { source_document_ids: ['source-1', 'source-2', 'source-3', 'source-4', 'source-5'] },
+        batch_id: 'batch-1',
+        input_uri_count: 4,
+      },
+    });
     expect(jobs.created[0]?.payload_json).toMatchObject({
+      tenant_id: TEST_TENANT_ID,
+      space_id: TEST_SPACE_ID,
+      run_id: runId,
+      mode: 'standard',
+      input_uris: ['s3://parsed/source-1.md', 's3://parsed/source-2.md', 's3://parsed/source-3.md', 's3://parsed/source-4.md'],
       batch_id: 'batch-1',
       source_document_ids: ['source-1', 'source-2', 'source-3', 'source-4', 'source-5'],
     });
+    expect(db.updates[0]?.table).toBe(graphifyRuns);
+    expect(asRecord(db.updates[0]?.value)).toMatchObject({ job_id: 'job-1' });
     expect(sourceDocuments.rows.every((row) => row.status === 'graphify_pending')).toBe(true);
+    expect(sourceDocuments.rows.every((row) => asRecord(row.metadata_json).graphify_run_id === runId)).toBe(true);
+    expect(sourceDocuments.rows.every((row) => asRecord(row.metadata_json).graphify_run_id !== 'job-1')).toBe(true);
   });
 
   it('does not graphify parsed documents with stash strategy', async () => {
@@ -813,6 +841,10 @@ function getHttpExceptionErrorCode(err: unknown): unknown {
   }
 
   return (response as Record<string, unknown>).error_code;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
 }
 
 function createJobRow(overrides: Partial<JobRow> = {}): JobRow {

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -2,6 +2,7 @@ import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { JobRepository, job_events, jobs, type JobRow } from '@cherrygraph/job-core';
 import {
   ErrorCode,
+  graphifyRuns,
   group_members,
   sourceDocumentMetadataSchema,
   space_permissions,
@@ -602,26 +603,61 @@ export class UploadsService {
       (item) => item.status === 'parsed' && normalizeProcessingStrategy(asJsonRecord(item.metadata_json).processing_strategy) === 'immediate',
     );
     const sourceDocumentIds = readyDocuments.length === 0 ? [document.id] : readyDocuments.map((item) => item.id);
-    const job = await JobRepository.create(this.db, {
-      tenant_id: tenantId,
-      space_id: document.space_id,
-      queue_name: UPLOAD_JOB_QUEUES.GRAPHIFY,
-      type: UPLOAD_JOB_TYPES.GRAPHIFY,
-      priority: 100,
-      payload_json: {
-        source_document_ids: sourceDocumentIds,
-        batch_id: batchId,
-      },
-      idempotency_key: `graphify:${tenantId}:${document.space_id}:${batchId}`,
-      created_by: context.actorUserId ?? context.userId ?? null,
+    const graphifyDocuments = readyDocuments.length === 0 ? [document] : readyDocuments;
+    const inputUris = graphifyDocuments.map(readParsedUriFromMetadata).filter((uri): uri is string => uri !== undefined);
+    const runId = randomUUID();
+    const createdBy = context.actorUserId ?? context.userId ?? null;
+    const now = new Date();
+    const job = await this.db.transaction(async (tx) => {
+      await tx
+        .insert(graphifyRuns)
+        .values({
+          id: runId,
+          tenant_id: tenantId,
+          space_id: document.space_id,
+          trigger_type: 'upload',
+          mode: 'standard',
+          status: 'pending',
+          schema_version: 'v1',
+          stats_json: {
+            input_scope: { source_document_ids: sourceDocumentIds },
+            batch_id: batchId,
+            input_uri_count: inputUris.length,
+          },
+          created_by: createdBy,
+          created_at: now,
+        });
+
+      const createdJob = await JobRepository.create(tx, {
+        tenant_id: tenantId,
+        space_id: document.space_id,
+        queue_name: UPLOAD_JOB_QUEUES.GRAPHIFY,
+        type: UPLOAD_JOB_TYPES.GRAPHIFY,
+        priority: 100,
+        payload_json: {
+          tenant_id: tenantId,
+          space_id: document.space_id,
+          run_id: runId,
+          mode: 'standard',
+          input_uris: inputUris,
+          source_document_ids: sourceDocumentIds,
+          batch_id: batchId,
+        },
+        idempotency_key: `graphify:${tenantId}:${document.space_id}:${batchId}`,
+        created_by: createdBy,
+      });
+
+      await tx.update(graphifyRuns).set({ job_id: createdJob.id }).where(eq(graphifyRuns.id, runId));
+
+      return createdJob;
     });
 
-    for (const item of readyDocuments.length === 0 ? [document] : readyDocuments) {
+    for (const item of graphifyDocuments) {
       if (item.status === 'parsed') {
         await this.sourceDocumentRepository.updateStatus(item.id, 'graphify_pending', {
           metadata_json: {
             ...asJsonRecord(item.metadata_json),
-            graphify_run_id: job.id,
+            graphify_run_id: runId,
           },
         });
       }
@@ -1098,6 +1134,12 @@ function hasImplicitSpaceAccess(role: string | undefined): boolean {
 
 function asJsonRecord(value: unknown): JsonRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as JsonRecord : {};
+}
+
+function readParsedUriFromMetadata(document: SourceDocumentRow): string | undefined {
+  const metadata = asJsonRecord(document.metadata_json);
+  const parsedUri = metadata.parsed_uri ?? metadata.parsed_md_uri ?? metadata.parsed_markdown_uri;
+  return typeof parsedUri === 'string' && parsedUri.trim().length > 0 ? parsedUri : undefined;
 }
 
 function isArchiveStorageUri(storageUri: string): boolean {


### PR DESCRIPTION
## Summary

Part of #163.

- `handleGraphifyHandoff` now creates `graphify_runs` row before job creation
- Job payload includes `run_id`, `input_uris`, `source_document_ids`, `batch_id`
- `input_uris` built from parsed document URIs (excludes unparsed docs)
- Source document metadata stores real `run_id` (not `job_id`)
- `trigger_type: 'upload'` on graphify_runs row

Closes #168

## Agent Review

- Reviewer agents used: Spec Compliance, Correctness, Integration, Security & Performance
- Reviewed head SHA: `25d41671e2007f77448b7fdce4eebd29621056c8`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/181#issuecomment-4394831652) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/181#issuecomment-4394831844) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/181#issuecomment-4394832114) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/181#issuecomment-4394832314)
- Key findings addressed: N/A — clean implementation

## Test plan

- [x] 191 API tests pass (1 skipped, no regression)
- [x] npm run build passes
- [x] npm run lint passes