### PR TITLE
fix(chat): guard Enter key during IME composition

### DIFF
--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -172,6 +172,17 @@ describe('Message input IME composition handling', () => {
 
     expect(onSend).not.toHaveBeenCalled();
   });
+
+  it('does not submit when keyCode is 229 (Safari IME fallback)', () => {
+    const onSend = vi.fn<(message: string) => Promise<void>>().mockResolvedValue(undefined);
+    renderWithRouter(<MessageInput disabled={false} isStreaming={false} onSend={onSend} />);
+
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>('消息');
+    fireEvent.change(textarea, { target: { value: 'safari ime input' } });
+    fireTextareaKeyDown(textarea, { key: 'Enter', keyCode: 229, isComposing: false });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
 });
 
 describe('Phase 3 chat controls and stream events', () => {

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -126,6 +126,54 @@ describe('Message input', () => {
   });
 });
 
+describe('Message input IME composition handling', () => {
+  it('does not submit on Enter during IME composition', () => {
+    const onSend = vi.fn<(message: string) => Promise<void>>().mockResolvedValue(undefined);
+    renderWithRouter(<MessageInput disabled={false} isStreaming={false} onSend={onSend} />);
+
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>('消息');
+    fireEvent.change(textarea, { target: { value: 'pin' } });
+    fireTextareaKeyDown(textarea, { key: 'Enter', isComposing: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('submits normally on Enter after composition', async () => {
+    const onSend = vi.fn<(message: string) => Promise<void>>().mockResolvedValue(undefined);
+    renderWithRouter(<MessageInput disabled={false} isStreaming={false} onSend={onSend} />);
+
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>('消息');
+    fireEvent.change(textarea, { target: { value: '完成输入' } });
+    fireTextareaKeyDown(textarea, { key: 'Enter', isComposing: false });
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend).toHaveBeenCalledWith('完成输入', expect.any(Object));
+  });
+
+  it('does not submit on Shift+Enter regardless of composition state', () => {
+    const onSend = vi.fn<(message: string) => Promise<void>>().mockResolvedValue(undefined);
+    renderWithRouter(<MessageInput disabled={false} isStreaming={false} onSend={onSend} />);
+
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>('消息');
+    fireEvent.change(textarea, { target: { value: 'line one' } });
+    fireTextareaKeyDown(textarea, { key: 'Enter', shiftKey: true, isComposing: false });
+    fireTextareaKeyDown(textarea, { key: 'Enter', shiftKey: true, isComposing: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('does not submit on the Process key during composition', () => {
+    const onSend = vi.fn<(message: string) => Promise<void>>().mockResolvedValue(undefined);
+    renderWithRouter(<MessageInput disabled={false} isStreaming={false} onSend={onSend} />);
+
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>('消息');
+    fireEvent.change(textarea, { target: { value: 'process key input' } });
+    fireTextareaKeyDown(textarea, { key: 'Process' });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
 describe('Phase 3 chat controls and stream events', () => {
   it('sends enable_deep_analysis when the deep analysis toggle is on', async () => {
     const fetchState = stubChatFetch({
@@ -308,6 +356,10 @@ function renderChatRoute(): void {
 
 function renderWithRouter(element: ReactElement): void {
   render(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+function fireTextareaKeyDown(textarea: HTMLTextAreaElement, init: KeyboardEventInit): void {
+  fireEvent(textarea, new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
 }
 
 function buildMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -433,6 +433,10 @@ export function MessageInput({
         placeholder={isStreaming ? t('chat.streamingPlaceholder') : t('chat.inputPlaceholder')}
         onChange={(event) => setValue(event.target.value.slice(0, CHAT_INPUT_MAX_LENGTH))}
         onKeyDown={(event) => {
+          if (event.nativeEvent.isComposing || event.key === 'Process') {
+            return;
+          }
+
           if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
             void submit();

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -433,7 +433,7 @@ export function MessageInput({
         placeholder={isStreaming ? t('chat.streamingPlaceholder') : t('chat.inputPlaceholder')}
         onChange={(event) => setValue(event.target.value.slice(0, CHAT_INPUT_MAX_LENGTH))}
         onKeyDown={(event) => {
-          if (event.nativeEvent.isComposing || event.key === 'Process') {
+          if (event.nativeEvent.isComposing || event.key === 'Process' || event.nativeEvent.keyCode === 229) {
             return;
           }
 


### PR DESCRIPTION
Closes #226
Part of #225

## Summary
- Add `isComposing`, `Process` key, and `keyCode 229` guard to the chat textarea `onKeyDown` handler, preventing accidental message submission during IME composition
- Add 5 test cases covering composing Enter, post-composition Enter, Shift+Enter, Process key, and Safari keyCode 229 scenarios

## Changes
- `apps/web/src/pages/Chat.tsx` — early return when `event.nativeEvent.isComposing || event.key === 'Process' || event.nativeEvent.keyCode === 229`
- `apps/web/src/__tests__/chat.test.tsx` — new `describe('Message input IME composition handling')` with 5 tests + `fireTextareaKeyDown` helper

## Test plan
- [x] IME composition Enter does not submit
- [x] Normal Enter after composition submits
- [x] Shift+Enter newline unaffected
- [x] Process key does not submit
- [x] Safari keyCode 229 fallback does not submit
- [x] All 80 existing tests pass (zero regression)
- [x] ESLint clean, build passes

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `4fbfc98ff27c777cd201c6dc07ddf97156f13625`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/243#issuecomment-4415074250) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/243#issuecomment-4415074309) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/243#issuecomment-4415074372) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/243#issuecomment-4415074432)
- Key findings addressed: Round 1 correctness review identified missing keyCode 229 Safari IME fallback — fixed and verified in round 2 with zero findings