### PR TITLE
feat(web,api): upload space selector + duplicate file feedback (#213)

### DIFF
--- a/apps/api/src/uploads/__tests__/uploads.service.test.ts
+++ b/apps/api/src/uploads/__tests__/uploads.service.test.ts
@@ -87,6 +87,7 @@ describe('UploadsService', () => {
       job_id: null,
       status: 'archived',
       created: false,
+      duplicate: true,
     });
     expect(storage.uploadToQuarantine).not.toHaveBeenCalled();
     expect(jobs.created).toHaveLength(0);

--- a/apps/api/src/uploads/uploads.dto.ts
+++ b/apps/api/src/uploads/uploads.dto.ts
@@ -76,6 +76,7 @@ export type UploadResponseDto = {
   job_id: string | null;
   status: string;
   created: boolean;
+  duplicate?: boolean;
   error_code?: ErrorCode;
 };
 

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -184,13 +184,7 @@ export class UploadsService {
 
     if (!sourceDocument.created) {
       await this.storageService.deleteQuarantineFile(quarantine.key);
-      return {
-        source_document_id: sourceDocument.row.id,
-        file_blob_id: sourceDocument.row.file_blob_id,
-        job_id: null,
-        status: sourceDocument.row.status,
-        created: false,
-      };
+      return toUploadResponse(sourceDocument.row, null, false, undefined, true);
     }
 
     const priority = priorityForSize(input.file.size);
@@ -682,7 +676,7 @@ export class UploadsService {
     );
 
     if (existingSource !== undefined) {
-      return toUploadResponse(existingSource, null, false);
+      return toUploadResponse(existingSource, null, false, undefined, true);
     }
 
     const isArchivedBlob = isArchiveStorageUri(input.blob.storage_uri);
@@ -718,7 +712,7 @@ export class UploadsService {
     });
 
     if (!sourceDocument.created) {
-      return toUploadResponse(sourceDocument.row, null, false);
+      return toUploadResponse(sourceDocument.row, null, false, undefined, true);
     }
 
     if (!isArchivedBlob) {
@@ -1036,6 +1030,7 @@ function toUploadResponse(
   job: JobRow | null,
   created: boolean,
   errorCode?: ErrorCode,
+  duplicate?: boolean,
 ): UploadResponseDto {
   return {
     source_document_id: document.id,
@@ -1043,6 +1038,7 @@ function toUploadResponse(
     job_id: job?.id ?? null,
     status: document.status,
     created,
+    ...(duplicate === true ? { duplicate: true } : {}),
     ...(errorCode !== undefined ? { error_code: errorCode } : {}),
   };
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -464,6 +464,10 @@
     "title": "Upload Center",
     "description": "Upload files and URLs, then track processing status for this space.",
     "loading": "Loading uploads...",
+    "spaceSelector": "Target space",
+    "spaceSelectorLabel": "Upload to space",
+    "duplicateWarning": "File \"{{name}}\" already exists in this space and has been linked.",
+    "uploadSuccess": "File \"{{name}}\" uploaded successfully.",
     "file": {
       "title": "Files",
       "description": "Drop files here or choose them from disk.",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -464,6 +464,10 @@
     "title": "上传中心",
     "description": "上传文件和 URL，跟踪此空间的处理状态。",
     "loading": "加载上传记录中...",
+    "spaceSelector": "目标空间",
+    "spaceSelectorLabel": "上传到空间",
+    "duplicateWarning": "文件「{{name}}」已存在于该空间，已自动关联。",
+    "uploadSuccess": "文件「{{name}}」上传成功。",
     "file": {
       "title": "文件",
       "description": "拖放文件至此处或从磁盘选择。",

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -1,5 +1,5 @@
 import { ReloadOutlined } from '@ant-design/icons';
-import { Alert, Button, Spin, Typography } from 'antd';
+import { Alert, Button, Select, Spin, Typography, message } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router';
@@ -23,19 +23,20 @@ const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
 export default function UploadCenter() {
   const { t } = useTranslation();
   const { spaceId = '' } = useParams();
-  const { accessToken, isAuthenticated } = useAuth();
+  const { accessToken, isAuthenticated, user } = useAuth();
   const [uploads, setUploads] = useState<UploadItem[]>([]);
   const [page, setPage] = useState(DEFAULT_PAGINATION.page);
   const [statusFilter, setStatusFilter] = useState('');
   const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [uploadSpaceId, setUploadSpaceId] = useState(spaceId);
   const [selectedUploadId, setSelectedUploadId] = useState<string | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<UploadStatus | null>(null);
 
   const loadUploads = useCallback(
     async (background = false) => {
-      if (spaceId.length === 0) {
+      if (uploadSpaceId.length === 0) {
         setUploads([]);
         setPagination(DEFAULT_PAGINATION);
         setIsLoading(false);
@@ -48,7 +49,7 @@ export default function UploadCenter() {
       setError(null);
 
       try {
-        const response = await api.getWrapped<UploadItem[]>(`/spaces/${encodeURIComponent(spaceId)}/uploads`, {
+        const response = await api.getWrapped<UploadItem[]>(`/spaces/${encodeURIComponent(uploadSpaceId)}/uploads`, {
           page,
           per_page: UPLOAD_PAGE_SIZE,
           status: statusFilter,
@@ -71,7 +72,7 @@ export default function UploadCenter() {
         }
       }
     },
-    [page, spaceId, statusFilter],
+    [page, uploadSpaceId, statusFilter],
   );
 
   useEffect(() => {
@@ -79,10 +80,14 @@ export default function UploadCenter() {
   }, [loadUploads]);
 
   useEffect(() => {
+    setUploadSpaceId(spaceId);
+  }, [spaceId]);
+
+  useEffect(() => {
     setSelectedUploadId(null);
     setSelectedStatus(null);
     setPage(1);
-  }, [spaceId]);
+  }, [uploadSpaceId]);
 
   const mergeStatuses = useCallback((statuses: UploadStatus[]) => {
     setUploads((current) =>
@@ -130,6 +135,12 @@ export default function UploadCenter() {
   }, []);
 
   function addOptimisticUpload(response: UploadResponse, input: { filename: string; sourceType: string; sizeBytes: number | null }): void {
+    if (response.duplicate === true) {
+      void message.warning(t('upload.duplicateWarning', { name: input.filename }));
+    } else {
+      void message.success(t('upload.uploadSuccess', { name: input.filename }));
+    }
+
     const now = new Date().toISOString();
     const upload: UploadItem = {
       id: response.source_document_id,
@@ -141,7 +152,7 @@ export default function UploadCenter() {
       classification: null,
       status: response.status,
       uploader_id: null,
-      space_id: spaceId,
+      space_id: uploadSpaceId,
       metadata_json: {},
       created_at: now,
       updated_at: now,
@@ -176,13 +187,25 @@ export default function UploadCenter() {
         </Button>
       </div>
 
+      <div style={{ marginBottom: 16 }}>
+        <Typography.Text style={{ marginRight: 8 }}>{t('upload.spaceSelectorLabel')}</Typography.Text>
+        <Select
+          value={uploadSpaceId}
+          onChange={(value: string) => setUploadSpaceId(value)}
+          options={user?.spaces?.map((s) => ({ value: s.id, label: s.name })) ?? []}
+          disabled={!user?.spaces?.length}
+          style={{ width: 200 }}
+          placeholder={t('upload.spaceSelector')}
+        />
+      </div>
+
       {error !== null && (
         <Alert message={error} type="error" showIcon closable style={{ marginBottom: 16 }} onClose={() => setError(null)} />
       )}
 
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}>
         <FileUploadZone
-          spaceId={spaceId}
+          spaceId={uploadSpaceId}
           accessToken={accessToken}
           onUploaded={(response, file) =>
             addOptimisticUpload(response, {
@@ -193,7 +216,7 @@ export default function UploadCenter() {
           }
         />
         <UrlUploadForm
-          spaceId={spaceId}
+          spaceId={uploadSpaceId}
           onUploaded={(response, url) =>
             addOptimisticUpload(response, {
               filename: url,

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -203,7 +203,7 @@ export default function UploadCenter() {
         <Alert message={error} type="error" showIcon closable style={{ marginBottom: 16 }} onClose={() => setError(null)} />
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16, ...(uploadSpaceId.length === 0 ? { opacity: 0.5, pointerEvents: 'none' } : {}) }}>
         <FileUploadZone
           spaceId={uploadSpaceId}
           accessToken={accessToken}

--- a/apps/web/src/pages/uploads/UrlUploadForm.tsx
+++ b/apps/web/src/pages/uploads/UrlUploadForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Card, Input, Typography, message } from 'antd';
+import { Alert, Button, Card, Input, Typography } from 'antd';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getErrorMessage } from '../../components/adminUi';
@@ -33,7 +33,6 @@ export default function UrlUploadForm({ spaceId, onUploaded }: UrlUploadFormProp
       });
       onUploaded(response, trimmedUrl);
       setUrl('');
-      void message.success(t('upload.url.success', { id: response.source_document_id }));
     } catch (err) {
       setError(getErrorMessage(err));
     } finally {

--- a/apps/web/src/pages/uploads/types.ts
+++ b/apps/web/src/pages/uploads/types.ts
@@ -39,6 +39,7 @@ export type UploadResponse = {
   job_id: string | null;
   status: string;
   created: boolean;
+  duplicate?: boolean;
   error_code?: string;
 };
 


### PR DESCRIPTION
## Summary
- 上传页面新增空间选择器（antd Select），用户可切换目标上传空间
- 后端 UploadResponseDto 新增 `duplicate` 字段，检测到同空间同 blob 时返回 true
- 前端根据 `duplicate` 显示 warning/success toast
- 无可用空间时上传区域禁用
- 中英文 i18n 完整

## Changes
- `apps/api/src/uploads/uploads.dto.ts` — UploadResponseDto 新增 duplicate 字段
- `apps/api/src/uploads/uploads.service.ts` — toUploadResponse 支持 duplicate 参数
- `apps/web/src/pages/uploads/UploadCenter.tsx` — 空间选择器 + duplicate warning + 禁用态
- `apps/web/src/pages/uploads/UrlUploadForm.tsx` — 移除重复 toast
- `apps/web/src/pages/uploads/types.ts` — UploadResponse 新增 duplicate 字段
- `apps/web/src/locales/en.json` / `zh-CN.json` — 4 个新 i18n key

## Test plan
- [ ] 上传页面显示空间选择器，默认选中当前 URL 空间
- [ ] 切换空间后上传列表重新加载
- [ ] FileUploadZone/UrlUploadForm 使用选中空间上传
- [ ] 无可用空间时上传区域不可操作
- [ ] 重复文件上传显示 warning toast
- [ ] 非重复文件上传显示 success toast
- [ ] TypeScript 编译通过
- [ ] upload 相关测试全部通过 (64/64)

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `d806043c1551beb706cb76cb7365578fd095539c`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/221#issuecomment-4413079336) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/221#issuecomment-4413079338) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/221#issuecomment-4413079340) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/221#issuecomment-4413079366)
- Key findings addressed: 无空间时禁用上传区域; UrlUploadForm 移除重复 toast; 两处 major finding 已修复

Closes #213