### PR TITLE
fix(web): group space functions in sidebar for admin nav (#207)

### DIFF
--- a/apps/web/src/__tests__/infrastructure.test.tsx
+++ b/apps/web/src/__tests__/infrastructure.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import '../i18n';
 import i18n from '../i18n';
@@ -245,6 +245,36 @@ describe('AppShell', () => {
     expect(screen.getAllByText('Chat').length).toBeGreaterThan(0);
     expect(screen.getByText('Wiki')).toBeInTheDocument();
     expect(screen.getByText('Uploads')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['Chat', 'Chat Harness'],
+    ['Wiki', 'Wiki Harness'],
+  ])('navigates to %s from an admin route', async (menuLabel, targetHeading) => {
+    render(
+      <MemoryRouter initialEntries={['/admin/users']}>
+        <AuthProvider initialSession={{ user: ADMIN_USER, accessToken: 'test-token' }}>
+          <ThemeProvider>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route path="/admin/users" element={<h1>Users Harness</h1>} />
+                <Route path="/spaces/:spaceId/chat" element={<h1>Chat Harness</h1>} />
+                <Route path="/spaces/:spaceId/wiki" element={<h1>Wiki Harness</h1>} />
+              </Route>
+            </Routes>
+          </ThemeProvider>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Space Functions')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Users Harness' })).toBeInTheDocument();
+
+    const menuItem = screen.getByText(menuLabel).closest('[role="menuitem"]');
+    expect(menuItem).not.toBeNull();
+    fireEvent.click(menuItem!);
+
+    expect(await screen.findByRole('heading', { name: targetHeading })).toBeInTheDocument();
   });
 
   it('shows user name in header', () => {

--- a/apps/web/src/components/AppShell.css
+++ b/apps/web/src/components/AppShell.css
@@ -73,6 +73,18 @@
   border-inline-end: 0 !important;
 }
 
+.app-shell-menu .ant-menu-item-group-title {
+  padding: 10px 24px 4px;
+  color: var(--color-text-2, #667085);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.app-shell-collapsed .app-shell-menu .ant-menu-item-group-title {
+  display: none;
+}
+
 .app-shell-bottom {
   display: grid;
   gap: 10px;

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -92,11 +92,18 @@ export default function AppShell() {
     const spaceItems =
       selectedSpaceId === undefined
         ? []
-        : SPACE_FUNCTIONS.map((item) => ({
-            key: item.key,
-            icon: item.icon,
-            label: t(item.translationKey),
-          }));
+        : [
+            {
+              key: 'space-functions',
+              type: 'group' as const,
+              label: t('shell.sidebar.spaceFunctions'),
+              children: SPACE_FUNCTIONS.map((item) => ({
+                key: item.key,
+                icon: item.icon,
+                label: t(item.translationKey),
+              })),
+            },
+          ];
 
     const adminItems = isAdmin
       ? [

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -68,6 +68,7 @@
       "empty": "No spaces available"
     },
     "sidebar": {
+      "spaceFunctions": "Space Functions",
       "chat": "Chat",
       "wiki": "Wiki",
       "uploads": "Uploads",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -68,6 +68,7 @@
       "empty": "暂无可用空间"
     },
     "sidebar": {
+      "spaceFunctions": "空间功能",
       "chat": "聊天",
       "wiki": "知识库",
       "uploads": "上传",


### PR DESCRIPTION
## Summary

- Wrap chat/wiki/uploads/graphify sidebar menu items under a labeled Space Functions group
- Adds visual separation between space navigation and admin management routes
- Hidden group title in collapsed sidebar mode
- Added regression test verifying Chat/Wiki clicks from admin route navigate correctly

Closes #207
Part of #204

## Agent Review

- Reviewer agents used: Independent Reviewer
- Reviewed head SHA: 7e1346240e58c0917dadee4b05d381668bd292d7
- Review evidence: Small UX-only change, no backend logic
- Key findings addressed: None critical

## Test plan

- [x] TypeScript compilation passes
- [x] All tests pass
- [x] New test: Chat/Wiki clicks from /admin/users navigate correctly