### PR TITLE
feat(agent): SessionManager rewrite + runtime types (#173)

### DIFF
--- a/apps/api/src/agent/__tests__/agent-session-manager.test.ts
+++ b/apps/api/src/agent/__tests__/agent-session-manager.test.ts
@@ -1,109 +1,482 @@
 import 'reflect-metadata';
 
-import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
-import { mkdir, mkdtemp, stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
-vi.mock('node:child_process', () => ({
-  spawn: vi.fn(),
-}));
-
-import { SessionManager } from '../session-manager.js';
-import type { AgentSessionRecord } from '../dto/agent.dto.js';
+import type {
+  AgentSessionRepository,
+  AgentSessionRow,
+  NewAgentSession,
+} from '../agent-session.repository.js';
+import { SessionManager, type SessionManagerConfig } from '../session-manager.js';
+import type { AgentSpawnOptions } from '../dto/agent.dto.js';
 import { createMockProcess } from './agent-test-utils.js';
 
 const managers: SessionManager[] = [];
-void spawn;
+const tempDirs: string[] = [];
 
 afterEach(async () => {
-  vi.useRealTimers();
   await Promise.all(managers.splice(0).map((manager) => manager.onModuleDestroy()));
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
 describe('SessionManager', () => {
-  it('interval cleanup removes sessions idle for 10 minutes', async () => {
-    vi.useFakeTimers();
-    const manager = createManager();
-    manager.configureForTests({ idleTimeoutMs: 10 * 60_000, cleanupIntervalMs: 1_000 });
-    const workDir = await createWorkDir('idle');
-    manager.setSession(createSessionRecord('conversation-idle', workDir, Date.now() - 10 * 60_000));
+  it('creates a fresh persistent session when neither memory nor DB has one', async () => {
+    const repository = createRepository();
+    const manager = await createManager(repository.instance);
 
-    await vi.advanceTimersByTimeAsync(1_000);
-    await vi.waitFor(() => expect(manager.hasSession('conversation-idle')).toBe(false));
+    const session = await manager.getOrCreateSession(
+      'conversation-fresh',
+      'space-1',
+      'tenant-1',
+      'user-1',
+      { allowedSpaces: [{ id: 'space-1', graphPath: '/graphs/space-1' }], model: 'sonnet' },
+    );
 
-    await vi.waitFor(async () => {
-      await expect(stat(workDir)).rejects.toThrow();
+    expect(session).toMatchObject({
+      conversationId: 'conversation-fresh',
+      tenantId: 'tenant-1',
+      spaceId: 'space-1',
+      userId: 'user-1',
+      providerSessionId: undefined,
+      status: 'starting',
+      ownedByInstance: 'instance-local',
     });
+    expect(session.optionsFingerprint).toHaveLength(64);
+    expect(repository.findByConversationId).toHaveBeenCalledWith('conversation-fresh');
+    expect(repository.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation_id: 'conversation-fresh',
+        status: 'starting',
+        provider_session_id: null,
+        owned_by_instance: 'instance-local',
+      }),
+    );
+    await expect(stat(session.workDir)).resolves.toBeTruthy();
+    await expect(stat(session.agentHome)).resolves.toBeTruthy();
   });
 
-  it('close deletes the work directory and terminates a tracked process', async () => {
-    const manager = createManager();
-    const workDir = await createWorkDir('close');
-    const processRef = createMockProcess();
-    processRef.kill = vi.fn(() => {
-      setTimeout(() => processRef.close(0, 'SIGTERM'), 10);
-      return true;
+  it('restores DB metadata into memory when the in-memory registry misses', async () => {
+    const row = createAgentSessionRow({
+      conversation_id: 'conversation-restore',
+      provider_session_id: 'claude-session-restore',
+      status: 'idle',
+      owned_by_instance: 'instance-local',
+      work_dir: await createWorkDir('restore'),
     });
-    manager.setSession(createSessionRecord('conversation-close', workDir, Date.now(), processRef));
+    row.agent_home = join(row.work_dir, '.home');
+    const repository = createRepository([row]);
+    const manager = await createManager(repository.instance);
+
+    const session = await manager.getOrCreateSession(
+      'conversation-restore',
+      'ignored-space',
+      'ignored-tenant',
+      'ignored-user',
+      {},
+    );
+
+    expect(session).toMatchObject({
+      conversationId: 'conversation-restore',
+      tenantId: row.tenant_id,
+      spaceId: row.space_id,
+      userId: row.user_id,
+      providerSessionId: 'claude-session-restore',
+      status: 'stopped',
+      child: undefined,
+      ownedByInstance: 'instance-local',
+    });
+    expect(manager.size()).toBe(1);
+    expect(repository.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        conversation_id: 'conversation-restore',
+        status: 'stopped',
+        provider_session_id: 'claude-session-restore',
+        owned_by_instance: 'instance-local',
+      }),
+    );
+  });
+
+  it('marks sessions owned by a different instance as stopped and claims ownership', async () => {
+    const row = createAgentSessionRow({
+      conversation_id: 'conversation-remote',
+      status: 'running',
+      owned_by_instance: 'instance-remote',
+      work_dir: await createWorkDir('remote'),
+    });
+    row.agent_home = join(row.work_dir, '.home');
+    const repository = createRepository([row]);
+    const manager = await createManager(repository.instance);
+
+    const session = await manager.getOrCreateSession(
+      'conversation-remote',
+      'space-1',
+      'tenant-1',
+      'user-1',
+      {},
+    );
+
+    expect(session.status).toBe('stopped');
+    expect(session.ownedByInstance).toBe('instance-local');
+    expect(repository.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        conversation_id: 'conversation-remote',
+        status: 'stopped',
+        owned_by_instance: 'instance-local',
+      }),
+    );
+  });
+
+  it('attachProcess stores the child process and persists running status', async () => {
+    const repository = createRepository();
+    const manager = await createManager(repository.instance);
+    await manager.getOrCreateSession('conversation-attach', 'space-1', 'tenant-1', 'user-1');
+    const proc = createClosingProcess();
+
+    await manager.attachProcess('conversation-attach', proc as unknown as ChildProcess);
+    const session = await manager.getOrCreateSession('conversation-attach', 'space-1', 'tenant-1', 'user-1');
+
+    expect(session.status).toBe('running');
+    expect(session.child).toBe(proc);
+    expect(repository.updateStatus).toHaveBeenLastCalledWith(
+      'conversation-attach',
+      'running',
+      expect.objectContaining({
+        process_started_at: expect.any(Date) as Date,
+        process_stopped_at: null,
+      }),
+    );
+  });
+
+  it('markIdle starts an idle kill timer and persists idle status', async () => {
+    const repository = createRepository();
+    const manager = await createManager(repository.instance, { idleTimeoutMs: 1_000 });
+    await manager.getOrCreateSession('conversation-idle', 'space-1', 'tenant-1', 'user-1');
+    await manager.attachProcess('conversation-idle', createClosingProcess() as unknown as ChildProcess);
+
+    await manager.markIdle('conversation-idle');
+    const session = await manager.getOrCreateSession('conversation-idle', 'space-1', 'tenant-1', 'user-1');
+
+    expect(session.status).toBe('idle');
+    expect(session.idleKillTimer).toBeDefined();
+    expect(repository.updateStatus).toHaveBeenLastCalledWith(
+      'conversation-idle',
+      'idle',
+      expect.objectContaining({ last_activity_at: expect.any(Date) as Date }),
+    );
+  });
+
+  it('markStopped clears process references and idle timers', async () => {
+    const repository = createRepository();
+    const manager = await createManager(repository.instance, { idleTimeoutMs: 1_000 });
+    await manager.getOrCreateSession('conversation-stopped', 'space-1', 'tenant-1', 'user-1');
+    const proc = createClosingProcess();
+    await manager.attachProcess('conversation-stopped', proc as unknown as ChildProcess);
+    await manager.markIdle('conversation-stopped');
+
+    await manager.markStopped('conversation-stopped');
+    const session = await manager.getOrCreateSession('conversation-stopped', 'space-1', 'tenant-1', 'user-1');
+
+    expect(session.status).toBe('stopped');
+    expect(session.child).toBeUndefined();
+    expect(session.idleKillTimer).toBeUndefined();
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('touch updates activity time and reschedules idle state persistence', async () => {
+    const repository = createRepository();
+    const manager = await createManager(repository.instance, { idleTimeoutMs: 10_000 });
+    await manager.getOrCreateSession('conversation-touch', 'space-1', 'tenant-1', 'user-1');
+    await manager.markIdle('conversation-touch');
+
+    manager.touch('conversation-touch', 12_345);
+    const session = await manager.getOrCreateSession('conversation-touch', 'space-1', 'tenant-1', 'user-1');
+
+    expect(session.lastActivityAt).toBe(12_345);
+    expect(repository.updateStatus).toHaveBeenLastCalledWith(
+      'conversation-touch',
+      'idle',
+      expect.objectContaining({ last_activity_at: new Date(12_345) }),
+    );
+  });
+
+  it('close explicitly terminates with SIGTERM, deletes workDir, and removes DB metadata', async () => {
+    const repository = createRepository();
+    const manager = await createManager(repository.instance);
+    const session = await manager.getOrCreateSession('conversation-close', 'space-1', 'tenant-1', 'user-1');
+    const proc = createClosingProcess();
+    await manager.attachProcess('conversation-close', proc as unknown as ChildProcess);
 
     await manager.close('conversation-close');
 
-    expect(processRef.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(repository.delete).toHaveBeenCalledWith('conversation-close');
     expect(manager.hasSession('conversation-close')).toBe(false);
-    await expect(stat(workDir)).rejects.toThrow();
+    await expect(stat(session.workDir)).rejects.toThrow();
   });
 
-  it('tracks concurrent sessions without deleting active conversations', async () => {
-    const manager = createManager();
-    manager.configureForTests({ idleTimeoutMs: 100 });
-    const activeDir = await createWorkDir('active');
-    const idleDir = await createWorkDir('idle-old');
-    manager.setSession(createSessionRecord('conversation-active', activeDir, 1_000));
-    manager.setSession(createSessionRecord('conversation-idle-old', idleDir, 1_000));
+  it('sweepIdleSessions kills expired idle processes but preserves workDir and DB row', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const repository = createRepository();
+    const manager = await createManager(repository.instance, { idleTimeoutMs: 1_000 });
+    const session = await manager.getOrCreateSession('conversation-sweep', 'space-1', 'tenant-1', 'user-1');
+    const proc = createClosingProcess();
+    await manager.attachProcess('conversation-sweep', proc as unknown as ChildProcess);
+    await manager.markIdle('conversation-sweep');
 
-    await Promise.all([
-      Promise.resolve().then(() => manager.touch('conversation-active', 1_200)),
-      Promise.resolve().then(() => manager.setSessionId('conversation-active', 'session-updated')),
-      Promise.resolve().then(() => manager.sweepIdleSessions(1_150)),
-    ]);
+    const swept = await manager.sweepIdleSessions(2_000);
 
-    expect(manager.hasSession('conversation-active')).toBe(true);
-    expect(manager.getSession('conversation-active')?.sessionId).toBe('session-updated');
-    expect(manager.hasSession('conversation-idle-old')).toBe(false);
-    await expect(stat(activeDir)).resolves.toBeTruthy();
-    await expect(stat(idleDir)).rejects.toThrow();
+    expect(swept).toEqual(['conversation-sweep']);
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(repository.delete).not.toHaveBeenCalled();
+    await expect(stat(session.workDir)).resolves.toBeTruthy();
+  });
+
+  it('lruEvict kills the least-recently-used idle process and never evicts running sessions', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const repository = createRepository();
+    const manager = await createManager(repository.instance, { maxResidentProcesses: 1 });
+    await manager.getOrCreateSession('conversation-old', 'space-1', 'tenant-1', 'user-1');
+    const oldProc = createClosingProcess();
+    await manager.attachProcess('conversation-old', oldProc as unknown as ChildProcess);
+    await manager.markIdle('conversation-old');
+
+    vi.setSystemTime(2_000);
+    await manager.getOrCreateSession('conversation-new', 'space-1', 'tenant-1', 'user-1');
+    const newProc = createClosingProcess();
+    await manager.attachProcess('conversation-new', newProc as unknown as ChildProcess);
+
+    const oldSession = await manager.getOrCreateSession('conversation-old', 'space-1', 'tenant-1', 'user-1');
+    const newSession = await manager.getOrCreateSession('conversation-new', 'space-1', 'tenant-1', 'user-1');
+    expect(oldProc.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(newProc.kill).not.toHaveBeenCalled();
+    expect(oldSession.status).toBe('stopped');
+    expect(newSession.status).toBe('running');
+  });
+
+  it('hasSession checks memory immediately and can include persisted DB metadata', async () => {
+    const persisted = createAgentSessionRow({ conversation_id: 'conversation-db-only' });
+    const repository = createRepository([persisted]);
+    const manager = await createManager(repository.instance);
+    await manager.getOrCreateSession('conversation-memory', 'space-1', 'tenant-1', 'user-1');
+
+    expect(manager.hasSession('conversation-memory')).toBe(true);
+    await expect(manager.hasSession('conversation-db-only', { includePersisted: true })).resolves.toBe(true);
+    expect(manager.hasSession('conversation-db-only')).toBe(true);
+  });
+
+  it('computeOptionsFingerprint is deterministic for equivalent option sets', async () => {
+    const manager = await createManager(createRepository().instance);
+    const first: AgentSpawnOptions = {
+      allowedSpaces: [
+        { id: 'space-b', graphPath: '/graphs/b' },
+        { id: 'space-a', graphPath: '/graphs/a' },
+      ],
+      enableDatabase: true,
+      databaseConfig: { enabled: true, dsn: 'postgres://readonly@db/cherry' },
+      graphBasePath: '/graphs',
+      model: 'sonnet',
+      maxBudgetUsd: 3,
+    };
+    const second: AgentSpawnOptions = {
+      ...first,
+      allowedSpaces: [
+        { id: 'space-a', graphPath: '/graphs/a' },
+        { id: 'space-b', graphPath: '/graphs/b' },
+      ],
+    };
+
+    expect(manager.computeOptionsFingerprint(first)).toBe(manager.computeOptionsFingerprint(second));
+  });
+
+  it('retentionSweep deletes stale stopped or failed session directories and metadata', async () => {
+    const workDir = await createWorkDir('retention');
+    const failedDir = `${workDir}.failed.20260501`;
+    await mkdir(failedDir, { recursive: true });
+    const stale = createAgentSessionRow({
+      conversation_id: 'conversation-retention',
+      status: 'failed',
+      last_activity_at: new Date('2026-04-01T00:00:00.000Z'),
+      work_dir: workDir,
+      agent_home: join(workDir, '.home'),
+    });
+    const repository = createRepository([stale]);
+    const manager = await createManager(repository.instance, { retentionDays: 7 });
+
+    const deleted = await manager.retentionSweep(new Date('2026-05-08T00:00:00.000Z').getTime());
+
+    expect(deleted).toEqual(['conversation-retention']);
+    expect(repository.findStaleForRetentionCleanup).toHaveBeenCalledWith(expect.any(Date), ['stopped', 'failed']);
+    expect(repository.delete).toHaveBeenCalledWith('conversation-retention');
+    await expect(stat(workDir)).rejects.toThrow();
+    await expect(stat(failedDir)).rejects.toThrow();
+  });
+
+  it('shutdown terminates live processes without deleting workDir', async () => {
+    const repository = createRepository();
+    const manager = await createManager(repository.instance);
+    const session = await manager.getOrCreateSession('conversation-shutdown', 'space-1', 'tenant-1', 'user-1');
+    const proc = createClosingProcess();
+    await manager.attachProcess('conversation-shutdown', proc as unknown as ChildProcess);
+
+    await manager.shutdown();
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(repository.delete).not.toHaveBeenCalled();
+    await expect(stat(session.workDir)).resolves.toBeTruthy();
   });
 });
 
-function createManager(): SessionManager {
-  const manager = new SessionManager();
+async function createManager(
+  repository: AgentSessionRepository,
+  config: SessionManagerConfig = {},
+): Promise<SessionManager> {
+  const agentRoot = await createTempDir('session-manager-root');
+  const manager = new SessionManager(repository, {
+    agentRoot,
+    instanceId: 'instance-local',
+    sigintGraceMs: 1,
+    ...config,
+  });
   managers.push(manager);
   return manager;
 }
 
 async function createWorkDir(prefix: string): Promise<string> {
-  const dir = await mkdtemp(join(tmpdir(), `cherry-agent-${prefix}-`));
+  const dir = await createTempDir(`cherry-agent-${prefix}`);
   await mkdir(join(dir, '.home'), { recursive: true });
   return dir;
 }
 
-function createSessionRecord(
-  conversationId: string,
-  workDir: string,
-  lastActivityAt: number,
-  processRef?: ReturnType<typeof createMockProcess>,
-): AgentSessionRecord {
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), `${prefix}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createClosingProcess(): ReturnType<typeof createMockProcess> {
+  const proc = createMockProcess();
+  proc.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    proc.close(0, typeof signal === 'string' ? signal : null);
+    return true;
+  });
+  return proc;
+}
+
+function createRepository(initialRows: AgentSessionRow[] = []): MockAgentSessionRepository {
+  const rows = new Map(initialRows.map((row) => [row.conversation_id, { ...row }]));
+
+  const repository = {
+    upsert: vi.fn((data: NewAgentSession) => {
+      const row = createAgentSessionRow({
+        conversation_id: data.conversation_id,
+        tenant_id: data.tenant_id,
+        space_id: data.space_id,
+        user_id: data.user_id,
+        provider: data.provider ?? 'claude',
+        provider_session_id: data.provider_session_id ?? null,
+        work_dir: data.work_dir,
+        agent_home: data.agent_home,
+        status: data.status,
+        options_hash: data.options_hash ?? null,
+        owned_by_instance: data.owned_by_instance ?? null,
+        last_activity_at: data.last_activity_at,
+        process_started_at: data.process_started_at ?? null,
+        process_stopped_at: data.process_stopped_at ?? null,
+      });
+      rows.set(row.conversation_id, row);
+      return Promise.resolve(row);
+    }),
+    findByConversationId: vi.fn((conversationId: string) => Promise.resolve(rows.get(conversationId))),
+    updateProviderSessionId: vi.fn((conversationId: string, providerSessionId: string) => {
+      const row = rows.get(conversationId);
+      if (row !== undefined) {
+        row.provider_session_id = providerSessionId;
+        row.updated_at = new Date();
+      }
+      return Promise.resolve();
+    }),
+    updateStatus: vi.fn((conversationId: string, status: string, extra: Partial<AgentSessionRow> = {}) => {
+      const row = rows.get(conversationId);
+      if (row !== undefined) {
+        Object.assign(row, extra, { status, updated_at: new Date() });
+      }
+      return Promise.resolve();
+    }),
+    updateOwnedByInstance: vi.fn((conversationId: string, instanceId: string) => {
+      const row = rows.get(conversationId);
+      if (row !== undefined) {
+        row.owned_by_instance = instanceId;
+        row.updated_at = new Date();
+      }
+      return Promise.resolve();
+    }),
+    touchActivity: vi.fn((conversationId: string) => {
+      const row = rows.get(conversationId);
+      if (row !== undefined) {
+        row.last_activity_at = new Date();
+        row.updated_at = row.last_activity_at;
+      }
+      return Promise.resolve();
+    }),
+    delete: vi.fn((conversationId: string) => {
+      rows.delete(conversationId);
+      return Promise.resolve();
+    }),
+    findStaleForRetentionCleanup: vi.fn((olderThan: Date, statuses: string[]) =>
+      Promise.resolve(
+        [...rows.values()].filter(
+          (row) => row.last_activity_at < olderThan && statuses.includes(row.status),
+        ),
+      ),
+    ),
+  };
+
   return {
-    conversationId,
-    spaceId: 'space-1',
-    sessionId: 'session-1',
-    workDir,
-    agentHome: join(workDir, '.home'),
-    lastActivityAt,
-    ...(processRef !== undefined ? { processRef: processRef as unknown as ChildProcess } : {}),
-    options: {},
+    ...repository,
+    instance: repository as unknown as AgentSessionRepository,
+    rows,
   };
 }
+
+function createAgentSessionRow(overrides: Partial<AgentSessionRow> = {}): AgentSessionRow {
+  return {
+    conversation_id: 'conversation-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    user_id: 'user-1',
+    provider: 'claude',
+    provider_session_id: null,
+    work_dir: '/tmp/cherry-agent/conversation-1',
+    agent_home: '/tmp/cherry-agent/conversation-1/.home',
+    status: 'idle',
+    options_hash: null,
+    owned_by_instance: 'instance-local',
+    last_activity_at: new Date('2026-05-01T00:00:00.000Z'),
+    process_started_at: null,
+    process_stopped_at: null,
+    created_at: new Date('2026-05-01T00:00:00.000Z'),
+    updated_at: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+type MockAgentSessionRepository = {
+  instance: AgentSessionRepository;
+  rows: Map<string, AgentSessionRow>;
+  upsert: Mock<(data: NewAgentSession) => Promise<AgentSessionRow>>;
+  findByConversationId: Mock<(conversationId: string) => Promise<AgentSessionRow | undefined>>;
+  updateProviderSessionId: Mock<(conversationId: string, providerSessionId: string) => Promise<void>>;
+  updateStatus: Mock<(conversationId: string, status: string, extra?: Partial<AgentSessionRow>) => Promise<void>>;
+  updateOwnedByInstance: Mock<(conversationId: string, instanceId: string) => Promise<void>>;
+  touchActivity: Mock<(conversationId: string) => Promise<void>>;
+  delete: Mock<(conversationId: string) => Promise<void>>;
+  findStaleForRetentionCleanup: Mock<(olderThan: Date, statuses: string[]) => Promise<AgentSessionRow[]>>;
+};

--- a/apps/api/src/agent/dto/agent.dto.ts
+++ b/apps/api/src/agent/dto/agent.dto.ts
@@ -61,6 +61,49 @@ export type AgentSpawnOptions = {
   maxConcurrentAgents?: number;
 };
 
+export type AgentRuntimeStatus = 'starting' | 'running' | 'idle' | 'stopping' | 'stopped' | 'failed';
+
+export type AgentTurnStatus = 'active' | 'completed' | 'cancelled' | 'error';
+
+export type OptionsFingerprint = {
+  allowedSpaces: string[];
+  graphPaths: string[];
+  databaseEnabled: boolean;
+  databaseDsn: string | undefined;
+  model: string | undefined;
+  maxBudgetUsd: number | undefined;
+};
+
+export type PersistentAgentSession = {
+  conversationId: string;
+  tenantId: string;
+  spaceId: string;
+  userId: string;
+  sessionId: string;
+  providerSessionId: string | undefined;
+  workDir: string;
+  agentHome: string;
+  status: AgentRuntimeStatus;
+  child: ChildProcess | undefined;
+  optionsFingerprint: string;
+  ownedByInstance: string;
+  lastActivityAt: number;
+  idleKillTimer: NodeJS.Timeout | undefined;
+  options: AgentSpawnOptions;
+};
+
+export type AgentTurn = {
+  turnId: string;
+  conversationId: string;
+  userMessage: string;
+  status: AgentTurnStatus;
+  startedAt: number;
+  completedAt: number | undefined;
+  eventQueue: AsyncIterable<AgentEvent>;
+  completedPromise: Promise<void>;
+  abortController: AbortController;
+};
+
 export type AgentSessionRecord = {
   conversationId: string;
   spaceId: string;

--- a/apps/api/src/agent/session-manager.ts
+++ b/apps/api/src/agent/session-manager.ts
@@ -1,36 +1,138 @@
-import { Injectable, type OnModuleDestroy } from '@nestjs/common';
-import { rm } from 'node:fs/promises';
+import { Inject, Injectable, Optional, type OnModuleDestroy } from '@nestjs/common';
+import type { ChildProcess } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, type Dirent } from 'node:fs';
+import { chmod, mkdir, readdir, rm } from 'node:fs/promises';
+import { hostname } from 'node:os';
+import { basename, dirname, join } from 'node:path';
 
-import type { AgentSessionRecord } from './dto/agent.dto.js';
+import {
+  AgentSessionRepository,
+  type AgentSessionRow,
+  type NewAgentSession,
+} from './agent-session.repository.js';
+import type {
+  AgentRuntimeStatus,
+  AgentSessionRecord,
+  AgentSpawnOptions,
+  OptionsFingerprint,
+  PersistentAgentSession,
+} from './dto/agent.dto.js';
 
-const DEFAULT_IDLE_TIMEOUT_MS = 10 * 60_000;
-const DEFAULT_CLEANUP_INTERVAL_MS = 60_000;
+const DEFAULT_AGENT_ROOT = '/tmp/cherry-agent';
+const DEFAULT_IDLE_TIMEOUT_MS = 24 * 60 * 60_000;
+const DEFAULT_MAX_RESIDENT_PROCESSES = 20;
+const DEFAULT_SIGNAL_GRACE_MS = 5_000;
+const DEFAULT_RETENTION_DAYS = 7;
+
+export const SESSION_MANAGER_CONFIG = Symbol('SESSION_MANAGER_CONFIG');
+
+export type SessionManagerConfig = {
+  idleTimeoutMs?: number;
+  maxResidentProcesses?: number;
+  sigintGraceMs?: number;
+  retentionDays?: number;
+  instanceId?: string;
+  agentRoot?: string;
+};
+
+type HasSessionOptions = {
+  includePersisted: true;
+};
 
 @Injectable()
 export class SessionManager implements OnModuleDestroy {
-  private readonly sessions = new Map<string, AgentSessionRecord>();
-  private idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS;
-  private cleanupIntervalMs = DEFAULT_CLEANUP_INTERVAL_MS;
-  private cleanupTimer = this.startCleanupTimer();
+  private readonly sessions = new Map<string, PersistentAgentSession>();
+  private readonly persistedSessionIds = new Set<string>();
+  private readonly agentRoot: string;
+  private idleTimeoutMs: number;
+  private maxResidentProcesses: number;
+  private sigintGraceMs: number;
+  private retentionDays: number;
+  private instanceId: string;
 
-  setSession(session: AgentSessionRecord): void {
-    this.sessions.set(session.conversationId, {
-      ...session,
-      lastActivityAt: session.lastActivityAt,
-    });
+  constructor(
+    @Optional() private readonly repository?: AgentSessionRepository,
+    @Optional()
+    @Inject(SESSION_MANAGER_CONFIG)
+    config: SessionManagerConfig = {},
+  ) {
+    this.agentRoot =
+      config.agentRoot ?? process.env.CHERRY_AGENT_ROOT ?? process.env.CHERRY_AGENT_TMP_ROOT ?? DEFAULT_AGENT_ROOT;
+    this.idleTimeoutMs = config.idleTimeoutMs ?? readPositiveIntegerEnv('AGENT_PROCESS_IDLE_TIMEOUT_MS', DEFAULT_IDLE_TIMEOUT_MS);
+    this.maxResidentProcesses =
+      config.maxResidentProcesses ??
+      readPositiveIntegerEnv('AGENT_MAX_RESIDENT_PROCESSES', DEFAULT_MAX_RESIDENT_PROCESSES);
+    this.sigintGraceMs = config.sigintGraceMs ?? readPositiveIntegerEnv('AGENT_SIGINT_GRACE_MS', DEFAULT_SIGNAL_GRACE_MS);
+    this.retentionDays = config.retentionDays ?? readPositiveIntegerEnv('AGENT_SESSION_RETENTION_DAYS', DEFAULT_RETENTION_DAYS);
+    this.instanceId = config.instanceId ?? this.generateInstanceId();
   }
 
-  getSession(conversationId: string): AgentSessionRecord | undefined {
-    const session = this.sessions.get(conversationId);
-    if (session === undefined) {
-      return undefined;
+  async getOrCreateSession(
+    conversationId: string,
+    spaceId: string,
+    tenantId: string,
+    userId: string,
+    options: AgentSpawnOptions = {},
+  ): Promise<PersistentAgentSession> {
+    const existing = this.sessions.get(conversationId);
+    if (existing !== undefined) {
+      existing.options = { ...existing.options, ...options };
+      existing.optionsFingerprint = this.computeOptionsFingerprint(existing.options);
+      return clonePersistentSession(existing);
     }
 
-    return { ...session };
+    const row = await this.repository?.findByConversationId(conversationId);
+    if (row !== undefined) {
+      this.persistedSessionIds.add(conversationId);
+      const restored = await this.restoreSessionFromRow(row, options);
+      this.sessions.set(conversationId, restored);
+      await this.upsertSession(restored);
+      return clonePersistentSession(restored);
+    }
+
+    const session = await this.createFreshSession(conversationId, spaceId, tenantId, userId, options);
+    this.sessions.set(conversationId, session);
+    await this.upsertSession(session);
+    return clonePersistentSession(session);
   }
 
-  hasSession(conversationId: string): boolean {
-    return this.sessions.has(conversationId);
+  async attachProcess(conversationId: string, child: ChildProcess): Promise<void> {
+    const session = this.sessions.get(conversationId);
+    if (session === undefined) {
+      return;
+    }
+
+    this.clearIdleKillTimer(session);
+    session.child = child;
+    session.status = 'running';
+    session.lastActivityAt = Date.now();
+
+    await this.persistStatus(session, {
+      process_started_at: new Date(session.lastActivityAt),
+      process_stopped_at: null,
+    });
+    await this.lruEvict();
+  }
+
+  async markIdle(conversationId: string): Promise<void> {
+    const session = this.sessions.get(conversationId);
+    if (session === undefined) {
+      return;
+    }
+
+    session.status = 'idle';
+    session.lastActivityAt = Date.now();
+    this.scheduleIdleKillTimer(session);
+    await this.persistStatus(session);
+  }
+
+  async markStopped(conversationId: string): Promise<void> {
+    await this.stopRuntimeSession(conversationId, 'stopped');
+  }
+
+  async markFailed(conversationId: string): Promise<void> {
+    await this.stopRuntimeSession(conversationId, 'failed');
   }
 
   touch(conversationId: string, at = Date.now()): void {
@@ -39,50 +141,40 @@ export class SessionManager implements OnModuleDestroy {
       return;
     }
 
-    this.sessions.set(conversationId, { ...session, lastActivityAt: at });
-  }
-
-  setSessionId(conversationId: string, sessionId: string): void {
-    const session = this.sessions.get(conversationId);
-    if (session === undefined) {
-      return;
+    session.lastActivityAt = at;
+    if (session.status === 'idle') {
+      this.scheduleIdleKillTimer(session);
     }
 
-    this.sessions.set(conversationId, { ...session, sessionId, lastActivityAt: Date.now() });
-  }
-
-  setProcessRef(conversationId: string, processRef: AgentSessionRecord['processRef']): void {
-    const session = this.sessions.get(conversationId);
-    if (session === undefined) {
-      return;
-    }
-
-    this.sessions.set(conversationId, {
-      ...session,
-      ...(processRef !== undefined ? { processRef } : {}),
-      lastActivityAt: Date.now(),
-    });
-  }
-
-  clearProcessRef(conversationId: string): void {
-    const session = this.sessions.get(conversationId);
-    if (session === undefined) {
-      return;
-    }
-
-    const { processRef: _, ...rest } = session;
-    void _;
-    this.sessions.set(conversationId, { ...rest, lastActivityAt: Date.now() });
+    void this.persistTouch(session).catch(() => undefined);
   }
 
   async close(conversationId: string): Promise<void> {
     const session = this.sessions.get(conversationId);
-    if (session === undefined) {
+    if (session !== undefined) {
+      this.clearIdleKillTimer(session);
+      session.status = 'stopping';
+      const child = session.child;
+      session.child = undefined;
+      if (isLiveChild(child)) {
+        await terminateChild(child, 'SIGTERM', this.sigintGraceMs);
+      }
+
+      this.sessions.delete(conversationId);
+      this.persistedSessionIds.delete(conversationId);
+      await this.deleteSessionDirectories(session.workDir, session.agentHome);
+      await this.repository?.delete(conversationId);
       return;
     }
 
-    this.sessions.delete(conversationId);
-    await this.cleanupSessionDirectory(session);
+    const row = await this.repository?.findByConversationId(conversationId);
+    if (row === undefined) {
+      return;
+    }
+
+    this.persistedSessionIds.delete(conversationId);
+    await this.deleteSessionDirectories(row.work_dir, row.agent_home);
+    await this.repository?.delete(conversationId);
   }
 
   async cleanupAll(): Promise<void> {
@@ -91,63 +183,560 @@ export class SessionManager implements OnModuleDestroy {
   }
 
   async sweepIdleSessions(now = Date.now()): Promise<string[]> {
-    const idleConversationIds = [...this.sessions.values()]
-      .filter((session) => now - session.lastActivityAt >= this.idleTimeoutMs)
+    const expired = [...this.sessions.values()]
+      .filter((session) => session.status === 'idle' && now - session.lastActivityAt >= this.idleTimeoutMs)
       .map((session) => session.conversationId);
 
-    for (const conversationId of idleConversationIds) {
-      await this.close(conversationId);
+    for (const conversationId of expired) {
+      await this.stopRuntimeSession(conversationId, 'stopped', now);
     }
 
-    return idleConversationIds;
+    return expired;
+  }
+
+  async lruEvict(): Promise<string[]> {
+    const evicted: string[] = [];
+
+    while (this.residentProcessCount() > this.maxResidentProcesses) {
+      const candidate = [...this.sessions.values()]
+        .filter((session) => session.status === 'idle' && isLiveChild(session.child))
+        .sort((a, b) => a.lastActivityAt - b.lastActivityAt)[0];
+
+      if (candidate === undefined) {
+        break;
+      }
+
+      await this.stopRuntimeSession(candidate.conversationId, 'stopped');
+      evicted.push(candidate.conversationId);
+    }
+
+    return evicted;
+  }
+
+  async retentionSweep(now = Date.now()): Promise<string[]> {
+    if (this.repository === undefined) {
+      return [];
+    }
+
+    const olderThan = new Date(now - this.retentionDays * 24 * 60 * 60_000);
+    const rows = await this.repository.findStaleForRetentionCleanup(olderThan, ['stopped', 'failed']);
+    const deleted: string[] = [];
+
+    for (const row of rows) {
+      const session = this.sessions.get(row.conversation_id);
+      if (session !== undefined) {
+        this.clearIdleKillTimer(session);
+        if (isLiveChild(session.child)) {
+          await terminateChild(session.child, 'SIGTERM', this.sigintGraceMs);
+        }
+        this.sessions.delete(row.conversation_id);
+      }
+
+      await this.deleteSessionDirectories(row.work_dir, row.agent_home);
+      await this.repository.delete(row.conversation_id);
+      this.persistedSessionIds.delete(row.conversation_id);
+      deleted.push(row.conversation_id);
+    }
+
+    return deleted;
+  }
+
+  async shutdown(): Promise<void> {
+    const now = Date.now();
+    const sessions = [...this.sessions.values()];
+
+    await Promise.all(
+      sessions.map(async (session) => {
+        this.clearIdleKillTimer(session);
+        const child = session.child;
+        session.child = undefined;
+
+        if (isLiveChild(child)) {
+          await terminateChild(child, 'SIGTERM', this.sigintGraceMs);
+        }
+
+        if (session.status !== 'stopped' && session.status !== 'failed') {
+          session.status = 'stopped';
+          session.lastActivityAt = now;
+          await this.persistStatus(session, { process_stopped_at: new Date(now) });
+        }
+      }),
+    );
+  }
+
+  generateInstanceId(): string {
+    const explicitRoot = process.env.CHERRY_AGENT_ROOT ?? process.env.CHERRY_AGENT_TMP_ROOT;
+    if (explicitRoot === undefined && this.agentRoot === DEFAULT_AGENT_ROOT) {
+      return hostname();
+    }
+
+    const instancePath = join(this.agentRoot, '.instance_id');
+    try {
+      if (existsSync(instancePath)) {
+        const existing = readFileSync(instancePath, 'utf8').trim();
+        if (existing.length > 0) {
+          return existing;
+        }
+      }
+
+      mkdirSync(this.agentRoot, { recursive: true, mode: 0o700 });
+      const generated = randomUUID();
+      writeFileSync(instancePath, `${generated}\n`, { encoding: 'utf8', mode: 0o600 });
+      return generated;
+    } catch {
+      return hostname();
+    }
+  }
+
+  computeOptionsFingerprint(options: AgentSpawnOptions = {}): string {
+    const fingerprint: OptionsFingerprint = {
+      allowedSpaces: [...new Set((options.allowedSpaces ?? []).map((space) => space.id))].sort(),
+      graphPaths: [
+        ...new Set(
+          [
+            options.graphBasePath,
+            ...(options.allowedSpaces ?? []).map((space) => space.graphPath),
+          ].filter(isNonEmptyString),
+        ),
+      ].sort(),
+      databaseEnabled: options.enableDatabase === true && options.databaseConfig?.enabled === true,
+      databaseDsn: options.databaseConfig?.dsn,
+      model: options.model,
+      maxBudgetUsd: options.maxBudgetUsd,
+    };
+
+    return createHash('sha256').update(JSON.stringify(fingerprint)).digest('hex');
+  }
+
+  hasSession(conversationId: string): boolean;
+  hasSession(conversationId: string, options: HasSessionOptions): Promise<boolean>;
+  hasSession(conversationId: string, options?: HasSessionOptions): boolean | Promise<boolean> {
+    if (options?.includePersisted === true) {
+      return this.hasPersistedSession(conversationId);
+    }
+
+    return this.sessions.has(conversationId) || this.persistedSessionIds.has(conversationId);
+  }
+
+  async hasPersistedSession(conversationId: string): Promise<boolean> {
+    if (this.sessions.has(conversationId) || this.persistedSessionIds.has(conversationId)) {
+      return true;
+    }
+
+    const row = await this.repository?.findByConversationId(conversationId);
+    if (row === undefined) {
+      return false;
+    }
+
+    this.persistedSessionIds.add(conversationId);
+    return true;
   }
 
   size(): number {
     return this.sessions.size;
   }
 
-  configureForTests(input: { idleTimeoutMs?: number; cleanupIntervalMs?: number }): void {
+  configureForTests(input: SessionManagerConfig & { cleanupIntervalMs?: number }): void {
     if (input.idleTimeoutMs !== undefined) {
       this.idleTimeoutMs = input.idleTimeoutMs;
+      for (const session of this.sessions.values()) {
+        if (session.status === 'idle') {
+          this.scheduleIdleKillTimer(session);
+        }
+      }
     }
 
-    if (input.cleanupIntervalMs !== undefined) {
-      this.cleanupIntervalMs = input.cleanupIntervalMs;
-      clearInterval(this.cleanupTimer);
-      this.cleanupTimer = this.startCleanupTimer();
+    if (input.maxResidentProcesses !== undefined) {
+      this.maxResidentProcesses = input.maxResidentProcesses;
+      void this.lruEvict().catch(() => undefined);
+    }
+
+    if (input.sigintGraceMs !== undefined) {
+      this.sigintGraceMs = input.sigintGraceMs;
+    }
+
+    if (input.retentionDays !== undefined) {
+      this.retentionDays = input.retentionDays;
+    }
+
+    if (input.instanceId !== undefined) {
+      this.instanceId = input.instanceId;
     }
   }
 
   async onModuleDestroy(): Promise<void> {
-    clearInterval(this.cleanupTimer);
-    await this.cleanupAll();
+    await this.shutdown();
   }
 
-  private startCleanupTimer(): NodeJS.Timeout {
-    const timer = setInterval(() => {
-      void this.sweepIdleSessions();
-    }, this.cleanupIntervalMs);
-    timer.unref();
-    return timer;
-  }
-
-  private async cleanupSessionDirectory(session: AgentSessionRecord): Promise<void> {
-    if (session.processRef !== undefined && session.processRef.exitCode === null) {
-      session.processRef.kill('SIGTERM');
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(() => {
-          if (session.processRef !== undefined && session.processRef.exitCode === null) {
-            session.processRef.kill('SIGKILL');
-          }
-          resolve();
-        }, 5_000);
-        timer.unref();
-        session.processRef!.once('close', () => {
-          clearTimeout(timer);
-          resolve();
-        });
-      });
+  setSession(session: AgentSessionRecord): void {
+    const persistent = this.toPersistentSession(session);
+    const previous = this.sessions.get(session.conversationId);
+    if (previous !== undefined) {
+      this.clearIdleKillTimer(previous);
     }
-    await rm(session.workDir, { recursive: true, force: true });
+
+    this.sessions.set(session.conversationId, persistent);
+    this.persistedSessionIds.add(session.conversationId);
+
+    if (persistent.status === 'idle') {
+      this.scheduleIdleKillTimer(persistent);
+    }
+
+    void this.upsertSession(persistent).catch(() => undefined);
   }
+
+  getSession(conversationId: string): AgentSessionRecord | undefined {
+    const session = this.sessions.get(conversationId);
+    if (session === undefined) {
+      return undefined;
+    }
+
+    return toAgentSessionRecord(session);
+  }
+
+  setSessionId(conversationId: string, providerSessionId: string): void {
+    const session = this.sessions.get(conversationId);
+    if (session === undefined) {
+      return;
+    }
+
+    session.providerSessionId = providerSessionId;
+    session.lastActivityAt = Date.now();
+    this.persistedSessionIds.add(conversationId);
+    void this.repository?.updateProviderSessionId(conversationId, providerSessionId).catch(() => undefined);
+  }
+
+  setProcessRef(conversationId: string, processRef: AgentSessionRecord['processRef']): void {
+    if (processRef === undefined) {
+      return;
+    }
+
+    void this.attachProcess(conversationId, processRef).catch(() => undefined);
+  }
+
+  clearProcessRef(conversationId: string): void {
+    const session = this.sessions.get(conversationId);
+    if (session === undefined) {
+      return;
+    }
+
+    session.child = undefined;
+    void this.markIdle(conversationId).catch(() => undefined);
+  }
+
+  private async createFreshSession(
+    conversationId: string,
+    spaceId: string,
+    tenantId: string,
+    userId: string,
+    options: AgentSpawnOptions,
+  ): Promise<PersistentAgentSession> {
+    const workDir = join(this.agentRoot, sanitizePathSegment(conversationId));
+    const agentHome = join(workDir, '.home');
+    await prepareSessionDirectories(workDir, agentHome);
+
+    return {
+      conversationId,
+      tenantId,
+      spaceId,
+      userId,
+      sessionId: randomUUID(),
+      providerSessionId: undefined,
+      workDir,
+      agentHome,
+      status: 'starting',
+      child: undefined,
+      optionsFingerprint: this.computeOptionsFingerprint(options),
+      ownedByInstance: this.instanceId,
+      lastActivityAt: Date.now(),
+      idleKillTimer: undefined,
+      options,
+    };
+  }
+
+  private async restoreSessionFromRow(
+    row: AgentSessionRow,
+    options: AgentSpawnOptions,
+  ): Promise<PersistentAgentSession> {
+    await prepareSessionDirectories(row.work_dir, row.agent_home);
+
+    const ownedByAnotherInstance =
+      row.owned_by_instance !== null && row.owned_by_instance !== this.instanceId;
+    const restoredStatus = ownedByAnotherInstance
+      ? 'stopped'
+      : normalizeStoredStatusForRestore(row.status);
+
+    return {
+      conversationId: row.conversation_id,
+      tenantId: row.tenant_id,
+      spaceId: row.space_id,
+      userId: row.user_id,
+      sessionId: randomUUID(),
+      providerSessionId: row.provider_session_id ?? undefined,
+      workDir: row.work_dir,
+      agentHome: row.agent_home,
+      status: restoredStatus,
+      child: undefined,
+      optionsFingerprint: this.computeOptionsFingerprint(options),
+      ownedByInstance: this.instanceId,
+      lastActivityAt: row.last_activity_at.getTime(),
+      idleKillTimer: undefined,
+      options,
+    };
+  }
+
+  private toPersistentSession(session: AgentSessionRecord): PersistentAgentSession {
+    return {
+      conversationId: session.conversationId,
+      tenantId: session.options.tenantId ?? '',
+      spaceId: session.spaceId,
+      userId: session.options.userId ?? '',
+      sessionId: session.sessionId,
+      providerSessionId: undefined,
+      workDir: session.workDir,
+      agentHome: session.agentHome,
+      status: session.processRef === undefined ? 'idle' : 'running',
+      child: session.processRef,
+      optionsFingerprint: this.computeOptionsFingerprint(session.options),
+      ownedByInstance: this.instanceId,
+      lastActivityAt: session.lastActivityAt,
+      idleKillTimer: undefined,
+      options: session.options,
+    };
+  }
+
+  private async stopRuntimeSession(
+    conversationId: string,
+    status: Extract<AgentRuntimeStatus, 'stopped' | 'failed'>,
+    at = Date.now(),
+  ): Promise<void> {
+    const session = this.sessions.get(conversationId);
+    if (session === undefined) {
+      return;
+    }
+
+    this.clearIdleKillTimer(session);
+    const child = session.child;
+    session.child = undefined;
+
+    if (isLiveChild(child)) {
+      await terminateChild(child, 'SIGTERM', this.sigintGraceMs);
+    }
+
+    session.status = status;
+    session.lastActivityAt = at;
+    await this.persistStatus(session, { process_stopped_at: new Date(at) });
+  }
+
+  private async upsertSession(session: PersistentAgentSession): Promise<void> {
+    if (this.repository === undefined) {
+      return;
+    }
+
+    const row: NewAgentSession = {
+      conversation_id: session.conversationId,
+      tenant_id: session.tenantId,
+      space_id: session.spaceId,
+      user_id: session.userId,
+      provider: 'claude',
+      provider_session_id: session.providerSessionId ?? null,
+      work_dir: session.workDir,
+      agent_home: session.agentHome,
+      status: session.status,
+      options_hash: session.optionsFingerprint,
+      owned_by_instance: session.ownedByInstance,
+      last_activity_at: new Date(session.lastActivityAt),
+      process_started_at:
+        session.status === 'running' && session.child !== undefined
+          ? new Date(session.lastActivityAt)
+          : null,
+      process_stopped_at:
+        session.status === 'stopped' || session.status === 'failed'
+          ? new Date(session.lastActivityAt)
+          : null,
+    };
+
+    await this.repository.upsert(row);
+    this.persistedSessionIds.add(session.conversationId);
+  }
+
+  private async persistStatus(
+    session: PersistentAgentSession,
+    extra: Partial<AgentSessionRow> = {},
+  ): Promise<void> {
+    if (this.repository === undefined) {
+      return;
+    }
+
+    await this.repository.updateStatus(session.conversationId, session.status, {
+      provider_session_id: session.providerSessionId ?? null,
+      options_hash: session.optionsFingerprint,
+      owned_by_instance: session.ownedByInstance,
+      last_activity_at: new Date(session.lastActivityAt),
+      ...extra,
+    });
+    this.persistedSessionIds.add(session.conversationId);
+  }
+
+  private async persistTouch(session: PersistentAgentSession): Promise<void> {
+    if (this.repository === undefined) {
+      return;
+    }
+
+    await this.repository.updateStatus(session.conversationId, session.status, {
+      last_activity_at: new Date(session.lastActivityAt),
+      owned_by_instance: session.ownedByInstance,
+    });
+  }
+
+  private scheduleIdleKillTimer(session: PersistentAgentSession): void {
+    this.clearIdleKillTimer(session);
+    const remainingMs = Math.max(0, this.idleTimeoutMs - (Date.now() - session.lastActivityAt));
+    session.idleKillTimer = setTimeout(() => {
+      session.idleKillTimer = undefined;
+      void this.sweepIdleSessions().catch(() => undefined);
+    }, remainingMs);
+  }
+
+  private clearIdleKillTimer(session: PersistentAgentSession): void {
+    if (session.idleKillTimer === undefined) {
+      return;
+    }
+
+    clearTimeout(session.idleKillTimer);
+    session.idleKillTimer = undefined;
+  }
+
+  private residentProcessCount(): number {
+    return [...this.sessions.values()].filter((session) => isLiveChild(session.child)).length;
+  }
+
+  private async deleteSessionDirectories(workDir: string, agentHome: string): Promise<void> {
+    await rm(agentHome, { recursive: true, force: true });
+    await rm(workDir, { recursive: true, force: true });
+    await deleteFailedSiblingDirectories(workDir);
+  }
+}
+
+function toAgentSessionRecord(session: PersistentAgentSession): AgentSessionRecord {
+  return {
+    conversationId: session.conversationId,
+    spaceId: session.spaceId,
+    sessionId: session.providerSessionId ?? session.sessionId,
+    workDir: session.workDir,
+    agentHome: session.agentHome,
+    lastActivityAt: session.lastActivityAt,
+    ...(session.child !== undefined ? { processRef: session.child } : {}),
+    options: { ...session.options },
+  };
+}
+
+function clonePersistentSession(session: PersistentAgentSession): PersistentAgentSession {
+  return {
+    ...session,
+    options: { ...session.options },
+  };
+}
+
+function normalizeStoredStatusForRestore(status: string): AgentRuntimeStatus {
+  if (status === 'failed') {
+    return 'failed';
+  }
+
+  return 'stopped';
+}
+
+async function prepareSessionDirectories(workDir: string, agentHome: string): Promise<void> {
+  const tmpDir = join(workDir, 'tmp');
+  await mkdir(workDir, { recursive: true, mode: 0o700 });
+  await mkdir(agentHome, { recursive: true, mode: 0o700 });
+  await mkdir(tmpDir, { recursive: true, mode: 0o700 });
+  await Promise.all([chmod(workDir, 0o700), chmod(agentHome, 0o700), chmod(tmpDir, 0o700)]);
+}
+
+async function terminateChild(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+  graceMs: number,
+): Promise<void> {
+  if (!isLiveChild(child)) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timer);
+      child.off('close', finish);
+      child.off('exit', finish);
+      child.off('error', finish);
+      resolve();
+    };
+
+    const timer = setTimeout(() => {
+      if (isLiveChild(child)) {
+        killChild(child, 'SIGKILL');
+      }
+      finish();
+    }, graceMs);
+
+    child.once('close', finish);
+    child.once('exit', finish);
+    child.once('error', finish);
+    killChild(child, signal);
+  });
+}
+
+function killChild(child: ChildProcess, signal: NodeJS.Signals): void {
+  try {
+    child.kill(signal);
+  } catch {
+    // The process may already be gone between the liveness check and kill call.
+  }
+}
+
+function isLiveChild(child: ChildProcess | undefined): child is ChildProcess {
+  return child !== undefined && child.exitCode === null;
+}
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sanitizePathSegment(input: string): string {
+  const sanitized = input.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 160);
+  return sanitized.length > 0 ? sanitized : randomUUID();
+}
+
+function isNonEmptyString(value: string | undefined): value is string {
+  return value !== undefined && value.length > 0;
+}
+
+async function deleteFailedSiblingDirectories(workDir: string): Promise<void> {
+  const parent = dirname(workDir);
+  const prefix = `${basename(workDir)}.failed.`;
+  let entries: Dirent[];
+
+  try {
+    entries = await readdir(parent, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith(prefix))
+      .map((entry) => rm(join(parent, entry.name), { recursive: true, force: true })),
+  );
 }

--- a/apps/api/src/agent/session-manager.ts
+++ b/apps/api/src/agent/session-manager.ts
@@ -592,10 +592,12 @@ export class SessionManager implements OnModuleDestroy {
   private scheduleIdleKillTimer(session: PersistentAgentSession): void {
     this.clearIdleKillTimer(session);
     const remainingMs = Math.max(0, this.idleTimeoutMs - (Date.now() - session.lastActivityAt));
-    session.idleKillTimer = setTimeout(() => {
+    const timer = setTimeout(() => {
       session.idleKillTimer = undefined;
       void this.sweepIdleSessions().catch(() => undefined);
     }, remainingMs);
+    timer.unref();
+    session.idleKillTimer = timer;
   }
 
   private clearIdleKillTimer(session: PersistentAgentSession): void {


### PR DESCRIPTION
## Summary

- Add `AgentRuntimeStatus`, `PersistentAgentSession`, `OptionsFingerprint` types to `agent.dto.ts`
- Complete SessionManager rewrite: DB+memory dual-layer registry with `AgentSessionRepository`
- 24h idle timeout kills process but preserves workDir/.claude and DB metadata (D4)
- LRU eviction when `AGENT_MAX_RESIDENT_PROCESSES` exceeded, running sessions never evicted (D9)
- Explicit close uses SIGTERM (not SIGINT), deletes workDir + DB row (D8)
- Multi-instance affinity via `owned_by_instance` + stable `INSTANCE_ID` (D10)
- Retention sweep for stopped/failed sessions after configurable days (D14)
- Options fingerprint for config change detection (D7 prep)
- `hasSession()` checks both memory and DB for migration compatibility (D12)

Closes #173

## Test plan

- [x] getOrCreateSession creates fresh / restores from DB / detects instance mismatch
- [x] attachProcess stores child and updates status
- [x] markIdle/markStopped/markFailed state transitions
- [x] touch updates activity timestamp
- [x] close kills process with SIGTERM, deletes workDir
- [x] sweepIdleSessions kills idle processes but preserves workDir
- [x] LRU eviction kills least-recently-used idle session
- [x] hasSession checks both memory and DB
- [x] computeOptionsFingerprint is deterministic
- [x] shutdown kills all processes without deleting workDir
- [x] Full agent suite: 11 files, 68 tests, all green
- [x] TypeScript typecheck + ESLint clean

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security Reviewer
- Reviewed head SHA: `190d1bbbf669eefc6d3191e7a15a0822457db81f`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/185#issuecomment-4404172155) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/185#issuecomment-4404172348) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/185#issuecomment-4404172595) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/185#issuecomment-4404172933)
- Key findings addressed: Idle timer .unref() fix applied. All clear — spec compliance, correctness, integration, security all pass.