### PR TITLE
feat(web): group delete + space archive UI with confirmation (#206)

### DIFF
--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -205,6 +205,9 @@
       },
       "noDescription": "No description",
       "noSpacePermissions": "No space permissions",
+      "deleteButton": "Delete",
+      "deleteConfirm": "Are you sure you want to delete group \"{{name}}\"? This will remove {{count}} member(s) and all associated permissions.",
+      "deleteSuccess": "Group deleted successfully",
       "form": {
         "name": "Name",
         "nameRequired": "Please enter a group name",
@@ -222,6 +225,10 @@
       "creating": "Creating...",
       "emptyList": "No spaces are available to administer.",
       "detailLoading": "Loading space details...",
+      "archiveButton": "Archive",
+      "archiveConfirm": "Are you sure you want to archive space \"{{name}}\"?",
+      "archiveWarning": "After archiving, this space will be invisible to all users.",
+      "archiveSuccess": "Space archived successfully",
       "columns": {
         "name": "Name",
         "slug": "Slug",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -205,6 +205,9 @@
       },
       "noDescription": "无描述",
       "noSpacePermissions": "无空间权限",
+      "deleteButton": "删除",
+      "deleteConfirm": "确定要删除分组“{{name}}”吗？将移除 {{count}} 名成员及其所有关联权限。",
+      "deleteSuccess": "分组已删除",
       "form": {
         "name": "名称",
         "nameRequired": "请输入分组名称",
@@ -222,6 +225,10 @@
       "creating": "创建中...",
       "emptyList": "暂无可管理的空间。",
       "detailLoading": "加载空间详情中...",
+      "archiveButton": "归档",
+      "archiveConfirm": "确定要归档空间“{{name}}”吗？",
+      "archiveWarning": "归档后该空间将对所有用户不可见。",
+      "archiveSuccess": "空间已归档",
       "columns": {
         "name": "名称",
         "slug": "标识",

--- a/apps/web/src/pages/admin/GroupsPage.tsx
+++ b/apps/web/src/pages/admin/GroupsPage.tsx
@@ -1,5 +1,5 @@
-import { EditOutlined, PlusOutlined, ReloadOutlined, TeamOutlined } from '@ant-design/icons';
-import { Button, Card, Checkbox, Collapse, Empty, Form, Input, Modal, Select, Space, Spin, Typography, message } from 'antd';
+import { DeleteOutlined, EditOutlined, PlusOutlined, ReloadOutlined, TeamOutlined } from '@ant-design/icons';
+import { Button, Card, Checkbox, Collapse, Empty, Form, Input, Modal, Popconfirm, Select, Space, Spin, Typography, message } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { requireAdminPage } from '../../components/RequireAdminPage';
@@ -79,6 +79,17 @@ function GroupsPage() {
     }
   }
 
+  async function deleteGroup(group: AdminGroup): Promise<void> {
+    try {
+      await api.delete(`/admin/groups/${group.id}`);
+      void message.success(t('admin.groups.deleteSuccess'));
+      await loadData();
+    } catch (err) {
+      void message.error(getErrorMessage(err));
+      throw err;
+    }
+  }
+
   function openCreateForm(): void {
     const newForm = createEmptyForm();
     setForm(newForm);
@@ -132,9 +143,24 @@ function GroupsPage() {
               key={group.id}
               title={group.name}
               extra={
-                <Button icon={<EditOutlined />} size="small" onClick={() => openEditForm(group)}>
-                  {t('common.action.edit')}
-                </Button>
+                <Space>
+                  <Button icon={<EditOutlined />} size="small" onClick={() => openEditForm(group)}>
+                    {t('common.action.edit')}
+                  </Button>
+                  <Popconfirm
+                    title={t('admin.groups.deleteConfirm', {
+                      name: group.name,
+                      count: memberSummary.get(group.id) ?? group.member_count,
+                    })}
+                    onConfirm={() => deleteGroup(group)}
+                    okText={t('common.action.confirm')}
+                    cancelText={t('common.action.cancel')}
+                  >
+                    <Button icon={<DeleteOutlined />} size="small" danger>
+                      {t('admin.groups.deleteButton')}
+                    </Button>
+                  </Popconfirm>
+                </Space>
               }
             >
               <Typography.Paragraph type="secondary" style={{ marginBottom: 8 }}>

--- a/apps/web/src/pages/admin/SpacesPage.tsx
+++ b/apps/web/src/pages/admin/SpacesPage.tsx
@@ -1,4 +1,4 @@
-import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
+import { DeleteOutlined, PlusOutlined, ReloadOutlined } from '@ant-design/icons';
 import {
   Button,
   Checkbox,
@@ -9,6 +9,7 @@ import {
   Form,
   Input,
   Modal,
+  Popconfirm,
   Space,
   Switch,
   Table,
@@ -151,6 +152,17 @@ function SpacesPage() {
     }
   }
 
+  async function archiveSpace(space: AdminSpace): Promise<void> {
+    try {
+      await api.delete(`/spaces/${space.id}`);
+      void message.success(t('admin.spaces.archiveSuccess'));
+      await loadSpaces();
+    } catch (err) {
+      void message.error(getErrorMessage(err));
+      throw err;
+    }
+  }
+
   const columns: ColumnsType<AdminSpace> = [
     {
       title: t('admin.spaces.columns.name'),
@@ -191,9 +203,22 @@ function SpacesPage() {
       title: t('admin.spaces.columns.actions'),
       key: 'actions',
       render: (_: unknown, space: AdminSpace) => (
-        <Button size="small" loading={isDetailLoading} onClick={() => { void openDetails(space); }}>
-          {t('common.action.configure')}
-        </Button>
+        <Space>
+          <Button size="small" loading={isDetailLoading} onClick={() => { void openDetails(space); }}>
+            {t('common.action.configure')}
+          </Button>
+          <Popconfirm
+            title={t('admin.spaces.archiveConfirm', { name: space.name })}
+            description={t('admin.spaces.archiveWarning')}
+            onConfirm={() => archiveSpace(space)}
+            okText={t('common.action.confirm')}
+            cancelText={t('common.action.cancel')}
+          >
+            <Button icon={<DeleteOutlined />} size="small" danger>
+              {t('admin.spaces.archiveButton')}
+            </Button>
+          </Popconfirm>
+        </Space>
       ),
     },
   ];


### PR DESCRIPTION
## Summary

- GroupsPage: Popconfirm delete button on each group card with member count in confirmation
- SpacesPage: Popconfirm archive button in table actions column with archival warning
- i18n: added en/zh-CN labels for delete/archive confirmation dialogs
- Popconfirm stays open on API error (throw err pattern), closes on success

Closes #206
Part of #204

## Agent Review

- Reviewer agents used: Independent Reviewer
- Reviewed head SHA: `38c5c3253dc7ee6dcb29e19ff36937ac68cb9bfc`
- Review evidence: Frontend-only change, uses established Popconfirm pattern from UsersPage
- Key findings addressed: None critical — pure UI addition

## Test plan

- [x] TypeScript compilation passes
- [x] All tests pass (8 web + 193 API)
- [x] Delete/archive buttons use Popconfirm with i18n text
- [x] Error handling: message.error on failure, Popconfirm stays open