### PR TITLE
feat(agent): persistent Claude process runner (#174)

### DIFF
--- a/apps/api/src/agent/__tests__/agent-persistent-runner.test.ts
+++ b/apps/api/src/agent/__tests__/agent-persistent-runner.test.ts
@@ -1,0 +1,289 @@
+import 'reflect-metadata';
+
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import type { AuditService } from '../../audit/audit.service.js';
+import type { DrizzleDatabase } from '../../database/drizzle.module.js';
+import { AgentService } from '../agent.service.js';
+import { AuditCapture } from '../audit-capture.js';
+import { ClaudeMdGenerator } from '../claude-md-generator.js';
+import type { PersistentAgentSession } from '../dto/agent.dto.js';
+import { SessionManager } from '../session-manager.js';
+import { SettingsGenerator } from '../settings-generator.js';
+import { StreamParser } from '../stream-parser.js';
+import { AgentTestDb, collectAsync, createMockProcess, type MockAgentProcess, writeJsonLine } from './agent-test-utils.js';
+
+const spawnMock = vi.mocked(spawn);
+const managers: SessionManager[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  await Promise.all(managers.splice(0).map((manager) => manager.onModuleDestroy()));
+});
+
+describe('AgentService persistent runner', () => {
+  it('spawns Claude with stream-json pipe args and no CLI prompt', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc as never);
+    const { service, manager } = createService();
+    const session = await createSession(manager, { maxBudgetUsd: 3 });
+
+    const spawnPromise = service.spawnPersistentProcess(session);
+    await waitForSpawn();
+    writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'provider-args' });
+    await spawnPromise;
+
+    const args = spawnMock.mock.calls[0]?.[1];
+    expect(args).toEqual(
+      expect.arrayContaining([
+        '-p',
+        '--input-format',
+        'stream-json',
+        '--output-format',
+        'stream-json',
+        '--verbose',
+        '--include-partial-messages',
+        '--tools',
+        'Bash,Read',
+        '--permission-mode',
+        'bypassPermissions',
+        '--max-budget-usd',
+        '3',
+      ]),
+    );
+    expect(args).toEqual(expect.arrayContaining(['--settings', `${session.workDir}/settings.json`]));
+    expect(args).not.toContain('--print');
+    expect(args).not.toContain('hello from cli');
+
+    proc.close(0);
+  });
+
+  it('uses --session-id for first spawn and --resume with providerSessionId for resume', async () => {
+    const first = createMockProcess();
+    const resumed = createMockProcess();
+    spawnMock.mockReturnValueOnce(first as never).mockReturnValueOnce(resumed as never);
+    const { service, manager } = createService();
+    const session = await createSession(manager);
+
+    const firstSpawn = service.spawnPersistentProcess(session);
+    await waitForSpawn(1);
+    writeJsonLine(first, { type: 'system', subtype: 'init', session_id: 'provider-resume' });
+    await firstSpawn;
+    first.close(0);
+    await vi.waitFor(() => expect(service.getActiveAgentCount()).toBe(0));
+
+    const secondSpawn = service.spawnPersistentProcess(session);
+    await waitForSpawn(2);
+    writeJsonLine(resumed, { type: 'system', subtype: 'init', session_id: 'provider-resume' });
+    await secondSpawn;
+
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual(expect.arrayContaining(['--session-id', session.sessionId]));
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(expect.arrayContaining(['--resume', 'provider-resume']));
+
+    resumed.close(0);
+  });
+
+  it('writes each turn to stdin as a stream-json user line', async () => {
+    const proc = createMockProcess();
+    const stdinChunks = captureStdin(proc);
+    spawnMock.mockReturnValue(proc as never);
+    const { service, manager } = createService();
+    const session = await createStartedSession(service, manager, proc, 'provider-stdin');
+
+    const eventsPromise = collectAsync(service.sendTurnToPersistentProcess(session, 'hello "json"'));
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('\n'));
+    writeJsonLine(proc, { type: 'result', subtype: 'success', session_id: 'provider-stdin' });
+    await eventsPromise;
+
+    expect(stdinChunks.join('')).toBe(
+      `${JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello "json"' } })}\n`,
+    );
+
+    proc.close(0);
+  });
+
+  it('captures system/init provider session id into SessionManager metadata', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc as never);
+    const { service, manager } = createService();
+    const session = await createSession(manager);
+
+    const spawnPromise = service.spawnPersistentProcess(session);
+    await waitForSpawn();
+    writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'provider-captured' });
+    await spawnPromise;
+
+    const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+    expect(saved.providerSessionId).toBe('provider-captured');
+    expect(session.providerSessionId).toBe('provider-captured');
+
+    proc.close(0);
+  });
+
+  it('marks result success as idle while keeping the process and slot alive', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc as never);
+    const { service, manager } = createService();
+    const session = await createStartedSession(service, manager, proc, 'provider-success', {
+      maxConcurrentAgents: 1,
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    });
+
+    const eventsPromise = collectAsync(service.sendTurnToPersistentProcess(session, 'finish successfully'));
+    writeJsonLine(proc, { type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } });
+    writeJsonLine(proc, {
+      type: 'result',
+      subtype: 'success',
+      session_id: 'provider-success',
+      usage: { input_tokens: 5, output_tokens: 2 },
+    });
+    const events = await eventsPromise;
+    const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+
+    expect(events.map((event) => event.type)).toEqual(['message.delta', 'message.completed']);
+    expect(saved.status).toBe('idle');
+    expect(saved.child).toBe(proc);
+    expect(proc.exitCode).toBeNull();
+    expect(service.getActiveAgentCount()).toBe(1);
+
+    proc.close(0);
+    await vi.waitFor(() => expect(service.getActiveAgentCount()).toBe(0));
+  });
+
+  it('marks result error as the end of the current turn and returns the live process to idle', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc as never);
+    const { service, manager } = createService();
+    const session = await createStartedSession(service, manager, proc, 'provider-error');
+
+    const eventsPromise = collectAsync(service.sendTurnToPersistentProcess(session, 'fail this turn'));
+    writeJsonLine(proc, {
+      type: 'result',
+      subtype: 'error_during_execution',
+      error: 'tool failed',
+    });
+    const events = await eventsPromise;
+    const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+
+    expect(events).toEqual([{ type: 'message.error', code: 'error_during_execution', message: 'tool failed' }]);
+    expect(saved.status).toBe('idle');
+    expect(saved.child).toBe(proc);
+
+    proc.close(0);
+  });
+
+  it('marks a non-zero process exit as failed and releases the process slot', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc as never);
+    const { service, manager } = createService();
+    const session = await createStartedSession(service, manager, proc, 'provider-exit', { maxConcurrentAgents: 1 });
+
+    expect(service.getActiveAgentCount()).toBe(1);
+    proc.close(1);
+
+    await vi.waitFor(async () => {
+      const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+      expect(saved.status).toBe('failed');
+    });
+    expect(service.getActiveAgentCount()).toBe(0);
+  });
+
+  it('keeps stderr audit capture active for the lifetime of the persistent process', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc as never);
+    const { service, manager, auditPush } = createService();
+    const session = await createStartedSession(service, manager, proc, 'provider-audit', {
+      tenantId: 'tenant-audit',
+      userId: 'user-audit',
+    });
+
+    proc.stderr.write(`${JSON.stringify({ event: 'database_query', sql: 'select 1' })}\n`);
+    const eventsPromise = collectAsync(service.sendTurnToPersistentProcess(session, 'audit turn'));
+    writeJsonLine(proc, { type: 'result', subtype: 'success', session_id: 'provider-audit' });
+    await eventsPromise;
+    proc.stderr.write(`${JSON.stringify({ event: 'database_query', sql: 'select 2' })}\n`);
+    await vi.waitFor(() => expect(auditPush).toHaveBeenCalledTimes(2));
+
+    expect(auditPush).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        tenant_id: 'tenant-audit',
+        actor_user_id: 'user-audit',
+        action: 'database_query',
+        metadata_json: expect.objectContaining({ conversation_id: session.conversationId, sql: 'select 2' }) as object,
+      }),
+    );
+
+    proc.close(0);
+  });
+});
+
+function createService(): {
+  service: AgentService;
+  manager: SessionManager;
+  db: AgentTestDb;
+  auditPush: ReturnType<typeof vi.fn>;
+} {
+  const db = new AgentTestDb();
+  const manager = new SessionManager();
+  manager.configureForTests({ sigintGraceMs: 1, idleTimeoutMs: 60_000 });
+  managers.push(manager);
+  const auditPush = vi.fn();
+  const auditService = { push: auditPush } as unknown as AuditService;
+  const service = new AgentService(
+    db as unknown as DrizzleDatabase,
+    manager,
+    new StreamParser(),
+    new AuditCapture(auditService),
+    new ClaudeMdGenerator(),
+    new SettingsGenerator(),
+  );
+
+  return { service, manager, db, auditPush };
+}
+
+async function createSession(
+  manager: SessionManager,
+  options: PersistentAgentSession['options'] = {},
+): Promise<PersistentAgentSession> {
+  const conversationId = `conversation-persistent-${randomUUID()}`;
+  return manager.getOrCreateSession(conversationId, 'space-1', 'tenant-1', 'user-1', {
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    ...options,
+  });
+}
+
+async function createStartedSession(
+  service: AgentService,
+  manager: SessionManager,
+  proc: MockAgentProcess,
+  providerSessionId: string,
+  options: PersistentAgentSession['options'] = {},
+): Promise<PersistentAgentSession> {
+  const session = await createSession(manager, options);
+  const spawnPromise = service.spawnPersistentProcess(session);
+  await waitForSpawn();
+  writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: providerSessionId });
+  await spawnPromise;
+  return session;
+}
+
+function captureStdin(proc: MockAgentProcess): string[] {
+  const chunks: string[] = [];
+  proc.stdin.on('data', (chunk: Buffer | string) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+  });
+  return chunks;
+}
+
+async function waitForSpawn(count = 1): Promise<void> {
+  await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(count));
+}

--- a/apps/api/src/agent/__tests__/agent-test-utils.ts
+++ b/apps/api/src/agent/__tests__/agent-test-utils.ts
@@ -16,6 +16,7 @@ export class AgentTestDb {
 }
 
 export type MockAgentProcess = EventEmitter & {
+  stdin: PassThrough;
   stdout: PassThrough;
   stderr: PassThrough;
   exitCode: number | null;
@@ -25,12 +26,14 @@ export type MockAgentProcess = EventEmitter & {
 
 export function createMockProcess(): MockAgentProcess {
   const proc = new EventEmitter() as MockAgentProcess;
+  proc.stdin = new PassThrough();
   proc.stdout = new PassThrough();
   proc.stderr = new PassThrough();
   proc.exitCode = null;
   proc.kill = vi.fn(() => true);
   proc.close = (code: number | null = 0, signal: NodeJS.Signals | null = null) => {
     proc.exitCode = code;
+    proc.stdin.end();
     proc.stdout.end();
     proc.stderr.end();
     proc.emit('close', code, signal);

--- a/apps/api/src/agent/agent.service.ts
+++ b/apps/api/src/agent/agent.service.ts
@@ -16,13 +16,17 @@ import type {
   AgentSessionRecord,
   AgentSpawnOptions,
   AgentTiming,
+  PersistentAgentSession,
 } from './dto/agent.dto.js';
+import { PersistentStreamParser } from './persistent-stream-parser.js';
+import { SessionMutex } from './session-mutex.js';
 import { SessionManager } from './session-manager.js';
 import { SettingsGenerator } from './settings-generator.js';
 import { StreamParser } from './stream-parser.js';
 
 const DEFAULT_MAX_CONCURRENT_AGENTS = 20;
 const DEFAULT_PROCESS_TIMEOUT_MS = 60 * 60_000;
+const DEFAULT_PROCESS_STARTUP_TIMEOUT_MS = 30_000;
 const HARD_KILL_GRACE_MS = 5_000;
 const MAX_QUEUE_SIZE = 50;
 const DEFAULT_MAX_BUDGET_USD = 2;
@@ -35,6 +39,9 @@ export class AgentService implements OnModuleDestroy {
   private readonly timings = new Map<string, AgentTiming>();
   private activeAgents = 0;
   private readonly queue: Array<() => void> = [];
+  private readonly persistentParsers = new Map<string, PersistentStreamParser>();
+  private readonly persistentSlotHolders = new Set<string>();
+  private readonly turnMutex = new SessionMutex();
 
   constructor(
     @Inject(DRIZZLE) private readonly db: DrizzleDatabase,
@@ -155,23 +162,12 @@ export class AgentService implements OnModuleDestroy {
     const workDir = join(process.env.CHERRY_AGENT_TMP_ROOT ?? DEFAULT_AGENT_ROOT, sanitizePathSegment(conversationId));
     const agentHome = join(workDir, '.home');
     const tmpDir = join(workDir, 'tmp');
-    const settingsPath = join(workDir, 'settings.json');
 
     await mkdir(workDir, { recursive: true, mode: 0o700 });
     await chmod(workDir, 0o700);
     await mkdir(agentHome, { recursive: true, mode: 0o700 });
     await mkdir(tmpDir, { recursive: true, mode: 0o700 });
     await Promise.all([chmod(agentHome, 0o700), chmod(tmpDir, 0o700)]);
-    const claudeMdInput = {
-      spaceId,
-      ...(options.allowedSpaces !== undefined ? { allowedSpaces: options.allowedSpaces } : {}),
-      ...(options.graphBasePath !== undefined ? { graphBasePath: options.graphBasePath } : {}),
-      ...(options.enableDatabase !== undefined ? { enableDatabase: options.enableDatabase } : {}),
-      ...(options.databaseConfig !== undefined ? { databaseConfig: options.databaseConfig } : {}),
-    };
-
-    await writeFile(join(workDir, 'CLAUDE.md'), this.claudeMdGenerator.generate(claudeMdInput), 'utf8');
-    await writeFile(settingsPath, `${JSON.stringify(this.settingsGenerator.generate(), null, 2)}\n`, 'utf8');
 
     const session: AgentSessionRecord = {
       conversationId,
@@ -182,9 +178,170 @@ export class AgentService implements OnModuleDestroy {
       lastActivityAt: Date.now(),
       options,
     };
+    await this.writeRuntimeFiles(session);
     this.sessionManager.setSession(session);
 
     return session;
+  }
+
+  async spawnPersistentProcess(session: PersistentAgentSession): Promise<void> {
+    const existing = session.child;
+    if (isLiveProcess(existing) && this.persistentParsers.has(session.conversationId)) {
+      return;
+    }
+
+    await this.acquireSlot(session.options.maxConcurrentAgents ?? DEFAULT_MAX_CONCURRENT_AGENTS);
+    this.persistentSlotHolders.add(session.conversationId);
+
+    let proc: ChildProcess | undefined;
+    let processAttached = false;
+    try {
+      await this.writeRuntimeFiles(session);
+      const args = buildPersistentClaudeArgs(session);
+      const env = buildAgentEnv(session);
+      proc = spawn(session.options.command ?? DEFAULT_COMMAND, args, {
+        cwd: session.workDir,
+        env,
+      });
+      const processExitPromise = waitForProcessExit(proc);
+
+      if (!isReadable(proc.stdout)) {
+        throw new AgentProcessError('Claude process did not expose stdout');
+      }
+
+      if (!isWritable(proc.stdin)) {
+        throw new AgentProcessError('Claude process did not expose stdin');
+      }
+
+      const parser = new PersistentStreamParser();
+      let resolveInit!: () => void;
+      const initPromise = new Promise<void>((resolve) => {
+        resolveInit = resolve;
+      });
+      const auditContext = buildAuditContext(session);
+      const auditPromise = isReadable(proc.stderr)
+        ? this.auditCapture.capture(proc.stderr, auditContext)
+        : Promise.resolve();
+
+      await this.sessionManager.attachProcess(session.conversationId, proc);
+      processAttached = true;
+      session.child = proc;
+      session.status = 'running';
+      session.lastActivityAt = Date.now();
+
+      parser.startReading(proc.stdout, {
+        onSessionId: (providerSessionId) => {
+          session.providerSessionId = providerSessionId;
+          this.sessionManager.setSessionId(session.conversationId, providerSessionId);
+          resolveInit();
+        },
+      });
+      this.persistentParsers.set(session.conversationId, parser);
+
+      const exitPromise = this.trackPersistentExit(session.conversationId, processExitPromise, parser, auditPromise);
+
+      await this.waitForPersistentStartup(session, initPromise, exitPromise);
+    } catch (err) {
+      this.persistentParsers.delete(session.conversationId);
+
+      if (!processAttached) {
+        this.releasePersistentSlot(session.conversationId);
+        await this.sessionManager.markFailed(session.conversationId);
+      }
+
+      if (proc !== undefined && proc.exitCode === null) {
+        proc.kill('SIGTERM');
+      }
+
+      throw err;
+    }
+  }
+
+  async *sendTurnToPersistentProcess(
+    session: PersistentAgentSession,
+    userMessage: string,
+  ): AsyncGenerator<AgentEvent> {
+    const releaseTurn = this.turnMutex.tryAcquire(session.conversationId);
+    if (releaseTurn === null) {
+      yield {
+        type: 'message.error',
+        code: 'agent_session_busy',
+        message: 'Agent session is already running',
+      };
+      return;
+    }
+
+    const usageWrites: Array<Promise<void>> = [];
+    let terminalEventSeen = false;
+
+    try {
+      if (!isLiveProcess(session.child) || !this.persistentParsers.has(session.conversationId)) {
+        await this.spawnPersistentProcess(session);
+      }
+
+      const parser = this.persistentParsers.get(session.conversationId);
+      const proc = session.child;
+      if (parser === undefined || !isLiveProcess(proc) || !isWritable(proc.stdin)) {
+        throw new AgentProcessError('Claude persistent process is not available');
+      }
+
+      const timing: AgentTiming = { spawn_at: new Date() };
+      this.timings.set(session.conversationId, timing);
+      let firstForwardedEventSeen = false;
+
+      const turn = parser.createTurn();
+      await writePersistentTurn(proc.stdin, userMessage);
+
+      for await (const event of turn) {
+        if (!firstForwardedEventSeen) {
+          firstForwardedEventSeen = true;
+          timing.first_sse_at = new Date();
+          this.timings.set(session.conversationId, timing);
+        }
+
+        if (event.type === 'message.completed') {
+          terminalEventSeen = true;
+          const completedAt = new Date();
+          timing.completed_at = completedAt;
+          event.latency_ms = completedAt.getTime() - timing.spawn_at.getTime();
+
+          if (timing.first_sse_at !== undefined) {
+            event.first_sse_latency_ms = timing.first_sse_at.getTime() - timing.spawn_at.getTime();
+          }
+
+          usageWrites.push(this.recordModelUsage(session, event).catch(() => undefined));
+        } else if (event.type === 'message.error') {
+          terminalEventSeen = true;
+        }
+
+        yield event;
+      }
+
+      if (terminalEventSeen && isLiveProcess(session.child)) {
+        await this.sessionManager.markIdle(session.conversationId);
+        session.status = 'idle';
+        session.lastActivityAt = Date.now();
+        this.sessionManager.touch(session.conversationId, session.lastActivityAt);
+      } else if (!terminalEventSeen && !isLiveProcess(session.child)) {
+        yield {
+          type: 'message.error',
+          code: 'process_exited',
+          message: 'Claude process exited before completing the turn',
+        };
+      }
+    } catch (err) {
+      const proc = session.child;
+      if (isLiveProcess(proc)) {
+        await this.sessionManager.markIdle(session.conversationId);
+      } else {
+        await this.sessionManager.markFailed(session.conversationId);
+      }
+
+      yield toAgentErrorEvent(err);
+    } finally {
+      releaseTurn();
+      await Promise.all(usageWrites);
+    }
   }
 
   private async *runClaudeProcess(
@@ -317,6 +474,92 @@ export class AgentService implements OnModuleDestroy {
     }
   }
 
+  private releasePersistentSlot(conversationId: string): void {
+    if (!this.persistentSlotHolders.delete(conversationId)) {
+      return;
+    }
+
+    this.releaseSlot();
+  }
+
+  private trackPersistentExit(
+    conversationId: string,
+    processExitPromise: Promise<ProcessExit>,
+    parser: PersistentStreamParser,
+    auditPromise: Promise<void>,
+  ): Promise<ProcessExit> {
+    return processExitPromise
+      .then(async (exit) => {
+        parser.stop();
+        this.persistentParsers.delete(conversationId);
+
+        if (exit.error !== undefined || exit.code !== 0) {
+          await this.sessionManager.markFailed(conversationId);
+        } else {
+          await this.sessionManager.markStopped(conversationId);
+        }
+
+        this.releasePersistentSlot(conversationId);
+        await auditPromise.catch(() => undefined);
+        return exit;
+      })
+      .catch(async (err: unknown) => {
+        parser.stop();
+        this.persistentParsers.delete(conversationId);
+        await this.sessionManager.markFailed(conversationId);
+        this.releasePersistentSlot(conversationId);
+        await auditPromise.catch(() => undefined);
+        return { code: null, signal: null, error: toError(err) };
+      });
+  }
+
+  private async waitForPersistentStartup(
+    session: PersistentAgentSession,
+    initPromise: Promise<void>,
+    exitPromise: Promise<ProcessExit>,
+  ): Promise<void> {
+    const timeoutMs = session.options.timeoutMs ?? DEFAULT_PROCESS_STARTUP_TIMEOUT_MS;
+    let startupTimer: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      startupTimer = setTimeout(() => {
+        reject(new AgentProcessError('Claude process did not send system/init before startup timeout'));
+      }, timeoutMs);
+    });
+
+    try {
+      await Promise.race([
+        initPromise,
+        exitPromise.then((exit) => {
+          if (exit.error !== undefined) {
+            throw new AgentProcessError(exit.error.message);
+          }
+
+          throw new AgentProcessError(`Claude process exited before system/init with code ${exit.code ?? 'unknown'}`);
+        }),
+        timeoutPromise,
+      ]);
+    } finally {
+      if (startupTimer !== undefined) {
+        clearTimeout(startupTimer);
+      }
+    }
+  }
+
+  private async writeRuntimeFiles(
+    session: Pick<AgentSessionRecord, 'workDir' | 'spaceId' | 'options'>,
+  ): Promise<void> {
+    const claudeMdInput = {
+      spaceId: session.spaceId,
+      ...(session.options.allowedSpaces !== undefined ? { allowedSpaces: session.options.allowedSpaces } : {}),
+      ...(session.options.graphBasePath !== undefined ? { graphBasePath: session.options.graphBasePath } : {}),
+      ...(session.options.enableDatabase !== undefined ? { enableDatabase: session.options.enableDatabase } : {}),
+      ...(session.options.databaseConfig !== undefined ? { databaseConfig: session.options.databaseConfig } : {}),
+    };
+
+    await writeFile(join(session.workDir, 'CLAUDE.md'), this.claudeMdGenerator.generate(claudeMdInput), 'utf8');
+    await writeFile(join(session.workDir, 'settings.json'), `${JSON.stringify(this.settingsGenerator.generate(), null, 2)}\n`, 'utf8');
+  }
+
   private async recordModelUsage(
     session: AgentSessionRecord,
     event: Extract<AgentEvent, { type: 'message.completed' }>,
@@ -390,6 +633,34 @@ function buildClaudeArgs(session: AgentSessionRecord, userMessage: string, resum
   return args;
 }
 
+function buildPersistentClaudeArgs(session: PersistentAgentSession): string[] {
+  const args = [
+    '-p',
+    '--input-format',
+    'stream-json',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--include-partial-messages',
+    '--tools',
+    'Bash,Read',
+    '--permission-mode',
+    'bypassPermissions',
+    '--settings',
+    join(session.workDir, 'settings.json'),
+    '--max-budget-usd',
+    String(session.options.maxBudgetUsd ?? DEFAULT_MAX_BUDGET_USD),
+  ];
+
+  if (session.providerSessionId !== undefined && session.providerSessionId.length > 0) {
+    args.push('--resume', session.providerSessionId);
+  } else {
+    args.push('--session-id', session.sessionId);
+  }
+
+  return args;
+}
+
 function buildAgentEnv(session: AgentSessionRecord): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     PATH: process.env.PATH ?? '',
@@ -438,7 +709,22 @@ function buildAgentEnv(session: AgentSessionRecord): NodeJS.ProcessEnv {
   return env;
 }
 
-function waitForProcessExit(proc: ChildProcess): Promise<{ code: number | null; signal: NodeJS.Signals | null; error?: Error }> {
+function buildAuditContext(session: Pick<PersistentAgentSession, 'conversationId' | 'spaceId' | 'options'>) {
+  return {
+    tenantId: session.options.tenantId ?? '',
+    spaceId: session.spaceId,
+    conversationId: session.conversationId,
+    ...(session.options.userId !== undefined ? { userId: session.options.userId } : {}),
+  };
+}
+
+type ProcessExit = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  error?: Error;
+};
+
+function waitForProcessExit(proc: ChildProcess): Promise<ProcessExit> {
   return new Promise((resolve) => {
     let settled = false;
     const onError = (error: Error): void => {
@@ -455,6 +741,29 @@ function waitForProcessExit(proc: ChildProcess): Promise<{ code: number | null; 
     };
     proc.once('error', onError);
     proc.once('close', onClose);
+  });
+}
+
+function isLiveProcess(proc: ChildProcess | undefined): proc is ChildProcess {
+  return proc !== undefined && proc.exitCode === null;
+}
+
+function isWritable(stream: ChildProcess['stdin']): stream is NonNullable<ChildProcess['stdin']> {
+  return stream !== null && !stream.destroyed;
+}
+
+function writePersistentTurn(stdin: NonNullable<ChildProcess['stdin']>, userMessage: string): Promise<void> {
+  const line = `${JSON.stringify({ type: 'user', message: { role: 'user', content: userMessage } })}\n`;
+
+  return new Promise((resolve, reject) => {
+    stdin.write(line, 'utf8', (err?: Error | null) => {
+      if (err !== undefined && err !== null) {
+        reject(err);
+        return;
+      }
+
+      resolve();
+    });
   });
 }
 
@@ -520,6 +829,10 @@ function toAgentErrorEvent(err: unknown): Extract<AgentEvent, { type: 'message.e
     code: err instanceof AgentProcessError ? 'process_error' : 'internal_error',
     message: err instanceof Error ? err.message : String(err),
   };
+}
+
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
 }
 
 function sanitizePathSegment(value: string): string {


### PR DESCRIPTION
## Summary

- Add `spawnPersistentProcess()`: spawns Claude Code with `-p --input-format stream-json --output-format stream-json` bidirectional protocol
- Add `sendTurnToPersistentProcess()`: writes stdin JSON line + returns turn event queue
- `buildPersistentClaudeArgs()`: no CLI prompt, first spawn uses `--session-id`, resume uses `--resume`
- Startup handshake waits for `system/init` to capture providerSessionId
- `result success` → session idle (process stays alive); `result error` → turn ends, state updated
- Non-zero exit / spawn error → markStopped/markFailed, metadata preserved for resume
- Slot management: acquired on spawn, released on exit (idle processes hold slots)

Closes #174

## Test plan

- [x] Spawn args include stream-json flags, no CLI prompt
- [x] First spawn uses --session-id, resume uses --resume with providerSessionId
- [x] stdin JSON write format correct
- [x] system/init captured → providerSessionId saved
- [x] result success → session idle, process alive
- [x] result error → turn ends, session state updated
- [x] Non-zero exit → session marked stopped/failed
- [x] Slot acquired on spawn, released on exit (not on idle)
- [x] Full agent suite: 12 files, 76 tests, all green
- [x] TypeScript typecheck + ESLint clean

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security Reviewer
- Reviewed head SHA: `73cf633149a39b037dc98f0645c360c6392cbd07`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/186#issuecomment-4404492438) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/186#issuecomment-4404492633) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/186#issuecomment-4404492885) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/186#issuecomment-4404493167)
- Key findings addressed: Tasks 4.0-4.9 fully implemented. Minor suggestions (--model flag, startupTimeoutMs naming) deferred. No blocking issues.