### PR TITLE
fix(admin): update health module labels for Postgres-backed stores

### DIFF
--- a/apps/api/src/admin/__tests__/admin-health.test.ts
+++ b/apps/api/src/admin/__tests__/admin-health.test.ts
@@ -1,14 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AdminHealthController } from '../admin-health.controller.js';
+import type { HealthComponent } from '../admin-health.controller.js';
 import type { StorageService } from '../../storage/storage.service.js';
 
 type DbQuery = ReturnType<typeof vi.fn<(queryText: string) => Promise<unknown>>>;
 type RedisPing = ReturnType<typeof vi.fn<() => Promise<unknown>>>;
 type StorageConfigured = ReturnType<typeof vi.fn<() => boolean>>;
-type StorageHealthCheck = ReturnType<
-  typeof vi.fn<() => Promise<{ status: 'healthy' | 'unhealthy'; latency_ms: number; error?: string }>>
->;
+type StorageHealthCheck = ReturnType<typeof vi.fn<() => Promise<HealthComponent>>>;
 
 describe('AdminHealthController', () => {
   afterEach(() => {
@@ -24,9 +23,20 @@ describe('AdminHealthController', () => {
     expect(result.components.database.status).toBe('healthy');
     expect(result.components.redis.status).toBe('healthy');
     expect(result.components.minio).toEqual({ status: 'healthy', latency_ms: 12 });
-    expect(result.components.vector_store.status).toBe('not_configured');
-    expect(result.components.graph_store.status).toBe('not_configured');
-    expect(result.components.docmost_bridge.status).toBe('not_configured');
+    expect(result.components.vector_store).toEqual({
+      status: 'healthy',
+      latency_ms: result.components.database.latency_ms,
+      details: expect.stringMatching(/Postgres/i),
+    });
+    expect(result.components.graph_store).toEqual({
+      status: 'healthy',
+      latency_ms: result.components.database.latency_ms,
+      details: expect.stringMatching(/Postgres/i),
+    });
+    expect(result.components.docmost_bridge).toEqual({
+      status: 'not_configured',
+      details: expect.stringMatching(/optional/i),
+    });
     expect(result.uptime).toBeGreaterThanOrEqual(1);
     expect(dbQuery).toHaveBeenCalledWith('select 1');
     expect(redisPing).toHaveBeenCalledTimes(1);
@@ -66,6 +76,26 @@ describe('AdminHealthController', () => {
     );
   });
 
+  it('marks Postgres-backed stores unhealthy when the database is unavailable', async () => {
+    const { controller } = createController({
+      dbQuery: vi.fn<(queryText: string) => Promise<unknown>>(() => Promise.reject(new Error('db down'))),
+    });
+
+    const result = await controller.getHealth();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.components.vector_store).toEqual({
+      status: 'unhealthy',
+      error: expect.stringMatching(/database/i),
+      details: expect.stringMatching(/Postgres/i),
+    });
+    expect(result.components.graph_store).toEqual({
+      status: 'unhealthy',
+      error: expect.stringMatching(/database/i),
+      details: expect.stringMatching(/Postgres/i),
+    });
+  });
+
   it('marks undeployed or absent components as not_configured', async () => {
     const { controller } = createController({ redisPing: undefined, storageConfigured: vi.fn(() => false) });
 
@@ -74,9 +104,32 @@ describe('AdminHealthController', () => {
     expect(result.status).toBe('healthy');
     expect(result.components.redis).toEqual({ status: 'not_configured' });
     expect(result.components.minio).toEqual({ status: 'not_configured' });
-    expect(result.components.vector_store).toEqual({ status: 'not_configured' });
-    expect(result.components.graph_store).toEqual({ status: 'not_configured' });
-    expect(result.components.docmost_bridge).toEqual({ status: 'not_configured' });
+    expect(result.components.vector_store).toEqual({
+      status: 'healthy',
+      latency_ms: result.components.database.latency_ms,
+      details: expect.stringMatching(/Postgres/i),
+    });
+    expect(result.components.graph_store).toEqual({
+      status: 'healthy',
+      latency_ms: result.components.database.latency_ms,
+      details: expect.stringMatching(/Postgres/i),
+    });
+    expect(result.components.docmost_bridge).toEqual({
+      status: 'not_configured',
+      details: expect.stringMatching(/optional/i),
+    });
+  });
+
+  it('keeps the optional docmost bridge neutral when it is not configured', async () => {
+    const { controller } = createController();
+
+    const result = await controller.getHealth();
+
+    expect(result.status).toBe('healthy');
+    expect(result.components.docmost_bridge).toEqual({
+      status: 'not_configured',
+      details: expect.stringMatching(/optional/i),
+    });
   });
 });
 

--- a/apps/api/src/admin/__tests__/admin-health.test.ts
+++ b/apps/api/src/admin/__tests__/admin-health.test.ts
@@ -26,16 +26,16 @@ describe('AdminHealthController', () => {
     expect(result.components.vector_store).toEqual({
       status: 'healthy',
       latency_ms: result.components.database.latency_ms,
-      details: expect.stringMatching(/Postgres/i),
+      details: expect.stringMatching(/Postgres/i) as unknown,
     });
     expect(result.components.graph_store).toEqual({
       status: 'healthy',
       latency_ms: result.components.database.latency_ms,
-      details: expect.stringMatching(/Postgres/i),
+      details: expect.stringMatching(/Postgres/i) as unknown,
     });
     expect(result.components.docmost_bridge).toEqual({
       status: 'not_configured',
-      details: expect.stringMatching(/optional/i),
+      details: expect.stringMatching(/optional/i) as unknown,
     });
     expect(result.uptime).toBeGreaterThanOrEqual(1);
     expect(dbQuery).toHaveBeenCalledWith('select 1');
@@ -86,13 +86,13 @@ describe('AdminHealthController', () => {
     expect(result.status).toBe('unhealthy');
     expect(result.components.vector_store).toEqual({
       status: 'unhealthy',
-      error: expect.stringMatching(/database/i),
-      details: expect.stringMatching(/Postgres/i),
+      error: expect.stringMatching(/database/i) as unknown,
+      details: expect.stringMatching(/Postgres/i) as unknown,
     });
     expect(result.components.graph_store).toEqual({
       status: 'unhealthy',
-      error: expect.stringMatching(/database/i),
-      details: expect.stringMatching(/Postgres/i),
+      error: expect.stringMatching(/database/i) as unknown,
+      details: expect.stringMatching(/Postgres/i) as unknown,
     });
   });
 
@@ -107,16 +107,16 @@ describe('AdminHealthController', () => {
     expect(result.components.vector_store).toEqual({
       status: 'healthy',
       latency_ms: result.components.database.latency_ms,
-      details: expect.stringMatching(/Postgres/i),
+      details: expect.stringMatching(/Postgres/i) as unknown,
     });
     expect(result.components.graph_store).toEqual({
       status: 'healthy',
       latency_ms: result.components.database.latency_ms,
-      details: expect.stringMatching(/Postgres/i),
+      details: expect.stringMatching(/Postgres/i) as unknown,
     });
     expect(result.components.docmost_bridge).toEqual({
       status: 'not_configured',
-      details: expect.stringMatching(/optional/i),
+      details: expect.stringMatching(/optional/i) as unknown,
     });
   });
 
@@ -128,7 +128,7 @@ describe('AdminHealthController', () => {
     expect(result.status).toBe('healthy');
     expect(result.components.docmost_bridge).toEqual({
       status: 'not_configured',
-      details: expect.stringMatching(/optional/i),
+      details: expect.stringMatching(/optional/i) as unknown,
     });
   });
 });

--- a/apps/api/src/admin/admin-health.controller.ts
+++ b/apps/api/src/admin/admin-health.controller.ts
@@ -23,6 +23,7 @@ export type HealthComponent = {
   status: ComponentStatus;
   latency_ms?: number;
   error?: string;
+  details?: string;
 };
 
 export type AdminSystemHealthResponse = {
@@ -47,9 +48,9 @@ export class AdminHealthController {
       database,
       redis,
       minio,
-      vector_store: { status: 'not_configured' },
-      graph_store: { status: 'not_configured' },
-      docmost_bridge: { status: 'not_configured' },
+      vector_store: postgresBackedComponent(database, 'Postgres-backed vector store'),
+      graph_store: postgresBackedComponent(database, 'Postgres-backed graph store'),
+      docmost_bridge: { status: 'not_configured', details: 'Optional integration' },
     };
 
     return {
@@ -107,11 +108,31 @@ function getOverallStatus(components: Record<ComponentName, HealthComponent>): H
     return 'unhealthy';
   }
 
-  const hasOptionalUnhealthy = Object.entries(components).some(
-    ([name, component]) => name !== 'database' && component.status === 'unhealthy',
-  );
+  const hasOptionalUnhealthy = Object.entries(components).some(([name, component]) => {
+    if (name === 'database' || component.status === 'not_configured') {
+      return false;
+    }
+
+    return component.status === 'unhealthy';
+  });
 
   return hasOptionalUnhealthy ? 'degraded' : 'healthy';
+}
+
+function postgresBackedComponent(database: HealthComponent, details: string): HealthComponent {
+  if (database.status === 'healthy') {
+    return {
+      status: 'healthy',
+      ...(database.latency_ms !== undefined ? { latency_ms: database.latency_ms } : {}),
+      details,
+    };
+  }
+
+  return {
+    status: 'unhealthy',
+    error: 'Depends on database health check',
+    details,
+  };
 }
 
 function elapsedMs(startedAt: number): number {

--- a/apps/web/src/__tests__/health-page.test.tsx
+++ b/apps/web/src/__tests__/health-page.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from '../i18n';
 import { AuthProvider, type AuthUser } from '../lib/auth';
+import type { SystemHealth } from '../lib/adminTypes';
 import HealthPage from '../pages/admin/HealthPage';
 
 const ADMIN_USER: AuthUser = {
@@ -39,6 +40,46 @@ describe('HealthPage', () => {
       expect(fetchMock).toHaveBeenCalled();
     });
   });
+
+  it('renders dependent stores as unhealthy when the database health check fails', async () => {
+    stubHealthApi({
+      status: 'unhealthy',
+      uptime: 42,
+      components: {
+        database: { status: 'unhealthy', error: 'db down' },
+        vector_store: {
+          status: 'unhealthy',
+          error: 'Depends on database health check',
+          details: 'Postgres-backed vector store',
+        },
+        graph_store: {
+          status: 'unhealthy',
+          error: 'Depends on database health check',
+          details: 'Postgres-backed graph store',
+        },
+        docmost_bridge: { status: 'not_configured', details: 'Optional integration' },
+      },
+    });
+
+    renderHealthRoute();
+
+    expect(await screen.findByRole('heading', { name: 'System Health' })).toBeInTheDocument();
+
+    const databaseCard = getComponentCard('Database');
+    expect(within(databaseCard).getByText('Unhealthy')).toBeInTheDocument();
+
+    const vectorStoreCard = getComponentCard('Vector Store');
+    expect(within(vectorStoreCard).getByText('Unhealthy')).toBeInTheDocument();
+    expect(vectorStoreCard).toHaveTextContent('Depends on database health check');
+    expect(vectorStoreCard).toHaveTextContent('Postgres-backed vector store');
+
+    const graphStoreCard = getComponentCard('Graph Store');
+    expect(within(graphStoreCard).getByText('Unhealthy')).toBeInTheDocument();
+    expect(graphStoreCard).toHaveTextContent('Depends on database health check');
+    expect(graphStoreCard).toHaveTextContent('Postgres-backed graph store');
+
+    expect(getComponentCard('Docmost Bridge')).toHaveTextContent('Optional integration');
+  });
 });
 
 function renderHealthRoute(): void {
@@ -53,23 +94,23 @@ function renderHealthRoute(): void {
   );
 }
 
-function stubHealthApi() {
+function stubHealthApi(health: SystemHealth = {
+  status: 'healthy',
+  uptime: 42,
+  components: {
+    database: { status: 'healthy', latency_ms: 5 },
+    redis: { status: 'healthy', latency_ms: 2 },
+    minio: { status: 'healthy', latency_ms: 12 },
+    vector_store: { status: 'healthy', latency_ms: 5, details: 'Postgres-backed vector store' },
+    graph_store: { status: 'healthy', latency_ms: 5, details: 'Postgres-backed graph store' },
+    docmost_bridge: { status: 'not_configured', details: 'Optional integration' },
+  },
+}) {
   const fetchMock = vi.fn<typeof fetch>((input) => {
     if (getRequestPath(input) === '/api/admin/system/health') {
       return Promise.resolve(
         jsonResponse({
-          data: {
-            status: 'healthy',
-            uptime: 42,
-            components: {
-              database: { status: 'healthy', latency_ms: 5 },
-              redis: { status: 'healthy', latency_ms: 2 },
-              minio: { status: 'healthy', latency_ms: 12 },
-              vector_store: { status: 'healthy', latency_ms: 5, details: 'Postgres-backed vector store' },
-              graph_store: { status: 'healthy', latency_ms: 5, details: 'Postgres-backed graph store' },
-              docmost_bridge: { status: 'not_configured', details: 'Optional integration' },
-            },
-          },
+          data: health,
         }),
       );
     }
@@ -98,4 +139,11 @@ function getRequestPath(input: RequestInfo | URL): string {
   }
 
   return input.url.split('?')[0] ?? '';
+}
+
+function getComponentCard(label: string): HTMLElement {
+  const title = screen.getByText(label);
+  const card = title.closest('.ant-card');
+  expect(card).not.toBeNull();
+  return card as HTMLElement;
 }

--- a/apps/web/src/__tests__/health-page.test.tsx
+++ b/apps/web/src/__tests__/health-page.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../i18n';
+import { AuthProvider, type AuthUser } from '../lib/auth';
+import HealthPage from '../pages/admin/HealthPage';
+
+const ADMIN_USER: AuthUser = {
+  id: 'user-admin',
+  email: 'admin@example.com',
+  name: 'Admin User',
+  role: 'admin',
+  groups: [],
+  spaces: [{ id: 'space-main', name: 'Main Space', role: 'admin' }],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('HealthPage', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders Postgres-backed and optional component details', async () => {
+    const fetchMock = stubHealthApi();
+
+    renderHealthRoute();
+
+    expect(await screen.findByRole('heading', { name: 'System Health' })).toBeInTheDocument();
+    expect(await screen.findByText('Postgres-backed vector store')).toBeInTheDocument();
+    expect(screen.getByText('Postgres-backed graph store')).toBeInTheDocument();
+    expect(screen.getByText('Optional integration')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+});
+
+function renderHealthRoute(): void {
+  render(
+    <MemoryRouter initialEntries={['/admin/health']}>
+      <AuthProvider initialSession={{ user: ADMIN_USER, accessToken: 'test-token' }}>
+        <Routes>
+          <Route path="/admin/health" element={<HealthPage />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+function stubHealthApi() {
+  const fetchMock = vi.fn<typeof fetch>((input) => {
+    if (getRequestPath(input) === '/api/admin/system/health') {
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            status: 'healthy',
+            uptime: 42,
+            components: {
+              database: { status: 'healthy', latency_ms: 5 },
+              redis: { status: 'healthy', latency_ms: 2 },
+              minio: { status: 'healthy', latency_ms: 12 },
+              vector_store: { status: 'healthy', latency_ms: 5, details: 'Postgres-backed vector store' },
+              graph_store: { status: 'healthy', latency_ms: 5, details: 'Postgres-backed graph store' },
+              docmost_bridge: { status: 'not_configured', details: 'Optional integration' },
+            },
+          },
+        }),
+      );
+    }
+
+    return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function getRequestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input.split('?')[0] ?? '';
+  }
+
+  if (input instanceof URL) {
+    return input.pathname;
+  }
+
+  return input.url.split('?')[0] ?? '';
+}

--- a/apps/web/src/lib/adminTypes.ts
+++ b/apps/web/src/lib/adminTypes.ts
@@ -107,6 +107,7 @@ export type HealthComponent = {
   status: HealthComponentStatus;
   latency_ms?: number;
   error?: string;
+  details?: string;
 };
 
 export type SystemHealth = {

--- a/apps/web/src/pages/admin/HealthPage.tsx
+++ b/apps/web/src/pages/admin/HealthPage.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { requireAdminPage } from '../../components/RequireAdminPage';
 import { api } from '../../lib/api';
 import { formatLabel, getErrorMessage } from '../../components/adminUi';
-import { type SystemHealth } from '../../lib/adminTypes';
+import { type HealthComponent, type SystemHealth } from '../../lib/adminTypes';
 import { message } from 'antd';
 
 const REFRESH_INTERVAL_MS = 30_000;
@@ -103,7 +103,10 @@ function HealthPage() {
                   <div>
                     <Typography.Text type="secondary">{t('admin.health.component.details')}: </Typography.Text>
                     <Typography.Text>
-                      {component.error ?? (component.status === 'not_configured' ? t('common.state.notConfigured') : t('common.state.operational'))}
+                      {formatComponentDetails(component, {
+                        notConfigured: t('common.state.notConfigured'),
+                        operational: t('common.state.operational'),
+                      })}
                     </Typography.Text>
                   </div>
                 </Space>
@@ -126,4 +129,19 @@ function formatUptime(seconds: number): string {
   if (hours > 0) return `${hours}h ${minutes}m`;
   if (minutes > 0) return `${minutes}m ${remainingSeconds}s`;
   return `${remainingSeconds}s`;
+}
+
+function formatComponentDetails(
+  component: HealthComponent,
+  fallback: { notConfigured: string; operational: string },
+): string {
+  const details = [component.error, component.details]
+    .filter((value): value is string => value !== undefined && value.trim().length > 0)
+    .join(' - ');
+
+  if (details.length > 0) {
+    return details;
+  }
+
+  return component.status === 'not_configured' ? fallback.notConfigured : fallback.operational;
 }


### PR DESCRIPTION
Closes #228
Part of #225

## Summary
- Derive `vector_store` and `graph_store` health status from the database check instead of hardcoding `not_configured`
- Mark `docmost_bridge` as optional integration with details field
- Add `details` field to `HealthComponent` type and render it on the health page
- 6 backend tests + 2 frontend tests covering all spec scenarios

## Changes
- `apps/api/src/admin/admin-health.controller.ts` — `postgresBackedComponent()` helper, `getOverallStatus` skips `not_configured`
- `apps/api/src/admin/__tests__/admin-health.test.ts` — 6 tests covering healthy/unhealthy/optional scenarios
- `apps/web/src/lib/adminTypes.ts` — `details?: string` on `HealthComponent`
- `apps/web/src/pages/admin/HealthPage.tsx` — `formatComponentDetails()` function
- `apps/web/src/__tests__/health-page.test.tsx` — 2 UI tests for healthy and unhealthy rendering

## Test plan
- [x] Vector/graph store healthy when DB healthy
- [x] Vector/graph store unhealthy when DB unhealthy
- [x] Docmost bridge not_configured does not degrade overall health
- [x] Details field renders on health page (healthy + unhealthy scenarios)
- [x] All 1082 tests pass (zero regression)
- [x] ESLint clean, build passes

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `25230f77da7b86e715c8a421a0c565cb9d900a74`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/244#issuecomment-4415126585) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/244#issuecomment-4415126683) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/244#issuecomment-4415126739) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/244#issuecomment-4415126797)
- Key findings addressed: Round 1 spec compliance review identified missing UI test for database failure scenario — fixed; lint type safety for expect.stringMatching fixed