### PR TITLE
fix(web): wiki detail page white-on-white text color (#214)

### DIFF
--- a/apps/web/src/pages/wiki/WikiPageDetail.tsx
+++ b/apps/web/src/pages/wiki/WikiPageDetail.tsx
@@ -132,7 +132,7 @@ export default function WikiPageDetail({ spaceId, pageId, versionId }: WikiPageD
       {isLoading ? (
         <Spin tip={t('wiki.detail.loadingPage')}><div style={{ minHeight: 200 }} /></Spin>
       ) : page !== null && content !== null ? (
-        <div style={{ background: 'var(--ant-color-bg-container, #fff)', padding: 24, borderRadius: 8 }}>
+        <div style={{ background: 'var(--ant-color-bg-container, #fff)', color: 'var(--ant-color-text, #1f2933)', padding: 24, borderRadius: 8 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
             <WikiStatusBadge status={page.status} />
             <Typography.Text type="secondary">


### PR DESCRIPTION
## Summary
- WikiPageDetail markdown 容器添加显式 `color: var(--ant-color-text, #1f2933)` 文字颜色，修复白底白字问题
- 使用与现有 `var(--ant-color-bg-container)` 相同的 CSS 变量模式，带硬编码 fallback

## Changes
- `apps/web/src/pages/wiki/WikiPageDetail.tsx:135` — 添加 color CSS 变量

## Test plan
- [ ] 亮色主题下 wiki 详情页文字可见
- [ ] 暗色主题下 wiki 详情页文字可见
- [ ] TypeScript 编译通过
- [ ] 所有现有测试通过

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `979e0aad5ae9a28130d569067741d214068f2c11`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/220#issuecomment-4413020181) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/220#issuecomment-4413020184) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/220#issuecomment-4413020188) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/220#issuecomment-4413020209)
- Key findings addressed: None — all reviewers passed clean

Closes #214