### PR TITLE
feat(agent): config refresh + resume failure + tests (#176)

### DIFF
--- a/apps/api/src/agent/__tests__/agent-config-refresh.test.ts
+++ b/apps/api/src/agent/__tests__/agent-config-refresh.test.ts
@@ -1,0 +1,281 @@
+import 'reflect-metadata';
+
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { afterEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import type { AuditService } from '../../audit/audit.service.js';
+import type { DrizzleDatabase } from '../../database/drizzle.module.js';
+import { AgentService } from '../agent.service.js';
+import { AuditCapture } from '../audit-capture.js';
+import { ClaudeMdGenerator } from '../claude-md-generator.js';
+import type { PersistentAgentSession } from '../dto/agent.dto.js';
+import { SessionManager } from '../session-manager.js';
+import { SettingsGenerator } from '../settings-generator.js';
+import { StreamParser } from '../stream-parser.js';
+import { AgentTestDb, collectAsync, createMockProcess, type MockAgentProcess, writeJsonLine } from './agent-test-utils.js';
+
+const spawnMock = vi.mocked(spawn);
+const managers: SessionManager[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  await Promise.all(managers.splice(0).map((manager) => manager.onModuleDestroy()));
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('AgentService config refresh and persistent resume', () => {
+  it('refreshes CLAUDE.md and settings.json before each turn without restarting when the fingerprint is stable', async () => {
+    const proc = createMockProcess();
+    const stdinChunks = captureStdin(proc);
+    spawnMock.mockReturnValue(proc as never);
+    const { service, claudeMdGenerate, settingsGenerate } = await createService();
+    const conversationId = uniqueConversationId();
+
+    const firstTurn = collectAsync(
+      service.sendTurn(conversationId, 'space-1', 'first turn', {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        allowedSpaces: [{ id: 'space-1', name: 'Knowledge' }],
+      }),
+    );
+    await waitForSpawn(1);
+    writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'provider-refresh-stable' });
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('first turn'));
+    writeJsonLine(proc, { type: 'result', subtype: 'success', session_id: 'provider-refresh-stable' });
+    await firstTurn;
+
+    const session = service.getSession(conversationId);
+    expect(session).toBeDefined();
+    await writeFile(join(session?.workDir ?? '', 'CLAUDE.md'), 'stale runtime file\n', 'utf8');
+
+    const secondTurn = collectAsync(
+      service.sendTurn(conversationId, 'space-1', 'second turn', {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        allowedSpaces: [{ id: 'space-1', name: 'Knowledge' }],
+      }),
+    );
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('second turn'));
+    writeJsonLine(proc, { type: 'result', subtype: 'success', session_id: 'provider-refresh-stable' });
+    await secondTurn;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(claudeMdGenerate).toHaveBeenCalledTimes(3);
+    expect(settingsGenerate).toHaveBeenCalledTimes(3);
+    await expect(readFile(join(session?.workDir ?? '', 'CLAUDE.md'), 'utf8')).resolves.toContain('CherryWiki Agent');
+
+    proc.close(0);
+  });
+
+  it('restarts an idle process with --resume when the options fingerprint changes and injects database env', async () => {
+    const first = createClosingOnKillProcess();
+    const firstStdin = captureStdin(first);
+    const resumed = createMockProcess();
+    const resumedStdin = captureStdin(resumed);
+    spawnMock.mockReturnValueOnce(first as never).mockReturnValueOnce(resumed as never);
+    const { service } = await createService();
+    const conversationId = uniqueConversationId();
+
+    const firstTurn = collectAsync(
+      service.sendTurn(conversationId, 'space-1', 'database off', {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        enableDatabase: false,
+      }),
+    );
+    await waitForSpawn(1);
+    writeJsonLine(first, { type: 'system', subtype: 'init', session_id: 'provider-db-toggle' });
+    await vi.waitFor(() => expect(firstStdin.join('')).toContain('database off'));
+    writeJsonLine(first, { type: 'result', subtype: 'success', session_id: 'provider-db-toggle' });
+    await firstTurn;
+
+    const secondTurn = collectAsync(
+      service.sendTurn(conversationId, 'space-1', 'database on', {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        enableDatabase: true,
+        databaseConfig: {
+          enabled: true,
+          dsn: 'postgresql://readonly:secret@db.internal:5432/analytics',
+          allowed_tables: ['orders'],
+          masked_columns: ['orders.customer_email'],
+        },
+      }),
+    );
+    await waitForSpawn(2);
+    writeJsonLine(resumed, { type: 'system', subtype: 'init', session_id: 'provider-db-toggle' });
+    await vi.waitFor(() => expect(resumedStdin.join('')).toContain('database on'));
+    writeJsonLine(resumed, { type: 'result', subtype: 'success', session_id: 'provider-db-toggle' });
+    await secondTurn;
+
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(expect.arrayContaining(['--resume', 'provider-db-toggle']));
+    expect(spawnMock.mock.calls[1]?.[2]?.env).toMatchObject({
+      CHERRY_DB_DSN: 'postgresql://readonly:secret@db.internal:5432/analytics',
+      CHERRY_DB_ALLOWED_TABLES: 'orders',
+      CHERRY_DB_MASKED_COLUMNS: 'orders.customer_email',
+    });
+
+    resumed.close(0);
+  });
+
+  it('spawns --resume when an idle-killed session has provider metadata but no live process', async () => {
+    const first = createClosingOnKillProcess();
+    const firstStdin = captureStdin(first);
+    const resumed = createMockProcess();
+    const resumedStdin = captureStdin(resumed);
+    spawnMock.mockReturnValueOnce(first as never).mockReturnValueOnce(resumed as never);
+    const { service, manager } = await createService({ idleTimeoutMs: 1 });
+    const conversationId = uniqueConversationId();
+
+    const firstTurn = collectAsync(
+      service.sendTurn(conversationId, 'space-1', 'before idle kill', {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      }),
+    );
+    await waitForSpawn(1);
+    writeJsonLine(first, { type: 'system', subtype: 'init', session_id: 'provider-idle-killed' });
+    await vi.waitFor(() => expect(firstStdin.join('')).toContain('before idle kill'));
+    writeJsonLine(first, { type: 'result', subtype: 'success', session_id: 'provider-idle-killed' });
+    await firstTurn;
+
+    await manager.sweepIdleSessions(Date.now() + 1_000);
+
+    const secondTurn = collectAsync(
+      service.sendTurn(conversationId, 'space-1', 'after idle kill', {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      }),
+    );
+    await waitForSpawn(2);
+    writeJsonLine(resumed, { type: 'system', subtype: 'init', session_id: 'provider-idle-killed' });
+    await vi.waitFor(() => expect(resumedStdin.join('')).toContain('after idle kill'));
+    writeJsonLine(resumed, { type: 'result', subtype: 'success', session_id: 'provider-idle-killed' });
+    await secondTurn;
+
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(expect.arrayContaining(['--resume', 'provider-idle-killed']));
+
+    resumed.close(0);
+  });
+
+  it('renames a failed resume workDir and falls back to a fresh session-id spawn', async () => {
+    const failedResume = createMockProcess();
+    const fresh = createMockProcess();
+    spawnMock.mockReturnValueOnce(failedResume as never).mockReturnValueOnce(fresh as never);
+    const { service, manager } = await createService();
+    const session = await createPersistentSession(manager);
+    manager.setSessionId(session.conversationId, 'provider-broken');
+    session.providerSessionId = 'provider-broken';
+    await writeFile(join(session.workDir, 'resume-marker.txt'), 'old workdir\n', 'utf8');
+
+    const spawnPromise = service.spawnPersistentProcess(session);
+    await waitForSpawn(1);
+    failedResume.close(1);
+    await waitForSpawn(2);
+    writeJsonLine(fresh, { type: 'system', subtype: 'init', session_id: 'provider-fresh' });
+    await spawnPromise;
+
+    const failedDirs = await findFailedSiblingDirs(session.workDir);
+    expect(failedDirs).toHaveLength(1);
+    await expect(stat(join(failedDirs[0] ?? '', 'resume-marker.txt'))).resolves.toBeTruthy();
+    await expect(stat(session.workDir)).resolves.toBeTruthy();
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual(expect.arrayContaining(['--resume', 'provider-broken']));
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(expect.arrayContaining(['--session-id', session.sessionId]));
+    expect(spawnMock.mock.calls[1]?.[1]).not.toContain('--resume');
+
+    const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+    expect(saved.providerSessionId).toBe('provider-fresh');
+    expect(saved.workDir).toBe(session.workDir);
+
+    fresh.close(0);
+  });
+});
+
+async function createService(config: { idleTimeoutMs?: number } = {}): Promise<{
+  service: AgentService;
+  manager: SessionManager;
+  claudeMdGenerate: MockInstance<ClaudeMdGenerator['generate']>;
+  settingsGenerate: MockInstance<SettingsGenerator['generate']>;
+}> {
+  const agentRoot = await createTempDir('agent-config-refresh-root');
+  const manager = new SessionManager(undefined, {
+    agentRoot,
+    sigintGraceMs: 1,
+    idleTimeoutMs: config.idleTimeoutMs ?? 60_000,
+  });
+  managers.push(manager);
+  const auditService = { push: vi.fn() } as unknown as AuditService;
+  const claudeMdGenerator = new ClaudeMdGenerator();
+  const settingsGenerator = new SettingsGenerator();
+  const claudeMdGenerate = vi.spyOn(claudeMdGenerator, 'generate');
+  const settingsGenerate = vi.spyOn(settingsGenerator, 'generate');
+  const service = new AgentService(
+    new AgentTestDb() as unknown as DrizzleDatabase,
+    manager,
+    new StreamParser(),
+    new AuditCapture(auditService),
+    claudeMdGenerator,
+    settingsGenerator,
+  );
+
+  return { service, manager, claudeMdGenerate, settingsGenerate };
+}
+
+async function createPersistentSession(manager: SessionManager): Promise<PersistentAgentSession> {
+  return manager.getOrCreateSession(uniqueConversationId(), 'space-1', 'tenant-1', 'user-1', {
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+  });
+}
+
+function createClosingOnKillProcess(): MockAgentProcess {
+  const proc = createMockProcess();
+  proc.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    proc.close(0, typeof signal === 'string' ? signal : null);
+    return true;
+  });
+  return proc;
+}
+
+function captureStdin(proc: MockAgentProcess): string[] {
+  const chunks: string[] = [];
+  proc.stdin.on('data', (chunk: Buffer | string) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+  });
+  return chunks;
+}
+
+async function waitForSpawn(count: number): Promise<void> {
+  await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(count));
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), `${prefix}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function findFailedSiblingDirs(workDir: string): Promise<string[]> {
+  const parent = dirname(workDir);
+  const prefix = `${basename(workDir)}.failed.`;
+  const entries = await readdir(parent, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(prefix))
+    .map((entry) => join(parent, entry.name));
+}
+
+function uniqueConversationId(): string {
+  return `conversation-config-${randomUUID()}`;
+}

--- a/apps/api/src/agent/__tests__/agent-turn-dispatch.test.ts
+++ b/apps/api/src/agent/__tests__/agent-turn-dispatch.test.ts
@@ -221,6 +221,39 @@ describe('AgentService sendTurn dispatch', () => {
 
     proc.close(0);
   });
+
+  it('escalates SSE disconnect cancellation to SIGKILL after the SIGINT grace timeout', async () => {
+    process.env.AGENT_SIGINT_GRACE_MS = '1';
+    const proc = createMockProcess();
+    const stdinChunks = captureStdin(proc);
+    spawnMock.mockReturnValue(proc as never);
+    const { service, manager } = createService();
+    const conversationId = uniqueConversationId();
+    const iterator = service.sendTurn(conversationId, 'space-1', 'stuck turn', {
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    });
+
+    const firstEvent = iterator.next();
+    await waitForSpawn();
+    writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'provider-sigkill' });
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('stuck turn'));
+    writeJsonLine(proc, {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'partial' }] },
+    });
+    await expect(firstEvent).resolves.toEqual({
+      done: false,
+      value: { type: 'message.delta', delta: 'partial' },
+    });
+
+    await iterator.return(undefined);
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGINT');
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+    const saved = await manager.getOrCreateSession(conversationId, 'space-1', 'tenant-1', 'user-1');
+    expect(saved.status).toBe('failed');
+  });
 });
 
 function createService(): {

--- a/apps/api/src/agent/agent.service.ts
+++ b/apps/api/src/agent/agent.service.ts
@@ -203,6 +203,22 @@ export class AgentService implements OnModuleDestroy {
   }
 
   async spawnPersistentProcess(session: PersistentAgentSession): Promise<void> {
+    const attemptedResumeSessionId = getNonEmptyString(session.providerSessionId);
+
+    try {
+      await this.spawnPersistentProcessOnce(session);
+      return;
+    } catch (err) {
+      if (attemptedResumeSessionId === undefined) {
+        throw err;
+      }
+
+      await this.recoverFromPersistentResumeFailure(session);
+      await this.spawnPersistentProcessOnce(session);
+    }
+  }
+
+  private async spawnPersistentProcessOnce(session: PersistentAgentSession): Promise<void> {
     const existing = session.child;
     if (isLiveProcess(existing) && this.persistentParsers.has(session.conversationId)) {
       return;
@@ -212,7 +228,7 @@ export class AgentService implements OnModuleDestroy {
     this.persistentSlotHolders.add(session.conversationId);
 
     let proc: ChildProcess | undefined;
-    let processAttached = false;
+    let trackedExitPromise: Promise<ProcessExit> | undefined;
     try {
       await this.writeRuntimeFiles(session);
       const args = buildPersistentClaudeArgs(session);
@@ -242,7 +258,6 @@ export class AgentService implements OnModuleDestroy {
         : Promise.resolve();
 
       await this.sessionManager.attachProcess(session.conversationId, proc);
-      processAttached = true;
       session.child = proc;
       session.status = 'running';
       session.lastActivityAt = Date.now();
@@ -256,20 +271,26 @@ export class AgentService implements OnModuleDestroy {
       });
       this.persistentParsers.set(session.conversationId, parser);
 
-      const exitPromise = this.trackPersistentExit(session.conversationId, processExitPromise, parser, auditPromise);
+      trackedExitPromise = this.trackPersistentExit(session.conversationId, processExitPromise, parser, auditPromise);
 
-      await this.waitForPersistentStartup(session, initPromise, exitPromise);
+      await this.waitForPersistentStartup(session, initPromise, trackedExitPromise);
     } catch (err) {
+      this.persistentParsers.get(session.conversationId)?.stop();
       this.persistentParsers.delete(session.conversationId);
-
-      if (!processAttached) {
-        this.releasePersistentSlot(session.conversationId);
-        await this.sessionManager.markFailed(session.conversationId);
-      }
 
       if (proc !== undefined && proc.exitCode === null) {
         proc.kill('SIGTERM');
       }
+
+      if (trackedExitPromise !== undefined) {
+        await Promise.race([
+          trackedExitPromise.catch(() => undefined),
+          delay(readPositiveIntegerEnv('AGENT_SIGINT_GRACE_MS', HARD_KILL_GRACE_MS)),
+        ]);
+      }
+
+      this.releasePersistentSlot(session.conversationId);
+      await this.sessionManager.markFailed(session.conversationId);
 
       throw err;
     }
@@ -294,17 +315,18 @@ export class AgentService implements OnModuleDestroy {
         options.userId ?? '',
         options,
       );
+      const refreshedSession = await this.refreshConfigIfNeeded(session, options);
 
       if (
-        !isLiveProcess(session.child) ||
-        session.status === 'starting' ||
-        session.status === 'stopped' ||
-        session.status === 'failed'
+        !isLiveProcess(refreshedSession.child) ||
+        refreshedSession.status === 'starting' ||
+        refreshedSession.status === 'stopped' ||
+        refreshedSession.status === 'failed'
       ) {
-        await this.spawnPersistentProcess(session);
+        await this.spawnPersistentProcess(refreshedSession);
       }
 
-      yield* this.sendTurnToPersistentProcessLocked(session, userMessage);
+      yield* this.sendTurnToPersistentProcessLocked(refreshedSession, userMessage);
     } finally {
       releaseTurn();
     }
@@ -351,11 +373,15 @@ export class AgentService implements OnModuleDestroy {
         throw new AgentProcessError('Claude persistent process is not available');
       }
 
+      turn = parser.createTurn();
+      await this.sessionManager.attachProcess(session.conversationId, proc);
+      session.status = 'running';
+      session.child = proc;
+
       const timing: AgentTiming = { spawn_at: new Date() };
       this.timings.set(session.conversationId, timing);
       let firstForwardedEventSeen = false;
 
-      turn = parser.createTurn();
       await writePersistentTurn(proc.stdin, userMessage);
 
       for await (const event of turn) {
@@ -403,6 +429,62 @@ export class AgentService implements OnModuleDestroy {
 
       await Promise.all(usageWrites);
     }
+  }
+
+  private async refreshConfigIfNeeded(
+    session: PersistentAgentSession,
+    options: AgentSpawnOptions,
+  ): Promise<PersistentAgentSession> {
+    const mergedOptions = { ...session.options, ...options };
+    const nextFingerprint = this.sessionManager.computeOptionsFingerprint(mergedOptions);
+    const fingerprintChanged = session.optionsFingerprint !== nextFingerprint;
+    const refreshedSession: PersistentAgentSession = {
+      ...session,
+      options: mergedOptions,
+      optionsFingerprint: nextFingerprint,
+    };
+
+    await this.writeRuntimeFiles(refreshedSession);
+
+    if (fingerprintChanged && isLiveProcess(session.child)) {
+      if (session.status !== 'idle') {
+        throw new AgentSessionBusyError(session.conversationId);
+      }
+
+      await this.stopPersistentProcessForRestart(session);
+      refreshedSession.child = undefined;
+      refreshedSession.status = 'stopped';
+    }
+
+    return (
+      (await this.sessionManager.updateRuntimeConfig(
+        session.conversationId,
+        mergedOptions,
+        nextFingerprint,
+      )) ?? refreshedSession
+    );
+  }
+
+  private async stopPersistentProcessForRestart(session: PersistentAgentSession): Promise<void> {
+    this.persistentParsers.get(session.conversationId)?.stop();
+    this.persistentParsers.delete(session.conversationId);
+    await this.sessionManager.markStopped(session.conversationId);
+    this.releasePersistentSlot(session.conversationId);
+    session.child = undefined;
+    session.status = 'stopped';
+  }
+
+  private async recoverFromPersistentResumeFailure(session: PersistentAgentSession): Promise<void> {
+    this.persistentParsers.get(session.conversationId)?.stop();
+    this.persistentParsers.delete(session.conversationId);
+    this.releasePersistentSlot(session.conversationId);
+
+    const recovered = await this.sessionManager.resetAfterResumeFailure(session.conversationId);
+    if (recovered === undefined) {
+      throw new AgentProcessError('Unable to reset Agent session after resume failure');
+    }
+
+    Object.assign(session, recovered);
   }
 
   private handlePersistentTerminalEvent(
@@ -636,24 +718,32 @@ export class AgentService implements OnModuleDestroy {
   ): Promise<ProcessExit> {
     return processExitPromise
       .then(async (exit) => {
+        const stillCurrentParser = this.persistentParsers.get(conversationId) === parser;
         parser.stop();
-        this.persistentParsers.delete(conversationId);
 
-        if (exit.error !== undefined || exit.code !== 0) {
-          await this.sessionManager.markFailed(conversationId);
-        } else {
-          await this.sessionManager.markStopped(conversationId);
+        if (stillCurrentParser) {
+          this.persistentParsers.delete(conversationId);
+
+          if (exit.error !== undefined || exit.code !== 0) {
+            await this.sessionManager.markFailed(conversationId);
+          } else {
+            await this.sessionManager.markStopped(conversationId);
+          }
+
+          this.releasePersistentSlot(conversationId);
         }
 
-        this.releasePersistentSlot(conversationId);
         await auditPromise.catch(() => undefined);
         return exit;
       })
       .catch(async (err: unknown) => {
+        const stillCurrentParser = this.persistentParsers.get(conversationId) === parser;
         parser.stop();
-        this.persistentParsers.delete(conversationId);
-        await this.sessionManager.markFailed(conversationId);
-        this.releasePersistentSlot(conversationId);
+        if (stillCurrentParser) {
+          this.persistentParsers.delete(conversationId);
+          await this.sessionManager.markFailed(conversationId);
+          this.releasePersistentSlot(conversationId);
+        }
         await auditPromise.catch(() => undefined);
         return { code: null, signal: null, error: toError(err) };
       });
@@ -997,6 +1087,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isString(value: unknown): value is string {
   return typeof value === 'string';
+}
+
+function getNonEmptyString(value: string | undefined): string | undefined {
+  return value !== undefined && value.length > 0 ? value : undefined;
 }
 
 function readPositiveIntegerEnv(name: string, fallback: number): number {

--- a/apps/api/src/agent/dto/agent.dto.ts
+++ b/apps/api/src/agent/dto/agent.dto.ts
@@ -72,6 +72,8 @@ export type OptionsFingerprint = {
   databaseDsn: string | undefined;
   model: string | undefined;
   maxBudgetUsd: number | undefined;
+  settingsVersion: number;
+  toolVersion: number;
 };
 
 export type PersistentAgentSession = {

--- a/apps/api/src/agent/session-manager.ts
+++ b/apps/api/src/agent/session-manager.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Optional, type OnModuleDestroy } from '@nestjs/comm
 import type { ChildProcess } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, type Dirent } from 'node:fs';
-import { chmod, mkdir, readdir, rm } from 'node:fs/promises';
+import { chmod, mkdir, readdir, rename, rm } from 'node:fs/promises';
 import { hostname } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
@@ -21,9 +21,11 @@ import type {
 
 const DEFAULT_AGENT_ROOT = '/tmp/cherry-agent';
 const DEFAULT_IDLE_TIMEOUT_MS = 24 * 60 * 60_000;
-const DEFAULT_MAX_RESIDENT_PROCESSES = 20;
+const DEFAULT_MAX_RESIDENT_PROCESSES = 5;
 const DEFAULT_SIGNAL_GRACE_MS = 5_000;
 const DEFAULT_RETENTION_DAYS = 7;
+const SETTINGS_FINGERPRINT_VERSION = 1;
+const TOOL_FINGERPRINT_VERSION = 1;
 
 export const SESSION_MANAGER_CONFIG = Symbol('SESSION_MANAGER_CONFIG');
 
@@ -78,7 +80,6 @@ export class SessionManager implements OnModuleDestroy {
     const existing = this.sessions.get(conversationId);
     if (existing !== undefined) {
       existing.options = { ...existing.options, ...options };
-      existing.optionsFingerprint = this.computeOptionsFingerprint(existing.options);
       return clonePersistentSession(existing);
     }
 
@@ -303,6 +304,8 @@ export class SessionManager implements OnModuleDestroy {
       databaseDsn: options.databaseConfig?.dsn,
       model: options.model,
       maxBudgetUsd: options.maxBudgetUsd,
+      settingsVersion: SETTINGS_FINGERPRINT_VERSION,
+      toolVersion: TOOL_FINGERPRINT_VERSION,
     };
 
     return createHash('sha256').update(JSON.stringify(fingerprint)).digest('hex');
@@ -330,6 +333,65 @@ export class SessionManager implements OnModuleDestroy {
 
     this.persistedSessionIds.add(conversationId);
     return true;
+  }
+
+  async updateRuntimeConfig(
+    conversationId: string,
+    options: AgentSpawnOptions,
+    optionsFingerprint: string,
+  ): Promise<PersistentAgentSession | undefined> {
+    const session = this.sessions.get(conversationId);
+    if (session === undefined) {
+      return undefined;
+    }
+
+    session.options = { ...options };
+    session.optionsFingerprint = optionsFingerprint;
+    session.lastActivityAt = Date.now();
+    await this.persistStatus(session);
+    return clonePersistentSession(session);
+  }
+
+  async resetAfterResumeFailure(
+    conversationId: string,
+    failedAt = Date.now(),
+  ): Promise<PersistentAgentSession | undefined> {
+    const session = this.sessions.get(conversationId);
+    if (session === undefined) {
+      return undefined;
+    }
+
+    this.clearIdleKillTimer(session);
+    const oldWorkDir = session.workDir;
+    const oldAgentHome = session.agentHome;
+    const failedWorkDir = `${oldWorkDir}.failed.${failedAt}`;
+
+    if (isLiveChild(session.child)) {
+      await terminateChild(session.child, 'SIGTERM', this.sigintGraceMs);
+    }
+
+    session.child = undefined;
+
+    try {
+      await rename(oldWorkDir, failedWorkDir);
+    } catch (err) {
+      if (!isNodeErrorCode(err, 'ENOENT')) {
+        throw err;
+      }
+    }
+
+    session.sessionId = randomUUID();
+    session.providerSessionId = undefined;
+    session.workDir = oldWorkDir;
+    session.agentHome = oldAgentHome;
+    session.status = 'starting';
+    session.optionsFingerprint = this.computeOptionsFingerprint(session.options);
+    session.ownedByInstance = this.instanceId;
+    session.lastActivityAt = failedAt;
+
+    await prepareSessionDirectories(session.workDir, session.agentHome);
+    await this.upsertSession(session);
+    return clonePersistentSession(session);
   }
 
   size(): number {
@@ -477,7 +539,7 @@ export class SessionManager implements OnModuleDestroy {
       agentHome: row.agent_home,
       status: restoredStatus,
       child: undefined,
-      optionsFingerprint: this.computeOptionsFingerprint(options),
+      optionsFingerprint: row.options_hash ?? this.computeOptionsFingerprint(options),
       ownedByInstance: this.instanceId,
       lastActivityAt: row.last_activity_at.getTime(),
       idleKillTimer: undefined,
@@ -723,6 +785,10 @@ function sanitizePathSegment(input: string): string {
 
 function isNonEmptyString(value: string | undefined): value is string {
   return value !== undefined && value.length > 0;
+}
+
+function isNodeErrorCode(value: unknown, code: string): boolean {
+  return value instanceof Error && 'code' in value && value.code === code;
 }
 
 async function deleteFailedSiblingDirectories(workDir: string): Promise<void> {

--- a/tests/integration/agent-persistent-runtime.test.ts
+++ b/tests/integration/agent-persistent-runtime.test.ts
@@ -1,0 +1,373 @@
+import '../../apps/api/node_modules/reflect-metadata/Reflect.js';
+
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import type { AuditService } from '../../apps/api/src/audit/audit.service.js';
+import { AgentService } from '../../apps/api/src/agent/agent.service.js';
+import type {
+  AgentSessionRepository,
+  AgentSessionRow,
+  NewAgentSession,
+} from '../../apps/api/src/agent/agent-session.repository.js';
+import { AuditCapture } from '../../apps/api/src/agent/audit-capture.js';
+import { ClaudeMdGenerator } from '../../apps/api/src/agent/claude-md-generator.js';
+import { SessionManager } from '../../apps/api/src/agent/session-manager.js';
+import { SettingsGenerator } from '../../apps/api/src/agent/settings-generator.js';
+import { StreamParser } from '../../apps/api/src/agent/stream-parser.js';
+import {
+  createMockProcess,
+  type MockAgentProcess,
+  writeJsonLine,
+} from '../../apps/api/src/agent/__tests__/agent-test-utils.js';
+import type { DrizzleDatabase } from '../../apps/api/src/database/drizzle.module.js';
+import { ChatService } from '../../apps/api/src/chat/chat.service.js';
+import {
+  collectAsync,
+  createRealAgentService,
+} from './agent-integration-test-utils.js';
+import {
+  collectEvents,
+  createMessageRow,
+  createModelRow,
+  createSessionRow,
+  createSpaceRow,
+  queueAssistantMessage,
+  queueStreamPrelude,
+  ScriptedChatDb,
+  ScriptedChatProvider,
+  ScriptedEmbeddingProvider,
+  TEST_GROUP_ID,
+  TEST_SPACE_ID,
+  TEST_TENANT_ID,
+  TEST_USER_ID,
+} from './chat-integration-test-utils.js';
+
+const spawnMock = vi.mocked(spawn);
+const managers: SessionManager[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await Promise.all(managers.splice(0).map((manager) => manager.onModuleDestroy()));
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('persistent Agent runtime integration', () => {
+  it('reuses one resident process across two Chat Agent turns while preserving tool, chart, and usage SSE events', async () => {
+    const proc = createMockProcess();
+    const stdinChunks = captureStdin(proc);
+    spawnMock.mockReturnValue(proc as never);
+    const db = new ScriptedChatDb();
+    const audit = { push: vi.fn() } as unknown as AuditService;
+    const agentService = createRealAgentService({ db, audit, managers });
+    const chatProvider = new ScriptedChatProvider([]);
+    const embeddingProvider = new ScriptedEmbeddingProvider();
+    const service = new ChatService(
+      db.asDrizzle(),
+      audit,
+      () => chatProvider,
+      () => embeddingProvider,
+      agentService,
+    );
+    const chatSessionId = uniqueId('chat-agent-persistent');
+
+    queueStreamPrelude(db, { session: createSessionRow({ id: chatSessionId }) });
+    queueAssistantMessage(db, { id: 'assistant-agent-1', session_id: chatSessionId });
+    const firstIterable = await service.streamCompletion({
+      tenantId: TEST_TENANT_ID,
+      spaceId: TEST_SPACE_ID,
+      userId: TEST_USER_ID,
+      userGroupIds: [TEST_GROUP_ID],
+      message: 'show SSO graph evidence',
+      enableDeepAnalysis: true,
+    });
+    const firstEventsPromise = collectEvents(firstIterable);
+    await waitForSpawn(1);
+    writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'provider-chat-persistent' });
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('show SSO graph evidence'));
+    writeJsonLine(proc, {
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', id: 'graph-tool', name: 'Bash', input: { command: 'graphify query "SSO"' } },
+          { type: 'text', text: 'SSO connects to session management.' },
+        ],
+      },
+    });
+    writeJsonLine(proc, {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            content: JSON.stringify({
+              type: 'cherrywiki.chart',
+              chart_type: 'bar',
+              echarts_option: { xAxis: { data: ['SSO'] }, series: [{ data: [1] }] },
+            }),
+          },
+        ],
+      },
+    });
+    writeJsonLine(proc, {
+      type: 'result',
+      subtype: 'success',
+      session_id: 'provider-chat-persistent',
+      usage: { input_tokens: 21, output_tokens: 8 },
+    });
+
+    expect(await firstEventsPromise).toMatchObject([
+      { type: 'session', session_id: chatSessionId },
+      { type: 'agent.tool_use', id: 'graph-tool', name: 'Bash', input: { command: 'graphify query "SSO"' } },
+      { type: 'content', delta: 'SSO connects to session management.' },
+      { type: 'chart.data', data: { type: 'cherrywiki.chart', chart_type: 'bar' } },
+      { type: 'usage', usage: { prompt_tokens: 21, completion_tokens: 8, total_tokens: 29 } },
+      { type: 'message.completed' },
+    ]);
+
+    queueExistingSessionPrelude(db, chatSessionId);
+    queueAssistantMessage(db, { id: 'assistant-agent-2', session_id: chatSessionId });
+    const secondIterable = await service.streamCompletion({
+      tenantId: TEST_TENANT_ID,
+      spaceId: TEST_SPACE_ID,
+      userId: TEST_USER_ID,
+      userGroupIds: [TEST_GROUP_ID],
+      sessionId: chatSessionId,
+      message: 'continue from that graph',
+      enableDeepAnalysis: true,
+    });
+    const secondEventsPromise = collectEvents(secondIterable);
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('continue from that graph'));
+    writeJsonLine(proc, {
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Continuing with the same resident process.' }] },
+    });
+    writeJsonLine(proc, {
+      type: 'result',
+      subtype: 'success',
+      session_id: 'provider-chat-persistent',
+      usage: { input_tokens: 7, output_tokens: 6 },
+    });
+
+    expect(await secondEventsPromise).toMatchObject([
+      { type: 'session', session_id: chatSessionId },
+      { type: 'content', delta: 'Continuing with the same resident process.' },
+      { type: 'usage', usage: { prompt_tokens: 7, completion_tokens: 6, total_tokens: 13 } },
+      { type: 'message.completed' },
+    ]);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    proc.close(0);
+  });
+
+  it('resumes from persisted metadata after an API runtime restart', async () => {
+    const first = createClosingOnKillProcess();
+    const firstStdin = captureStdin(first);
+    const resumed = createMockProcess();
+    const resumedStdin = captureStdin(resumed);
+    spawnMock.mockReturnValueOnce(first as never).mockReturnValueOnce(resumed as never);
+    const repository = createRepository();
+    const agentRoot = await createTempDir('agent-runtime-restart-root');
+    const conversationId = uniqueId('agent-runtime-restart');
+    const firstManager = new SessionManager(repository.instance, {
+      agentRoot,
+      instanceId: 'api-instance-1',
+      sigintGraceMs: 1,
+    });
+    managers.push(firstManager);
+    const firstService = createAgentService(firstManager);
+
+    const firstTurn = collectAsync(
+      firstService.sendTurn(conversationId, 'space-1', 'before restart', {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      }),
+    );
+    await waitForSpawn(1);
+    writeJsonLine(first, { type: 'system', subtype: 'init', session_id: 'provider-restart' });
+    await vi.waitFor(() => expect(firstStdin.join('')).toContain('before restart'));
+    writeJsonLine(first, { type: 'result', subtype: 'success', session_id: 'provider-restart' });
+    await firstTurn;
+
+    await firstManager.shutdown();
+    const secondManager = new SessionManager(repository.instance, {
+      agentRoot,
+      instanceId: 'api-instance-2',
+      sigintGraceMs: 1,
+    });
+    managers.push(secondManager);
+    const secondService = createAgentService(secondManager);
+
+    const secondTurn = collectAsync(
+      secondService.sendTurn(conversationId, 'space-1', 'after restart', {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      }),
+    );
+    await waitForSpawn(2);
+    writeJsonLine(resumed, { type: 'system', subtype: 'init', session_id: 'provider-restart' });
+    await vi.waitFor(() => expect(resumedStdin.join('')).toContain('after restart'));
+    writeJsonLine(resumed, { type: 'result', subtype: 'success', session_id: 'provider-restart' });
+    await secondTurn;
+
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(spawnMock.mock.calls[1]?.[1]).toEqual(expect.arrayContaining(['--resume', 'provider-restart']));
+    expect(repository.rows.get(conversationId)?.owned_by_instance).toBe('api-instance-2');
+
+    resumed.close(0);
+  });
+});
+
+function createAgentService(manager: SessionManager): AgentService {
+  const db = new ScriptedChatDb();
+  const audit = { push: vi.fn() } as unknown as AuditService;
+  return new AgentService(
+    db.asDrizzle() as unknown as DrizzleDatabase,
+    manager,
+    new StreamParser(),
+    new AuditCapture(audit),
+    new ClaudeMdGenerator(),
+    new SettingsGenerator(),
+  );
+}
+
+function queueExistingSessionPrelude(db: ScriptedChatDb, sessionId: string): void {
+  db.queueSelect([createSpaceRow()]);
+  db.queueSelect([createModelRow({ model_type: 'chat' })]);
+  db.queueSelect([createSessionRow({ id: sessionId })]);
+  db.queueSelect([createMessageRow({ id: 'history-1', session_id: sessionId, role: 'assistant' })]);
+  db.queueInsert([createMessageRow({ id: uniqueId('user-message'), session_id: sessionId, role: 'user' })]);
+}
+
+function createClosingOnKillProcess(): MockAgentProcess {
+  const proc = createMockProcess();
+  proc.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    proc.close(0, typeof signal === 'string' ? signal : null);
+    return true;
+  });
+  return proc;
+}
+
+function captureStdin(proc: MockAgentProcess): string[] {
+  const chunks: string[] = [];
+  proc.stdin.on('data', (chunk: Buffer | string) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+  });
+  return chunks;
+}
+
+async function waitForSpawn(count: number): Promise<void> {
+  await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(count));
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), `${prefix}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createRepository(initialRows: AgentSessionRow[] = []): {
+  instance: AgentSessionRepository;
+  rows: Map<string, AgentSessionRow>;
+} {
+  const rows = new Map(initialRows.map((row) => [row.conversation_id, { ...row }]));
+  const repository = {
+    upsert: vi.fn((data: NewAgentSession) => {
+      const row = createAgentSessionRow({
+        conversation_id: data.conversation_id,
+        tenant_id: data.tenant_id,
+        space_id: data.space_id,
+        user_id: data.user_id,
+        provider: data.provider ?? 'claude',
+        provider_session_id: data.provider_session_id ?? null,
+        work_dir: data.work_dir,
+        agent_home: data.agent_home,
+        status: data.status,
+        options_hash: data.options_hash ?? null,
+        owned_by_instance: data.owned_by_instance ?? null,
+        last_activity_at: data.last_activity_at,
+        process_started_at: data.process_started_at ?? null,
+        process_stopped_at: data.process_stopped_at ?? null,
+      });
+      rows.set(row.conversation_id, row);
+      return Promise.resolve(row);
+    }),
+    findByConversationId: vi.fn((conversationId: string) => Promise.resolve(rows.get(conversationId))),
+    updateProviderSessionId: vi.fn((conversationId: string, providerSessionId: string) => {
+      const row = rows.get(conversationId);
+      if (row !== undefined) {
+        row.provider_session_id = providerSessionId;
+      }
+      return Promise.resolve();
+    }),
+    updateStatus: vi.fn((conversationId: string, status: string, extra: Partial<AgentSessionRow> = {}) => {
+      const row = rows.get(conversationId);
+      if (row !== undefined) {
+        Object.assign(row, extra, { status, updated_at: new Date() });
+      }
+      return Promise.resolve();
+    }),
+    updateOwnedByInstance: vi.fn((conversationId: string, instanceId: string) => {
+      const row = rows.get(conversationId);
+      if (row !== undefined) {
+        row.owned_by_instance = instanceId;
+      }
+      return Promise.resolve();
+    }),
+    touchActivity: vi.fn((conversationId: string) => {
+      const row = rows.get(conversationId);
+      if (row !== undefined) {
+        row.last_activity_at = new Date();
+      }
+      return Promise.resolve();
+    }),
+    delete: vi.fn((conversationId: string) => {
+      rows.delete(conversationId);
+      return Promise.resolve();
+    }),
+    findStaleForRetentionCleanup: vi.fn((olderThan: Date, statuses: string[]) =>
+      Promise.resolve(
+        [...rows.values()].filter(
+          (row) => row.last_activity_at < olderThan && statuses.includes(row.status),
+        ),
+      ),
+    ),
+  };
+
+  return { instance: repository as unknown as AgentSessionRepository, rows };
+}
+
+function createAgentSessionRow(overrides: Partial<AgentSessionRow> = {}): AgentSessionRow {
+  return {
+    conversation_id: 'conversation-1',
+    tenant_id: 'tenant-1',
+    space_id: 'space-1',
+    user_id: 'user-1',
+    provider: 'claude',
+    provider_session_id: null,
+    work_dir: '/tmp/cherry-agent/conversation-1',
+    agent_home: '/tmp/cherry-agent/conversation-1/.home',
+    status: 'idle',
+    options_hash: null,
+    owned_by_instance: 'api-instance-1',
+    last_activity_at: new Date('2026-05-01T00:00:00.000Z'),
+    process_started_at: null,
+    process_stopped_at: null,
+    created_at: new Date('2026-05-01T00:00:00.000Z'),
+    updated_at: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function uniqueId(prefix: string): string {
+  return `${prefix}-${randomUUID()}`;
+}

--- a/tests/integration/cherrydb-e2e.test.ts
+++ b/tests/integration/cherrydb-e2e.test.ts
@@ -42,9 +42,9 @@ afterEach(async () => {
 });
 
 describe('cherrydb Agent integration', () => {
-  // TODO(#176): update for persistent sendTurn path — currently expects one-shot spawnNew flow
-  it.skip('enables database tools, streams table/query/chart events, and captures SQL audit logs', async () => {
+  it('enables database tools, streams table/query/chart events, and captures SQL audit logs', async () => {
     const proc = createMockProcess();
+    const stdinChunks = captureStdin(proc);
     spawnMock.mockReturnValue(proc as never);
     const { service, db, audit } = createChatAgentHarness();
     const chatSessionId = uniqueChatSessionId('cherrydb-happy');
@@ -74,6 +74,7 @@ describe('cherrydb Agent integration', () => {
     await waitForSpawn(1);
 
     writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'db-session' });
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('show orders by month as a chart'));
     writeJsonLine(proc, {
       type: 'assistant',
       message: {
@@ -125,7 +126,6 @@ describe('cherrydb Agent integration', () => {
       session_id: 'db-session',
       usage: { input_tokens: 30, output_tokens: 11 },
     });
-    proc.close(0);
 
     const events = await eventsPromise;
     expect(events.map((event) => event.type)).toEqual([
@@ -166,11 +166,12 @@ describe('cherrydb Agent integration', () => {
         conversation_id: chatSessionId,
       }),
     });
+    proc.close(0);
   });
 
-  // TODO(#176): update for persistent sendTurn path — currently expects one-shot spawnNew flow
-  it.skip('surfaces cherrydb execution failures as chat errors without chart SSE', async () => {
+  it('surfaces cherrydb execution failures as chat errors without chart SSE', async () => {
     const proc = createMockProcess();
+    const stdinChunks = captureStdin(proc);
     spawnMock.mockReturnValue(proc as never);
     const { service, db, audit } = createChatAgentHarness();
     const chatSessionId = uniqueChatSessionId('cherrydb-error');
@@ -197,6 +198,8 @@ describe('cherrydb Agent integration', () => {
     const eventsPromise = collectEvents(iterable);
     await waitForSpawn(1);
 
+    writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'db-error-session' });
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('delete old orders'));
     writeJsonLine(proc, {
       type: 'assistant',
       message: {
@@ -210,7 +213,6 @@ describe('cherrydb Agent integration', () => {
       subtype: 'error_during_execution',
       error: 'cherrydb rejected non-readonly SQL',
     });
-    proc.close(0);
 
     const events = await eventsPromise;
     expect(events).toEqual([
@@ -219,6 +221,7 @@ describe('cherrydb Agent integration', () => {
       { type: 'error', code: 'error_during_execution', message: 'cherrydb rejected non-readonly SQL' },
     ]);
     expect(audit.push.mock.calls.some(([entry]) => entry.action === 'database_query')).toBe(false);
+    proc.close(0);
   });
 });
 
@@ -249,4 +252,12 @@ async function waitForSpawn(count: number): Promise<void> {
 
 function uniqueChatSessionId(prefix: string): string {
   return `${prefix}-${process.pid}-${randomUUID()}`;
+}
+
+function captureStdin(proc: ReturnType<typeof createMockProcess>): string[] {
+  const chunks: string[] = [];
+  proc.stdin.on('data', (chunk: Buffer | string) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+  });
+  return chunks;
 }


### PR DESCRIPTION
## Summary

- Config refresh: per-turn fingerprint comparison, restart+resume on options change (D7)
- Resume failure handling: rename workDir to `.failed.{timestamp}`, fresh spawn, DB upsert (D13)
- Database toggle on → restart+resume to inject `CHERRY_DB_*` env
- Configuration env vars: `AGENT_PROCESS_IDLE_TIMEOUT_MS`, `AGENT_MAX_RESIDENT_PROCESSES`, `AGENT_SIGINT_GRACE_MS`, `AGENT_SESSION_RETENTION_DAYS`
- Comprehensive test suite: 88 tests across 14 files covering all Section 9 scenarios
- New integration test: persistent runtime two-turn process reuse
- Updated cherrydb integration tests for sendTurn path

Closes #176

## Test plan

- [x] Fingerprint change triggers restart+resume (9.6)
- [x] Resume failure → workDir rename + fresh spawn (9.12)
- [x] Config refresh regenerates CLAUDE.md/settings per turn (6.1)
- [x] All Section 9 test scenarios covered (9.1-9.14)
- [x] Integration: two-turn persistent process reuse (9.15)
- [x] Full suite: 14 files, 88 tests, all green
- [x] ESLint clean

## Agent Review

- Reviewer agents used: Spec Compliance, Correctness, Integration, Security
- Reviewed head SHA: `56100eb34f0ad864fe44be5fc9f691a89b6a89fa`
- Review evidence: 4 comments posted on PR #188
- Key findings:
  - **Spec**: Tasks 6.1/6.2/6.4/6.5 and D7/D13/D14 compliant. `DEFAULT_MAX_RESIDENT_PROCESSES` lowered to 5 — verify for multi-user deployments. Fingerprint no longer recomputed on `getOrCreateSession` cache hit; safe because `sendTurn` always calls `refreshConfigIfNeeded`.
  - **Correctness**: `stillCurrentParser` guard in `trackPersistentExit` correctly prevents stale exit handlers from double-freeing slots. `spawnPersistentProcessOnce` error path now awaits exit promise with grace timeout before slot release. `Object.assign` mutation pattern in `recoverFromPersistentResumeFailure` works but is fragile.
  - **Integration**: cherrydb e2e tests unskipped and updated for sendTurn. New persistent runtime test covers 9.15 + 9.16. Missing test: `AgentSessionBusyError` when fingerprint changes while process is running.
  - **Security**: No new risks. DSN stays in process env only. `.failed.*` directories inherit source permissions (0700). No untrusted input paths added.