### PR TITLE
feat(auth,web): admin auto-access all spaces + remove header duplication (#200)

### DIFF
--- a/apps/api/src/auth/__tests__/auth-test-utils.ts
+++ b/apps/api/src/auth/__tests__/auth-test-utils.ts
@@ -1,6 +1,7 @@
 import { HttpException } from '@nestjs/common';
 import type { AuthenticatedRequestUser } from '@cherrygraph/auth-core';
 import { sessions, users } from '@cherrygraph/shared';
+import type { SQL } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { vi } from 'vitest';
 
@@ -23,6 +24,7 @@ export class FakeDb {
   readonly inserts: unknown[] = [];
   readonly updates: unknown[] = [];
   readonly selectFields: unknown[] = [];
+  readonly whereCalls: SQL[] = [];
   readonly selectResults: unknown[][] = [];
   readonly insertResults: unknown[][] = [];
   readonly updateResults: unknown[][] = [];
@@ -49,7 +51,7 @@ export class FakeDb {
 
   select(fields?: unknown): FakeQueryBuilder {
     this.selectFields.push(fields);
-    return new FakeQueryBuilder(this.selectResults.shift() ?? []);
+    return new FakeQueryBuilder(this.selectResults.shift() ?? [], this);
   }
 
   insert(): { values: (value: unknown) => FakeInsertReturningBuilder } {
@@ -67,14 +69,17 @@ export class FakeDb {
     return {
       set: (value: unknown) => {
         this.updates.push(value);
-        return new FakeQueryBuilder(this.updateResults.shift() ?? []);
+        return new FakeQueryBuilder(this.updateResults.shift() ?? [], this);
       },
     };
   }
 }
 
 class FakeQueryBuilder implements PromiseLike<unknown[]> {
-  constructor(private readonly result: unknown[]) {}
+  constructor(
+    private readonly result: unknown[],
+    private readonly db: FakeDb,
+  ) {}
 
   from(): this {
     return this;
@@ -84,7 +89,8 @@ class FakeQueryBuilder implements PromiseLike<unknown[]> {
     return this;
   }
 
-  where(): this {
+  where(where: SQL): this {
+    this.db.whereCalls.push(where);
     return this;
   }
 

--- a/apps/api/src/auth/__tests__/auth.service.test.ts
+++ b/apps/api/src/auth/__tests__/auth.service.test.ts
@@ -6,6 +6,7 @@ import {
   verifyToken,
 } from '@cherrygraph/auth-core';
 import { ErrorCode } from '@cherrygraph/shared';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@cherrygraph/auth-core', async (importOriginal) => {
@@ -35,6 +36,7 @@ import {
 } from './auth-test-utils.js';
 
 const originalDefaultTenantId = process.env.DEFAULT_TENANT_ID;
+const dialect = new PgDialect();
 
 describe('AuthService', () => {
   beforeEach(() => {
@@ -359,27 +361,173 @@ describe('AuthService', () => {
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.PASSWORD_TOO_WEAK);
   });
 
-  it('returns the current user with groups and highest space roles', async () => {
-    const passwordHash = await hashPassword('Correct1!');
-    const { service, db } = createServiceContext();
-    db.queueSelect([createUser(passwordHash)]);
-    db.queueSelect([{ id: 'group-1', name: 'Editors' }]);
-    db.queueSelect([
-      { id: 'space-1', name: 'Space One', permission: 'space:view' },
-      { id: 'space-1', name: 'Space One', permission: 'space:edit' },
-      { id: 'space-2', name: 'Space Two', permission: 'space:admin' },
-    ]);
+  describe('getCurrentUser - space roles', () => {
+    it('returns all active spaces as admin roles for admin users', async () => {
+      const { service, db } = createServiceContext();
+      db.queueSelect([
+        createUser('password-hash', {
+          id: 'admin-user',
+          email: 'admin@example.com',
+          display_name: 'Admin User',
+          role: 'admin',
+        }),
+      ]);
+      db.queueSelect([]);
+      db.queueSelect([
+        { id: 'space-active-1', name: 'Active One' },
+        { id: 'space-active-2', name: 'Active Two' },
+      ]);
 
-    await expect(service.getCurrentUser(createAuthenticatedUser())).resolves.toEqual({
-      id: TEST_USER_ID,
-      email: TEST_EMAIL,
-      name: 'Test User',
-      role: 'editor',
-      groups: [{ id: 'group-1', name: 'Editors' }],
-      spaces: [
-        { id: 'space-1', name: 'Space One', role: 'editor' },
-        { id: 'space-2', name: 'Space Two', role: 'admin' },
-      ],
+      await expect(
+        service.getCurrentUser(
+          createAuthenticatedUser({
+            sub: 'admin-user',
+            email: 'admin@example.com',
+            role: 'admin',
+            group_ids: [],
+          }),
+        ),
+      ).resolves.toEqual({
+        id: 'admin-user',
+        email: 'admin@example.com',
+        name: 'Admin User',
+        role: 'admin',
+        groups: [],
+        spaces: [
+          { id: 'space-active-1', name: 'Active One', role: 'admin' },
+          { id: 'space-active-2', name: 'Active Two', role: 'admin' },
+        ],
+      });
+      expect(requireRecord(db.selectFields[2])).not.toHaveProperty('permission');
+    });
+
+    it('filters archived spaces from the admin space query', async () => {
+      const { service, db } = createServiceContext();
+      const archivedSpace = { id: 'space-archived', name: 'Archived Space' };
+      db.queueSelect([
+        createUser('password-hash', {
+          id: 'admin-user',
+          email: 'admin@example.com',
+          display_name: 'Admin User',
+          role: 'admin',
+        }),
+      ]);
+      db.queueSelect([]);
+      db.queueSelect([{ id: 'space-active', name: 'Active Space' }]);
+
+      const result = await service.getCurrentUser(
+        createAuthenticatedUser({
+          sub: 'admin-user',
+          email: 'admin@example.com',
+          role: 'admin',
+          group_ids: [],
+        }),
+      );
+
+      expect(result.spaces).toEqual([{ id: 'space-active', name: 'Active Space', role: 'admin' }]);
+      expect(result.spaces).not.toContainEqual(expect.objectContaining({ id: archivedSpace.id }));
+      const adminSpaceWhere = getWhereQuery(db, 2);
+      expect(adminSpaceWhere.sql).toContain('"spaces"."status" =');
+      expect(adminSpaceWhere.params).toEqual([TEST_TENANT_ID, 'active']);
+    });
+
+    it('returns all active spaces for admin users without group memberships', async () => {
+      const { service, db } = createServiceContext();
+      db.queueSelect([
+        createUser('password-hash', {
+          id: 'admin-user',
+          email: 'admin@example.com',
+          display_name: 'Admin User',
+          role: 'admin',
+        }),
+      ]);
+      db.queueSelect([]);
+      db.queueSelect([
+        { id: 'space-active-1', name: 'Active One' },
+        { id: 'space-active-2', name: 'Active Two' },
+      ]);
+
+      const result = await service.getCurrentUser(
+        createAuthenticatedUser({
+          sub: 'admin-user',
+          email: 'admin@example.com',
+          role: 'admin',
+          group_ids: [],
+        }),
+      );
+
+      expect(result.groups).toEqual([]);
+      expect(result.spaces).toEqual([
+        { id: 'space-active-1', name: 'Active One', role: 'admin' },
+        { id: 'space-active-2', name: 'Active Two', role: 'admin' },
+      ]);
+    });
+
+    it('returns an empty space list for admin users when no active spaces exist', async () => {
+      const { service, db } = createServiceContext();
+      db.queueSelect([
+        createUser('password-hash', {
+          id: 'admin-user',
+          email: 'admin@example.com',
+          display_name: 'Admin User',
+          role: 'admin',
+        }),
+      ]);
+      db.queueSelect([]);
+      db.queueSelect([]);
+
+      const result = await service.getCurrentUser(
+        createAuthenticatedUser({
+          sub: 'admin-user',
+          email: 'admin@example.com',
+          role: 'admin',
+          group_ids: [],
+        }),
+      );
+
+      expect(result.spaces).toEqual([]);
+    });
+
+    it('returns only group-authorized spaces for non-admin users', async () => {
+      const { service, db } = createServiceContext();
+      const unauthorizedSpace = { id: 'space-unauthorized', name: 'Unauthorized Space' };
+      db.queueSelect([
+        createUser('password-hash', {
+          id: 'editor-user',
+          email: 'editor@example.com',
+          display_name: 'Editor User',
+          role: 'editor',
+        }),
+      ]);
+      db.queueSelect([{ id: 'group-editors', name: 'Editors' }]);
+      db.queueSelect([
+        { id: 'space-1', name: 'Space One', permission: 'space:view' },
+        { id: 'space-1', name: 'Space One', permission: 'space:edit' },
+        { id: 'space-2', name: 'Space Two', permission: 'space:admin' },
+      ]);
+
+      const result = await service.getCurrentUser(
+        createAuthenticatedUser({
+          sub: 'editor-user',
+          email: 'editor@example.com',
+          role: 'editor',
+          group_ids: ['group-editors'],
+        }),
+      );
+
+      expect(result).toEqual({
+        id: 'editor-user',
+        email: 'editor@example.com',
+        name: 'Editor User',
+        role: 'editor',
+        groups: [{ id: 'group-editors', name: 'Editors' }],
+        spaces: [
+          { id: 'space-1', name: 'Space One', role: 'editor' },
+          { id: 'space-2', name: 'Space Two', role: 'admin' },
+        ],
+      });
+      expect(result.spaces).not.toContainEqual(expect.objectContaining({ id: unauthorizedSpace.id }));
+      expect(requireRecord(db.selectFields[2])).toHaveProperty('permission');
     });
   });
 });
@@ -423,4 +571,17 @@ function restoreDefaultTenantId(): void {
   }
 
   process.env.DEFAULT_TENANT_ID = originalDefaultTenantId;
+}
+
+function getWhereQuery(db: FakeDb, index: number): { sql: string; params: unknown[] } {
+  const where = db.whereCalls[index];
+  if (where === undefined) {
+    throw new Error(`Expected where clause at index ${index}`);
+  }
+
+  const query = dialect.sqlToQuery(where);
+  return {
+    sql: query.sql,
+    params: query.params,
+  };
 }

--- a/apps/api/src/auth/__tests__/auth.service.test.ts
+++ b/apps/api/src/auth/__tests__/auth.service.test.ts
@@ -488,6 +488,37 @@ describe('AuthService', () => {
       expect(result.spaces).toEqual([]);
     });
 
+    it('returns all active spaces for owner users (same as admin)', async () => {
+      const { service, db } = createServiceContext();
+      db.queueSelect([
+        createUser('password-hash', {
+          id: 'owner-user',
+          email: 'owner@example.com',
+          display_name: 'Owner User',
+          role: 'owner',
+        }),
+      ]);
+      db.queueSelect([]);
+      db.queueSelect([
+        { id: 'space-active-1', name: 'Active One' },
+        { id: 'space-active-2', name: 'Active Two' },
+      ]);
+
+      const result = await service.getCurrentUser(
+        createAuthenticatedUser({
+          sub: 'owner-user',
+          email: 'owner@example.com',
+          role: 'owner',
+          group_ids: [],
+        }),
+      );
+
+      expect(result.spaces).toEqual([
+        { id: 'space-active-1', name: 'Active One', role: 'admin' },
+        { id: 'space-active-2', name: 'Active Two', role: 'admin' },
+      ]);
+    });
+
     it('returns only group-authorized spaces for non-admin users', async () => {
       const { service, db } = createServiceContext();
       const unauthorizedSpace = { id: 'space-unauthorized', name: 'Unauthorized Space' };

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -538,7 +538,7 @@ export class AuthService {
     role: string,
     db: AuthDatabase = this.db,
   ): Promise<CurrentUserResponse['spaces']> {
-    if (role === 'admin') {
+    if (role === 'admin' || role === 'owner') {
       const adminSpaces = await db
         .select({ id: spaces.id, name: spaces.name })
         .from(spaces)

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -347,7 +347,7 @@ export class AuthService {
       name: row.display_name,
       role: row.role,
       groups: await this.getUserGroups(user.tenant_id, row.id),
-      spaces: await this.getUserSpaceRoles(user.tenant_id, row.id),
+      spaces: await this.getUserSpaceRoles(user.tenant_id, row.id, row.role),
     };
   }
 
@@ -535,8 +535,18 @@ export class AuthService {
   private async getUserSpaceRoles(
     tenantId: string,
     userId: string,
+    role: string,
     db: AuthDatabase = this.db,
   ): Promise<CurrentUserResponse['spaces']> {
+    if (role === 'admin') {
+      const adminSpaces = await db
+        .select({ id: spaces.id, name: spaces.name })
+        .from(spaces)
+        .where(and(eq(spaces.tenant_id, tenantId), eq(spaces.status, 'active')));
+
+      return adminSpaces.map((space) => ({ id: space.id, name: space.name, role: 'admin' as const }));
+    }
+
     const rows = await db
       .select({
         id: spaces.id,

--- a/apps/web/src/components/AppShell.css
+++ b/apps/web/src/components/AppShell.css
@@ -118,11 +118,6 @@
   background: rgba(26, 26, 46, 0.72);
 }
 
-.app-shell-header-user {
-  min-width: 0;
-  color: var(--color-text-2, #667085);
-}
-
 .app-shell-content {
   min-height: calc(100vh - 64px);
   padding: 24px;

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -2,7 +2,6 @@ import {
   ApartmentOutlined,
   AuditOutlined,
   BookOutlined,
-  BulbOutlined,
   CloudUploadOutlined,
   DatabaseOutlined,
   HeartOutlined,
@@ -320,11 +319,6 @@ export default function AppShell() {
       <Layout>
         <Layout.Header className="app-shell-header">
           <Breadcrumb items={breadcrumbItems} />
-          <Space className="app-shell-header-user" size="small">
-            <BulbOutlined />
-            <span>{user?.name ?? user?.email ?? t('shell.user.profile')}</span>
-            <Typography.Text type="secondary">{getRoleLabel(user, t)}</Typography.Text>
-          </Space>
         </Layout.Header>
         <Layout.Content className="app-shell-content">
           <Outlet />


### PR DESCRIPTION
## Summary

- Admin/owner 用户 `getUserSpaceRoles` 增加角色快捷路径，直接返回所有 active 空间（`role: 'admin'`），无需 group membership
- 移除 `AppShell.tsx` header 右侧冗余的用户名+角色显示（与侧边栏底部重复）
- 新增 6 个单元测试覆盖 admin/owner/non-admin 空间角色逻辑

Closes #200

## Changes

| File | Change |
|---|---|
| `apps/api/src/auth/auth.service.ts` | `getUserSpaceRoles` 增加 `role` 参数，admin/owner 分支直查 spaces 表 |
| `apps/api/src/auth/__tests__/auth.service.test.ts` | 新增 `getCurrentUser - space roles` describe 块，6 个测试场景 |
| `apps/api/src/auth/__tests__/auth-test-utils.ts` | 新增 `getWhereQuery` 测试工具 |
| `apps/web/src/components/AppShell.tsx` | 移除 header `app-shell-header-user` 区域 |
| `apps/web/src/components/AppShell.css` | 移除对应 CSS 规则 |

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `3e0ca6f43cd6dda66b4bcedb9449164bf5e7e6fd`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/201#issuecomment-4411541027) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/201#issuecomment-4411541082) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/201#issuecomment-4411541156) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/201#issuecomment-4411541211)
- Key findings addressed: Owner role was missing from admin fast path (fixed in round 1 commit)

## Test plan

- [x] 193 test files passed, 1057 tests passed (including 6 new)
- [x] Admin user returns all active spaces with role 'admin'
- [x] Admin user filters out archived spaces
- [x] Admin user without group membership still gets all spaces
- [x] Zero active spaces returns empty array for admin
- [x] Owner user gets same treatment as admin
- [x] Non-admin user only gets group-authorized spaces
- [ ] Manual: login as admin, verify sidebar shows all spaces
- [ ] Manual: verify header no longer shows username/role