### PR TITLE
feat(admin): replace space ID text input with dropdown in Jobs page

### DIFF
--- a/apps/web/src/__tests__/jobs-page.test.tsx
+++ b/apps/web/src/__tests__/jobs-page.test.tsx
@@ -43,10 +43,71 @@ describe('JobsPage', () => {
     renderJobsRoute('/admin/jobs');
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalled();
-      expect(getRequestUrl(fetchMock.mock.calls[0]?.[0] ?? '')).toContain(
-        '/api/admin/jobs?page=1&per_page=20&sort=-created_at',
-      );
+      expect(getRequestUrls(fetchMock)).toContain('/api/admin/jobs?page=1&per_page=20&sort=-created_at');
+    });
+  });
+
+  it('loads space options in the dropdown', async () => {
+    const fetchMock = stubJobApi();
+
+    renderJobsRoute('/admin/jobs');
+
+    await waitFor(() => {
+      expect(getRequestUrls(fetchMock)).toContain('/api/spaces?per_page=100&sort=name');
+    });
+    await openSpaceSelect();
+
+    expect(await screen.findByText('Main Space')).toBeInTheDocument();
+  });
+
+  it('selecting a space filters jobs', async () => {
+    const fetchMock = stubJobApi();
+
+    renderJobsRoute('/admin/jobs');
+
+    await selectSpaceOption('Main Space');
+
+    await waitFor(() => {
+      expect(getAdminJobRequestUrls(fetchMock).some((url) => getQueryParam(url, 'space_id') === 'space-main')).toBe(true);
+    });
+  });
+
+  it('clearing a space removes the filter', async () => {
+    const fetchMock = stubJobApi();
+
+    renderJobsRoute('/admin/jobs');
+
+    await selectSpaceOption('Main Space');
+
+    await waitFor(() => {
+      expect(getAdminJobRequestUrls(fetchMock).some((url) => getQueryParam(url, 'space_id') === 'space-main')).toBe(true);
+    });
+
+    const requestCountAfterSelect = getAdminJobRequestUrls(fetchMock).length;
+    const clearButton = getSpaceSelectContainer().querySelector<HTMLElement>('.ant-select-clear');
+    expect(clearButton).not.toBeNull();
+    fireEvent.mouseDown(clearButton!);
+    fireEvent.click(clearButton!);
+
+    await waitFor(() => {
+      expect(
+        getAdminJobRequestUrls(fetchMock)
+          .slice(requestCountAfterSelect)
+          .some((url) => !getQueryParams(url).has('space_id')),
+      ).toBe(true);
+    });
+  });
+
+  it('keeps the jobs table usable when space options fail to load', async () => {
+    const fetchMock = stubJobApi({ failSpaces: true });
+
+    renderJobsRoute('/admin/jobs');
+
+    expect(await screen.findByText('job-1')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(getSpaceSelectContainer()).toHaveClass('ant-select-status-error');
+      expect(getAdminJobRequestUrls(fetchMock).length).toBeGreaterThan(0);
     });
   });
 });
@@ -108,11 +169,31 @@ function renderJobsRoute(path: string): void {
   );
 }
 
-function stubJobApi() {
+function stubJobApi(options: { failSpaces?: boolean } = {}) {
   let cancelRequestedAt: string | null = null;
 
   const fetchMock = vi.fn<typeof fetch>((input, init) => {
     const path = getRequestPath(input);
+
+    if (path === '/api/spaces') {
+      if (options.failSpaces === true) {
+        return Promise.resolve(jsonResponse({ error: { code: 'SPACES_UNAVAILABLE', message: 'Spaces unavailable' } }, 500));
+      }
+
+      return Promise.resolve(
+        jsonResponse({
+          data: [{ id: 'space-main', name: 'Main Space' }],
+          meta: {
+            pagination: {
+              page: 1,
+              per_page: 100,
+              total: 1,
+              has_next: false,
+            },
+          },
+        }),
+      );
+    }
 
     if (path === '/api/admin/jobs') {
       return Promise.resolve(
@@ -188,6 +269,44 @@ function stubJobApi() {
   return fetchMock;
 }
 
+async function openSpaceSelect(): Promise<void> {
+  const combobox = await findSpaceCombobox();
+  fireEvent.mouseDown(combobox);
+}
+
+async function selectSpaceOption(name: string): Promise<void> {
+  await openSpaceSelect();
+  fireEvent.click(await screen.findByText(name));
+}
+
+function getSpaceSelectContainer(): HTMLElement {
+  const combobox = getSpaceCombobox();
+  const container = combobox.closest('.ant-select');
+  if (container === null) {
+    throw new Error('Space Select container was not found');
+  }
+  return container as HTMLElement;
+}
+
+async function findSpaceCombobox(): Promise<HTMLElement> {
+  const labelledElements = await screen.findAllByLabelText('空间');
+  const combobox = labelledElements.find((element) => element.getAttribute('role') === 'combobox');
+  if (combobox === undefined) {
+    throw new Error('Space Select combobox was not found');
+  }
+  return combobox;
+}
+
+function getSpaceCombobox(): HTMLElement {
+  const combobox = screen
+    .getAllByLabelText('空间')
+    .find((element) => element.getAttribute('role') === 'combobox');
+  if (combobox === undefined) {
+    throw new Error('Space Select combobox was not found');
+  }
+  return combobox;
+}
+
 function buildJob(cancelRequestedAt: string | null = null) {
   return {
     job_id: 'job-1',
@@ -234,4 +353,20 @@ function getRequestUrl(input: RequestInfo | URL): string {
   }
 
   return input.url;
+}
+
+function getRequestUrls(fetchMock: ReturnType<typeof stubJobApi>): string[] {
+  return fetchMock.mock.calls.map(([input]) => getRequestUrl(input));
+}
+
+function getAdminJobRequestUrls(fetchMock: ReturnType<typeof stubJobApi>): string[] {
+  return getRequestUrls(fetchMock).filter((url) => getRequestPath(url) === '/api/admin/jobs');
+}
+
+function getQueryParam(url: string, key: string): string | null {
+  return getQueryParams(url).get(key);
+}
+
+function getQueryParams(url: string): URLSearchParams {
+  return new URLSearchParams(url.split('?')[1] ?? '');
 }

--- a/apps/web/src/__tests__/jobs-page.test.tsx
+++ b/apps/web/src/__tests__/jobs-page.test.tsx
@@ -60,6 +60,20 @@ describe('JobsPage', () => {
     expect(await screen.findByText('Main Space')).toBeInTheDocument();
   });
 
+  it('stops showing the space filter loading indicator when the spaces list is empty', async () => {
+    const fetchMock = stubJobApi({ spaces: [] });
+
+    renderJobsRoute('/admin/jobs');
+
+    await waitFor(() => {
+      expect(getRequestUrls(fetchMock)).toContain('/api/spaces?per_page=100&sort=name');
+    });
+
+    await waitFor(() => {
+      expect(getSpaceSelectContainer().querySelector('.anticon-loading')).not.toBeInTheDocument();
+    });
+  });
+
   it('selecting a space filters jobs', async () => {
     const fetchMock = stubJobApi();
 
@@ -169,8 +183,9 @@ function renderJobsRoute(path: string): void {
   );
 }
 
-function stubJobApi(options: { failSpaces?: boolean } = {}) {
+function stubJobApi(options: { failSpaces?: boolean; spaces?: { id: string; name: string }[] } = {}) {
   let cancelRequestedAt: string | null = null;
+  const spaces = options.spaces ?? [{ id: 'space-main', name: 'Main Space' }];
 
   const fetchMock = vi.fn<typeof fetch>((input, init) => {
     const path = getRequestPath(input);
@@ -182,12 +197,12 @@ function stubJobApi(options: { failSpaces?: boolean } = {}) {
 
       return Promise.resolve(
         jsonResponse({
-          data: [{ id: 'space-main', name: 'Main Space' }],
+          data: spaces,
           meta: {
             pagination: {
               page: 1,
               per_page: 100,
-              total: 1,
+              total: spaces.length,
               has_next: false,
             },
           },

--- a/apps/web/src/pages/admin/JobsPage.tsx
+++ b/apps/web/src/pages/admin/JobsPage.tsx
@@ -39,6 +39,7 @@ function JobsPage() {
   const [status, setStatus] = useState('');
   const [spaceId, setSpaceId] = useState('');
   const [spaces, setSpaces] = useState<{ id: string; name: string }[]>([]);
+  const [spacesLoaded, setSpacesLoaded] = useState(false);
   const [spacesError, setSpacesError] = useState(false);
   const [page, setPage] = useState(DEFAULT_PAGINATION.page);
   const [perPage, setPerPage] = useState(DEFAULT_PAGINATION.per_page);
@@ -88,6 +89,7 @@ function JobsPage() {
           sort: 'name',
         });
         setSpaces(response.data);
+        setSpacesLoaded(true);
         setSpacesError(false);
       } catch (err) {
         setSpacesError(true);
@@ -211,7 +213,7 @@ function JobsPage() {
           showSearch
           optionFilterProp="label"
           style={{ width: 200 }}
-          loading={spaces.length === 0 && !spacesError}
+          loading={!spacesLoaded && !spacesError}
           {...(spacesError ? { status: 'error' as const } : {})}
           options={spaces.map((space) => ({ value: space.id, label: space.name }))}
         />

--- a/apps/web/src/pages/admin/JobsPage.tsx
+++ b/apps/web/src/pages/admin/JobsPage.tsx
@@ -1,7 +1,7 @@
 import { ReloadOutlined } from '@ant-design/icons';
-import { Button, Input, Progress, Select, Space, Table, Tag, Typography, message } from 'antd';
+import { Button, Progress, Select, Space, Table, Tag, Typography, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { useCallback, useDeferredValue, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { requireAdminPage } from '../../components/RequireAdminPage';
@@ -38,7 +38,8 @@ function JobsPage() {
   const [type, setType] = useState('');
   const [status, setStatus] = useState('');
   const [spaceId, setSpaceId] = useState('');
-  const deferredSpaceId = useDeferredValue(spaceId);
+  const [spaces, setSpaces] = useState<{ id: string; name: string }[]>([]);
+  const [spacesError, setSpacesError] = useState(false);
   const [page, setPage] = useState(DEFAULT_PAGINATION.page);
   const [perPage, setPerPage] = useState(DEFAULT_PAGINATION.per_page);
   const [pagination, setPagination] = useState(DEFAULT_PAGINATION);
@@ -52,7 +53,7 @@ function JobsPage() {
         const response = await api.getWrapped<AdminJob[]>('/admin/jobs', {
           type,
           status,
-          space_id: deferredSpaceId,
+          space_id: spaceId,
           page,
           per_page: perPage,
           sort: '-created_at',
@@ -72,12 +73,30 @@ function JobsPage() {
         if (!background) setIsLoading(false);
       }
     },
-    [deferredSpaceId, page, perPage, status, type],
+    [page, perPage, spaceId, status, type],
   );
 
   useEffect(() => {
     void loadJobs();
   }, [loadJobs]);
+
+  useEffect(() => {
+    async function loadSpaces() {
+      try {
+        const response = await api.getWrapped<{ id: string; name: string }[]>('/spaces', {
+          per_page: 100,
+          sort: 'name',
+        });
+        setSpaces(response.data);
+        setSpacesError(false);
+      } catch (err) {
+        setSpacesError(true);
+        void message.error(getErrorMessage(err));
+      }
+    }
+
+    void loadSpaces();
+  }, []);
 
   const shouldPoll = status === 'running' || jobs.some((job) => job.status === 'running');
 
@@ -183,12 +202,18 @@ function JobsPage() {
             <Select.Option key={jobStatus} value={jobStatus}>{formatLabel(jobStatus)}</Select.Option>
           ))}
         </Select>
-        <Input.Search
+        <Select
+          aria-label={t('admin.jobs.filter.space')}
           placeholder={t('admin.jobs.filter.spacePlaceholder')}
-          value={spaceId}
-          onChange={(e) => { setSpaceId(e.target.value); setPage(1); }}
+          value={spaceId || undefined}
+          onChange={(val) => { setSpaceId(val ?? ''); setPage(1); }}
           allowClear
+          showSearch
+          optionFilterProp="label"
           style={{ width: 200 }}
+          loading={spaces.length === 0 && !spacesError}
+          {...(spacesError ? { status: 'error' as const } : {})}
+          options={spaces.map((space) => ({ value: space.id, label: space.name }))}
         />
       </Space>
 


### PR DESCRIPTION
Closes #227
Part of #225

## Summary
- Replace raw `Input.Search` space filter with a searchable antd `Select` dropdown populated from `GET /spaces?per_page=100&sort=name`
- Space names shown as labels, IDs used as filter values
- Selecting/clearing resets pagination to page 1
- Graceful error handling when spaces load fails
- Explicit `spacesLoaded` state prevents permanent loading on empty responses

## Changes
- `apps/web/src/pages/admin/JobsPage.tsx` — `Select` dropdown with `showSearch`, spaces loading effect, `spacesLoaded` state
- `apps/web/src/__tests__/jobs-page.test.tsx` — 5 new tests for option loading, empty response, selecting, clearing, and failure

## Test plan
- [x] Space dropdown loads and displays space names
- [x] Empty spaces response shows empty dropdown (no permanent loading)
- [x] Selecting a space filters jobs with correct space_id
- [x] Clearing the filter removes space_id from request
- [x] Spaces load failure shows error, jobs table remains usable
- [x] All 88 web tests pass (zero regression)
- [x] ESLint clean, build passes

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `a684118e376847190e3f729fc6d8b6233190ea90`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/245#issuecomment-4415190640) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/245#issuecomment-4415190685) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/245#issuecomment-4415190749) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/245#issuecomment-4415190811)
- Key findings addressed: Round 1 correctness review identified empty-spaces permanent loading state — fixed with explicit spacesLoaded boolean