### PR TITLE
feat(api): LLM auto-generate chat session title (#215)

### DIFF
--- a/apps/api/src/chat/__tests__/chat.service.test.ts
+++ b/apps/api/src/chat/__tests__/chat.service.test.ts
@@ -921,13 +921,13 @@ async function flushAsyncTasks(): Promise<void> {
   }
 }
 
-function findTitleUpdate(db: ScriptedChatDb): Record<string, unknown> | undefined {
+function findTitleUpdate(db: ScriptedChatDb): { title: unknown } | undefined {
   for (let index = db.updates.length - 1; index >= 0; index -= 1) {
     const update = db.updates[index];
     const value = update?.value;
 
     if (update?.table === chatSessions && typeof value === 'object' && value !== null && 'title' in value) {
-      return value as Record<string, unknown>;
+      return value;
     }
   }
 

--- a/apps/api/src/chat/__tests__/chat.service.test.ts
+++ b/apps/api/src/chat/__tests__/chat.service.test.ts
@@ -342,6 +342,156 @@ describe('ChatService streamCompletion', () => {
     expect(err.getStatus()).toBe(422);
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.NO_CHAT_MODEL_CONFIGURED);
   });
+
+  it('generates title after first round of chat', async () => {
+    const chatProvider = new ScriptedChatProvider([
+      { type: 'content', delta: 'SSO配置' },
+      { type: 'done', finish_reason: 'stop', usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 } },
+    ]);
+    const { service, db, chatFactory } = createServiceContext({ chatProvider });
+    queuePreparedCompletion(db, { space: createSpaceRow({ strict_knowledge_only: true }) });
+    db.queueSelect([]);
+    db.queueInsert([createMessageRow({ id: 'assistant-no-hit', role: 'assistant', content: NO_HIT_MESSAGE })]);
+    db.queueSelect([createSessionRow({ title: null })]);
+    db.queueSelect([{ count: 2 }]);
+    db.queueSelect([createModelRow({ model_type: 'chat' })]);
+
+    const events = await collectEvents(
+      await service.streamCompletion({
+        tenantId: TEST_TENANT_ID,
+        spaceId: TEST_SPACE_ID,
+        userId: TEST_USER_ID,
+        userGroupIds: [],
+        message: 'How is SSO configured?',
+      }),
+    );
+    await flushAsyncTasks();
+
+    expect(events[events.length - 1]).toEqual({ type: 'message.completed' });
+    expect(chatFactory).toHaveBeenCalledTimes(1);
+    expect(chatProvider.lastParams).toMatchObject({
+      model: 'gpt-test',
+      messages: [
+        { role: 'user', content: 'How is SSO configured?' },
+        { role: 'assistant', content: NO_HIT_MESSAGE },
+      ],
+      systemPrompt: '用不超过15个字概括这段对话的主题，只输出标题文本，不要加引号或标点。',
+      max_tokens: 50,
+      temperature: 0.3,
+    });
+    expect(findTitleUpdate(db)?.title).toBe('SSO配置');
+  });
+
+  it('does not generate title when title already exists', async () => {
+    const chatProvider = new ScriptedChatProvider([
+      { type: 'content', delta: '新标题' },
+      { type: 'done', finish_reason: 'stop', usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 } },
+    ]);
+    const { service, db, chatFactory } = createServiceContext({ chatProvider });
+    queuePreparedCompletion(db, { space: createSpaceRow({ strict_knowledge_only: true }) });
+    db.queueSelect([]);
+    db.queueInsert([createMessageRow({ id: 'assistant-no-hit', role: 'assistant', content: NO_HIT_MESSAGE })]);
+    db.queueSelect([createSessionRow({ title: 'Existing title' })]);
+
+    await collectEvents(
+      await service.streamCompletion({
+        tenantId: TEST_TENANT_ID,
+        spaceId: TEST_SPACE_ID,
+        userId: TEST_USER_ID,
+        userGroupIds: [],
+        message: 'missing topic',
+      }),
+    );
+    await flushAsyncTasks();
+
+    expect(chatFactory).not.toHaveBeenCalled();
+    expect(findTitleUpdate(db)).toBeUndefined();
+  });
+
+  it('does not generate title when message count is not 2', async () => {
+    const chatProvider = new ScriptedChatProvider([
+      { type: 'content', delta: '新标题' },
+      { type: 'done', finish_reason: 'stop', usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 } },
+    ]);
+    const { service, db, chatFactory } = createServiceContext({ chatProvider });
+    queuePreparedCompletion(db, { space: createSpaceRow({ strict_knowledge_only: true }) });
+    db.queueSelect([]);
+    db.queueInsert([createMessageRow({ id: 'assistant-no-hit', role: 'assistant', content: NO_HIT_MESSAGE })]);
+    db.queueSelect([createSessionRow({ title: null })]);
+    db.queueSelect([{ count: 3 }]);
+
+    await collectEvents(
+      await service.streamCompletion({
+        tenantId: TEST_TENANT_ID,
+        spaceId: TEST_SPACE_ID,
+        userId: TEST_USER_ID,
+        userGroupIds: [],
+        message: 'missing topic',
+      }),
+    );
+    await flushAsyncTasks();
+
+    expect(chatFactory).not.toHaveBeenCalled();
+    expect(findTitleUpdate(db)).toBeUndefined();
+  });
+
+  it('handles LLM failure gracefully without affecting chat', async () => {
+    const chatProvider = new ScriptedChatProvider([{ type: 'error', error: 'title failed' }]);
+    const { service, db } = createServiceContext({ chatProvider });
+    queuePreparedCompletion(db, { space: createSpaceRow({ strict_knowledge_only: true }) });
+    db.queueSelect([]);
+    db.queueInsert([createMessageRow({ id: 'assistant-no-hit', role: 'assistant', content: NO_HIT_MESSAGE })]);
+    db.queueSelect([createSessionRow({ title: null })]);
+    db.queueSelect([{ count: 2 }]);
+    db.queueSelect([createModelRow({ model_type: 'chat' })]);
+
+    const events = await collectEvents(
+      await service.streamCompletion({
+        tenantId: TEST_TENANT_ID,
+        spaceId: TEST_SPACE_ID,
+        userId: TEST_USER_ID,
+        userGroupIds: [],
+        message: 'missing topic',
+      }),
+    );
+    await flushAsyncTasks();
+
+    expect(events).toEqual([
+      { type: 'session', session_id: 'session-1' },
+      { type: 'content', delta: NO_HIT_MESSAGE },
+      { type: 'citations', citations: [] },
+      { type: 'usage', usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 } },
+      { type: 'message.completed' },
+    ]);
+    expect(findTitleUpdate(db)).toBeUndefined();
+  });
+
+  it('truncates title to 30 characters and strips quotes', async () => {
+    const chatProvider = new ScriptedChatProvider([
+      { type: 'content', delta: '"12345678901234567890123456789012345"' },
+      { type: 'done', finish_reason: 'stop', usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 } },
+    ]);
+    const { service, db } = createServiceContext({ chatProvider });
+    queuePreparedCompletion(db, { space: createSpaceRow({ strict_knowledge_only: true }) });
+    db.queueSelect([]);
+    db.queueInsert([createMessageRow({ id: 'assistant-no-hit', role: 'assistant', content: NO_HIT_MESSAGE })]);
+    db.queueSelect([createSessionRow({ title: null })]);
+    db.queueSelect([{ count: 2 }]);
+    db.queueSelect([createModelRow({ model_type: 'chat' })]);
+
+    await collectEvents(
+      await service.streamCompletion({
+        tenantId: TEST_TENANT_ID,
+        spaceId: TEST_SPACE_ID,
+        userId: TEST_USER_ID,
+        userGroupIds: [],
+        message: 'missing topic',
+      }),
+    );
+    await flushAsyncTasks();
+
+    expect(findTitleUpdate(db)?.title).toBe('123456789012345678901234567890');
+  });
 });
 
 describe('ChatController', () => {
@@ -415,16 +565,27 @@ const NO_HIT_MESSAGE = '未找到相关知识，请尝试不同的提问方式';
 
 class ScriptedChatProvider implements ChatProvider {
   lastParams: ChatCompletionParams | undefined;
+  readonly calls: ChatCompletionParams[] = [];
+  private readonly chunkBatches: ChatChunk[][];
 
-  constructor(private readonly chunks: ChatChunk[]) {}
+  constructor(chunks: ChatChunk[] | ChatChunk[][]) {
+    this.chunkBatches = isChunkBatchList(chunks) ? chunks.map((batch) => [...batch]) : [[...chunks]];
+  }
 
   async *streamCompletion(params: ChatCompletionParams): AsyncIterable<ChatChunk> {
     this.lastParams = params;
+    this.calls.push(params);
     await Promise.resolve();
-    for (const chunk of this.chunks) {
+    const chunks = this.chunkBatches.length > 1 ? (this.chunkBatches.shift() ?? []) : (this.chunkBatches[0] ?? []);
+
+    for (const chunk of chunks) {
       yield chunk;
     }
   }
+}
+
+function isChunkBatchList(chunks: ChatChunk[] | ChatChunk[][]): chunks is ChatChunk[][] {
+  return Array.isArray(chunks[0]);
 }
 
 class ScriptedEmbeddingProvider implements EmbeddingProvider {
@@ -752,6 +913,25 @@ async function collectEvents(events: AsyncIterable<ChatStreamEvent>): Promise<Ch
   }
 
   return collected;
+}
+
+async function flushAsyncTasks(): Promise<void> {
+  for (let index = 0; index < 20; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function findTitleUpdate(db: ScriptedChatDb): Record<string, unknown> | undefined {
+  for (let index = db.updates.length - 1; index >= 0; index -= 1) {
+    const update = db.updates[index];
+    const value = update?.value;
+
+    if (update?.table === chatSessions && typeof value === 'object' && value !== null && 'title' in value) {
+      return value as Record<string, unknown>;
+    }
+  }
+
+  return undefined;
 }
 
 async function* toAsyncIterable<T>(items: T[]): AsyncIterable<T> {

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -366,6 +366,76 @@ export class ChatService {
     return created;
   }
 
+  private async generateSessionTitle(
+    tenantId: string,
+    sessionId: string,
+    userMessage: string,
+    assistantReply: string,
+  ): Promise<void> {
+    try {
+      const chatModel = await this.resolveEnabledModel(tenantId, 'chat', ErrorCode.NO_CHAT_MODEL_CONFIGURED);
+      const provider = this.chatProviderFactory(toChatProviderConfig(chatModel));
+      let title = '';
+
+      for await (const chunk of provider.streamCompletion({
+        model: chatModel.model_id,
+        messages: [
+          { role: 'user', content: userMessage },
+          { role: 'assistant', content: assistantReply.slice(0, 500) },
+        ],
+        systemPrompt: '用不超过15个字概括这段对话的主题，只输出标题文本，不要加引号或标点。',
+        max_tokens: 50,
+        temperature: 0.3,
+      })) {
+        if (chunk.type === 'content') {
+          title += chunk.delta;
+        }
+
+        if (chunk.type === 'done') {
+          break;
+        }
+
+        if (chunk.type === 'error') {
+          return;
+        }
+      }
+
+      title = title.trim().replace(/^["'""'']+|["'""'']+$/g, '').slice(0, 30);
+      if (title.length > 0) {
+        await this.db.update(chatSessions).set({ title, updated_at: new Date() }).where(eq(chatSessions.id, sessionId));
+      }
+    } catch {
+      // fire-and-forget: failure does not affect chat
+    }
+  }
+
+  private async maybeGenerateTitle(
+    prepared: PreparedCompletion,
+    userMessage: string,
+    assistantReply: string,
+  ): Promise<void> {
+    try {
+      const session = await this.findSessionById(prepared.tenantId, prepared.session.id);
+      if (session === undefined || session.title !== null) return;
+
+      const messageCount = await this.countSessionMessages(prepared.session.id);
+      if (messageCount !== 2) return;
+
+      void this.generateSessionTitle(prepared.tenantId, prepared.session.id, userMessage, assistantReply);
+    } catch {
+      // ignore
+    }
+  }
+
+  private async countSessionMessages(sessionId: string): Promise<number> {
+    const [result] = await this.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(chatMessages)
+      .where(eq(chatMessages.session_id, sessionId));
+
+    return result?.count ?? 0;
+  }
+
   async streamCompletion(input: StreamCompletionInput): Promise<AsyncIterable<ChatStreamEvent>> {
     const space = await this.requireSpace(input.tenantId, input.spaceId);
     const chatModel = await this.resolveEnabledModel(input.tenantId, 'chat', ErrorCode.NO_CHAT_MODEL_CONFIGURED);
@@ -542,6 +612,7 @@ export class ChatService {
             source: 'agent',
           });
           yield { type: 'usage', usage };
+          void this.maybeGenerateTitle(prepared, input.message, assistantText);
           yield { type: 'message.completed' };
           this.auditCompletion(prepared, usage, 0, false, assistant.id);
           return;
@@ -601,6 +672,7 @@ export class ChatService {
         yield { type: 'content', delta: NO_HIT_MESSAGE };
         yield { type: 'citations', citations: [] };
         yield { type: 'usage', usage };
+        void this.maybeGenerateTitle(prepared, input.message, NO_HIT_MESSAGE);
         yield { type: 'message.completed' };
         this.auditCompletion(prepared, usage, retrievalResults.length, false, assistant.id);
         return;
@@ -673,6 +745,7 @@ export class ChatService {
 
       yield { type: 'citations', citations };
       yield { type: 'usage', usage };
+      void this.maybeGenerateTitle(prepared, input.message, assistantText);
       yield { type: 'message.completed' };
       this.auditCompletion(prepared, usage, retrievalResults.length, citations.length > 0, assistant.id);
     } catch {


### PR DESCRIPTION
## Summary
- 新聊天首轮对话完成后异步调用 LLM 生成标题（<=30 字符）
- Fire-and-forget 模式：LLM 失败不影响聊天流
- 覆盖所有三个完成路径：agent mode、no-hit strict、normal RAG
- 前端无需修改（已有 loadSessions re-fetch 机制）

## Changes
- `apps/api/src/chat/chat.service.ts` — 新增 generateSessionTitle、maybeGenerateTitle、countSessionMessages；三处 message.completed 路径调用
- `apps/api/src/chat/__tests__/chat.service.test.ts` — 5 个新测试覆盖全部场景

## Test plan
- [ ] 新聊天首条回复后标题自动更新
- [ ] 二次消息不重复生成
- [ ] title 已存在时不重复生成
- [ ] LLM 失败不影响聊天功能
- [ ] 标题截断去引号正确
- [ ] TypeScript 编译通过
- [ ] 所有 chat 测试通过 (32/32)

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `cd060d2d2019ce71b845fef577ec7a01ef82869f`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/222#issuecomment-4413150026) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/222#issuecomment-4413150028) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/222#issuecomment-4413150029) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/222#issuecomment-4413150031)
- Key findings addressed: 测试已补充提交; lint error 已修复

Closes #215