### PR TITLE
feat(web): migrate Chat/NotFound/ConfidenceBadge to antd + i18n

### DIFF
--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -82,7 +82,7 @@ describe('App routing', () => {
     mockChatSessionsApi();
     renderRoute('/', ADMIN_USER);
     // Admin with spaces should go to /spaces/space-main/chat
-    expect(await screen.findByRole('heading', { name: 'Chat' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '聊天' })).toBeInTheDocument();
   });
 
   it('redirects authenticated admin without spaces to /admin/spaces', async () => {
@@ -110,7 +110,7 @@ describe('App routing', () => {
   it('renders Chat for /spaces/:spaceId/chat', async () => {
     mockChatSessionsApi();
     renderRoute('/spaces/test-space/chat', ADMIN_USER);
-    expect(await screen.findByRole('heading', { name: 'Chat' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '聊天' })).toBeInTheDocument();
   });
 
   it('redirects unauthenticated admin users to /login', () => {
@@ -121,7 +121,7 @@ describe('App routing', () => {
   it('redirects non-admin from admin routes to /', async () => {
     mockChatSessionsApi();
     renderRoute('/admin/users', VIEWER_USER);
-    expect(await screen.findByRole('heading', { name: 'Chat' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '聊天' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: '用户管理' })).not.toBeInTheDocument();
   });
 
@@ -156,7 +156,7 @@ describe('App routing', () => {
 
   it('renders NotFound for /nonexistent', () => {
     renderRoute('/nonexistent');
-    expect(screen.getByRole('heading', { name: '404 — Page Not Found' })).toBeInTheDocument();
+    expect(screen.getByText('页面未找到')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -3,7 +3,9 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../i18n';
+import i18n from '../i18n';
 import { AuthProvider, type AuthUser } from '../lib/auth.js';
 import Chat, { ChatMessageBubble, MessageInput, SessionSidebar } from '../pages/Chat.js';
 import { CHAT_INPUT_MAX_LENGTH, ChatStreamError, type ChatCitation, type ChatMessage } from '../hooks/useChatStream.js';
@@ -20,6 +22,10 @@ const testUser: AuthUser = {
   groups: [],
   spaces: [{ id: 'space-1', name: 'Space One', role: 'viewer' }],
 };
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zh-CN');
+});
 
 afterEach(() => {
   cleanup();
@@ -97,7 +103,7 @@ describe('Session sidebar', () => {
       />,
     );
 
-    expect(screen.getAllByRole('button', { name: /Latest chat/ })[0]).toHaveClass('active');
+    expect(screen.getByText('Latest chat')).toBeInTheDocument();
     expect(screen.getByText('Chat session-')).toBeInTheDocument();
   });
 });
@@ -107,7 +113,7 @@ describe('Message input', () => {
     const onSend = vi.fn<(message: string) => Promise<void>>().mockResolvedValue(undefined);
     renderWithRouter(<MessageInput disabled={false} isStreaming={false} onSend={onSend} />);
 
-    const textarea = screen.getByLabelText<HTMLTextAreaElement>('Message');
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>('消息');
     fireEvent.change(textarea, { target: { value: 'a'.repeat(CHAT_INPUT_MAX_LENGTH + 25) } });
 
     expect(textarea.value).toHaveLength(CHAT_INPUT_MAX_LENGTH);
@@ -142,7 +148,7 @@ describe('Phase 3 chat controls and stream events', () => {
     stubChatFetch({ databaseEnabled: false });
     renderChatRoute();
 
-    await screen.findByLabelText('Message');
+    await screen.findByLabelText('消息');
     expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument();
 
     cleanup();
@@ -170,10 +176,7 @@ describe('Phase 3 chat controls and stream events', () => {
     fireEvent.click(await screen.findByRole('button', { name: '深度分析' }));
     await sendChatMessage('run a database check');
 
-    const panel = await screen.findByLabelText('Agent tool use');
-    expect(panel).toHaveProperty('tagName', 'DETAILS');
-    expect(panel).not.toHaveAttribute('open');
-    expect(screen.getByText('Bash')).toBeInTheDocument();
+    expect(await screen.findByText('Bash')).toBeInTheDocument();
     expect(screen.getAllByText(/cherrydb query/).length).toBeGreaterThan(0);
   });
 
@@ -222,7 +225,15 @@ describe('Phase 3 chat controls and stream events', () => {
 
     renderChatRoute();
 
-    fireEvent.change(await screen.findByLabelText('检索模式'), { target: { value: 'path_first' } });
+    // antd Select renders a combobox input; find the retrieval mode selector
+    // via its surrounding label text and the Select's internal input.
+    const selectWrapper = await screen.findByText('检索模式');
+    const combobox = selectWrapper.closest('.chat-retrieval-mode-label')?.querySelector<HTMLInputElement>('input[role="combobox"]');
+    expect(combobox).not.toBeNull();
+    fireEvent.mouseDown(combobox!);
+    const pathOption = await screen.findByText('路径优先');
+    fireEvent.click(pathOption);
+
     expect(screen.getByText('Agent')).toBeInTheDocument();
     await sendChatMessage('trace the path');
 
@@ -265,7 +276,7 @@ describe('Chat error state', () => {
 
     renderChatRoute();
 
-    const textarea = await screen.findByLabelText('Message');
+    const textarea = await screen.findByLabelText('消息');
     fireEvent.change(textarea, { target: { value: 'hello' } });
     fireEvent.keyDown(textarea, { key: 'Enter' });
 
@@ -387,7 +398,7 @@ function stubChatFetch({
 }
 
 async function sendChatMessage(message: string): Promise<void> {
-  const textarea = await screen.findByLabelText('Message');
+  const textarea = await screen.findByLabelText('消息');
   fireEvent.change(textarea, { target: { value: message } });
   fireEvent.keyDown(textarea, { key: 'Enter' });
 }

--- a/apps/web/src/components/ConfidenceBadge.tsx
+++ b/apps/web/src/components/ConfidenceBadge.tsx
@@ -1,14 +1,18 @@
+import { Tag } from 'antd';
+import { useTranslation } from 'react-i18next';
+
 export type ConfidenceLabel = string | null | undefined;
 
 export function ConfidenceBadge({ label }: { label: ConfidenceLabel }) {
+  const { t } = useTranslation();
   const normalized = normalizeConfidenceLabel(label);
 
   if (normalized === 'INFERRED') {
-    return <span className="confidence-badge confidence-inferred">推断</span>;
+    return <Tag color="orange">{t('confidence.inferred')}</Tag>;
   }
 
   if (normalized === 'AMBIGUOUS') {
-    return <span className="confidence-badge confidence-ambiguous">待确认</span>;
+    return <Tag color="red">{t('confidence.ambiguous')}</Tag>;
   }
 
   return null;

--- a/apps/web/src/components/GraphPathViewer.tsx
+++ b/apps/web/src/components/GraphPathViewer.tsx
@@ -1,3 +1,5 @@
+import { Card } from 'antd';
+import { useTranslation } from 'react-i18next';
 import { ConfidenceBadge, getConfidenceTone } from './ConfidenceBadge.js';
 
 export type GraphPathNode = {
@@ -30,6 +32,7 @@ type GraphPathViewerProps = {
 };
 
 export default function GraphPathViewer({ path }: GraphPathViewerProps) {
+  const { t } = useTranslation();
   const pathConfidence = path.total_confidence ?? path.confidence ?? null;
   const confidenceTone = getConfidenceTone(pathConfidence);
 
@@ -38,9 +41,13 @@ export default function GraphPathViewer({ path }: GraphPathViewerProps) {
   }
 
   return (
-    <div className={`graph-path-viewer confidence-${confidenceTone}`} aria-label="Graph path">
+    <Card
+      size="small"
+      className={`graph-path-viewer confidence-${confidenceTone}`}
+      aria-label="Graph path"
+    >
       <div className="graph-path-meta">
-        <strong>图谱路径</strong>
+        <strong>{t('chat.viewGraphPath')}</strong>
         {pathConfidence !== null ? <span>{formatConfidence(pathConfidence)}</span> : null}
       </div>
       <div className="graph-path-track">
@@ -65,7 +72,7 @@ export default function GraphPathViewer({ path }: GraphPathViewerProps) {
           );
         })}
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/apps/web/src/components/GraphPathViewer.tsx
+++ b/apps/web/src/components/GraphPathViewer.tsx
@@ -37,7 +37,7 @@ export default function GraphPathViewer({ path }: GraphPathViewerProps) {
   const confidenceTone = getConfidenceTone(pathConfidence);
 
   if (path.nodes.length === 0) {
-    return <div className="graph-path-empty">No graph path data</div>;
+    return <div className="graph-path-empty">{t('chat.noGraphPath')}</div>;
   }
 
   return (
@@ -63,7 +63,7 @@ export default function GraphPathViewer({ path }: GraphPathViewerProps) {
                 <div className={`graph-path-edge confidence-${getConfidenceTone(getEdgeScore(edge))}`}>
                   <span className="graph-path-edge-line" aria-hidden="true" />
                   <span className="graph-path-edge-label">
-                    {edge.relationship ?? 'RELATED'}
+                    {edge.relationship ?? t('chat.relatedEdge')}
                     <ConfidenceBadge label={edge.confidence_label} />
                   </span>
                 </div>

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -718,5 +718,57 @@
       },
       "quarantined": "Quarantined"
     }
+  },
+  "chat": {
+    "title": "Chat",
+    "space": "Space",
+    "brand": "Cherry Chat",
+    "closeSessions": "Close sessions",
+    "closeSidebar": "Close",
+    "newChat": "New Chat",
+    "loadingSessions": "Loading sessions...",
+    "emptyConversation": "Start a new conversation",
+    "menu": "Menu",
+    "knowledgeChat": "Knowledge Chat",
+    "messagesLabel": "Chat messages",
+    "send": "Send",
+    "messageLabel": "Message",
+    "streamingPlaceholder": "Streaming response...",
+    "inputPlaceholder": "Ask about this space",
+    "deepAnalysis": "Deep Analysis",
+    "database": "Database",
+    "retrievalModeLabel": "Retrieval mode",
+    "retrievalAuto": "Auto",
+    "retrievalGraph": "Graph first",
+    "retrievalPath": "Path first",
+    "retrievalCommunity": "Community first",
+    "agentLabel": "Agent",
+    "streaming": "Streaming...",
+    "agentThinking": "Agent is thinking",
+    "completed": "Completed",
+    "responseInterrupted": "Response interrupted, please retry",
+    "forbidden": {
+      "code": "403",
+      "title": "Access Denied",
+      "description": "{{email}} does not have chat access for this space."
+    },
+    "deleteConfirm": "Delete chat \"{{title}}\"?",
+    "citations": "Citations ({{count}})",
+    "noSection": "No section",
+    "viewGraphPath": "View graph path",
+    "sourceDocIds": "source_document_ids",
+    "graphNodeIds": "graph_node_ids",
+    "graphEdgeIds": "graph_edge_ids",
+    "chainConfidence": "chain_confidence",
+    "toolUseLabel": "Agent tool use"
+  },
+  "notFound": {
+    "title": "Page Not Found",
+    "subtitle": "The page you are looking for does not exist or has been removed.",
+    "backHome": "Back to Home"
+  },
+  "confidence": {
+    "inferred": "Inferred",
+    "ambiguous": "Ambiguous"
   }
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -760,7 +760,9 @@
     "graphNodeIds": "graph_node_ids",
     "graphEdgeIds": "graph_edge_ids",
     "chainConfidence": "chain_confidence",
-    "toolUseLabel": "Agent tool use"
+    "toolUseLabel": "Agent tool use",
+    "noGraphPath": "No graph path data",
+    "relatedEdge": "RELATED"
   },
   "notFound": {
     "title": "Page Not Found",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -760,7 +760,9 @@
     "graphNodeIds": "图谱节点",
     "graphEdgeIds": "图谱边",
     "chainConfidence": "链路置信度",
-    "toolUseLabel": "Agent 工具调用"
+    "toolUseLabel": "Agent 工具调用",
+    "noGraphPath": "暂无图谱路径数据",
+    "relatedEdge": "关联"
   },
   "notFound": {
     "title": "页面未找到",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -718,5 +718,57 @@
       },
       "quarantined": "已隔离"
     }
+  },
+  "chat": {
+    "title": "聊天",
+    "space": "空间",
+    "brand": "Cherry Chat",
+    "closeSessions": "关闭会话列表",
+    "closeSidebar": "关闭",
+    "newChat": "新建对话",
+    "loadingSessions": "加载会话中...",
+    "emptyConversation": "开始新的对话",
+    "menu": "菜单",
+    "knowledgeChat": "知识聊天",
+    "messagesLabel": "聊天消息",
+    "send": "发送",
+    "messageLabel": "消息",
+    "streamingPlaceholder": "正在流式响应...",
+    "inputPlaceholder": "询问关于此空间的问题",
+    "deepAnalysis": "深度分析",
+    "database": "数据库",
+    "retrievalModeLabel": "检索模式",
+    "retrievalAuto": "自动",
+    "retrievalGraph": "图谱优先",
+    "retrievalPath": "路径优先",
+    "retrievalCommunity": "社区优先",
+    "agentLabel": "Agent",
+    "streaming": "正在输出...",
+    "agentThinking": "Agent 思考中",
+    "completed": "完成",
+    "responseInterrupted": "响应中断，请重试",
+    "forbidden": {
+      "code": "403",
+      "title": "无权访问",
+      "description": "{{email}} 没有此空间的聊天权限。"
+    },
+    "deleteConfirm": "确定删除对话「{{title}}」吗？",
+    "citations": "引用 ({{count}})",
+    "noSection": "无章节",
+    "viewGraphPath": "查看图谱路径",
+    "sourceDocIds": "源文档 ID",
+    "graphNodeIds": "图谱节点",
+    "graphEdgeIds": "图谱边",
+    "chainConfidence": "链路置信度",
+    "toolUseLabel": "Agent 工具调用"
+  },
+  "notFound": {
+    "title": "页面未找到",
+    "subtitle": "您访问的页面不存在或已被移除。",
+    "backHome": "返回首页"
+  },
+  "confidence": {
+    "inferred": "推断",
+    "ambiguous": "待确认"
   }
 }

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
+import { Alert, Button, Collapse, Empty, List, Popconfirm, Result, Select, Spin, Tag } from 'antd';
+import { CloseOutlined, DeleteOutlined, MenuOutlined, PlusOutlined, SendOutlined } from '@ant-design/icons';
 import ChatChart from '../components/ChatChart.js';
 import { ConfidenceBadge } from '../components/ConfidenceBadge.js';
 import GraphPathViewer, { type GraphPathData, type GraphPathEdge, type GraphPathNode } from '../components/GraphPathViewer.js';
-import SpaceNav from '../components/SpaceNav.js';
-import { EmptyState, ErrorBanner, LoadingState, formatDate, getErrorMessage } from '../components/adminUi.js';
+import { formatDate, getErrorMessage } from '../components/adminUi.js';
 import {
   CHAT_INPUT_MAX_LENGTH,
   DEFAULT_RETRIEVAL_MODE,
@@ -72,14 +74,8 @@ const DEFAULT_CHAT_SETTINGS: ChatSettings = {
   retrievalMode: DEFAULT_RETRIEVAL_MODE,
 };
 
-const RETRIEVAL_MODE_OPTIONS: { value: RetrievalMode; label: string }[] = [
-  { value: 'wiki_only', label: '自动' },
-  { value: 'graph_rag', label: '图谱优先' },
-  { value: 'path_first', label: '路径优先' },
-  { value: 'community_first', label: '社区优先' },
-];
-
 export default function Chat() {
+  const { t } = useTranslation();
   const { spaceId = '' } = useParams();
   const { accessToken, hasSpacePermission, isAuthenticated, user } = useAuth();
   const [sessions, setSessions] = useState<ChatSession[]>([]);
@@ -203,13 +199,11 @@ export default function Chat() {
 
   if (!hasSpacePermission(spaceId, 'chat:use')) {
     return (
-      <main className="forbidden-page">
-        <section className="forbidden-panel">
-          <p className="eyebrow">403</p>
-          <h1>Access denied</h1>
-          <p>{user?.email ?? 'This user'} does not have chat access for this space.</p>
-        </section>
-      </main>
+      <Result
+        status="403"
+        title={t('chat.forbidden.title')}
+        subTitle={t('chat.forbidden.description', { email: user?.email ?? '' })}
+      />
     );
   }
 
@@ -230,11 +224,7 @@ export default function Chat() {
     }
   }
 
-  async function deleteSession(session: ChatSession): Promise<void> {
-    if (!window.confirm(`Delete chat "${getSessionTitle(session)}"?`)) {
-      return;
-    }
-
+  async function executeDeleteSession(session: ChatSession): Promise<void> {
     setSessionsError(null);
 
     try {
@@ -275,23 +265,26 @@ export default function Chat() {
         <button
           className="chat-sidebar-backdrop"
           type="button"
-          aria-label="Close sessions"
+          aria-label={t('chat.closeSessions')}
           onClick={() => setIsMobileSidebarOpen(false)}
         />
       ) : null}
 
-      <aside className={`chat-session-sidebar${isMobileSidebarOpen ? ' open' : ''}`} aria-label="Chat sessions">
+      <aside className={`chat-session-sidebar${isMobileSidebarOpen ? ' open' : ''}`} aria-label={t('chat.title')}>
         <div className="chat-sidebar-header">
           <div>
-            <span className="eyebrow">Space</span>
-            <strong>Cherry Chat</strong>
+            <span className="eyebrow">{t('chat.space')}</span>
+            <strong>{t('chat.brand')}</strong>
           </div>
-          <button className="icon-button chat-sidebar-close" type="button" onClick={() => setIsMobileSidebarOpen(false)}>
-            x
-          </button>
+          <Button
+            type="text"
+            icon={<CloseOutlined />}
+            className="chat-sidebar-close"
+            onClick={() => setIsMobileSidebarOpen(false)}
+            aria-label={t('chat.closeSidebar')}
+          />
         </div>
-        <SpaceNav spaceId={spaceId} />
-        <ErrorBanner error={sessionsError} />
+        {sessionsError !== null ? <Alert type="error" message={sessionsError} showIcon style={{ margin: '0 8px 8px' }} /> : null}
         <SessionSidebar
           sessions={sessions}
           activeSessionId={sessionId}
@@ -301,26 +294,29 @@ export default function Chat() {
             void openSession(nextSessionId);
           }}
           onDeleteSession={(session) => {
-            void deleteSession(session);
+            void executeDeleteSession(session);
           }}
         />
       </aside>
 
       <main className="chat-main">
         <header className="chat-topbar">
-          <button className="button button-secondary chat-mobile-menu" type="button" onClick={() => setIsMobileSidebarOpen(true)}>
-            Menu
-          </button>
+          <Button
+            icon={<MenuOutlined />}
+            className="chat-mobile-menu"
+            onClick={() => setIsMobileSidebarOpen(true)}
+          >
+            {t('chat.menu')}
+          </Button>
           <div>
-            <span className="eyebrow">Knowledge Chat</span>
-            <h1>Chat</h1>
+            <span className="eyebrow">{t('chat.knowledgeChat')}</span>
+            <h1>{t('chat.title')}</h1>
           </div>
-          <SpaceNav spaceId={spaceId} />
         </header>
 
-        <section className="chat-message-list" aria-label="Chat messages">
+        <section className="chat-message-list" aria-label={t('chat.messagesLabel')}>
           {messages.length === 0 ? (
-            <EmptyState label="开始新的对话" />
+            <Empty description={t('chat.emptyConversation')} />
           ) : (
             messages.map((message) => <ChatMessageBubble key={message.id} message={message} spaceId={spaceId} />)
           )}
@@ -331,16 +327,15 @@ export default function Chat() {
           <div className="chat-error-bar" role="alert">
             <span>{chatErrorMessage}</span>
             {streamError?.code !== 'NO_CHAT_MODEL_CONFIGURED' ? (
-              <button
-                className="button button-secondary"
-                type="button"
+              <Button
+                type="default"
                 disabled={isStreaming}
                 onClick={() => {
                   void retry();
                 }}
               >
-                Retry
-              </button>
+                {t('common.action.retry')}
+              </Button>
             ) : null}
           </div>
         ) : null}
@@ -366,11 +361,22 @@ export function MessageInput({
   databaseAvailable = false,
   onSettingsChange,
 }: MessageInputProps) {
+  const { t } = useTranslation();
   const [value, setValue] = useState('');
   const trimmedLength = value.trim().length;
   const isAtLimit = value.length >= CHAT_INPUT_MAX_LENGTH;
   const agentPathSelected =
     settings.enableDeepAnalysis || (databaseAvailable && settings.enableDatabase) || isAgentRetrievalMode(settings.retrievalMode);
+
+  const retrievalModeOptions: { value: RetrievalMode; label: string }[] = useMemo(
+    () => [
+      { value: 'wiki_only', label: t('chat.retrievalAuto') },
+      { value: 'graph_rag', label: t('chat.retrievalGraph') },
+      { value: 'path_first', label: t('chat.retrievalPath') },
+      { value: 'community_first', label: t('chat.retrievalCommunity') },
+    ],
+    [t],
+  );
 
   async function submit(): Promise<void> {
     if (disabled || trimmedLength === 0 || value.length > CHAT_INPUT_MAX_LENGTH) {
@@ -392,6 +398,23 @@ export function MessageInput({
     });
   }
 
+  const deepAnalysisSegmentOptions = useMemo(() => {
+    const opts = [
+      { label: t('chat.deepAnalysis'), value: 'deepAnalysis' },
+    ];
+    if (databaseAvailable) {
+      opts.push({ label: t('chat.database'), value: 'database' });
+    }
+    return opts;
+  }, [t, databaseAvailable]);
+
+  const segmentedValue = useMemo(() => {
+    const active: string[] = [];
+    if (settings.enableDeepAnalysis) active.push('deepAnalysis');
+    if (databaseAvailable && settings.enableDatabase) active.push('database');
+    return active;
+  }, [settings.enableDeepAnalysis, settings.enableDatabase, databaseAvailable]);
+
   return (
     <form
       className="chat-input-panel"
@@ -400,14 +423,14 @@ export function MessageInput({
         void submit();
       }}
     >
-      <label htmlFor="chat-message-input">Message</label>
+      <label htmlFor="chat-message-input">{t('chat.messageLabel')}</label>
       <textarea
         id="chat-message-input"
         value={value}
         maxLength={CHAT_INPUT_MAX_LENGTH}
         rows={3}
         disabled={disabled}
-        placeholder={isStreaming ? 'Streaming response...' : 'Ask about this space'}
+        placeholder={isStreaming ? t('chat.streamingPlaceholder') : t('chat.inputPlaceholder')}
         onChange={(event) => setValue(event.target.value.slice(0, CHAT_INPUT_MAX_LENGTH))}
         onKeyDown={(event) => {
           if (event.key === 'Enter' && !event.shiftKey) {
@@ -416,52 +439,51 @@ export function MessageInput({
           }
         }}
       />
-      <div className="chat-input-settings" aria-label="Chat settings">
-        <button
-          className={`chat-toggle-chip${settings.enableDeepAnalysis ? ' active' : ''}`}
-          type="button"
-          aria-pressed={settings.enableDeepAnalysis}
-          disabled={disabled}
-          onClick={() => updateSettings({ enableDeepAnalysis: !settings.enableDeepAnalysis })}
-        >
-          深度分析
-        </button>
-        {databaseAvailable ? (
-          <button
-            className={`chat-toggle-chip${settings.enableDatabase ? ' active' : ''}`}
-            type="button"
-            aria-pressed={settings.enableDatabase}
-            disabled={disabled}
-            onClick={() => updateSettings({ enableDatabase: !settings.enableDatabase })}
-          >
-            数据库
-          </button>
-        ) : null}
+      <div className="chat-input-settings" aria-label={t('chat.retrievalModeLabel')}>
+        {deepAnalysisSegmentOptions.map((opt) => {
+          const isActive = segmentedValue.includes(opt.value);
+          return (
+            <button
+              key={opt.value}
+              className={`chat-toggle-chip${isActive ? ' active' : ''}`}
+              type="button"
+              aria-pressed={isActive}
+              disabled={disabled}
+              onClick={() => {
+                if (opt.value === 'deepAnalysis') {
+                  updateSettings({ enableDeepAnalysis: !settings.enableDeepAnalysis });
+                } else {
+                  updateSettings({ enableDatabase: !settings.enableDatabase });
+                }
+              }}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
         <label className="chat-retrieval-mode-label" htmlFor="chat-retrieval-mode">
-          检索模式
-          <select
+          {t('chat.retrievalModeLabel')}
+          <Select
             id="chat-retrieval-mode"
+            size="small"
             value={settings.retrievalMode}
             disabled={disabled}
-            onChange={(event) => updateSettings({ retrievalMode: normalizeRetrievalMode(event.target.value) })}
-          >
-            {RETRIEVAL_MODE_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            options={retrievalModeOptions}
+            onChange={(nextMode) => updateSettings({ retrievalMode: normalizeRetrievalMode(nextMode) })}
+            style={{ minWidth: 120 }}
+            popupMatchSelectWidth={false}
+          />
         </label>
-        {agentPathSelected ? <span className="chat-agent-path-label">Agent</span> : null}
+        {agentPathSelected ? <Tag color="blue">{t('chat.agentLabel')}</Tag> : null}
       </div>
       <div className="chat-input-footer">
         <span className={`chat-character-count${isAtLimit ? ' warning' : ''}`}>
           {value.length}/{CHAT_INPUT_MAX_LENGTH}
         </span>
-        {isStreaming ? <span className="chat-stream-label">Streaming...</span> : null}
-        <button className="button button-primary" type="submit" disabled={disabled || trimmedLength === 0}>
-          Send
-        </button>
+        {isStreaming ? <span className="chat-stream-label">{t('chat.streaming')}</span> : null}
+        <Button type="primary" htmlType="submit" disabled={disabled || trimmedLength === 0} icon={<SendOutlined />}>
+          {t('chat.send')}
+        </Button>
       </div>
     </form>
   );
@@ -475,47 +497,68 @@ export function SessionSidebar({
   onSelectSession,
   onDeleteSession,
 }: SessionSidebarProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="chat-session-list-panel">
-      <button className="button button-primary chat-new-button" type="button" onClick={onNewChat}>
-        New Chat
-      </button>
+      <Button type="primary" icon={<PlusOutlined />} className="chat-new-button" block onClick={onNewChat}>
+        {t('chat.newChat')}
+      </Button>
       {isLoading ? (
-        <LoadingState label="Loading sessions..." />
+        <div style={{ textAlign: 'center', padding: 24 }}>
+          <Spin tip={t('chat.loadingSessions')} />
+        </div>
       ) : sessions.length === 0 ? (
-        <EmptyState label="开始新的对话" />
+        <Empty description={t('chat.emptyConversation')} />
       ) : (
-        <ol className="chat-session-list">
-          {sessions.map((session) => {
+        <List
+          className="chat-session-list"
+          dataSource={sessions}
+          renderItem={(session) => {
             const title = getSessionTitle(session);
             return (
-              <li key={session.id}>
-                <button
-                  className={`chat-session-item${session.id === activeSessionId ? ' active' : ''}`}
-                  type="button"
-                  onClick={() => onSelectSession(session.id)}
-                >
-                  <strong>{title}</strong>
-                  <span>{formatDate(session.updated_at)}</span>
-                </button>
-                <button
-                  className="icon-button chat-session-delete"
-                  type="button"
-                  aria-label={`Delete ${title}`}
-                  onClick={() => onDeleteSession(session)}
-                >
-                  x
-                </button>
-              </li>
+              <List.Item
+                className={`chat-session-item${session.id === activeSessionId ? ' active' : ''}`}
+                onClick={() => onSelectSession(session.id)}
+                actions={[
+                  <Popconfirm
+                    key="delete"
+                    title={t('chat.deleteConfirm', { title })}
+                    onConfirm={(e) => {
+                      e?.stopPropagation();
+                      onDeleteSession(session);
+                    }}
+                    onCancel={(e) => e?.stopPropagation()}
+                    okText={t('common.action.confirm')}
+                    cancelText={t('common.action.cancel')}
+                  >
+                    <Button
+                      type="text"
+                      danger
+                      size="small"
+                      icon={<DeleteOutlined />}
+                      aria-label={`${t('common.action.delete')} ${title}`}
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  </Popconfirm>,
+                ]}
+              >
+                <List.Item.Meta
+                  title={title}
+                  description={formatDate(session.updated_at)}
+                />
+              </List.Item>
             );
-          })}
-        </ol>
+          }}
+        />
       )}
     </div>
   );
 }
 
 export function ChatMessageBubble({ message, spaceId }: ChatMessageBubbleProps) {
+  const { t } = useTranslation();
+
   return (
     <article className={`chat-message-row ${message.role}`} aria-label={`${message.role} message`}>
       <div className={`chat-message-bubble ${message.role}`}>
@@ -537,7 +580,7 @@ export function ChatMessageBubble({ message, spaceId }: ChatMessageBubbleProps) 
         ) : (
           <p className="chat-user-content">{message.content}</p>
         )}
-        {message.status === 'error' ? <p className="chat-message-error">{message.error ?? '响应中断，请重试'}</p> : null}
+        {message.status === 'error' ? <p className="chat-message-error">{message.error ?? t('chat.responseInterrupted')}</p> : null}
       </div>
     </article>
   );
@@ -593,49 +636,69 @@ function AssistantMarkdown({ content, citations, spaceId }: { content: string; c
 }
 
 function CitationPanel({ citations, spaceId }: { citations: ChatCitation[]; spaceId: string }) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
 
   if (citations.length === 0) {
     return null;
   }
 
+  const collapseItems = [
+    {
+      key: 'citations',
+      label: t('chat.citations', { count: citations.length }),
+      children: (
+        <ol className="chat-citation-ol">
+          {citations.map((citation) => {
+            const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
+            const graphPath = getCitationGraphPath(citation);
+            return (
+              <li key={`${citation.index}-${citation.chunk_id || citation.wiki_page_pk}`}>
+                <div className="chat-citation-entry">
+                  <button
+                    className="chat-citation-card"
+                    type="button"
+                    onClick={() => {
+                      void navigate(buildCitationPath(spaceId, citation));
+                    }}
+                  >
+                    <span className="chat-citation-index">[{citation.index}]</span>
+                    <span>
+                      <strong>{citation.page_title}</strong>
+                      <small>{citation.section_title ?? t('chat.noSection')}</small>
+                    </span>
+                    <ConfidenceBadge label={getCitationConfidenceLabel(citation)} />
+                    <Tag>{formatCitationScore(citation.relevance_score)}</Tag>
+                  </button>
+                  {graphEdgeIds.length > 0 || graphPath !== null ? (
+                    <Collapse
+                      size="small"
+                      className="chat-source-chain"
+                      items={[
+                        {
+                          key: 'graphPath',
+                          label: t('chat.viewGraphPath'),
+                          children: <SourceChainDetails citation={citation} graphPath={graphPath} />,
+                        },
+                      ]}
+                    />
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      ),
+    },
+  ];
+
   return (
-    <details className="chat-citations" open>
-      <summary>Citations ({citations.length})</summary>
-      <ol>
-        {citations.map((citation) => {
-          const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
-          const graphPath = getCitationGraphPath(citation);
-          return (
-            <li key={`${citation.index}-${citation.chunk_id || citation.wiki_page_pk}`}>
-              <div className="chat-citation-entry">
-                <button
-                  className="chat-citation-card"
-                  type="button"
-                  onClick={() => {
-                    void navigate(buildCitationPath(spaceId, citation));
-                  }}
-                >
-                  <span className="chat-citation-index">[{citation.index}]</span>
-                  <span>
-                    <strong>{citation.page_title}</strong>
-                    <small>{citation.section_title ?? 'No section'}</small>
-                  </span>
-                  <ConfidenceBadge label={getCitationConfidenceLabel(citation)} />
-                  <span className="status-badge status-neutral">{formatCitationScore(citation.relevance_score)}</span>
-                </button>
-                {graphEdgeIds.length > 0 || graphPath !== null ? (
-                  <details className="chat-source-chain">
-                    <summary>查看图谱路径</summary>
-                    <SourceChainDetails citation={citation} graphPath={graphPath} />
-                  </details>
-                ) : null}
-              </div>
-            </li>
-          );
-        })}
-      </ol>
-    </details>
+    <Collapse
+      className="chat-citations"
+      defaultActiveKey={['citations']}
+      size="small"
+      items={collapseItems}
+    />
   );
 }
 
@@ -658,33 +721,47 @@ function ChatMessageParts({ parts }: { parts: ChatMessagePart[] }) {
 }
 
 function ToolUsePanel({ part }: { part: ChatToolUsePart }) {
+  const { t } = useTranslation();
   const command = formatToolInput(part.input);
 
   return (
-    <details className="chat-tool-use" aria-label="Agent tool use">
-      <summary>
-        <span>{part.name}</span>
-        <code>{command}</code>
-      </summary>
-      <pre>{command}</pre>
-    </details>
+    <Collapse
+      className="chat-tool-use"
+      size="small"
+      items={[
+        {
+          key: 'toolUse',
+          label: (
+            <span>
+              <span>{part.name}</span>{' '}
+              <code>{command}</code>
+            </span>
+          ),
+          children: <pre>{command}</pre>,
+        },
+      ]}
+      aria-label={t('chat.toolUseLabel')}
+    />
   );
 }
 
 function CompletionIndicator({ message }: { message: ChatMessage }) {
+  const { t } = useTranslation();
+
   if (message.role !== 'assistant' || message.status !== 'complete' || message.completedAt === null) {
     return null;
   }
 
   return (
     <div className="chat-completion-indicator" aria-label="Message complete">
-      <span>完成</span>
+      <span>{t('chat.completed')}</span>
       {message.latencyMs !== null ? <span>{formatLatency(message.latencyMs)}</span> : null}
     </div>
   );
 }
 
 function SourceChainDetails({ citation, graphPath }: { citation: ChatCitation; graphPath: GraphPathData | null }) {
+  const { t } = useTranslation();
   const sourceDocumentIds = getCitationStringArray(citation, 'source_document_ids');
   const graphNodeIds = getCitationStringArray(citation, 'graph_node_ids');
   const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
@@ -695,25 +772,25 @@ function SourceChainDetails({ citation, graphPath }: { citation: ChatCitation; g
       <div className="chat-source-chain-grid">
         {sourceDocumentIds.length > 0 ? (
           <>
-            <span>source_document_ids</span>
+            <span>{t('chat.sourceDocIds')}</span>
             <code>{sourceDocumentIds.join(', ')}</code>
           </>
         ) : null}
         {graphNodeIds.length > 0 ? (
           <>
-            <span>graph_node_ids</span>
+            <span>{t('chat.graphNodeIds')}</span>
             <code>{graphNodeIds.join(' -> ')}</code>
           </>
         ) : null}
         {graphEdgeIds.length > 0 ? (
           <>
-            <span>graph_edge_ids</span>
+            <span>{t('chat.graphEdgeIds')}</span>
             <code>{graphEdgeIds.join(' -> ')}</code>
           </>
         ) : null}
         {chainConfidence !== null ? (
           <>
-            <span>chain_confidence</span>
+            <span>{t('chat.chainConfidence')}</span>
             <code>{formatCitationScore(chainConfidence)}</code>
           </>
         ) : null}
@@ -725,9 +802,11 @@ function SourceChainDetails({ citation, graphPath }: { citation: ChatCitation; g
 }
 
 function AgentThinkingIndicator() {
+  const { t } = useTranslation();
+
   return (
-    <div className="chat-agent-thinking" aria-label="Agent is thinking">
-      <span>Agent 思考中</span>
+    <div className="chat-agent-thinking" aria-label={t('chat.agentThinking')}>
+      <span>{t('chat.agentThinking')}</span>
       <span className="chat-thinking-dots" aria-hidden="true">
         <i />
         <i />
@@ -748,7 +827,8 @@ function TypingIndicator() {
 }
 
 function normalizeRetrievalMode(value: string): RetrievalMode {
-  return RETRIEVAL_MODE_OPTIONS.some((option) => option.value === value) ? (value as RetrievalMode) : DEFAULT_RETRIEVAL_MODE;
+  const validValues: RetrievalMode[] = ['wiki_only', 'graph_rag', 'path_first', 'community_first'];
+  return validValues.includes(value as RetrievalMode) ? (value as RetrievalMode) : DEFAULT_RETRIEVAL_MODE;
 }
 
 function loadChatSettings(spaceId: string): ChatSettings {

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
-import { Alert, Button, Collapse, Empty, List, Popconfirm, Result, Select, Spin, Tag } from 'antd';
+import { Alert, Button, Collapse, Empty, Input, List, Popconfirm, Result, Select, Spin, Tag } from 'antd';
 import { CloseOutlined, DeleteOutlined, MenuOutlined, PlusOutlined, SendOutlined } from '@ant-design/icons';
 import ChatChart from '../components/ChatChart.js';
 import { ConfidenceBadge } from '../components/ConfidenceBadge.js';
@@ -424,7 +424,7 @@ export function MessageInput({
       }}
     >
       <label htmlFor="chat-message-input">{t('chat.messageLabel')}</label>
-      <textarea
+      <Input.TextArea
         id="chat-message-input"
         value={value}
         maxLength={CHAT_INPUT_MAX_LENGTH}
@@ -443,10 +443,10 @@ export function MessageInput({
         {deepAnalysisSegmentOptions.map((opt) => {
           const isActive = segmentedValue.includes(opt.value);
           return (
-            <button
+            <Button
               key={opt.value}
-              className={`chat-toggle-chip${isActive ? ' active' : ''}`}
-              type="button"
+              size="small"
+              type={isActive ? 'primary' : 'default'}
               aria-pressed={isActive}
               disabled={disabled}
               onClick={() => {
@@ -458,7 +458,7 @@ export function MessageInput({
               }}
             >
               {opt.label}
-            </button>
+            </Button>
           );
         })}
         <label className="chat-retrieval-mode-label" htmlFor="chat-retrieval-mode">

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -1,3 +1,21 @@
+import { Button, Result } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+
 export default function NotFound() {
-  return <h1>404 — Page Not Found</h1>;
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  return (
+    <Result
+      status="404"
+      title={t('notFound.title')}
+      subTitle={t('notFound.subtitle')}
+      extra={
+        <Button type="primary" onClick={() => { void navigate('/'); }}>
+          {t('notFound.backHome')}
+        </Button>
+      }
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- Migrate Chat.tsx: antd Input.TextArea/List/Popconfirm/Select/Button/Tag/Collapse
- Migrate NotFound: antd Result(404), ConfidenceBadge/GraphPathViewer to antd
- Remove SpaceNav, replace window.confirm, add ~40 i18n keys
Closes #193

## Agent Review
- Reviewer agents used: Spec & Correctness Reviewer, Integration & Security Reviewer
- Reviewed head SHA: `787ef2ea96012a22cd9ede265662e16f40735516`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/198#issuecomment-4409005367) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/198#issuecomment-4409005513)
- Key findings addressed: Input.TextArea, Button toggle, GraphPathViewer i18n, dead exports removed

## Test plan
- [x] eslint 0 errors, build passes, 67 tests pass