### PR TITLE
fix(ops): install agent CLI tools in API container (#217)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,57 @@
+FROM node:20-slim AS base
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl python3 python3-pip \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN addgroup --system --gid 10001 agent \
+ && adduser --system --uid 10001 --ingroup agent --home /home/agent agent
+
+ARG CLAUDE_CODE_VERSION=2.1.131
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+ENV DISABLE_AUTOUPDATER=1
+
+RUN corepack enable
+
+WORKDIR /app
+
+# ── dependency resolution ──
+FROM base AS deps
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+COPY packages/shared/package.json      packages/shared/
+COPY packages/ai-core/package.json     packages/ai-core/
+COPY packages/auth-core/package.json   packages/auth-core/
+COPY packages/graph-core/package.json  packages/graph-core/
+COPY packages/job-core/package.json    packages/job-core/
+COPY packages/rag-core/package.json    packages/rag-core/
+COPY packages/wiki-core/package.json   packages/wiki-core/
+
+COPY apps/api/package.json             apps/api/
+
+RUN pnpm install --frozen-lockfile
+
+# ── build ──
+FROM deps AS build
+
+COPY tsconfig.base.json ./
+COPY packages/ packages/
+COPY apps/api/ apps/api/
+COPY schemas/ schemas/
+COPY drizzle.config.ts ./
+
+RUN pnpm build
+
+# ── runtime ──
+FROM base AS runtime
+
+WORKDIR /app
+
+COPY --from=build /app ./
+COPY tools/ tools/
+RUN pip3 install --no-cache-dir --break-system-packages tools/cherrywiki tools/cherrydb
+
+EXPOSE 8080
+
+CMD ["sh", "/app/ops/entrypoint-api.sh"]


### PR DESCRIPTION
## Summary

- Added `python3` and `python3-pip` to API Dockerfile base stage (`node:20-slim` → with Python 3)
- Added `COPY tools/` + `pip install` for `cherrywiki` and `cherrydb` CLI packages in runtime stage
- Both CLI entry points are now available on `PATH` inside the container

## Root Cause

The API container was based on `node:20-slim` with no Python runtime. Agent calls `cherrywiki search` and `cherrydb query` via Bash but these are Python CLI tools requiring pip install.

## Changes

- `apps/api/Dockerfile`: 3 lines added (python3 apt packages, COPY tools, pip install)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `330092bec13dfc7ebfc10c5dff2caa53937c0156`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/218#issuecomment-4412877561) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/218#issuecomment-4412877716) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/218#issuecomment-4412877940) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/218#issuecomment-4412878051)
- Key findings addressed: All findings are minor — python3-venv intentionally omitted (--break-system-packages used), USER agent deferred to follow-up, tests/__pycache__ in COPY negligible. No critical or major issues found.

## Test plan

- [ ] `docker build -f apps/api/Dockerfile .` succeeds
- [ ] `docker exec <container> cherrywiki --help` outputs help text
- [ ] `docker exec <container> cherrydb --help` outputs help text
- [ ] Agent chat can search wiki content via CLI tools

## Note

Node CI failure is pre-existing on main branch (lint errors in GroupsPage.tsx and SpacesPage.tsx from PR #210), unrelated to this Dockerfile change.