### PR TITLE
feat(admin): show human-readable names instead of UUIDs

### DIFF
--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -23,6 +23,8 @@ import { getApiLogger } from '../common/logger/logger.module.js';
 import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { GraphifyService } from '../graphify/graphify.service.js';
+import { deriveDisplayName } from '../jobs/jobs.service.js';
+import type { JobDto, JobProgressDto } from '../jobs/jobs.dto.js';
 import { UploadsService } from '../uploads/uploads.service.js';
 import type {
   JobCompletionDto,
@@ -32,7 +34,6 @@ import type {
   WorkerHeartbeatDto,
   WorkerHeartbeatResponseDto,
 } from './internal.dto.js';
-import type { JobDto, JobProgressDto } from '../jobs/jobs.dto.js';
 
 type JobsDatabase = NodePgDatabase;
 type InternalRedisClient = {
@@ -789,6 +790,7 @@ function toJobDto(job: JobRow, progress: JobProgressDto | null = null): JobDto {
     job_id: job.id,
     tenant_id: job.tenant_id,
     type: job.type,
+    display_name: deriveDisplayName(job),
     status: job.status,
     space_id: job.space_id,
     progress,

--- a/apps/api/src/jobs/__tests__/jobs.service.test.ts
+++ b/apps/api/src/jobs/__tests__/jobs.service.test.ts
@@ -12,7 +12,7 @@ import {
   requireRecord,
 } from '../../users/__tests__/user-group-service-test-utils.js';
 import { AdminJobListQueryDto, JobEventsQueryDto } from '../jobs.dto.js';
-import { JobsService, type JobContext } from '../jobs.service.js';
+import { JobsService, deriveDisplayName, type JobContext } from '../jobs.service.js';
 
 describe('JobsService', () => {
   afterEach(() => {
@@ -325,6 +325,22 @@ describe('JobsService', () => {
       total: 1,
       has_next: false,
     });
+  });
+});
+
+describe('deriveDisplayName', () => {
+  it('uses a payload filename', () => {
+    expect(deriveDisplayName(createJobRow({ payload_json: { filename: ' readme.md ' } }))).toBe('readme.md');
+  });
+
+  it('uses a result title when payload has no display metadata', () => {
+    expect(deriveDisplayName(createJobRow({ payload_json: {}, result_json: { title: 'Graph Report' } }))).toBe(
+      'Graph Report',
+    );
+  });
+
+  it('returns null when no display metadata is available', () => {
+    expect(deriveDisplayName(createJobRow())).toBeNull();
   });
 });
 

--- a/apps/api/src/jobs/__tests__/jobs.service.test.ts
+++ b/apps/api/src/jobs/__tests__/jobs.service.test.ts
@@ -339,6 +339,17 @@ describe('deriveDisplayName', () => {
     );
   });
 
+  it('uses a result metadata filename when top-level fields are unavailable', () => {
+    expect(
+      deriveDisplayName(
+        createJobRow({
+          payload_json: { source_document_id: 'doc-1' },
+          result_json: { metadata: { filename: 'report.pdf', original_filename: 'report.pdf' } },
+        }),
+      ),
+    ).toBe('report.pdf');
+  });
+
   it('returns null when no display metadata is available', () => {
     expect(deriveDisplayName(createJobRow())).toBeNull();
   });

--- a/apps/api/src/jobs/jobs.dto.ts
+++ b/apps/api/src/jobs/jobs.dto.ts
@@ -48,6 +48,7 @@ export class JobDto {
   job_id!: string;
   tenant_id!: string;
   type!: string;
+  display_name!: string | null;
   status!: string;
   space_id!: string | null;
   progress!: JobProgressDto | null;

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -427,11 +427,52 @@ function isJobSortField(field: string): field is JobSortField {
   return JOB_SORT_FIELD_SET.has(field);
 }
 
+export function deriveDisplayName(job: JobRow): string | null {
+  const candidates = [job.payload_json, job.result_json];
+  const primaryFields = ['display_name', 'name', 'title', 'filename', 'file_name'];
+  const fallbackFields = ['source_document_filename', 'original_filename'];
+
+  for (const source of candidates) {
+    for (const field of primaryFields) {
+      const value = readDisplayNameField(source, field);
+      if (value !== null) {
+        return value;
+      }
+    }
+  }
+
+  for (const source of candidates) {
+    for (const field of fallbackFields) {
+      const value = readDisplayNameField(source, field);
+      if (value !== null) {
+        return value;
+      }
+    }
+  }
+
+  return null;
+}
+
+function readDisplayNameField(source: unknown, field: string): string | null {
+  if (typeof source !== 'object' || source === null) {
+    return null;
+  }
+
+  const value = (source as Record<string, unknown>)[field];
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 function toJobDto(job: JobRow, progress: JobProgressDto | null): JobDto {
   return {
     job_id: job.id,
     tenant_id: job.tenant_id,
     type: job.type,
+    display_name: deriveDisplayName(job),
     status: job.status,
     space_id: job.space_id,
     progress,

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -429,23 +429,36 @@ function isJobSortField(field: string): field is JobSortField {
 
 export function deriveDisplayName(job: JobRow): string | null {
   const candidates = [job.payload_json, job.result_json];
-  const primaryFields = ['display_name', 'name', 'title', 'filename', 'file_name'];
-  const fallbackFields = ['source_document_filename', 'original_filename'];
+  const fields = [
+    'display_name',
+    'name',
+    'title',
+    'filename',
+    'file_name',
+    'source_document_filename',
+    'original_filename',
+  ];
 
   for (const source of candidates) {
-    for (const field of primaryFields) {
-      const value = readDisplayNameField(source, field);
+    if (typeof source !== 'object' || source === null) {
+      continue;
+    }
+
+    const record = source as Record<string, unknown>;
+    for (const field of fields) {
+      const value = readDisplayNameValue(record[field]);
       if (value !== null) {
         return value;
       }
     }
-  }
 
-  for (const source of candidates) {
-    for (const field of fallbackFields) {
-      const value = readDisplayNameField(source, field);
-      if (value !== null) {
-        return value;
+    if (typeof record.metadata === 'object' && record.metadata !== null) {
+      const metadata = record.metadata as Record<string, unknown>;
+      for (const field of fields) {
+        const value = readDisplayNameValue(metadata[field]);
+        if (value !== null) {
+          return value;
+        }
       }
     }
   }
@@ -453,12 +466,7 @@ export function deriveDisplayName(job: JobRow): string | null {
   return null;
 }
 
-function readDisplayNameField(source: unknown, field: string): string | null {
-  if (typeof source !== 'object' || source === null) {
-    return null;
-  }
-
-  const value = (source as Record<string, unknown>)[field];
+function readDisplayNameValue(value: unknown): string | null {
   if (typeof value !== 'string') {
     return null;
   }

--- a/apps/web/src/__tests__/jobs-page.test.tsx
+++ b/apps/web/src/__tests__/jobs-page.test.tsx
@@ -175,11 +175,12 @@ describe('JobDetailPage', () => {
   });
 
   it('renders job details and the event timeline', async () => {
-    stubJobApi();
+    stubJobApi({ job: { display_name: 'readme.md' } });
 
     renderJobsRoute('/admin/jobs/job-1');
 
     expect(await screen.findByRole('heading', { name: '任务详情' })).toBeInTheDocument();
+    expect(await screen.findByText('readme.md')).toBeInTheDocument();
     expect(await screen.findByText('space-main')).toBeInTheDocument();
     expect(screen.getAllByText('Graphify').length).toBeGreaterThan(0);
     expect(screen.getByText('Progress Updated')).toBeInTheDocument();

--- a/apps/web/src/__tests__/jobs-page.test.tsx
+++ b/apps/web/src/__tests__/jobs-page.test.tsx
@@ -17,6 +17,30 @@ const ADMIN_USER: AuthUser = {
   spaces: [{ id: 'space-main', name: 'Main Space', role: 'admin' }],
 };
 
+type JobStub = {
+  job_id: string;
+  type: string;
+  display_name: string | null;
+  status: string;
+  space_id: string;
+  progress: {
+    percent: number;
+    stage: string;
+  };
+  created_by: string;
+  payload_json: {
+    source_id: string;
+  };
+  result_json: null;
+  error_json: null;
+  cancel_requested_at: string | null;
+  attempt_count: number;
+  max_attempts: number;
+  created_at: string;
+  started_at: string;
+  completed_at: string | null;
+};
+
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
@@ -33,8 +57,27 @@ describe('JobsPage', () => {
     renderJobsRoute('/admin/jobs');
 
     expect(await screen.findByRole('heading', { name: '任务中心' })).toBeInTheDocument();
-    expect(await screen.findByText('job-1')).toBeInTheDocument();
+    expect(await screen.findByText('readme.md')).toBeInTheDocument();
+    expect(await screen.findByText('Graphify · job-1')).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('shows display_name as primary label when available', async () => {
+    stubJobApi();
+
+    renderJobsRoute('/admin/jobs');
+
+    expect(await screen.findByText('readme.md')).toBeInTheDocument();
+    expect(screen.getByText('Graphify · job-1')).toBeInTheDocument();
+  });
+
+  it('falls back to type label when display_name is null', async () => {
+    stubJobApi({ job: { display_name: null } });
+
+    renderJobsRoute('/admin/jobs');
+
+    expect(await screen.findByText('Graphify')).toBeInTheDocument();
+    expect(screen.getByText('job-1')).toBeInTheDocument();
   });
 
   it('fetches the jobs list from /api/admin/jobs', async () => {
@@ -117,7 +160,7 @@ describe('JobsPage', () => {
 
     renderJobsRoute('/admin/jobs');
 
-    expect(await screen.findByText('job-1')).toBeInTheDocument();
+    expect(await screen.findByText('readme.md')).toBeInTheDocument();
 
     await waitFor(() => {
       expect(getSpaceSelectContainer()).toHaveClass('ant-select-status-error');
@@ -183,7 +226,13 @@ function renderJobsRoute(path: string): void {
   );
 }
 
-function stubJobApi(options: { failSpaces?: boolean; spaces?: { id: string; name: string }[] } = {}) {
+function stubJobApi(
+  options: {
+    failSpaces?: boolean;
+    spaces?: { id: string; name: string }[];
+    job?: Partial<JobStub>;
+  } = {},
+) {
   let cancelRequestedAt: string | null = null;
   const spaces = options.spaces ?? [{ id: 'space-main', name: 'Main Space' }];
 
@@ -213,7 +262,7 @@ function stubJobApi(options: { failSpaces?: boolean; spaces?: { id: string; name
     if (path === '/api/admin/jobs') {
       return Promise.resolve(
         jsonResponse({
-          data: [buildJob(cancelRequestedAt)],
+          data: [buildJob(cancelRequestedAt, options.job)],
           meta: {
             request_id: 'req-admin-jobs',
             pagination: {
@@ -230,7 +279,7 @@ function stubJobApi(options: { failSpaces?: boolean; spaces?: { id: string; name
     if (path === '/api/jobs/job-1' && init?.method !== 'POST') {
       return Promise.resolve(
         jsonResponse({
-          data: buildJob(cancelRequestedAt),
+          data: buildJob(cancelRequestedAt, options.job),
           meta: { request_id: 'req-job-detail' },
         }),
       );
@@ -322,10 +371,11 @@ function getSpaceCombobox(): HTMLElement {
   return combobox;
 }
 
-function buildJob(cancelRequestedAt: string | null = null) {
+function buildJob(cancelRequestedAt: string | null = null, overrides: Partial<JobStub> = {}): JobStub {
   return {
     job_id: 'job-1',
     type: 'graphify',
+    display_name: 'readme.md',
     status: 'running',
     space_id: 'space-main',
     progress: {
@@ -344,6 +394,7 @@ function buildJob(cancelRequestedAt: string | null = null) {
     created_at: '2026-04-29T10:00:00.000Z',
     started_at: '2026-04-29T10:01:00.000Z',
     completed_at: null,
+    ...overrides,
   };
 }
 

--- a/apps/web/src/lib/adminTypes.ts
+++ b/apps/web/src/lib/adminTypes.ts
@@ -128,6 +128,7 @@ export type JobProgress = {
 export type AdminJob = {
   job_id: string;
   type: string;
+  display_name: string | null;
   status: string;
   space_id: string | null;
   progress: JobProgress | null;

--- a/apps/web/src/pages/admin/JobDetailPage.tsx
+++ b/apps/web/src/pages/admin/JobDetailPage.tsx
@@ -144,6 +144,14 @@ function JobDetailPage() {
         <Empty description={t('admin.jobDetail.unavailable')} />
       ) : (
         <>
+          <div style={{ marginBottom: 16 }}>
+            <Typography.Title level={3} style={{ margin: 0 }}>
+              {job.display_name ?? formatLabel(job.type)}
+            </Typography.Title>
+            <Typography.Text type="secondary">
+              {job.display_name ? `${formatLabel(job.type)} · ${job.job_id}` : job.job_id}
+            </Typography.Text>
+          </div>
           <Card title={t('admin.jobDetail.overview.title')} style={{ marginBottom: 16 }}>
             {job.progress?.percent !== undefined ? (
               <Progress

--- a/apps/web/src/pages/admin/JobsPage.tsx
+++ b/apps/web/src/pages/admin/JobsPage.tsx
@@ -118,9 +118,11 @@ function JobsPage() {
       key: 'type',
       render: (_: unknown, job: AdminJob) => (
         <div>
-          <Typography.Text strong>{formatLabel(job.type)}</Typography.Text>
+          <Typography.Text strong>{job.display_name ?? formatLabel(job.type)}</Typography.Text>
           <br />
-          <Typography.Text type="secondary" style={{ fontSize: 12 }}>{job.job_id}</Typography.Text>
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            {job.display_name ? `${formatLabel(job.type)} · ${job.job_id}` : job.job_id}
+          </Typography.Text>
         </div>
       ),
     },


### PR DESCRIPTION
Closes #229
Part of #225

## Summary
- Add `display_name` to `JobDto` derived from payload/result metadata (filename, title, name fields, including nested `metadata` objects)
- Jobs table shows `display_name` as primary label, type and job_id as secondary
- Job detail page shows display_name prominently when available
- Falls back to type + id when no display name can be derived

## Changes
- `apps/api/src/jobs/jobs.dto.ts` — add `display_name` field
- `apps/api/src/jobs/jobs.service.ts` — `deriveDisplayName()` with top-level + nested metadata support
- `apps/api/src/internal/internal-jobs.service.ts` — align internal DTO mapping
- `apps/web/src/lib/adminTypes.ts` — add `display_name` to `AdminJob`
- `apps/web/src/pages/admin/JobsPage.tsx` — show display_name as primary in type column
- `apps/web/src/pages/admin/JobDetailPage.tsx` — show display_name in header
- Tests: backend `deriveDisplayName` (top-level + nested metadata) + frontend rendering

## Test plan
- [x] Job with payload filename shows it as display_name
- [x] Job with result title shows it as display_name
- [x] Job with nested result_json.metadata.filename is resolved
- [x] Job without metadata returns null, UI falls back to type label
- [x] Job detail page shows display_name prominently
- [x] All 1086 tests pass (zero regression)
- [x] ESLint clean, build passes

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `70ae54c880fca8e89076e3f190ca1f44376181db`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/246#issuecomment-4415251591) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/246#issuecomment-4415251642) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/246#issuecomment-4415251677) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/246#issuecomment-4415251716)
- Key findings addressed: Round 1 identified missing nested metadata.filename check — fixed with metadata sub-object scanning and regression test