### PR TITLE
feat(admin): user soft-delete + permission select/deselect all (#202)

### DIFF
--- a/apps/api/src/audit/__tests__/audit-events.test.ts
+++ b/apps/api/src/audit/__tests__/audit-events.test.ts
@@ -12,6 +12,7 @@ const EXPECTED_AUDIT_EVENTS = [
   'admin.user.create',
   'admin.user.update',
   'admin.user.disable',
+  'admin.user.delete',
   'admin.group.create',
   'user.group_change',
   'space.create',
@@ -24,11 +25,11 @@ const EXPECTED_AUDIT_EVENTS = [
 ] as const;
 
 describe('AUDIT_EVENTS', () => {
-  it('defines all 18 mandatory audit events', () => {
+  it('defines all 19 mandatory audit events', () => {
     const values = Object.values(AUDIT_EVENTS);
 
-    expect(values).toHaveLength(18);
-    expect(new Set(values).size).toBe(18);
+    expect(values).toHaveLength(19);
+    expect(new Set(values).size).toBe(19);
   });
 
   it('matches the expected event strings', () => {

--- a/apps/api/src/audit/audit-events.ts
+++ b/apps/api/src/audit/audit-events.ts
@@ -8,6 +8,7 @@ export const AUDIT_EVENTS = {
   ADMIN_USER_CREATE: 'admin.user.create',
   ADMIN_USER_UPDATE: 'admin.user.update',
   ADMIN_USER_DISABLE: 'admin.user.disable',
+  ADMIN_USER_DELETE: 'admin.user.delete',
   ADMIN_GROUP_CREATE: 'admin.group.create',
   USER_GROUP_CHANGE: 'user.group_change',
   SPACE_CREATE: 'space.create',

--- a/apps/api/src/auth/__tests__/auth.service.test.ts
+++ b/apps/api/src/auth/__tests__/auth.service.test.ts
@@ -153,6 +153,19 @@ describe('AuthService', () => {
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.ACCOUNT_DISABLED);
   });
 
+  it('rejects deleted accounts with ACCOUNT_DISABLED', async () => {
+    const passwordHash = await hashPassword('Correct1!');
+    const { service, db } = createServiceContext();
+    db.queueSelect([createUser(passwordHash, { status: 'deleted' })]);
+
+    const err = await getRejectedHttpException(
+      service.login({ email: TEST_EMAIL, password: 'Correct1!' }),
+    );
+
+    expect(err.getStatus()).toBe(401);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.ACCOUNT_DISABLED);
+  });
+
   it('returns INVALID_CREDENTIALS on the fifth failed login attempt and ACCOUNT_LOCKED on the sixth', async () => {
     const passwordHash = await hashPassword('Correct1!');
     const { service, redis, db } = createServiceContext();

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -161,7 +161,7 @@ export class AuthService {
       throwAuthError(ErrorCode.INVALID_CREDENTIALS, 'Invalid email or password');
     }
 
-    if (user.status === 'disabled') {
+    if (user.status !== 'active') {
       throwAuthError(ErrorCode.ACCOUNT_DISABLED, 'Account is disabled');
     }
 
@@ -252,7 +252,7 @@ export class AuthService {
         throwAuthError(ErrorCode.INVALID_REFRESH_TOKEN, 'Invalid refresh token');
       }
 
-      if (user.status === 'disabled') {
+      if (user.status !== 'active') {
         throwAuthError(ErrorCode.ACCOUNT_DISABLED, 'Account is disabled');
       }
 

--- a/apps/api/src/users/__tests__/user-group-service-test-utils.ts
+++ b/apps/api/src/users/__tests__/user-group-service-test-utils.ts
@@ -41,6 +41,7 @@ export class ScriptedDb {
   readonly updates: OperationRecord[] = [];
   readonly deletes: OperationRecord[] = [];
   readonly selectFields: unknown[] = [];
+  readonly whereClauses: unknown[] = [];
   readonly limitCalls: number[] = [];
   readonly offsetCalls: number[] = [];
   readonly selectResults: unknown[][] = [];
@@ -138,7 +139,8 @@ export class ScriptedQueryBuilder implements PromiseLike<unknown[]> {
     return this;
   }
 
-  where(): this {
+  where(condition?: unknown): this {
+    this.db.whereClauses.push(condition);
     return this;
   }
 

--- a/apps/api/src/users/__tests__/user.service.test.ts
+++ b/apps/api/src/users/__tests__/user.service.test.ts
@@ -1,4 +1,5 @@
-import { ErrorCode } from '@cherrygraph/shared';
+import { group_members, ErrorCode, sessions, users } from '@cherrygraph/shared';
+import { inspect } from 'node:util';
 import { describe, expect, it } from 'vitest';
 
 import { AUDIT_EVENTS } from '../../audit/audit-events.js';
@@ -42,6 +43,17 @@ describe('UserService', () => {
       }),
     ]);
     expect(result.pagination).toMatchObject({ page: 1, per_page: 10, total: 1, has_next: false });
+  });
+
+  it('excludes deleted users from default list filters', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([]);
+    db.queueSelect([{ total: 0 }]);
+
+    await service.listUsers({}, createContext());
+
+    expect(sqlDebug(db.whereClauses[0])).toContain("!= 'deleted'");
+    expect(sqlDebug(db.whereClauses[1])).toContain("!= 'deleted'");
   });
 
   it('creates a user with groups and records admin.user.create', async () => {
@@ -251,6 +263,78 @@ describe('UserService', () => {
     expect(err.getStatus()).toBe(404);
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.USER_NOT_FOUND);
   });
+
+  it('deletes a user, clears groups and sessions, publishes Redis, and records admin.user.delete', async () => {
+    const { service, db, audit, redis } = createServiceContext();
+    db.queueSelect([createUserRow({ status: 'active' })]);
+    db.queueUpdate([createUserRow({ status: 'deleted', permission_version: 2 })]);
+
+    await service.deleteUser(TEST_USER_ID, createContext());
+
+    expect(db.updates[0]?.table).toBe(users);
+    expect(requireRecord(db.updates[0]?.value)).toMatchObject({ status: 'deleted' });
+    expect(hasPermissionVersionIncrement(db.updates[0]?.value)).toBe(true);
+    expect(db.deletes.map((operation) => operation.table)).toEqual([group_members, sessions]);
+    expect(redis.publish).toHaveBeenCalledWith(
+      `user_permission_changed:${TEST_USER_ID}`,
+      JSON.stringify({ tenant_id: TEST_TENANT_ID }),
+    );
+    expect(audit.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: AUDIT_EVENTS.ADMIN_USER_DELETE,
+        tenant_id: TEST_TENANT_ID,
+        actor_user_id: TEST_ACTOR_ID,
+        resource_type: 'user',
+        resource_id: TEST_USER_ID,
+      }),
+    );
+  });
+
+  it('denies deleting yourself', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createUserRow({ id: TEST_ACTOR_ID })]);
+
+    const err = await getRejectedHttpException(
+      service.deleteUser(TEST_ACTOR_ID, createContext({ actorUserId: TEST_ACTOR_ID })),
+    );
+
+    expect(err.getStatus()).toBe(403);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+    expect(db.updates).toHaveLength(0);
+  });
+
+  it('denies deleting owner users', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createUserRow({ role: 'owner' })]);
+
+    const err = await getRejectedHttpException(service.deleteUser(TEST_USER_ID, createContext()));
+
+    expect(err.getStatus()).toBe(403);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+    expect(db.updates).toHaveLength(0);
+  });
+
+  it('returns USER_NOT_FOUND when deleting a missing user', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([]);
+
+    const err = await getRejectedHttpException(service.deleteUser('missing-user', createContext()));
+
+    expect(err.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.USER_NOT_FOUND);
+    expect(db.updates).toHaveLength(0);
+  });
+
+  it('returns USER_NOT_FOUND when deleting an already deleted user', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createUserRow({ status: 'deleted' })]);
+
+    const err = await getRejectedHttpException(service.deleteUser(TEST_USER_ID, createContext()));
+
+    expect(err.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.USER_NOT_FOUND);
+    expect(db.updates).toHaveLength(0);
+  });
 });
 
 function createServiceContext(): {
@@ -282,4 +366,8 @@ function createContext(
 
 function hasPermissionVersionIncrement(value: unknown): boolean {
   return 'permission_version' in requireRecord(value);
+}
+
+function sqlDebug(value: unknown): string {
+  return inspect(value, { depth: 12 });
 }

--- a/apps/api/src/users/user.controller.ts
+++ b/apps/api/src/users/user.controller.ts
@@ -71,7 +71,7 @@ class UpdateUserDto {
   role?: string;
 
   @IsOptional()
-  @IsIn(['active', 'disabled', 'deleted'])
+  @IsIn(['active', 'disabled'])
   status?: string;
 }
 

--- a/apps/api/src/users/user.controller.ts
+++ b/apps/api/src/users/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, HttpException, HttpStatus, Param, Patch, Post, Query, Req } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpException, HttpStatus, Param, Patch, Post, Query, Req } from '@nestjs/common';
 import { Permissions, type AuthenticatedRequestUser } from '@cherrygraph/auth-core';
 import { ErrorCode } from '@cherrygraph/shared';
 import {
@@ -71,7 +71,7 @@ class UpdateUserDto {
   role?: string;
 
   @IsOptional()
-  @IsIn(['active', 'disabled'])
+  @IsIn(['active', 'disabled', 'deleted'])
   status?: string;
 }
 
@@ -118,6 +118,20 @@ export class UserController {
   ): Promise<AdminUserResponse> {
     const user = getAuthenticatedUser(request);
     return this.userService.updateUser(userId, body, {
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+      actorRole: user.role,
+    });
+  }
+
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Delete(':user_id')
+  async deleteUser(
+    @Param('user_id') userId: string,
+    @Req() request: RequestWithAuth,
+  ): Promise<void> {
+    const user = getAuthenticatedUser(request);
+    await this.userService.deleteUser(userId, {
       tenantId: user.tenant_id,
       actorUserId: user.sub,
       actorRole: user.role,

--- a/apps/api/src/users/user.service.ts
+++ b/apps/api/src/users/user.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
 import { ROLES, hashPassword, normalizeRole, type Role } from '@cherrygraph/auth-core';
-import { ErrorCode, group_members, groups, tenants, users } from '@cherrygraph/shared';
+import { ErrorCode, group_members, groups, sessions, tenants, users } from '@cherrygraph/shared';
 import { and, asc, count, desc, eq, ilike, inArray, or, sql, type SQL } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { randomUUID } from 'node:crypto';
@@ -73,7 +73,7 @@ type UserSortField = keyof Pick<
 const DEFAULT_PAGE = 1;
 const DEFAULT_PER_PAGE = 20;
 const MAX_PER_PAGE = 100;
-const VALID_STATUSES = new Set(['active', 'disabled']);
+const VALID_STATUSES = new Set(['active', 'disabled', 'deleted']);
 const ROLE_RANK: Record<Role, number> = {
   [ROLES.OWNER]: 6,
   [ROLES.ADMIN]: 5,
@@ -297,6 +297,64 @@ export class UserService {
     return toAdminUserResponse(updatedUser, groupsByUser.get(userId) ?? []);
   }
 
+  async deleteUser(userId: string, context: AdminContext = {}): Promise<void> {
+    const tenantId = await this.resolveTenantId(context);
+    const existing = await findUserById(this.db, tenantId, userId);
+    if (existing === undefined || existing.status === 'deleted') {
+      throwApiError(ErrorCode.USER_NOT_FOUND, 'User not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (userId === context.actorUserId) {
+      throwApiError(ErrorCode.PERMISSION_DENIED, 'Cannot delete yourself', HttpStatus.FORBIDDEN);
+    }
+
+    if (existing.role === ROLES.OWNER) {
+      throwApiError(ErrorCode.PERMISSION_DENIED, 'Cannot delete owner', HttpStatus.FORBIDDEN);
+    }
+
+    const now = new Date();
+    await this.db.transaction(async (tx) => {
+      const txDb = tx as UserDatabase;
+      const [deleted] = await txDb
+        .update(users)
+        .set({
+          status: 'deleted',
+          permission_version: sql<number>`${users.permission_version} + 1`,
+          updated_at: now,
+        })
+        .where(and(eq(users.tenant_id, tenantId), eq(users.id, userId), sql`${users.status} != 'deleted'`))
+        .returning();
+
+      if (deleted === undefined) {
+        throwApiError(ErrorCode.USER_NOT_FOUND, 'User not found', HttpStatus.NOT_FOUND);
+      }
+
+      await txDb
+        .delete(group_members)
+        .where(and(eq(group_members.tenant_id, tenantId), eq(group_members.user_id, userId)));
+
+      await txDb
+        .delete(sessions)
+        .where(and(eq(sessions.tenant_id, tenantId), eq(sessions.user_id, userId)));
+    });
+
+    await this.publishUserPermissionChanged(tenantId, userId);
+
+    this.auditService.push({
+      tenant_id: tenantId,
+      ...(context.actorUserId !== undefined ? { actor_user_id: context.actorUserId } : {}),
+      action: AUDIT_EVENTS.ADMIN_USER_DELETE,
+      resource_type: 'user',
+      resource_id: userId,
+      metadata_json: {
+        old_status: existing.status,
+        new_status: 'deleted',
+        role: existing.role,
+        email: existing.email,
+      },
+    });
+  }
+
   private async getUserGroupIds(tenantId: string, userIds: string[]): Promise<Map<string, string[]>> {
     const groupsByUser = new Map<string, string[]>();
     if (userIds.length === 0) {
@@ -357,6 +415,8 @@ function buildUserWhere(tenantId: string, input: ListUsersInput): SQL {
 
   if (input.status !== undefined && input.status.trim().length > 0) {
     conditions.push(eq(users.status, normalizeStatusOrThrow(input.status)));
+  } else {
+    conditions.push(sql`${users.status} != 'deleted'`);
   }
 
   if (input.search !== undefined && input.search.trim().length > 0) {

--- a/apps/api/src/users/user.service.ts
+++ b/apps/api/src/users/user.service.ts
@@ -200,7 +200,7 @@ export class UserService {
   ): Promise<AdminUserResponse> {
     const tenantId = await this.resolveTenantId(context);
     const existing = await findUserById(this.db, tenantId, userId);
-    if (existing === undefined) {
+    if (existing === undefined || existing.status === 'deleted') {
       throwApiError(ErrorCode.USER_NOT_FOUND, 'User not found', HttpStatus.NOT_FOUND);
     }
 

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -45,6 +45,7 @@
     "status": {
       "active": "Active",
       "disabled": "Disabled",
+      "deleted": "Deleted",
       "healthy": "Healthy",
       "degraded": "Degraded",
       "unhealthy": "Unhealthy",
@@ -177,7 +178,13 @@
         "displayNameRequired": "Please enter a display name"
       },
       "confirmDisable": "Are you sure you want to disable this user?",
-      "confirmEnable": "Are you sure you want to enable this user?"
+      "confirmEnable": "Are you sure you want to enable this user?",
+      "confirmDelete": "Are you sure you want to delete this user?",
+      "deleteSuccess": "User deleted successfully"
+    },
+    "permissions": {
+      "selectAll": "Select All",
+      "deselectAll": "Deselect All"
     },
     "groups": {
       "title": "Group Management",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -45,6 +45,7 @@
     "status": {
       "active": "活跃",
       "disabled": "已禁用",
+      "deleted": "已删除",
       "healthy": "健康",
       "degraded": "降级",
       "unhealthy": "异常",
@@ -177,7 +178,13 @@
         "displayNameRequired": "请输入显示名称"
       },
       "confirmDisable": "确定要禁用此用户吗？",
-      "confirmEnable": "确定要启用此用户吗？"
+      "confirmEnable": "确定要启用此用户吗？",
+      "confirmDelete": "确定要删除该用户吗？",
+      "deleteSuccess": "用户已删除"
+    },
+    "permissions": {
+      "selectAll": "全选",
+      "deselectAll": "全不选"
     },
     "groups": {
       "title": "分组管理",

--- a/apps/web/src/pages/admin/GroupsPage.tsx
+++ b/apps/web/src/pages/admin/GroupsPage.tsx
@@ -198,6 +198,39 @@ function GroupsPage() {
                 <Collapse>
                   {spaces.map((space) => (
                     <Collapse.Panel key={space.id} header={space.name}>
+                      <Space style={{ marginBottom: 8 }}>
+                        <Button
+                          size="small"
+                          onClick={() => {
+                            setForm((current) => {
+                              if (current === null) return current;
+                              return {
+                                ...current,
+                                permissionsBySpace: {
+                                  ...current.permissionsBySpace,
+                                  [space.id]: [...SPACE_PERMISSION_OPTIONS],
+                                },
+                              };
+                            });
+                          }}
+                        >
+                          {t('admin.permissions.selectAll')}
+                        </Button>
+                        <Button
+                          size="small"
+                          onClick={() => {
+                            setForm((current) => {
+                              if (current === null) return current;
+                              return {
+                                ...current,
+                                permissionsBySpace: { ...current.permissionsBySpace, [space.id]: [] },
+                              };
+                            });
+                          }}
+                        >
+                          {t('admin.permissions.deselectAll')}
+                        </Button>
+                      </Space>
                       <Checkbox.Group
                         value={form.permissionsBySpace[space.id] ?? []}
                         onChange={(checked) => {

--- a/apps/web/src/pages/admin/SpacesPage.tsx
+++ b/apps/web/src/pages/admin/SpacesPage.tsx
@@ -276,6 +276,30 @@ function SpacesPage() {
                 <Collapse>
                   {groups.map((group) => (
                     <Collapse.Panel key={group.id} header={group.name}>
+                      <Space style={{ marginBottom: 8 }}>
+                        <Button
+                          size="small"
+                          onClick={() => {
+                            setPermissionsByGroup((current) => ({
+                              ...current,
+                              [group.id]: [...SPACE_PERMISSION_OPTIONS],
+                            }));
+                          }}
+                        >
+                          {t('admin.permissions.selectAll')}
+                        </Button>
+                        <Button
+                          size="small"
+                          onClick={() => {
+                            setPermissionsByGroup((current) => ({
+                              ...current,
+                              [group.id]: [],
+                            }));
+                          }}
+                        >
+                          {t('admin.permissions.deselectAll')}
+                        </Button>
+                      </Space>
                       <Checkbox.Group
                         value={permissionsByGroup[group.id] ?? []}
                         onChange={(checked) => {

--- a/apps/web/src/pages/admin/UsersPage.tsx
+++ b/apps/web/src/pages/admin/UsersPage.tsx
@@ -7,6 +7,7 @@ import { requireAdminPage } from '../../components/RequireAdminPage';
 import { api } from '../../lib/api';
 import { formatDate, getErrorMessage, parseIdList } from '../../components/adminUi';
 import { ROLE_OPTIONS, type AdminUser } from '../../lib/adminTypes';
+import { useAuth } from '../../lib/auth';
 
 type CreateUserForm = {
   email: string;
@@ -38,6 +39,7 @@ function statusColor(status: string): string {
 
 function UsersPage() {
   const { t } = useTranslation();
+  const { user: currentUser } = useAuth();
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [search, setSearch] = useState('');
   const [role, setRole] = useState('');
@@ -128,6 +130,16 @@ function UsersPage() {
     }
   }
 
+  async function deleteUser(user: AdminUser): Promise<void> {
+    try {
+      await api.delete(`/admin/users/${user.id}`);
+      void message.success(t('admin.users.deleteSuccess'));
+      await loadUsers();
+    } catch (err) {
+      void message.error(getErrorMessage(err));
+    }
+  }
+
   const columns: ColumnsType<AdminUser> = [
     {
       title: t('admin.users.columns.email'),
@@ -197,6 +209,16 @@ function UsersPage() {
               size="small"
             />
           </Popconfirm>
+          {user.id !== currentUser?.id && user.role !== 'owner' ? (
+            <Popconfirm
+              title={t('admin.users.confirmDelete')}
+              onConfirm={() => { void deleteUser(user); }}
+              okText={t('common.action.confirm')}
+              cancelText={t('common.action.cancel')}
+            >
+              <Button size="small" danger>{t('common.action.delete')}</Button>
+            </Popconfirm>
+          ) : null}
         </Space>
       ),
     },

--- a/packages/shared/src/schema/validation.ts
+++ b/packages/shared/src/schema/validation.ts
@@ -15,7 +15,7 @@ import {
 } from './core.js';
 
 export const userRoleSchema = z.enum(['owner', 'admin', 'space_admin', 'editor', 'viewer', 'auditor']);
-export const userStatusSchema = z.enum(['active', 'disabled']);
+export const userStatusSchema = z.enum(['active', 'disabled', 'deleted']);
 export const spaceStatusSchema = z.enum(['active', 'archived']);
 export const modelTypeSchema = z.enum(['chat', 'embedding', 'rerank']);
 export const sourceDocumentSourceTypeSchema = z.enum(['upload', 'url']);

--- a/tests/integration/audit-events-completeness.test.ts
+++ b/tests/integration/audit-events-completeness.test.ts
@@ -12,6 +12,7 @@ const REQUIRED_AUDIT_EVENTS = [
   'admin.user.create',
   'admin.user.update',
   'admin.user.disable',
+  'admin.user.delete',
   'admin.group.create',
   'user.group_change',
   'space.create',
@@ -24,11 +25,11 @@ const REQUIRED_AUDIT_EVENTS = [
 ] as const;
 
 describe('audit event completeness', () => {
-  it('defines all 18 required audit events', () => {
+  it('defines all 19 required audit events', () => {
     const definedEvents = Object.values(AUDIT_EVENTS);
 
-    expect(definedEvents).toHaveLength(18);
-    expect(new Set(definedEvents).size).toBe(18);
+    expect(definedEvents).toHaveLength(19);
+    expect(new Set(definedEvents).size).toBe(19);
     expect(new Set(definedEvents)).toEqual(new Set(REQUIRED_AUDIT_EVENTS));
   });
 });


### PR DESCRIPTION
## Summary

- 后端新增 `DELETE /admin/users/:user_id` 软删除端点（status→deleted + 清理 group_members/sessions）
- 前端 UsersPage 新增删除按钮（Popconfirm 二次确认，隐藏自身和 owner）
- 前端 SpacesPage/GroupsPage 权限面板新增全选/全不选快捷按钮
- 新增 7 个后端测试 + i18n 支持（en + zh-CN）

Closes #202

## Changes

| File | Change |
|---|---|
| `apps/api/src/users/user.service.ts` | 新增 `deleteUser`（事务软删除+清理）、`buildUserWhere` 默认排除 deleted、`updateUser` 拒绝 deleted 用户 |
| `apps/api/src/users/user.controller.ts` | 新增 `@Delete` 端点返回 204，PATCH 不接受 deleted |
| `apps/api/src/auth/auth.service.ts` | 登录拒绝 deleted 用户 |
| `packages/shared/src/schema/validation.ts` | `userStatusSchema` 增加 `deleted` |
| `apps/api/src/users/__tests__/user.service.test.ts` | 7 个新测试场景 |
| `apps/web/src/pages/admin/UsersPage.tsx` | 删除按钮 + Popconfirm + 权限控制 |
| `apps/web/src/pages/admin/SpacesPage.tsx` | 权限面板全选/全不选按钮 |
| `apps/web/src/pages/admin/GroupsPage.tsx` | 权限面板全选/全不选按钮 |
| `apps/web/src/locales/*.json` | i18n 支持 |

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `baa6379a24d69b069ed5ccac50f45908b3130c7b`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/203#issuecomment-4411627851) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/203#issuecomment-4411627894) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/203#issuecomment-4411627949) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/203#issuecomment-4411628003)
- Key findings addressed: PATCH bypass of delete flow fixed (removed deleted from UpdateUserDto, updateUser rejects deleted users)

## Test plan

- [x] 1064 tests passed, 0 failures
- [x] Delete user: status→deleted, group_members cleared, sessions cleared
- [x] Delete self → 403
- [x] Delete owner → 403
- [x] Delete non-existent → 404
- [x] Repeat delete → 404
- [x] Default listing excludes deleted users
- [x] Login rejects deleted users
- [x] PATCH cannot set status to deleted
- [ ] Manual: delete a test user, verify list refreshes
- [ ] Manual: test select all / deselect all in space/group permission panels