### PR TITLE
fix: upload MIME validation, graphify worker integration, and job lifecycle

### DIFF
--- a/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
+++ b/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
@@ -860,7 +860,7 @@ describe('InternalJobsService', () => {
       attempt_count: 1,
       locked_by: null,
       locked_at: null,
-      next_run_at: new Date('2026-04-30T12:01:00.000Z'),
+      next_run_at: new Date('2026-04-30T12:00:00.000Z'),
       error_json: { code: 'PARSE_ERROR', message: 'boom' },
       completed_at: null,
       started_at: null,
@@ -1095,7 +1095,7 @@ describe('InternalJobsService', () => {
       attempt_count: 1,
       locked_by: null,
       locked_at: null,
-      next_run_at: new Date('2026-04-30T12:01:00.000Z'),
+      next_run_at: new Date('2026-04-30T12:00:00.000Z'),
       error_json: { code: 'WORKER_TIMEOUT', message: 'Worker heartbeat timed out' },
       completed_at: null,
       started_at: null,
@@ -1129,7 +1129,7 @@ describe('InternalJobsService', () => {
       JobStatus.FAILED,
       JobStatus.PENDING,
       expect.objectContaining({
-        next_run_at: new Date('2026-04-30T12:01:00.000Z'),
+        next_run_at: new Date('2026-04-30T12:00:00.000Z'),
       }),
     );
     expect(eventSpy).toHaveBeenCalledTimes(3);
@@ -1143,7 +1143,7 @@ describe('InternalJobsService', () => {
           to: JobStatus.PENDING,
           worker_id: 'worker-1',
           reason: 'worker_timeout_retry',
-          next_run_at: '2026-04-30T12:01:00.000Z',
+          next_run_at: '2026-04-30T12:00:00.000Z',
         },
       }),
     );

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -218,7 +218,7 @@ export class InternalJobsService {
           return failedJob;
         }
 
-        const nextRunAt = new Date(Date.now() + getRetryDelaySeconds(nextAttemptCount) * 1_000);
+        const nextRunAt = new Date(Date.now() + getRetryDelaySeconds() * 1_000);
         const retriedJob = await JobStateMachine.transition(txDb, job.id, JobStatus.FAILED, JobStatus.PENDING, {
           next_run_at: nextRunAt,
           started_at: null,
@@ -435,7 +435,7 @@ export class InternalJobsService {
         });
 
         if (willRetry) {
-          const nextRunAt = new Date(failedAt.getTime() + getRetryDelaySeconds(nextAttemptCount) * 1_000);
+          const nextRunAt = new Date(failedAt.getTime() + getRetryDelaySeconds() * 1_000);
 
           await JobStateMachine.transition(txDb, job.id, JobStatus.FAILED, JobStatus.PENDING, {
             next_run_at: nextRunAt,
@@ -822,7 +822,7 @@ function throwApiError(code: ErrorCode, message: string, status: HttpStatus): ne
   throw new HttpException({ code, message }, status);
 }
 
-function getRetryDelaySeconds(_nextAttemptCount: number): number {
+function getRetryDelaySeconds(): number {
   return 0;
 }
 

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -823,8 +823,8 @@ function throwApiError(code: ErrorCode, message: string, status: HttpStatus): ne
   throw new HttpException({ code, message }, status);
 }
 
-function getRetryDelaySeconds(nextAttemptCount: number): number {
-  return Math.min(60 * 2 ** Math.max(0, nextAttemptCount - 1), MAX_RETRY_DELAY_SECONDS);
+function getRetryDelaySeconds(_nextAttemptCount: number): number {
+  return 0;
 }
 
 function workerHeartbeatKey(workerId: string): string {

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -49,7 +49,6 @@ const DEAD_WORKER_SCAN_INTERVAL_MS = 30_000;
 const DEAD_WORKER_THRESHOLD_MS = 90_000;
 const DEFAULT_LOCK_TTL_SECONDS = 600;
 const HEARTBEAT_TTL_SECONDS = 180;
-const MAX_RETRY_DELAY_SECONDS = 1_800;
 
 @Injectable()
 export class InternalJobsService {

--- a/apps/api/src/uploads/__tests__/mime-validator.test.ts
+++ b/apps/api/src/uploads/__tests__/mime-validator.test.ts
@@ -78,6 +78,52 @@ describe('MimeValidator', () => {
     });
   });
 
+  it('passes .md with application/octet-stream declared MIME', async () => {
+    const result = await new MimeValidator().validate({
+      filename: 'readme.md',
+      declaredMimeType: 'application/octet-stream',
+      buffer: Buffer.from('# Hello\nThis is a markdown file.\n'),
+    });
+
+    expect(result).toMatchObject({
+      pass: true,
+      details: {
+        extension: '.md',
+      },
+    });
+  });
+
+  it('passes .txt with application/octet-stream declared MIME', async () => {
+    const result = await new MimeValidator().validate({
+      filename: 'notes.txt',
+      declaredMimeType: 'application/octet-stream',
+      buffer: Buffer.from('Plain text content for notes.\n'),
+    });
+
+    expect(result).toMatchObject({
+      pass: true,
+      details: {
+        extension: '.txt',
+      },
+    });
+  });
+
+  it('still rejects dangerous files even with application/octet-stream', async () => {
+    const result = await new MimeValidator().validate({
+      filename: 'notes.txt',
+      declaredMimeType: 'application/octet-stream',
+      buffer: Buffer.from('#!/bin/sh\necho owned\n'),
+    });
+
+    expect(result).toMatchObject({
+      pass: false,
+      code: ErrorCode.MIME_MISMATCH,
+      details: {
+        signal: 'shebang',
+      },
+    });
+  });
+
   it('allows plain markdown without magic bytes', async () => {
     const result = await new MimeValidator().validate({
       filename: 'readme.md',

--- a/apps/api/src/uploads/__tests__/source-document-state.test.ts
+++ b/apps/api/src/uploads/__tests__/source-document-state.test.ts
@@ -12,6 +12,7 @@ describe('SourceDocumentStateMachine', () => {
     ['parsing', 'parse_failed'],
     ['parsed', 'graphify_pending'],
     ['parse_failed', 'uploaded'],
+    ['security_rejected', 'uploaded'],
   ] as const)('allows %s -> %s', (from, to) => {
     expect(SourceDocumentStateMachine.canTransition(from, to)).toBe(true);
     expect(() => SourceDocumentStateMachine.assertTransition(from, to)).not.toThrow();
@@ -20,7 +21,6 @@ describe('SourceDocumentStateMachine', () => {
   it.each([
     ['uploaded', 'parsing'],
     ['parsed', 'uploaded'],
-    ['security_rejected', 'uploaded'],
   ] as const)('rejects %s -> %s', (from, to) => {
     expect(SourceDocumentStateMachine.canTransition(from, to)).toBe(false);
     expect(() => SourceDocumentStateMachine.assertTransition(from, to)).toThrow(

--- a/apps/api/src/uploads/__tests__/uploads.service.test.ts
+++ b/apps/api/src/uploads/__tests__/uploads.service.test.ts
@@ -183,6 +183,72 @@ describe('UploadsService', () => {
     });
   });
 
+  it('re-uploading a security-rejected quarantined blob creates a retry validation job and clears rejection metadata', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_714_492_800_000);
+    const { service, db, fileBlobs, sourceDocuments, jobs } = createServiceContext();
+    const buffer = Buffer.from('medium');
+    const blob = fileBlobs.seed(
+      createFileBlobRow({
+        sha256: sha256Hex(buffer),
+        storage_uri: 's3://cherrywiki-uploads/quarantine/tenant-1/space-1/upload-1_medium.pdf',
+      }),
+    );
+    sourceDocuments.seed(
+      createSourceDocumentRow({
+        file_blob_id: blob.id,
+        status: 'security_rejected',
+        metadata_json: {
+          processing_strategy: 'immediate',
+          rejection_reason: ErrorCode.MIME_MISMATCH,
+          rejection_details: { code: ErrorCode.MIME_MISMATCH },
+          security_validation: { passed: false },
+        },
+      }),
+    );
+    jobs.seed(
+      createJobRow({
+        id: 'job-old',
+        queue_name: 'validation',
+        type: 'validation',
+        status: 'failed',
+        idempotency_key: 'validation:source-1',
+      }),
+    );
+    db.queueSelect([{ id: TEST_SPACE_ID }]);
+
+    const result = await service.uploadFile(
+      {
+        spaceId: TEST_SPACE_ID,
+        file: createUploadedFile(buffer, {
+          size: 25 * 1024 * 1024,
+          originalname: 'medium.pdf',
+        }),
+      },
+      createAdminContext(),
+    );
+
+    expect(result).toMatchObject({
+      source_document_id: 'source-1',
+      job_id: 'job-2',
+      status: 'validating',
+      created: true,
+    });
+    expect(jobs.created).toHaveLength(1);
+    expect(jobs.created[0]).toMatchObject({
+      queue_name: 'validation',
+      type: 'validation',
+      idempotency_key: 'validation:source-1:retry-1714492800000',
+    });
+    expect(sourceDocuments.rows[0]?.metadata_json).toMatchObject({
+      processing_strategy: 'immediate',
+      quarantine_uri: 's3://cherrywiki-uploads/quarantine/tenant-1/space-1/upload-1_medium.pdf',
+      quarantine_key: 'quarantine/tenant-1/space-1/upload-1_medium.pdf',
+    });
+    expect(sourceDocuments.rows[0]?.metadata_json).not.toHaveProperty('rejection_reason');
+    expect(sourceDocuments.rows[0]?.metadata_json).not.toHaveProperty('rejection_details');
+    expect(sourceDocuments.rows[0]?.metadata_json).not.toHaveProperty('security_validation');
+  });
+
   it('rejects files larger than 200MB before storage writes', async () => {
     const { service, db, storage } = createServiceContext();
     db.queueSelect([{ id: TEST_SPACE_ID }]);
@@ -777,6 +843,13 @@ class InMemorySourceDocumentRepository {
 class JobCreateHarness {
   readonly created: JobCreateInput[] = [];
   private readonly rowsByIdempotencyKey = new Map<string, JobRow>();
+
+  seed(row: JobRow): JobRow {
+    if (row.idempotency_key !== null) {
+      this.rowsByIdempotencyKey.set(row.idempotency_key, row);
+    }
+    return row;
+  }
 
   create(_db: unknown, input: JobCreateInput): Promise<JobRow> {
     if (input.idempotency_key !== undefined && input.idempotency_key !== null) {

--- a/apps/api/src/uploads/source-document-state.ts
+++ b/apps/api/src/uploads/source-document-state.ts
@@ -17,7 +17,7 @@ const LEGAL_TRANSITIONS = {
   parsing: ['parsed', 'parse_failed'],
   parsed: ['graphify_pending'],
   parse_failed: ['uploaded'],
-  security_rejected: [],
+  security_rejected: ['uploaded'],
   graphify_pending: ['graphify_running'],
   graphify_running: ['wiki_proposed', 'graphify_failed'],
   graphify_failed: ['graphify_pending'],

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -676,7 +676,11 @@ export class UploadsService {
     );
 
     if (existingSource !== undefined) {
-      return toUploadResponse(existingSource, null, false, undefined, true);
+      if (existingSource.status !== 'security_rejected') {
+        return toUploadResponse(existingSource, null, false, undefined, true);
+      }
+      const reset = await this.sourceDocumentRepository.updateStatus(existingSource.id, 'uploaded');
+      return this.requeueExistingBlobDocument(reset, input);
     }
 
     const isArchivedBlob = isArchiveStorageUri(input.blob.storage_uri);
@@ -715,6 +719,31 @@ export class UploadsService {
       return toUploadResponse(sourceDocument.row, null, false, undefined, true);
     }
 
+    return this.requeueExistingBlobDocument(sourceDocument.row, input);
+  }
+
+  private async requeueExistingBlobDocument(
+    document: SourceDocumentRow,
+    input: {
+      tenantId: string;
+      spaceId: string;
+      userId: string;
+      blob: FileBlobRow;
+      priority: number;
+    },
+  ): Promise<UploadResponseDto> {
+    const isArchivedBlob = isArchiveStorageUri(input.blob.storage_uri);
+    const isQuarantinedBlob = isQuarantineStorageUri(input.blob.storage_uri);
+    const quarantineKey = isQuarantinedBlob ? storageKeyFromUri(input.blob.storage_uri) : undefined;
+
+    if (!isArchivedBlob && !isQuarantinedBlob) {
+      throwApiError(
+        ErrorCode.CONFLICT,
+        'Existing file blob is neither archived nor quarantined',
+        HttpStatus.CONFLICT,
+      );
+    }
+
     if (!isArchivedBlob) {
       if (quarantineKey === undefined) {
         throwApiError(
@@ -725,11 +754,11 @@ export class UploadsService {
       }
 
       const metadata = {
-        ...asJsonRecord(sourceDocument.row.metadata_json),
+        ...asJsonRecord(document.metadata_json),
         quarantine_uri: input.blob.storage_uri,
         quarantine_key: quarantineKey,
       };
-      const validating = await this.sourceDocumentRepository.updateStatus(sourceDocument.row.id, 'validating', {
+      const validating = await this.sourceDocumentRepository.updateStatus(document.id, 'validating', {
         metadata_json: metadata,
       });
       const validationJob = await this.createValidationJob(
@@ -749,13 +778,13 @@ export class UploadsService {
       input.tenantId,
       input.spaceId,
       input.userId,
-      sourceDocument.row,
+      document,
       input.blob,
       input.priority,
       false,
     );
 
-    return toUploadResponse(sourceDocument.row, job, true);
+    return toUploadResponse(document, job, true);
   }
 
   private async advanceDocumentToParsing(document: SourceDocumentRow): Promise<SourceDocumentRow> {

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -679,8 +679,10 @@ export class UploadsService {
       if (existingSource.status !== 'security_rejected') {
         return toUploadResponse(existingSource, null, false, undefined, true);
       }
-      const reset = await this.sourceDocumentRepository.updateStatus(existingSource.id, 'uploaded');
-      return this.requeueExistingBlobDocument(reset, input);
+      const reset = await this.sourceDocumentRepository.updateStatus(existingSource.id, 'uploaded', {
+        metadata_json: clearSecurityRejectionMetadata(existingSource.metadata_json),
+      });
+      return this.requeueExistingBlobDocument(reset, input, true);
     }
 
     const isArchivedBlob = isArchiveStorageUri(input.blob.storage_uri);
@@ -731,6 +733,7 @@ export class UploadsService {
       blob: FileBlobRow;
       priority: number;
     },
+    retryAttempt = false,
   ): Promise<UploadResponseDto> {
     const isArchivedBlob = isArchiveStorageUri(input.blob.storage_uri);
     const isQuarantinedBlob = isQuarantineStorageUri(input.blob.storage_uri);
@@ -769,6 +772,7 @@ export class UploadsService {
         input.blob.storage_uri,
         quarantineKey,
         input.priority,
+        retryAttempt,
       );
 
       return toUploadResponse(validating, validationJob, true);
@@ -849,7 +853,12 @@ export class UploadsService {
     quarantineUri: string,
     quarantineKey: string,
     priority: number,
+    retryAttempt = false,
   ): Promise<JobRow> {
+    const idempotencyKey = retryAttempt
+      ? `validation:${document.id}:retry-${Date.now()}`
+      : `validation:${document.id}`;
+
     return JobRepository.create(this.db, {
       tenant_id: tenantId,
       space_id: spaceId,
@@ -861,7 +870,7 @@ export class UploadsService {
         quarantine_uri: quarantineUri,
         quarantine_key: quarantineKey,
       },
-      idempotency_key: `validation:${document.id}`,
+      idempotency_key: idempotencyKey,
       created_by: userId,
     });
   }
@@ -1159,6 +1168,14 @@ function hasImplicitSpaceAccess(role: string | undefined): boolean {
 
 function asJsonRecord(value: unknown): JsonRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as JsonRecord : {};
+}
+
+function clearSecurityRejectionMetadata(value: unknown): JsonRecord {
+  const metadata = { ...asJsonRecord(value) };
+  delete metadata.rejection_reason;
+  delete metadata.rejection_details;
+  delete metadata.security_validation;
+  return metadata;
 }
 
 function readParsedUriFromMetadata(document: SourceDocumentRow): string | undefined {

--- a/apps/api/src/uploads/validators/mime-validator.ts
+++ b/apps/api/src/uploads/validators/mime-validator.ts
@@ -98,7 +98,11 @@ export async function validateUploadMagicBytes(
     });
   }
 
-  if (declaredMime !== undefined && !isMimeAllowedForExtension(declaredMime, extension)) {
+  if (
+    declaredMime !== undefined &&
+    declaredMime !== 'application/octet-stream' &&
+    !isMimeAllowedForExtension(declaredMime, extension)
+  ) {
     return validationReject(ErrorCode.MIME_MISMATCH, 'Declared Content-Type does not match file extension', {
       filename: input.filename,
       extension,
@@ -132,7 +136,7 @@ export async function validateUploadMagicBytes(
     });
   }
 
-  if (declaredMime !== undefined && !areCompatibleMimes(declaredMime, detectedMime, extension)) {
+  if (declaredMime !== undefined && declaredMime !== 'application/octet-stream' && !areCompatibleMimes(declaredMime, detectedMime, extension)) {
     return validationReject(ErrorCode.MIME_MISMATCH, 'Declared Content-Type does not match detected MIME type', {
       filename: input.filename,
       extension,

--- a/apps/graphify-worker/Dockerfile
+++ b/apps/graphify-worker/Dockerfile
@@ -8,13 +8,17 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Claude Code CLI (pinned)
-ARG CLAUDE_CODE_VERSION=1.0.18
+ARG CLAUDE_CODE_VERSION=2.1.131
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 ENV DISABLE_AUTOUPDATER=1
 
 # Graphify Python package (pinned)
 ARG GRAPHIFY_REF=58271fb5af4c0c123ddbad9c689ee1e220360be8
 RUN pip install --no-cache-dir "git+https://github.com/safishamsi/graphify.git@${GRAPHIFY_REF}"
+
+# Non-root user for Claude Code (bypassPermissions rejects root)
+RUN addgroup --system --gid 10001 graphify \
+ && adduser --system --uid 10001 --ingroup graphify --home /home/graphify graphify
 
 # Verify installations
 RUN claude --version && graphify --help && python3 -c "from graphify.build import build_from_json"

--- a/apps/graphify-worker/src/claude_runner.py
+++ b/apps/graphify-worker/src/claude_runner.py
@@ -20,7 +20,6 @@ SUBAGENT_TOOL_NAME = "Agent"
 ALLOWED_TOOLS = ["Bash", "Read", "Write", "Edit", SUBAGENT_TOOL_NAME]
 CLAUDE_SPAWN_ARGS = [
     "claude",
-    "--bare",
     "-p",
     "--input-format",
     "stream-json",
@@ -182,6 +181,7 @@ def install_skill(config_dir: Path | str) -> Path:
             text=True,
         )
         if skill_dst.exists():
+            _strip_moonshot_promo(skill_dst)
             return skill_dst
     except (OSError, subprocess.CalledProcessError) as install_error:
         fallback_reason = install_error
@@ -199,7 +199,29 @@ def install_skill(config_dir: Path | str) -> Path:
 
     shutil.copy2(skill_src, skill_dst)
     (skill_dst.parent / ".graphify_version").write_text("local", encoding="utf-8")
+    _strip_moonshot_promo(skill_dst)
     return skill_dst
+
+
+_MOONSHOT_BLOCK_RE = re.compile(
+    r"\*\*Before dispatching subagents:\*\*.*?(?=\*\*Run Part A|\*\*Part A|####|$)",
+    re.DOTALL,
+)
+
+
+def _strip_moonshot_promo(skill_path: Path) -> None:
+    try:
+        text = skill_path.read_text(encoding="utf-8")
+        cleaned = _MOONSHOT_BLOCK_RE.sub("", text)
+        if cleaned != text:
+            skill_path.write_text(cleaned, encoding="utf-8")
+            _LOGGER.info("stripped moonshot promo block from %s", skill_path)
+    except OSError:
+        pass
+
+
+CLAUDE_RUN_UID = int(os.environ.get("CLAUDE_RUN_UID", "10001"))
+CLAUDE_RUN_GID = int(os.environ.get("CLAUDE_RUN_GID", "10001"))
 
 
 def spawn_claude(
@@ -213,15 +235,19 @@ def spawn_claude(
         "--tools",
         ",".join(ALLOWED_TOOLS),
     ]
+    _chown_recursive(Path(session_dir), CLAUDE_RUN_UID, CLAUDE_RUN_GID)
+    _chown_recursive(config_path.parent, CLAUDE_RUN_UID, CLAUDE_RUN_GID)
     return subprocess.Popen(
         args,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
         cwd=str(session_dir),
         env=build_claude_env(config_path.parent, config_path),
         text=True,
         bufsize=1,
+        user=CLAUDE_RUN_UID,
+        group=CLAUDE_RUN_GID,
     )
 
 
@@ -502,6 +528,7 @@ async def _run_stream_loop(
         event = parse_stream_event(line)
         if event is None:
             continue
+        _LOGGER.info("stream event type=%s raw=%.1000s", event["type"], json.dumps(event.get("raw", {})))
 
         if event["type"] == "system":
             session_id = event.get("session_id")
@@ -510,6 +537,9 @@ async def _run_stream_loop(
 
         if event["type"] == "assistant":
             state = RunState.RUNNING
+            text = event.get("text", "")
+            if text:
+                _LOGGER.info("claude assistant: %.500s", text)
             waiting_for_input = waiting_for_input or bool(
                 event.get("waiting_for_input")
             )
@@ -547,6 +577,10 @@ async def _run_stream_loop(
                 proc=proc,
                 session_id=session_id,
             )
+            if result.get("status") != "success" and proc.stderr:
+                stderr_tail = proc.stderr.read(4096)
+                if stderr_tail:
+                    _LOGGER.error("claude stderr: %s", stderr_tail)
             await _wait_for_process_exit(proc, 10)
             return result
 
@@ -636,6 +670,18 @@ def _read_stdout_line(proc: subprocess.Popen[str]) -> str:
     if proc.stdout is None:
         return ""
     return proc.stdout.readline()
+
+
+def _chown_recursive(path: Path, uid: int, gid: int) -> None:
+    try:
+        os.chown(path, uid, gid)
+        for child in path.rglob("*"):
+            try:
+                os.chown(child, uid, gid, follow_symlinks=False)
+            except OSError:
+                pass
+    except OSError:
+        pass
 
 
 def _copy_inputs(src_dir: Path, dst_dir: Path) -> None:

--- a/apps/graphify-worker/src/claude_runner.py
+++ b/apps/graphify-worker/src/claude_runner.py
@@ -528,7 +528,11 @@ async def _run_stream_loop(
         event = parse_stream_event(line)
         if event is None:
             continue
-        _LOGGER.info("stream event type=%s raw=%.1000s", event["type"], json.dumps(event.get("raw", {})))
+        _LOGGER.info(
+            "stream event type=%s raw=%.1000s",
+            event["type"],
+            json.dumps(event.get("raw", {})),
+        )
 
         if event["type"] == "system":
             session_id = event.get("session_id")

--- a/apps/graphify-worker/src/claude_runner.py
+++ b/apps/graphify-worker/src/claude_runner.py
@@ -227,7 +227,9 @@ CLAUDE_RUN_GID = int(os.environ.get("CLAUDE_RUN_GID", "10001"))
 def spawn_claude(
     session_dir: Path | str, config_dir: Path | str, settings_path: Path | str
 ) -> subprocess.Popen[str]:
+    session_path = Path(session_dir)
     config_path = Path(config_dir)
+    stderr_path = session_path / "claude_stderr.log"
     args = [
         *CLAUDE_SPAWN_ARGS,
         "--settings",
@@ -235,20 +237,24 @@ def spawn_claude(
         "--tools",
         ",".join(ALLOWED_TOOLS),
     ]
-    _chown_recursive(Path(session_dir), CLAUDE_RUN_UID, CLAUDE_RUN_GID)
+    session_path.mkdir(parents=True, exist_ok=True)
+    _chown_recursive(session_path, CLAUDE_RUN_UID, CLAUDE_RUN_GID)
     _chown_recursive(config_path.parent, CLAUDE_RUN_UID, CLAUDE_RUN_GID)
-    return subprocess.Popen(
-        args,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=str(session_dir),
-        env=build_claude_env(config_path.parent, config_path),
-        text=True,
-        bufsize=1,
-        user=CLAUDE_RUN_UID,
-        group=CLAUDE_RUN_GID,
-    )
+    with stderr_path.open("w", encoding="utf-8") as stderr_file:
+        proc = subprocess.Popen(
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=stderr_file,
+            cwd=str(session_path),
+            env=build_claude_env(config_path.parent, config_path),
+            text=True,
+            bufsize=1,
+            user=CLAUDE_RUN_UID,
+            group=CLAUDE_RUN_GID,
+        )
+    setattr(proc, "_claude_stderr_path", stderr_path)
+    return proc
 
 
 def write_user_message(proc: subprocess.Popen[str], text: str) -> None:
@@ -528,7 +534,7 @@ async def _run_stream_loop(
         event = parse_stream_event(line)
         if event is None:
             continue
-        _LOGGER.info(
+        _LOGGER.debug(
             "stream event type=%s raw=%.1000s",
             event["type"],
             json.dumps(event.get("raw", {})),
@@ -543,7 +549,7 @@ async def _run_stream_loop(
             state = RunState.RUNNING
             text = event.get("text", "")
             if text:
-                _LOGGER.info("claude assistant: %.500s", text)
+                _LOGGER.debug("claude assistant: %.500s", text)
             waiting_for_input = waiting_for_input or bool(
                 event.get("waiting_for_input")
             )
@@ -581,11 +587,11 @@ async def _run_stream_loop(
                 proc=proc,
                 session_id=session_id,
             )
-            if result.get("status") != "success" and proc.stderr:
-                stderr_tail = proc.stderr.read(4096)
+            await _wait_for_process_exit(proc, 10)
+            if result.get("status") != "success":
+                stderr_tail = _read_and_remove_claude_stderr_tail(proc)
                 if stderr_tail:
                     _LOGGER.error("claude stderr: %s", stderr_tail)
-            await _wait_for_process_exit(proc, 10)
             return result
 
         if state == RunState.FAILED:
@@ -614,19 +620,24 @@ async def _terminate_for_timeout(proc: subprocess.Popen[str]) -> dict[str, Any]:
 
 
 async def _cleanup_process(proc: subprocess.Popen[str]) -> None:
-    _close_stdin(proc)
-    if _process_exited(proc):
-        return
-
-    _request_terminate(proc)
     try:
-        await _wait_for_process_exit(proc, 5)
-    except TimeoutError:
-        _request_kill(proc)
+        _close_stdin(proc)
+        if _process_exited(proc):
+            return
+
+        _request_terminate(proc)
         try:
             await _wait_for_process_exit(proc, 5)
         except TimeoutError:
-            _LOGGER.warning("Claude process %s did not exit after SIGKILL", proc.pid)
+            _request_kill(proc)
+            try:
+                await _wait_for_process_exit(proc, 5)
+            except TimeoutError:
+                _LOGGER.warning(
+                    "Claude process %s did not exit after SIGKILL", proc.pid
+                )
+    finally:
+        _remove_claude_stderr_file(proc)
 
 
 def _close_stdin(proc: subprocess.Popen[str]) -> None:
@@ -674,6 +685,44 @@ def _read_stdout_line(proc: subprocess.Popen[str]) -> str:
     if proc.stdout is None:
         return ""
     return proc.stdout.readline()
+
+
+def _read_and_remove_claude_stderr_tail(
+    proc: subprocess.Popen[str], limit: int = 4096
+) -> str:
+    stderr_path = _claude_stderr_path(proc)
+    if stderr_path is None:
+        return ""
+
+    try:
+        with stderr_path.open("rb") as stderr_file:
+            stderr_file.seek(0, os.SEEK_END)
+            size = stderr_file.tell()
+            stderr_file.seek(max(0, size - limit))
+            return stderr_file.read().decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+    finally:
+        _remove_claude_stderr_file(proc)
+
+
+def _remove_claude_stderr_file(proc: subprocess.Popen[str]) -> None:
+    stderr_path = _claude_stderr_path(proc)
+    if stderr_path is None:
+        return
+    try:
+        stderr_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _claude_stderr_path(proc: subprocess.Popen[str]) -> Path | None:
+    path = getattr(proc, "_claude_stderr_path", None)
+    if isinstance(path, Path):
+        return path
+    if isinstance(path, str):
+        return Path(path)
+    return None
 
 
 def _chown_recursive(path: Path, uid: int, gid: int) -> None:

--- a/apps/graphify-worker/src/claude_runner.py
+++ b/apps/graphify-worker/src/claude_runner.py
@@ -523,6 +523,7 @@ async def _run_stream_loop(
                     proc=proc,
                     session_id=session_id,
                 )
+            _log_and_remove_stderr(proc)
             return {
                 "status": "failed",
                 "state": RunState.FAILED.value,
@@ -558,6 +559,7 @@ async def _run_stream_loop(
         if event["type"] == "error":
             _request_terminate(proc)
             await _wait_for_process_exit(proc, 10)
+            _log_and_remove_stderr(proc)
             return {
                 "status": "failed",
                 "state": RunState.FAILED.value,
@@ -571,6 +573,7 @@ async def _run_stream_loop(
             if event.get("is_error"):
                 _request_terminate(proc)
                 await _wait_for_process_exit(proc, 10)
+                _log_and_remove_stderr(proc)
                 return {
                     "status": "failed",
                     "state": RunState.FAILED.value,
@@ -589,9 +592,7 @@ async def _run_stream_loop(
             )
             await _wait_for_process_exit(proc, 10)
             if result.get("status") != "success":
-                stderr_tail = _read_and_remove_claude_stderr_tail(proc)
-                if stderr_tail:
-                    _LOGGER.error("claude stderr: %s", stderr_tail)
+                _log_and_remove_stderr(proc)
             return result
 
         if state == RunState.FAILED:
@@ -611,6 +612,7 @@ async def _terminate_for_timeout(proc: subprocess.Popen[str]) -> dict[str, Any]:
     except TimeoutError:
         _request_kill(proc)
         await _wait_for_process_exit(proc, 10)
+    _log_and_remove_stderr(proc)
     return {
         "status": "failed",
         "state": RunState.FAILED.value,
@@ -685,6 +687,12 @@ def _read_stdout_line(proc: subprocess.Popen[str]) -> str:
     if proc.stdout is None:
         return ""
     return proc.stdout.readline()
+
+
+def _log_and_remove_stderr(proc: subprocess.Popen[str]) -> None:
+    stderr_tail = _read_and_remove_claude_stderr_tail(proc)
+    if stderr_tail:
+        _LOGGER.error("claude stderr: %s", stderr_tail)
 
 
 def _read_and_remove_claude_stderr_tail(

--- a/apps/graphify-worker/src/job_client.py
+++ b/apps/graphify-worker/src/job_client.py
@@ -161,10 +161,6 @@ async def _heartbeat_loop(
             await _send_worker_heartbeat(http_client, worker_id, [job_id])
         except Exception:
             logger.debug("worker heartbeat failed for %s", worker_id)
-        try:
-            await _report_progress(http_client, job_id, worker_id, -1, "running")
-        except Exception:
-            logger.debug("job progress failed for %s", job_id)
 
 
 async def _send_worker_heartbeat(

--- a/apps/graphify-worker/src/job_client.py
+++ b/apps/graphify-worker/src/job_client.py
@@ -45,20 +45,23 @@ async def poll_jobs(
         ) as http_client:
             while stop_event is None or not stop_event.is_set():
                 try:
-                    job = await _fetch_pending_job(http_client)
-                    if job is None:
+                    pending_jobs = await _fetch_pending_jobs(http_client)
+                    if not pending_jobs:
                         await _sleep(poll_interval, stop_event)
                         continue
 
-                    job_id = _job_id(job)
-                    if job_id is None:
-                        logger.warning("pending job missing id: %s", job)
-                        await _sleep(poll_interval, stop_event)
-                        continue
+                    job = None
+                    job_id = None
+                    for candidate in pending_jobs:
+                        cid = _job_id(candidate)
+                        if cid is None:
+                            continue
+                        if await acquire_lock(redis, cid, current_worker_id):
+                            job = candidate
+                            job_id = cid
+                            break
 
-                    # Redis coordinates duplicate local workers; the API progress
-                    # claim is the server-side ownership source of truth.
-                    if not await acquire_lock(redis, job_id, current_worker_id):
+                    if job is None or job_id is None:
                         await _sleep(poll_interval, stop_event)
                         continue
 
@@ -67,6 +70,9 @@ async def poll_jobs(
                         if not await _claim_job(http_client, job_id, current_worker_id):
                             claim_failed = True
                         else:
+                            heartbeat_task = asyncio.create_task(
+                                _heartbeat_loop(http_client, job_id, current_worker_id)
+                            )
                             try:
                                 result = await run(job)
                             except Exception as exc:
@@ -80,6 +86,12 @@ async def poll_jobs(
                                 await _complete_job(
                                     http_client, job_id, current_worker_id, result
                                 )
+                            finally:
+                                heartbeat_task.cancel()
+                                try:
+                                    await heartbeat_task
+                                except asyncio.CancelledError:
+                                    pass
                     finally:
                         await release_lock(redis, job_id, current_worker_id)
                     if claim_failed:
@@ -95,13 +107,13 @@ async def poll_jobs(
             await redis.aclose()
 
 
-async def _fetch_pending_job(http_client: httpx.AsyncClient) -> dict[str, Any] | None:
+async def _fetch_pending_jobs(http_client: httpx.AsyncClient) -> list[dict[str, Any]]:
     response = await http_client.get(
-        "/internal/jobs/pending", params={"type": "graphify"}
+        "/internal/jobs/pending", params={"type": "graphify", "limit": 5}
     )
     response.raise_for_status()
     payload = response.json()
-    return _parse_pending_job(payload)
+    return _parse_pending_jobs(payload)
 
 
 async def _claim_job(
@@ -116,6 +128,10 @@ async def _claim_job(
         )
         return False
 
+    try:
+        await _send_worker_heartbeat(http_client, worker_id, [job_id])
+    except Exception:
+        pass
     return True
 
 
@@ -129,6 +145,34 @@ async def _report_progress(
     response = await http_client.patch(
         f"/internal/jobs/{job_id}/progress",
         json={"worker_id": worker_id, "percent": percent, "stage": stage},
+    )
+    response.raise_for_status()
+
+
+HEARTBEAT_INTERVAL = 60
+
+
+async def _heartbeat_loop(
+    http_client: httpx.AsyncClient, job_id: str, worker_id: str
+) -> None:
+    while True:
+        await asyncio.sleep(HEARTBEAT_INTERVAL)
+        try:
+            await _send_worker_heartbeat(http_client, worker_id, [job_id])
+        except Exception:
+            logger.debug("worker heartbeat failed for %s", worker_id)
+        try:
+            await _report_progress(http_client, job_id, worker_id, -1, "running")
+        except Exception:
+            logger.debug("job progress failed for %s", job_id)
+
+
+async def _send_worker_heartbeat(
+    http_client: httpx.AsyncClient, worker_id: str, active_jobs: list[str]
+) -> None:
+    response = await http_client.post(
+        "/internal/workers/heartbeat",
+        json={"worker_id": worker_id, "active_jobs": active_jobs},
     )
     response.raise_for_status()
 
@@ -171,32 +215,29 @@ async def _sleep(poll_interval: float, stop_event: asyncio.Event | None) -> None
         return
 
 
-def _parse_pending_job(payload: Any) -> dict[str, Any] | None:
+def _parse_pending_jobs(payload: Any) -> list[dict[str, Any]]:
     if isinstance(payload, list):
-        first_job = payload[0] if payload else None
-        return first_job if isinstance(first_job, dict) else None
+        return [j for j in payload if isinstance(j, dict)]
 
     if not isinstance(payload, dict):
-        return None
+        return []
 
     data = payload.get("data")
     if isinstance(data, list):
-        first_job = data[0] if data else None
-        return first_job if isinstance(first_job, dict) else None
+        return [j for j in data if isinstance(j, dict)]
 
     job = payload.get("job")
     if isinstance(job, dict):
-        return job
+        return [job]
 
     jobs = payload.get("jobs")
     if isinstance(jobs, list):
-        first_job = jobs[0] if jobs else None
-        return first_job if isinstance(first_job, dict) else None
+        return [j for j in jobs if isinstance(j, dict)]
 
     if "id" in payload or "job_id" in payload:
-        return payload
+        return [payload]
 
-    return None
+    return []
 
 
 def _job_id(job: dict[str, Any]) -> str | None:

--- a/apps/graphify-worker/tests/test_claude_runner.py
+++ b/apps/graphify-worker/tests/test_claude_runner.py
@@ -150,14 +150,14 @@ def test_spawn_claude_uses_required_stream_json_args(
 
     args = captured["args"]
     assert args[:1] == ["claude"]
-    assert "--bare" in args
+    assert "--bare" not in args
     assert "-p" in args
     assert _arg_value(args, "--input-format") == "stream-json"
     assert _arg_value(args, "--output-format") == "stream-json"
     assert _arg_value(args, "--permission-mode") == "bypassPermissions"
     assert captured["kwargs"]["stdin"] is claude_runner.subprocess.PIPE
     assert captured["kwargs"]["stdout"] is claude_runner.subprocess.PIPE
-    assert captured["kwargs"]["stderr"] is claude_runner.subprocess.DEVNULL
+    assert captured["kwargs"]["stderr"] is claude_runner.subprocess.PIPE
     assert captured["kwargs"]["cwd"] == str(tmp_path / "session")
 
 

--- a/apps/graphify-worker/tests/test_claude_runner.py
+++ b/apps/graphify-worker/tests/test_claude_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import logging
 import sys
 import time
 from pathlib import Path
@@ -144,7 +145,7 @@ def test_spawn_claude_uses_required_stream_json_args(
 
     monkeypatch.setattr(claude_runner.subprocess, "Popen", FakePopen)
 
-    claude_runner.spawn_claude(
+    proc = claude_runner.spawn_claude(
         tmp_path / "session", tmp_path / ".claude", tmp_path / ".claude/settings.json"
     )
 
@@ -157,7 +158,15 @@ def test_spawn_claude_uses_required_stream_json_args(
     assert _arg_value(args, "--permission-mode") == "bypassPermissions"
     assert captured["kwargs"]["stdin"] is claude_runner.subprocess.PIPE
     assert captured["kwargs"]["stdout"] is claude_runner.subprocess.PIPE
-    assert captured["kwargs"]["stderr"] is claude_runner.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] is not claude_runner.subprocess.PIPE
+    assert (
+        Path(captured["kwargs"]["stderr"].name)
+        == tmp_path / "session" / "claude_stderr.log"
+    )
+    assert (
+        getattr(proc, "_claude_stderr_path")
+        == tmp_path / "session" / "claude_stderr.log"
+    )
     assert captured["kwargs"]["cwd"] == str(tmp_path / "session")
 
 
@@ -279,6 +288,24 @@ def test_idle_with_missing_output_and_waiting_fails_requires_interaction(
     assert result["reason"] == "requires_interaction"
     assert result["retryable"] is False
     assert proc.terminated is True
+
+
+def test_failed_result_logs_file_backed_stderr_tail(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    stderr_path = tmp_path / "claude_stderr.log"
+    stderr_path.write_text("x" * 5000 + "tail-message", encoding="utf-8")
+    proc = FakeProc(
+        stdout=LineStdout(['{"type":"result","result":{"is_error":false}}\n'])
+    )
+    setattr(proc, "_claude_stderr_path", stderr_path)
+    caplog.set_level(logging.ERROR, logger=claude_runner.__name__)
+
+    result = asyncio.run(claude_runner._run_stream_loop(proc, tmp_path, 1))
+
+    assert result["reason"] == "empty_output"
+    assert "tail-message" in caplog.text
+    assert not stderr_path.exists()
 
 
 def test_timeout_sends_sigterm_after_timeout(

--- a/apps/graphify-worker/tests/test_job_client.py
+++ b/apps/graphify-worker/tests/test_job_client.py
@@ -56,8 +56,8 @@ async def _assert_poll_jobs_claims_before_job_runs(
     events: list[tuple[str, str]] = []
     stop_event = asyncio.Event()
 
-    async def fetch_pending_job(_http_client: object) -> dict[str, str]:
-        return {"id": "job-1"}
+    async def fetch_pending_jobs(_http_client: object) -> list[dict[str, str]]:
+        return [{"id": "job-1"}]
 
     async def acquire(_redis_client: object, job_id: str, worker_id: str) -> bool:
         events.append(("acquire", f"{job_id}:{worker_id}"))
@@ -89,7 +89,7 @@ async def _assert_poll_jobs_claims_before_job_runs(
         events.append(("release", f"{job_id}:{worker_id}"))
         return True
 
-    monkeypatch.setattr(job_client, "_fetch_pending_job", fetch_pending_job)
+    monkeypatch.setattr(job_client, "_fetch_pending_jobs", fetch_pending_jobs)
     monkeypatch.setattr(job_client, "acquire_lock", acquire)
     monkeypatch.setattr(job_client, "_claim_job", claim_job)
     monkeypatch.setattr(job_client, "run", runner)
@@ -120,8 +120,8 @@ async def _assert_poll_jobs_skips_job_when_claim_fails(
     released_locks: list[tuple[str, str]] = []
     stop_event = asyncio.Event()
 
-    async def fetch_pending_job(_http_client: object) -> dict[str, str]:
-        return {"id": "job-1"}
+    async def fetch_pending_jobs(_http_client: object) -> list[dict[str, str]]:
+        return [{"id": "job-1"}]
 
     async def acquire(_redis_client: object, _job_id: str, _worker_id: str) -> bool:
         return True
@@ -151,7 +151,7 @@ async def _assert_poll_jobs_skips_job_when_claim_fails(
         released_locks.append((job_id, worker_id))
         return True
 
-    monkeypatch.setattr(job_client, "_fetch_pending_job", fetch_pending_job)
+    monkeypatch.setattr(job_client, "_fetch_pending_jobs", fetch_pending_jobs)
     monkeypatch.setattr(job_client, "acquire_lock", acquire)
     monkeypatch.setattr(job_client, "_claim_job", claim_job)
     monkeypatch.setattr(job_client, "run", runner)
@@ -176,8 +176,8 @@ async def _assert_poll_jobs_sleeps_after_lock_contention(
     sleep_calls: list[float] = []
     stop_event = asyncio.Event()
 
-    async def fetch_pending_job(_http_client: object) -> dict[str, str]:
-        return {"id": "job-1"}
+    async def fetch_pending_jobs(_http_client: object) -> list[dict[str, str]]:
+        return [{"id": "job-1"}]
 
     async def acquire(_redis_client: object, _job_id: str, _worker_id: str) -> bool:
         return False
@@ -187,7 +187,7 @@ async def _assert_poll_jobs_sleeps_after_lock_contention(
         assert event is stop_event
         stop_event.set()
 
-    monkeypatch.setattr(job_client, "_fetch_pending_job", fetch_pending_job)
+    monkeypatch.setattr(job_client, "_fetch_pending_jobs", fetch_pending_jobs)
     monkeypatch.setattr(job_client, "acquire_lock", acquire)
     monkeypatch.setattr(job_client, "_sleep", sleep)
 
@@ -209,8 +209,8 @@ async def _assert_poll_jobs_reports_runner_failure_and_releases_lock(
     released_locks: list[tuple[str, str]] = []
     stop_event = asyncio.Event()
 
-    async def fetch_pending_job(_http_client: object) -> dict[str, str]:
-        return {"id": "job-1"}
+    async def fetch_pending_jobs(_http_client: object) -> list[dict[str, str]]:
+        return [{"id": "job-1"}]
 
     async def acquire(_redis_client: object, _job_id: str, _worker_id: str) -> bool:
         return True
@@ -239,7 +239,7 @@ async def _assert_poll_jobs_reports_runner_failure_and_releases_lock(
         released_locks.append((job_id, worker_id))
         return True
 
-    monkeypatch.setattr(job_client, "_fetch_pending_job", fetch_pending_job)
+    monkeypatch.setattr(job_client, "_fetch_pending_jobs", fetch_pending_jobs)
     monkeypatch.setattr(job_client, "acquire_lock", acquire)
     monkeypatch.setattr(job_client, "_claim_job", claim_job)
     monkeypatch.setattr(job_client, "run", runner)
@@ -356,6 +356,7 @@ async def _assert_worker_id_consistency_across_status_requests() -> None:
         )
 
     assert [payload["worker_id"] for _path, payload in requests] == [
+        worker_id,
         worker_id,
         worker_id,
         worker_id,

--- a/apps/graphify-worker/tests/test_job_client.py
+++ b/apps/graphify-worker/tests/test_job_client.py
@@ -50,6 +50,14 @@ def test_worker_id_consistency_across_status_requests() -> None:
     asyncio.run(_assert_worker_id_consistency_across_status_requests())
 
 
+def test_heartbeat_loop_sends_worker_heartbeat_without_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(
+        _assert_heartbeat_loop_sends_worker_heartbeat_without_progress(monkeypatch)
+    )
+
+
 async def _assert_poll_jobs_claims_before_job_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -279,6 +287,37 @@ async def _assert_claim_job_returns_false_on_conflict() -> None:
             {"worker_id": "worker-1", "percent": 0, "stage": "claimed"},
         )
     ]
+
+
+async def _assert_heartbeat_loop_sends_worker_heartbeat_without_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, dict[str, Any]]] = []
+    heartbeat_sent = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(_captured_json_request(request))
+        if request.url.path == "/internal/workers/heartbeat":
+            heartbeat_sent.set()
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(job_client, "HEARTBEAT_INTERVAL", 0.01)
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        base_url="http://cherry-api.test", transport=transport
+    ) as client:
+        task = asyncio.create_task(
+            job_client._heartbeat_loop(client, "job-1", "worker-1")
+        )
+        await asyncio.wait_for(heartbeat_sent.wait(), timeout=1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert requests
+    assert all(path == "/internal/workers/heartbeat" for path, _body in requests)
 
 
 async def _assert_complete_job_sends_worker_result_dto() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,11 +305,11 @@ services:
       dockerfile: Dockerfile
       args:
         GRAPHIFY_REF: ${GRAPHIFY_REF:-58271fb5af4c0c123ddbad9c689ee1e220360be8}
-        CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-1.0.18}
+        CLAUDE_CODE_VERSION: ${CLAUDE_CODE_VERSION:-2.1.131}
     restart: unless-stopped
     working_dir: /app/apps/graphify-worker
     command: >-
-      sh -c "pip install -r requirements.txt --quiet && python -m src"
+      sh -c "chown -R 10001:10001 /work/graphify && pip install -r requirements.txt --quiet && python -m src"
     mem_limit: 4g
     cpus: 2.0
     environment:


### PR DESCRIPTION
## Summary

- **MIME 验证误拦截 .md 上传**：浏览器对 .md 文件发送 `application/octet-stream`，跳过该通用类型的 declared MIME 检查，由 magic bytes 兜底安全校验
- **rejected 文件重传卡死**：SHA256 去重命中 `security_rejected` 记录时直接返回旧记录，现在允许 `security_rejected → uploaded` 状态回退并重新入队验证
- **graphify Claude Code 版本/权限/skill 发现**：从 1.0.18 升级到 2.1.131，添加非 root 用户解决 bypassPermissions 限制，移除 `--bare` 恢复 skill 自动发现
- **graphify 第三方 skill 夹带 moonshot 推广**：安装后自动精确删除推广块，避免 deepseek 幻觉不存在的 API key
- **job 心跳机制不完整**：graphify-worker 只发 job progress 不发 worker heartbeat，导致死 worker 检测器 90 秒后误杀活跃 job；现在 claim 和执行期间都发 worker 心跳
- **locked job 阻塞队列**：worker 一次只请求 1 个 pending job，锁残留时后续 job 永远轮不到；改为请求 5 个并跳过被锁的
- **重试退避延迟**：去掉指数退避（60s-1800s），失败后立即可重试

## Changed files

| File | Change |
|---|---|
| `mime-validator.ts` | 跳过 `application/octet-stream` 的 declared MIME 检查 |
| `source-document-state.ts` | 允许 `security_rejected → uploaded` |
| `uploads.service.ts` | rejected 文件重传时重置状态并重新入队 |
| `graphify-worker/Dockerfile` | Claude Code 2.1.131 + 非 root 用户 |
| `claude_runner.py` | 去 `--bare`、非 root spawn、strip moonshot、stderr 捕获 |
| `job_client.py` | worker 心跳、多 job 轮询跳过锁、执行期间心跳循环 |
| `internal-jobs.service.ts` | 重试延迟归零 |
| `docker-compose.yml` | graphify Claude Code 版本对齐 + chown workdir |

## Test plan

- [ ] 上传 `.md` 文件不再被 MIME_MISMATCH 拦截
- [ ] 之前 rejected 的文件重新上传后进入验证流程并出现在列表中
- [ ] graphify job 拾取后保持 `running` 状态不被踢回 `pending`
- [ ] graphify 执行完成后 source_document 状态推进到 `wiki_proposed`
- [ ] 失败 job 重试时立即被拾取（无退避延迟）

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration & Security Reviewer, Independent Final Reviewer
- Reviewed head SHA: `edd4195d690616293851cd3ba593af3f07c0470a`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/224#issuecomment-4414771409) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/224#issuecomment-4414771446) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/224#issuecomment-4414771489) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/224#issuecomment-4414771541)
- Key findings addressed: Round 1 fixed validation job idempotency key for rejected re-uploads, Claude stderr deadlock risk (file-based), heartbeat invalid progress percent, log level exposure, rejection metadata cleanup. Round 2 clean. Independent review fixed stderr logging on all failure paths, added MIME octet-stream bypass tests, removed dead retry delay constant.