### PR TITLE
fix(web): fix no-misused-promises lint errors in admin pages

### DIFF
--- a/apps/web/src/pages/admin/GroupsPage.tsx
+++ b/apps/web/src/pages/admin/GroupsPage.tsx
@@ -152,7 +152,7 @@ function GroupsPage() {
                       name: group.name,
                       count: memberSummary.get(group.id) ?? group.member_count,
                     })}
-                    onConfirm={() => deleteGroup(group)}
+                    onConfirm={() => { void deleteGroup(group); }}
                     okText={t('common.action.confirm')}
                     cancelText={t('common.action.cancel')}
                   >

--- a/apps/web/src/pages/admin/SpacesPage.tsx
+++ b/apps/web/src/pages/admin/SpacesPage.tsx
@@ -210,7 +210,7 @@ function SpacesPage() {
           <Popconfirm
             title={t('admin.spaces.archiveConfirm', { name: space.name })}
             description={t('admin.spaces.archiveWarning')}
-            onConfirm={() => archiveSpace(space)}
+            onConfirm={() => { void archiveSpace(space); }}
             okText={t('common.action.confirm')}
             cancelText={t('common.action.cancel')}
           >


### PR DESCRIPTION
## Summary

- Wrapped async `deleteGroup` and `archiveSpace` callbacks with `void` in Popconfirm `onConfirm` handlers
- Fixes `@typescript-eslint/no-misused-promises` lint errors breaking CI on main

## Changes

- `apps/web/src/pages/admin/GroupsPage.tsx:155`: `onConfirm={() => deleteGroup(group)}` → `onConfirm={() => { void deleteGroup(group); }}`
- `apps/web/src/pages/admin/SpacesPage.tsx:213`: `onConfirm={() => archiveSpace(space)}` → `onConfirm={() => { void archiveSpace(space); }}`

## Test plan

- [x] `npx eslint` passes with zero errors on both files
- [ ] CI Node lint/typecheck/build/test passes