### PR TITLE
fix(security): add tenant/user scoping to agent session repository (#239)

### DIFF
--- a/apps/api/src/agent/__tests__/agent-config-refresh.test.ts
+++ b/apps/api/src/agent/__tests__/agent-config-refresh.test.ts
@@ -197,10 +197,14 @@ describe('AgentService config refresh and persistent resume', () => {
 
     // providerSessionId is set asynchronously via onSessionId callback
     await vi.waitFor(async () => {
-      const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+      const saved = expectDefined(
+        await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId),
+      );
       expect(saved.providerSessionId).toBe('provider-fresh');
     });
-    const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+    const saved = expectDefined(
+      await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId),
+    );
     expect(saved.workDir).toBe(session.workDir);
 
     fresh.close(0);
@@ -238,10 +242,17 @@ async function createService(config: { idleTimeoutMs?: number } = {}): Promise<{
 }
 
 async function createPersistentSession(manager: SessionManager): Promise<PersistentAgentSession> {
-  return manager.getOrCreateSession(uniqueConversationId(), 'space-1', 'tenant-1', 'user-1', {
-    tenantId: 'tenant-1',
-    userId: 'user-1',
-  });
+  return expectDefined(
+    await manager.getOrCreateSession(uniqueConversationId(), 'space-1', 'tenant-1', 'user-1', {
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    }),
+  );
+}
+
+function expectDefined<T>(value: T | undefined): T {
+  expect(value).toBeDefined();
+  return value as T;
 }
 
 function createClosingOnKillProcess(): MockAgentProcess {

--- a/apps/api/src/agent/__tests__/agent-persistent-runner.test.ts
+++ b/apps/api/src/agent/__tests__/agent-persistent-runner.test.ts
@@ -115,7 +115,9 @@ describe('AgentService persistent runner', () => {
     writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'provider-captured' });
     await vi.waitFor(() => expect(session.providerSessionId).toBe('provider-captured'));
 
-    const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+    const saved = expectDefined(
+      await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId),
+    );
     expect(saved.providerSessionId).toBe('provider-captured');
 
     proc.close(0);
@@ -140,7 +142,9 @@ describe('AgentService persistent runner', () => {
       usage: { input_tokens: 5, output_tokens: 2 },
     });
     const events = await eventsPromise;
-    const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+    const saved = expectDefined(
+      await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId),
+    );
 
     expect(events.map((event) => event.type)).toEqual(['message.delta', 'message.completed']);
     expect(saved.status).toBe('idle');
@@ -165,7 +169,9 @@ describe('AgentService persistent runner', () => {
       error: 'tool failed',
     });
     const events = await eventsPromise;
-    const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+    const saved = expectDefined(
+      await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId),
+    );
 
     expect(events).toEqual([{ type: 'message.error', code: 'error_during_execution', message: 'tool failed' }]);
     expect(saved.status).toBe('idle');
@@ -184,7 +190,9 @@ describe('AgentService persistent runner', () => {
     proc.close(1);
 
     await vi.waitFor(async () => {
-      const saved = await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId);
+      const saved = expectDefined(
+        await manager.getOrCreateSession(session.conversationId, session.spaceId, session.tenantId, session.userId),
+      );
       expect(saved.status).toBe('failed');
     });
     expect(service.getActiveAgentCount()).toBe(0);
@@ -248,11 +256,18 @@ async function createSession(
   options: PersistentAgentSession['options'] = {},
 ): Promise<PersistentAgentSession> {
   const conversationId = `conversation-persistent-${randomUUID()}`;
-  return manager.getOrCreateSession(conversationId, 'space-1', 'tenant-1', 'user-1', {
-    tenantId: 'tenant-1',
-    userId: 'user-1',
-    ...options,
-  });
+  return expectDefined(
+    await manager.getOrCreateSession(conversationId, 'space-1', 'tenant-1', 'user-1', {
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      ...options,
+    }),
+  );
+}
+
+function expectDefined<T>(value: T | undefined): T {
+  expect(value).toBeDefined();
+  return value as T;
 }
 
 async function createStartedSession(
@@ -276,4 +291,3 @@ function captureStdin(proc: MockAgentProcess): string[] {
   });
   return chunks;
 }
-

--- a/apps/api/src/agent/__tests__/agent-session-manager.test.ts
+++ b/apps/api/src/agent/__tests__/agent-session-manager.test.ts
@@ -30,12 +30,14 @@ describe('SessionManager', () => {
     const repository = createRepository();
     const manager = await createManager(repository.instance);
 
-    const session = await manager.getOrCreateSession(
-      'conversation-fresh',
-      'space-1',
-      'tenant-1',
-      'user-1',
-      { allowedSpaces: [{ id: 'space-1', graphPath: '/graphs/space-1' }], model: 'sonnet' },
+    const session = expectDefined(
+      await manager.getOrCreateSession(
+        'conversation-fresh',
+        'space-1',
+        'tenant-1',
+        'user-1',
+        { allowedSpaces: [{ id: 'space-1', graphPath: '/graphs/space-1' }], model: 'sonnet' },
+      ),
     );
 
     expect(session).toMatchObject({
@@ -53,7 +55,7 @@ describe('SessionManager', () => {
       'tenant-1',
       'user-1',
     );
-    expect(repository.findByConversationId).not.toHaveBeenCalled();
+    expect(repository.findByConversationId).toHaveBeenCalledWith('conversation-fresh');
     expect(repository.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         conversation_id: 'conversation-fresh',
@@ -113,7 +115,8 @@ describe('SessionManager', () => {
     );
   });
 
-  it('getOrCreateSession creates fresh session when persisted row has wrong tenant', async () => {
+  it('getOrCreateSession returns undefined without mutating when persisted row has wrong tenant', async () => {
+    const agentRoot = await createTempDir('wrong-tenant-root');
     const row = createAgentSessionRow({
       conversation_id: 'conversation-wrong-tenant',
       tenant_id: 'tenant-original',
@@ -124,7 +127,7 @@ describe('SessionManager', () => {
     });
     row.agent_home = join(row.work_dir, '.home');
     const repository = createRepository([row]);
-    const manager = await createManager(repository.instance);
+    const manager = await createManager(repository.instance, { agentRoot });
 
     const session = await manager.getOrCreateSession(
       'conversation-wrong-tenant',
@@ -139,31 +142,18 @@ describe('SessionManager', () => {
       'tenant-request',
       'user-1',
     );
-    expect(repository.findByConversationId).not.toHaveBeenCalled();
-    expect(session).toMatchObject({
-      conversationId: 'conversation-wrong-tenant',
-      tenantId: 'tenant-request',
-      spaceId: 'space-request',
-      userId: 'user-1',
-      providerSessionId: undefined,
-      status: 'starting',
-    });
-    expect(session.workDir).not.toBe(row.work_dir);
-    expect(repository.upsert).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        conversation_id: 'conversation-wrong-tenant',
-        tenant_id: 'tenant-request',
-        user_id: 'user-1',
-        provider_session_id: null,
-        status: 'starting',
-      }),
-    );
+    expect(repository.findByConversationId).toHaveBeenCalledWith('conversation-wrong-tenant');
+    expect(session).toBeUndefined();
+    expect(manager.size()).toBe(0);
+    expect(repository.upsert).not.toHaveBeenCalled();
     expect(repository.updateStatus).not.toHaveBeenCalled();
     expect(repository.updateProviderSessionId).not.toHaveBeenCalled();
     expect(repository.touchActivity).not.toHaveBeenCalled();
+    await expect(stat(join(agentRoot, 'conversation-wrong-tenant'))).rejects.toThrow();
   });
 
-  it('getOrCreateSession creates fresh session when persisted row has wrong user', async () => {
+  it('getOrCreateSession returns undefined without mutating when persisted row has wrong user', async () => {
+    const agentRoot = await createTempDir('wrong-user-root');
     const row = createAgentSessionRow({
       conversation_id: 'conversation-wrong-user',
       tenant_id: 'tenant-1',
@@ -174,7 +164,7 @@ describe('SessionManager', () => {
     });
     row.agent_home = join(row.work_dir, '.home');
     const repository = createRepository([row]);
-    const manager = await createManager(repository.instance);
+    const manager = await createManager(repository.instance, { agentRoot });
 
     const session = await manager.getOrCreateSession(
       'conversation-wrong-user',
@@ -189,28 +179,51 @@ describe('SessionManager', () => {
       'tenant-1',
       'user-request',
     );
-    expect(repository.findByConversationId).not.toHaveBeenCalled();
-    expect(session).toMatchObject({
-      conversationId: 'conversation-wrong-user',
-      tenantId: 'tenant-1',
-      spaceId: 'space-request',
-      userId: 'user-request',
-      providerSessionId: undefined,
-      status: 'starting',
-    });
-    expect(session.workDir).not.toBe(row.work_dir);
-    expect(repository.upsert).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        conversation_id: 'conversation-wrong-user',
-        tenant_id: 'tenant-1',
-        user_id: 'user-request',
-        provider_session_id: null,
-        status: 'starting',
-      }),
-    );
+    expect(repository.findByConversationId).toHaveBeenCalledWith('conversation-wrong-user');
+    expect(session).toBeUndefined();
+    expect(manager.size()).toBe(0);
+    expect(repository.upsert).not.toHaveBeenCalled();
     expect(repository.updateStatus).not.toHaveBeenCalled();
     expect(repository.updateProviderSessionId).not.toHaveBeenCalled();
     expect(repository.touchActivity).not.toHaveBeenCalled();
+    await expect(stat(join(agentRoot, 'conversation-wrong-user'))).rejects.toThrow();
+  });
+
+  it('getOrCreateSession does not return in-memory sessions to a different tenant or user', async () => {
+    const repository = createRepository();
+    const manager = await createManager(repository.instance);
+    const original = await manager.getOrCreateSession(
+      'conversation-memory-scope',
+      'space-1',
+      'tenant-a',
+      'user-a',
+    );
+    vi.clearAllMocks();
+
+    const mismatched = await manager.getOrCreateSession(
+      'conversation-memory-scope',
+      'space-2',
+      'tenant-b',
+      'user-b',
+    );
+
+    expect(mismatched).toBeUndefined();
+    expect(repository.findByConversationScope).not.toHaveBeenCalled();
+    expect(repository.findByConversationId).not.toHaveBeenCalled();
+    expect(repository.upsert).not.toHaveBeenCalled();
+    expect(manager.size()).toBe(1);
+
+    const matching = await manager.getOrCreateSession(
+      'conversation-memory-scope',
+      'space-1',
+      'tenant-a',
+      'user-a',
+    );
+    expect(matching).toMatchObject({
+      conversationId: original?.conversationId,
+      tenantId: 'tenant-a',
+      userId: 'user-a',
+    });
   });
 
   it('marks sessions owned by a different instance as stopped and claims ownership', async () => {
@@ -224,12 +237,14 @@ describe('SessionManager', () => {
     const repository = createRepository([row]);
     const manager = await createManager(repository.instance);
 
-    const session = await manager.getOrCreateSession(
-      'conversation-remote',
-      'space-1',
-      'tenant-1',
-      'user-1',
-      {},
+    const session = expectDefined(
+      await manager.getOrCreateSession(
+        'conversation-remote',
+        'space-1',
+        'tenant-1',
+        'user-1',
+        {},
+      ),
     );
 
     expect(session.status).toBe('stopped');
@@ -250,7 +265,9 @@ describe('SessionManager', () => {
     const proc = createClosingProcess();
 
     await manager.attachProcess('conversation-attach', proc as unknown as ChildProcess);
-    const session = await manager.getOrCreateSession('conversation-attach', 'space-1', 'tenant-1', 'user-1');
+    const session = expectDefined(
+      await manager.getOrCreateSession('conversation-attach', 'space-1', 'tenant-1', 'user-1'),
+    );
 
     expect(session.status).toBe('running');
     expect(session.child).toBe(proc);
@@ -271,7 +288,9 @@ describe('SessionManager', () => {
     await manager.attachProcess('conversation-idle', createClosingProcess() as unknown as ChildProcess);
 
     await manager.markIdle('conversation-idle');
-    const session = await manager.getOrCreateSession('conversation-idle', 'space-1', 'tenant-1', 'user-1');
+    const session = expectDefined(
+      await manager.getOrCreateSession('conversation-idle', 'space-1', 'tenant-1', 'user-1'),
+    );
 
     expect(session.status).toBe('idle');
     expect(session.idleKillTimer).toBeDefined();
@@ -291,7 +310,9 @@ describe('SessionManager', () => {
     await manager.markIdle('conversation-stopped');
 
     await manager.markStopped('conversation-stopped');
-    const session = await manager.getOrCreateSession('conversation-stopped', 'space-1', 'tenant-1', 'user-1');
+    const session = expectDefined(
+      await manager.getOrCreateSession('conversation-stopped', 'space-1', 'tenant-1', 'user-1'),
+    );
 
     expect(session.status).toBe('stopped');
     expect(session.child).toBeUndefined();
@@ -306,7 +327,9 @@ describe('SessionManager', () => {
     await manager.markIdle('conversation-touch');
 
     manager.touch('conversation-touch', 12_345);
-    const session = await manager.getOrCreateSession('conversation-touch', 'space-1', 'tenant-1', 'user-1');
+    const session = expectDefined(
+      await manager.getOrCreateSession('conversation-touch', 'space-1', 'tenant-1', 'user-1'),
+    );
 
     expect(session.lastActivityAt).toBe(12_345);
     expect(repository.updateStatus).toHaveBeenLastCalledWith(
@@ -319,7 +342,9 @@ describe('SessionManager', () => {
   it('close explicitly terminates with SIGTERM, deletes workDir, and removes DB metadata', async () => {
     const repository = createRepository();
     const manager = await createManager(repository.instance);
-    const session = await manager.getOrCreateSession('conversation-close', 'space-1', 'tenant-1', 'user-1');
+    const session = expectDefined(
+      await manager.getOrCreateSession('conversation-close', 'space-1', 'tenant-1', 'user-1'),
+    );
     const proc = createClosingProcess();
     await manager.attachProcess('conversation-close', proc as unknown as ChildProcess);
 
@@ -336,7 +361,9 @@ describe('SessionManager', () => {
     vi.setSystemTime(1_000);
     const repository = createRepository();
     const manager = await createManager(repository.instance, { idleTimeoutMs: 1_000 });
-    const session = await manager.getOrCreateSession('conversation-sweep', 'space-1', 'tenant-1', 'user-1');
+    const session = expectDefined(
+      await manager.getOrCreateSession('conversation-sweep', 'space-1', 'tenant-1', 'user-1'),
+    );
     const proc = createClosingProcess();
     await manager.attachProcess('conversation-sweep', proc as unknown as ChildProcess);
     await manager.markIdle('conversation-sweep');
@@ -364,8 +391,12 @@ describe('SessionManager', () => {
     const newProc = createClosingProcess();
     await manager.attachProcess('conversation-new', newProc as unknown as ChildProcess);
 
-    const oldSession = await manager.getOrCreateSession('conversation-old', 'space-1', 'tenant-1', 'user-1');
-    const newSession = await manager.getOrCreateSession('conversation-new', 'space-1', 'tenant-1', 'user-1');
+    const oldSession = expectDefined(
+      await manager.getOrCreateSession('conversation-old', 'space-1', 'tenant-1', 'user-1'),
+    );
+    const newSession = expectDefined(
+      await manager.getOrCreateSession('conversation-new', 'space-1', 'tenant-1', 'user-1'),
+    );
     expect(oldProc.kill).toHaveBeenCalledWith('SIGTERM');
     expect(newProc.kill).not.toHaveBeenCalled();
     expect(oldSession.status).toBe('stopped');
@@ -433,7 +464,9 @@ describe('SessionManager', () => {
   it('shutdown terminates live processes without deleting workDir', async () => {
     const repository = createRepository();
     const manager = await createManager(repository.instance);
-    const session = await manager.getOrCreateSession('conversation-shutdown', 'space-1', 'tenant-1', 'user-1');
+    const session = expectDefined(
+      await manager.getOrCreateSession('conversation-shutdown', 'space-1', 'tenant-1', 'user-1'),
+    );
     const proc = createClosingProcess();
     await manager.attachProcess('conversation-shutdown', proc as unknown as ChildProcess);
 
@@ -479,6 +512,11 @@ function createClosingProcess(): ReturnType<typeof createMockProcess> {
     return true;
   });
   return proc;
+}
+
+function expectDefined<T>(value: T | undefined): T {
+  expect(value).toBeDefined();
+  return value as T;
 }
 
 function createRepository(initialRows: AgentSessionRow[] = []): MockAgentSessionRepository {

--- a/apps/api/src/agent/__tests__/agent-session-manager.test.ts
+++ b/apps/api/src/agent/__tests__/agent-session-manager.test.ts
@@ -48,7 +48,12 @@ describe('SessionManager', () => {
       ownedByInstance: 'instance-local',
     });
     expect(session.optionsFingerprint).toHaveLength(64);
-    expect(repository.findByConversationId).toHaveBeenCalledWith('conversation-fresh');
+    expect(repository.findByConversationScope).toHaveBeenCalledWith(
+      'conversation-fresh',
+      'tenant-1',
+      'user-1',
+    );
+    expect(repository.findByConversationId).not.toHaveBeenCalled();
     expect(repository.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         conversation_id: 'conversation-fresh',
@@ -61,7 +66,7 @@ describe('SessionManager', () => {
     await expect(stat(session.agentHome)).resolves.toBeTruthy();
   });
 
-  it('restores DB metadata into memory when the in-memory registry misses', async () => {
+  it('getOrCreateSession restores persisted session when tenant and user match', async () => {
     const row = createAgentSessionRow({
       conversation_id: 'conversation-restore',
       provider_session_id: 'claude-session-restore',
@@ -76,11 +81,17 @@ describe('SessionManager', () => {
     const session = await manager.getOrCreateSession(
       'conversation-restore',
       'ignored-space',
-      'ignored-tenant',
-      'ignored-user',
+      row.tenant_id,
+      row.user_id,
       {},
     );
 
+    expect(repository.findByConversationScope).toHaveBeenCalledWith(
+      'conversation-restore',
+      row.tenant_id,
+      row.user_id,
+    );
+    expect(repository.findByConversationId).not.toHaveBeenCalled();
     expect(session).toMatchObject({
       conversationId: 'conversation-restore',
       tenantId: row.tenant_id,
@@ -100,6 +111,106 @@ describe('SessionManager', () => {
         owned_by_instance: 'instance-local',
       }),
     );
+  });
+
+  it('getOrCreateSession creates fresh session when persisted row has wrong tenant', async () => {
+    const row = createAgentSessionRow({
+      conversation_id: 'conversation-wrong-tenant',
+      tenant_id: 'tenant-original',
+      user_id: 'user-1',
+      provider_session_id: 'claude-session-original',
+      status: 'idle',
+      work_dir: await createWorkDir('wrong-tenant'),
+    });
+    row.agent_home = join(row.work_dir, '.home');
+    const repository = createRepository([row]);
+    const manager = await createManager(repository.instance);
+
+    const session = await manager.getOrCreateSession(
+      'conversation-wrong-tenant',
+      'space-request',
+      'tenant-request',
+      'user-1',
+      {},
+    );
+
+    expect(repository.findByConversationScope).toHaveBeenCalledWith(
+      'conversation-wrong-tenant',
+      'tenant-request',
+      'user-1',
+    );
+    expect(repository.findByConversationId).not.toHaveBeenCalled();
+    expect(session).toMatchObject({
+      conversationId: 'conversation-wrong-tenant',
+      tenantId: 'tenant-request',
+      spaceId: 'space-request',
+      userId: 'user-1',
+      providerSessionId: undefined,
+      status: 'starting',
+    });
+    expect(session.workDir).not.toBe(row.work_dir);
+    expect(repository.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        conversation_id: 'conversation-wrong-tenant',
+        tenant_id: 'tenant-request',
+        user_id: 'user-1',
+        provider_session_id: null,
+        status: 'starting',
+      }),
+    );
+    expect(repository.updateStatus).not.toHaveBeenCalled();
+    expect(repository.updateProviderSessionId).not.toHaveBeenCalled();
+    expect(repository.touchActivity).not.toHaveBeenCalled();
+  });
+
+  it('getOrCreateSession creates fresh session when persisted row has wrong user', async () => {
+    const row = createAgentSessionRow({
+      conversation_id: 'conversation-wrong-user',
+      tenant_id: 'tenant-1',
+      user_id: 'user-original',
+      provider_session_id: 'claude-session-original',
+      status: 'idle',
+      work_dir: await createWorkDir('wrong-user'),
+    });
+    row.agent_home = join(row.work_dir, '.home');
+    const repository = createRepository([row]);
+    const manager = await createManager(repository.instance);
+
+    const session = await manager.getOrCreateSession(
+      'conversation-wrong-user',
+      'space-request',
+      'tenant-1',
+      'user-request',
+      {},
+    );
+
+    expect(repository.findByConversationScope).toHaveBeenCalledWith(
+      'conversation-wrong-user',
+      'tenant-1',
+      'user-request',
+    );
+    expect(repository.findByConversationId).not.toHaveBeenCalled();
+    expect(session).toMatchObject({
+      conversationId: 'conversation-wrong-user',
+      tenantId: 'tenant-1',
+      spaceId: 'space-request',
+      userId: 'user-request',
+      providerSessionId: undefined,
+      status: 'starting',
+    });
+    expect(session.workDir).not.toBe(row.work_dir);
+    expect(repository.upsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        conversation_id: 'conversation-wrong-user',
+        tenant_id: 'tenant-1',
+        user_id: 'user-request',
+        provider_session_id: null,
+        status: 'starting',
+      }),
+    );
+    expect(repository.updateStatus).not.toHaveBeenCalled();
+    expect(repository.updateProviderSessionId).not.toHaveBeenCalled();
+    expect(repository.touchActivity).not.toHaveBeenCalled();
   });
 
   it('marks sessions owned by a different instance as stopped and claims ownership', async () => {
@@ -395,6 +506,13 @@ function createRepository(initialRows: AgentSessionRow[] = []): MockAgentSession
       return Promise.resolve(row);
     }),
     findByConversationId: vi.fn((conversationId: string) => Promise.resolve(rows.get(conversationId))),
+    findByConversationScope: vi.fn((conversationId: string, tenantId: string, userId: string) => {
+      const row = rows.get(conversationId);
+      if (row?.tenant_id !== tenantId || row.user_id !== userId) {
+        return Promise.resolve(undefined);
+      }
+      return Promise.resolve(row);
+    }),
     updateProviderSessionId: vi.fn((conversationId: string, providerSessionId: string) => {
       const row = rows.get(conversationId);
       if (row !== undefined) {
@@ -473,6 +591,9 @@ type MockAgentSessionRepository = {
   rows: Map<string, AgentSessionRow>;
   upsert: Mock<(data: NewAgentSession) => Promise<AgentSessionRow>>;
   findByConversationId: Mock<(conversationId: string) => Promise<AgentSessionRow | undefined>>;
+  findByConversationScope: Mock<
+    (conversationId: string, tenantId: string, userId: string) => Promise<AgentSessionRow | undefined>
+  >;
   updateProviderSessionId: Mock<(conversationId: string, providerSessionId: string) => Promise<void>>;
   updateStatus: Mock<(conversationId: string, status: string, extra?: Partial<AgentSessionRow>) => Promise<void>>;
   updateOwnedByInstance: Mock<(conversationId: string, instanceId: string) => Promise<void>>;

--- a/apps/api/src/agent/__tests__/agent-session-repository.test.ts
+++ b/apps/api/src/agent/__tests__/agent-session-repository.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 import type { DrizzleDatabase } from '../../database/drizzle.module.js';
 import {
@@ -12,6 +14,8 @@ import {
   type AgentSessionRow,
   type NewAgentSession,
 } from '../agent-session.repository.js';
+
+const dialect = new PgDialect();
 
 describe('AgentSessionRepository', () => {
   it('upserts a new agent session row', async () => {
@@ -76,6 +80,62 @@ describe('AgentSessionRepository', () => {
 
     expect(db.selects).toHaveLength(2);
     expect(db.selects[0]?.limit).toBe(1);
+  });
+
+  it('findByConversationScope returns row when all three fields match', async () => {
+    const db = new ScriptedAgentSessionDb();
+    const repository = new AgentSessionRepository(db.asDrizzle());
+    const matching = createAgentSessionRow();
+    db.seedRows([
+      createAgentSessionRow({
+        tenant_id: 'tenant-other',
+        user_id: 'user-other',
+        space_id: 'space-other',
+      }),
+      matching,
+    ]);
+
+    await expect(
+      repository.findByConversationScope('conversation-1', TEST_TENANT_ID, TEST_USER_ID),
+    ).resolves.toEqual(matching);
+
+    expect(db.selects).toHaveLength(1);
+    expect(db.selects[0]?.limit).toBe(1);
+    const where = getWhereQuery(db);
+    expect(where.sql).toContain('"agent_sessions"."conversation_id" =');
+    expect(where.sql).toContain('"agent_sessions"."tenant_id" =');
+    expect(where.sql).toContain('"agent_sessions"."user_id" =');
+    expect(where.params).toEqual(['conversation-1', TEST_TENANT_ID, TEST_USER_ID]);
+  });
+
+  it('findByConversationScope returns undefined for tenant mismatch', async () => {
+    const db = new ScriptedAgentSessionDb();
+    const repository = new AgentSessionRepository(db.asDrizzle());
+    db.seedRows([createAgentSessionRow()]);
+
+    await expect(
+      repository.findByConversationScope('conversation-1', 'tenant-other', TEST_USER_ID),
+    ).resolves.toBeUndefined();
+  });
+
+  it('findByConversationScope returns undefined for user mismatch', async () => {
+    const db = new ScriptedAgentSessionDb();
+    const repository = new AgentSessionRepository(db.asDrizzle());
+    db.seedRows([createAgentSessionRow()]);
+
+    await expect(
+      repository.findByConversationScope('conversation-1', TEST_TENANT_ID, 'user-other'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('findByConversationScope returns undefined for both tenant and user mismatch', async () => {
+    const db = new ScriptedAgentSessionDb();
+    const repository = new AgentSessionRepository(db.asDrizzle());
+    db.seedRows([createAgentSessionRow()]);
+
+    await expect(
+      repository.findByConversationScope('conversation-1', 'tenant-other', 'user-other'),
+    ).resolves.toBeUndefined();
   });
 
   it('updates the provider session id and updated timestamp', async () => {
@@ -235,6 +295,7 @@ class ScriptedAgentSessionDb {
   readonly deletes: OperationRecord[] = [];
   readonly selectResults: unknown[][] = [];
   readonly insertResults: unknown[][] = [];
+  private readonly seededRows: AgentSessionRow[] = [];
 
   asDrizzle(): DrizzleDatabase {
     return this as unknown as DrizzleDatabase;
@@ -244,6 +305,10 @@ class ScriptedAgentSessionDb {
     this.selectResults.push(result);
   }
 
+  seedRows(rows: AgentSessionRow[]): void {
+    this.seededRows.push(...rows);
+  }
+
   queueInsert(result: unknown[]): void {
     this.insertResults.push(result);
   }
@@ -251,7 +316,7 @@ class ScriptedAgentSessionDb {
   select(fields?: unknown): ScriptedSelectBuilder {
     const operation: OperationRecord = { fields };
     this.selects.push(operation);
-    return new ScriptedSelectBuilder(this.selectResults.shift() ?? [], operation);
+    return new ScriptedSelectBuilder(this.selectResults.shift(), operation, this.seededRows);
   }
 
   insert(table?: unknown): { values: (value: unknown) => ScriptedInsertBuilder } {
@@ -287,8 +352,9 @@ class ScriptedAgentSessionDb {
 
 class ScriptedSelectBuilder implements PromiseLike<unknown[]> {
   constructor(
-    private readonly result: unknown[],
+    private readonly result: unknown[] | undefined,
     private readonly operation: OperationRecord,
+    private readonly seededRows: AgentSessionRow[],
   ) {}
 
   from(table?: unknown): this {
@@ -310,7 +376,38 @@ class ScriptedSelectBuilder implements PromiseLike<unknown[]> {
     onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2> {
-    return Promise.resolve(this.result).then(onfulfilled ?? undefined, onrejected ?? undefined);
+    return Promise.resolve(this.resolveResult()).then(onfulfilled ?? undefined, onrejected ?? undefined);
+  }
+
+  private resolveResult(): unknown[] {
+    if (this.result !== undefined) {
+      return this.result;
+    }
+
+    if (this.seededRows.length === 0) {
+      return [];
+    }
+
+    const where = this.operation.where?.[0] as SQL | undefined;
+    if (where === undefined) {
+      return this.seededRows.slice(0, this.operation.limit);
+    }
+
+    const [conversationId, tenantId, userId] = dialect.sqlToQuery(where).params;
+    return this.seededRows
+      .filter((row) => {
+        if (conversationId !== undefined && row.conversation_id !== conversationId) {
+          return false;
+        }
+        if (tenantId !== undefined && row.tenant_id !== tenantId) {
+          return false;
+        }
+        if (userId !== undefined && row.user_id !== userId) {
+          return false;
+        }
+        return true;
+      })
+      .slice(0, this.operation.limit);
   }
 }
 
@@ -360,4 +457,17 @@ class ScriptedDeleteBuilder implements PromiseLike<unknown[]> {
   ): Promise<TResult1 | TResult2> {
     return Promise.resolve([]).then(onfulfilled ?? undefined, onrejected ?? undefined);
   }
+}
+
+function getWhereQuery(db: ScriptedAgentSessionDb): { sql: string; params: unknown[] } {
+  const where = db.selects[0]?.where?.[0] as SQL | undefined;
+  if (where === undefined) {
+    throw new Error('Expected where clause');
+  }
+
+  const query = dialect.sqlToQuery(where);
+  return {
+    sql: query.sql,
+    params: query.params,
+  };
 }

--- a/apps/api/src/agent/__tests__/agent-session-repository.test.ts
+++ b/apps/api/src/agent/__tests__/agent-session-repository.test.ts
@@ -61,10 +61,10 @@ describe('AgentSessionRepository', () => {
     expect(set).toMatchObject({
       status: 'running',
       provider_session_id: 'claude-session-2',
-      tenant_id: TEST_TENANT_ID,
       space_id: TEST_SPACE_ID,
-      user_id: TEST_USER_ID,
     });
+    expect(set).not.toHaveProperty('tenant_id');
+    expect(set).not.toHaveProperty('user_id');
     expect(set).not.toHaveProperty('created_at');
   });
 

--- a/apps/api/src/agent/__tests__/agent-turn-dispatch.test.ts
+++ b/apps/api/src/agent/__tests__/agent-turn-dispatch.test.ts
@@ -185,6 +185,31 @@ describe('AgentService sendTurn dispatch', () => {
     proc.close(0);
   });
 
+  it('does not spawn when the conversation is owned by another tenant or user', async () => {
+    const { service, manager } = createService();
+    const conversationId = uniqueConversationId();
+    await manager.getOrCreateSession(conversationId, 'space-1', 'tenant-a', 'user-a', {
+      tenantId: 'tenant-a',
+      userId: 'user-a',
+    });
+
+    const events = await collectAsync(
+      service.sendTurn(conversationId, 'space-2', 'cross-scope turn', {
+        tenantId: 'tenant-b',
+        userId: 'user-b',
+      }),
+    );
+
+    expect(events).toEqual([
+      {
+        type: 'message.error',
+        code: 'agent_session_scope_mismatch',
+        message: 'Agent session is not available for this tenant or user',
+      },
+    ]);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it('sends SIGINT on SSE disconnect and keeps the process alive if Claude returns to idle', async () => {
     const proc = createMockProcess();
     const stdinChunks = captureStdin(proc);
@@ -214,7 +239,9 @@ describe('AgentService sendTurn dispatch', () => {
     writeJsonLine(proc, { type: 'result', subtype: 'success', session_id: 'provider-cancel' });
     await returnPromise;
 
-    const saved = await manager.getOrCreateSession(conversationId, 'space-1', 'tenant-1', 'user-1');
+    const saved = expectDefined(
+      await manager.getOrCreateSession(conversationId, 'space-1', 'tenant-1', 'user-1'),
+    );
     expect(saved.status).toBe('idle');
     expect(saved.child).toBe(proc);
     expect(proc.kill).not.toHaveBeenCalledWith('SIGKILL');
@@ -251,7 +278,9 @@ describe('AgentService sendTurn dispatch', () => {
 
     expect(proc.kill).toHaveBeenCalledWith('SIGINT');
     expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
-    const saved = await manager.getOrCreateSession(conversationId, 'space-1', 'tenant-1', 'user-1');
+    const saved = expectDefined(
+      await manager.getOrCreateSession(conversationId, 'space-1', 'tenant-1', 'user-1'),
+    );
     expect(saved.status).toBe('failed');
   });
 });
@@ -283,14 +312,21 @@ async function createStartedSession(
   proc: MockAgentProcess,
   providerSessionId: string,
 ): Promise<PersistentAgentSession> {
-  const session = await manager.getOrCreateSession(uniqueConversationId(), 'space-1', 'tenant-1', 'user-1', {
-    tenantId: 'tenant-1',
-    userId: 'user-1',
-  });
+  const session = expectDefined(
+    await manager.getOrCreateSession(uniqueConversationId(), 'space-1', 'tenant-1', 'user-1', {
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    }),
+  );
   await service.spawnPersistentProcess(session);
   writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: providerSessionId });
   await vi.waitFor(() => expect(session.providerSessionId).toBe(providerSessionId));
   return session;
+}
+
+function expectDefined<T>(value: T | undefined): T {
+  expect(value).toBeDefined();
+  return value as T;
 }
 
 function captureStdin(proc: MockAgentProcess): string[] {

--- a/apps/api/src/agent/__tests__/agent-turn-dispatch.test.ts
+++ b/apps/api/src/agent/__tests__/agent-turn-dispatch.test.ts
@@ -210,6 +210,45 @@ describe('AgentService sendTurn dispatch', () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  it('checks in-memory scope before the turn mutex for active conversations', async () => {
+    const proc = createMockProcess();
+    const stdinChunks = captureStdin(proc);
+    spawnMock.mockReturnValue(proc as never);
+    const { service } = createService();
+    const conversationId = uniqueConversationId();
+
+    const firstTurn = collectAsync(
+      service.sendTurn(conversationId, 'space-1', 'active turn', {
+        tenantId: 'tenant-a',
+        userId: 'user-a',
+      }),
+    );
+    await waitForSpawn();
+    writeJsonLine(proc, { type: 'system', subtype: 'init', session_id: 'provider-active-scope' });
+    await vi.waitFor(() => expect(stdinChunks.join('')).toContain('active turn'));
+
+    const events = await collectAsync(
+      service.sendTurn(conversationId, 'space-2', 'cross-scope active turn', {
+        tenantId: 'tenant-b',
+        userId: 'user-b',
+      }),
+    );
+
+    expect(events).toEqual([
+      {
+        type: 'message.error',
+        code: 'agent_session_scope_mismatch',
+        message: 'Agent session is not available for this tenant or user',
+      },
+    ]);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    writeJsonLine(proc, { type: 'result', subtype: 'success', session_id: 'provider-active-scope' });
+    await firstTurn;
+
+    proc.close(0);
+  });
+
   it('sends SIGINT on SSE disconnect and keeps the process alive if Claude returns to idle', async () => {
     const proc = createMockProcess();
     const stdinChunks = captureStdin(proc);

--- a/apps/api/src/agent/agent-session.repository.ts
+++ b/apps/api/src/agent/agent-session.repository.ts
@@ -55,6 +55,26 @@ export class AgentSessionRepository {
     return row;
   }
 
+  async findByConversationScope(
+    conversationId: string,
+    tenantId: string,
+    userId: string,
+  ): Promise<AgentSessionRow | undefined> {
+    const [row] = await this.db
+      .select()
+      .from(agentSessions)
+      .where(
+        and(
+          eq(agentSessions.conversation_id, conversationId),
+          eq(agentSessions.tenant_id, tenantId),
+          eq(agentSessions.user_id, userId),
+        ),
+      )
+      .limit(1);
+
+    return row;
+  }
+
   async updateProviderSessionId(conversationId: string, providerSessionId: string): Promise<void> {
     await this.db
       .update(agentSessions)

--- a/apps/api/src/agent/agent-session.repository.ts
+++ b/apps/api/src/agent/agent-session.repository.ts
@@ -20,9 +20,7 @@ export class AgentSessionRepository {
       .onConflictDoUpdate({
         target: agentSessions.conversation_id,
         set: {
-          tenant_id: values.tenant_id,
           space_id: values.space_id,
-          user_id: values.user_id,
           provider: values.provider,
           provider_session_id: values.provider_session_id,
           work_dir: values.work_dir,

--- a/apps/api/src/agent/agent.service.ts
+++ b/apps/api/src/agent/agent.service.ts
@@ -360,6 +360,15 @@ export class AgentService implements OnModuleDestroy {
         options.userId ?? '',
         options,
       );
+      if (session === undefined) {
+        yield {
+          type: 'message.error',
+          code: 'agent_session_scope_mismatch',
+          message: 'Agent session is not available for this tenant or user',
+        };
+        return;
+      }
+
       const refreshedSession = await this.refreshConfigIfNeeded(session, options);
 
       const needsSpawn =

--- a/apps/api/src/agent/agent.service.ts
+++ b/apps/api/src/agent/agent.service.ts
@@ -347,6 +347,18 @@ export class AgentService implements OnModuleDestroy {
     userMessage: string,
     options: AgentSpawnOptions = {},
   ): AsyncGenerator<AgentEvent> {
+    const tenantId = options.tenantId ?? '';
+    const userId = options.userId ?? '';
+    const inMemorySession = this.sessionManager.getSession(conversationId);
+    if (
+      inMemorySession !== undefined &&
+      ((inMemorySession.options.tenantId ?? '') !== tenantId ||
+        (inMemorySession.options.userId ?? '') !== userId)
+    ) {
+      yield agentSessionScopeMismatchEvent();
+      return;
+    }
+
     const releaseTurn = this.turnMutex.tryAcquire(conversationId);
     if (releaseTurn === null) {
       throw new AgentSessionBusyError(conversationId);
@@ -356,16 +368,12 @@ export class AgentService implements OnModuleDestroy {
       const session = await this.sessionManager.getOrCreateSession(
         conversationId,
         spaceId,
-        options.tenantId ?? '',
-        options.userId ?? '',
+        tenantId,
+        userId,
         options,
       );
       if (session === undefined) {
-        yield {
-          type: 'message.error',
-          code: 'agent_session_scope_mismatch',
-          message: 'Agent session is not available for this tenant or user',
-        };
+        yield agentSessionScopeMismatchEvent();
         return;
       }
 
@@ -1116,6 +1124,14 @@ function toAgentErrorEvent(err: unknown): Extract<AgentEvent, { type: 'message.e
     type: 'message.error',
     code: err instanceof AgentProcessError ? 'process_error' : 'internal_error',
     message: err instanceof Error ? err.message : String(err),
+  };
+}
+
+function agentSessionScopeMismatchEvent(): Extract<AgentEvent, { type: 'message.error' }> {
+  return {
+    type: 'message.error',
+    code: 'agent_session_scope_mismatch',
+    message: 'Agent session is not available for this tenant or user',
   };
 }
 

--- a/apps/api/src/agent/session-manager.ts
+++ b/apps/api/src/agent/session-manager.ts
@@ -70,15 +70,22 @@ export class SessionManager implements OnModuleDestroy {
     this.instanceId = config.instanceId ?? this.generateInstanceId();
   }
 
+  /**
+   * Returns undefined when the conversation id is already owned by another tenant/user scope.
+   */
   async getOrCreateSession(
     conversationId: string,
     spaceId: string,
     tenantId: string,
     userId: string,
     options: AgentSpawnOptions = {},
-  ): Promise<PersistentAgentSession> {
+  ): Promise<PersistentAgentSession | undefined> {
     const existing = this.sessions.get(conversationId);
     if (existing !== undefined) {
+      if (existing.tenantId !== tenantId || existing.userId !== userId) {
+        return undefined;
+      }
+
       existing.options = { ...existing.options, ...options };
       return clonePersistentSession(existing);
     }
@@ -90,6 +97,11 @@ export class SessionManager implements OnModuleDestroy {
       this.sessions.set(conversationId, restored);
       await this.upsertSession(restored);
       return clonePersistentSession(restored);
+    }
+
+    const existingRow = await this.repository?.findByConversationId(conversationId);
+    if (existingRow !== undefined) {
+      return undefined;
     }
 
     const session = await this.createFreshSession(conversationId, spaceId, tenantId, userId, options);

--- a/apps/api/src/agent/session-manager.ts
+++ b/apps/api/src/agent/session-manager.ts
@@ -83,7 +83,7 @@ export class SessionManager implements OnModuleDestroy {
       return clonePersistentSession(existing);
     }
 
-    const row = await this.repository?.findByConversationId(conversationId);
+    const row = await this.repository?.findByConversationScope(conversationId, tenantId, userId);
     if (row !== undefined) {
       this.persistedSessionIds.add(conversationId);
       const restored = await this.restoreSessionFromRow(row, options);

--- a/apps/web/src/__tests__/health-page.test.tsx
+++ b/apps/web/src/__tests__/health-page.test.tsx
@@ -65,20 +65,20 @@ describe('HealthPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'System Health' })).toBeInTheDocument();
 
-    const databaseCard = getComponentCard('Database');
+    const databaseCard = await getComponentCard('Database');
     expect(within(databaseCard).getByText('Unhealthy')).toBeInTheDocument();
 
-    const vectorStoreCard = getComponentCard('Vector Store');
+    const vectorStoreCard = await getComponentCard('Vector Store');
     expect(within(vectorStoreCard).getByText('Unhealthy')).toBeInTheDocument();
     expect(vectorStoreCard).toHaveTextContent('Depends on database health check');
     expect(vectorStoreCard).toHaveTextContent('Postgres-backed vector store');
 
-    const graphStoreCard = getComponentCard('Graph Store');
+    const graphStoreCard = await getComponentCard('Graph Store');
     expect(within(graphStoreCard).getByText('Unhealthy')).toBeInTheDocument();
     expect(graphStoreCard).toHaveTextContent('Depends on database health check');
     expect(graphStoreCard).toHaveTextContent('Postgres-backed graph store');
 
-    expect(getComponentCard('Docmost Bridge')).toHaveTextContent('Optional integration');
+    expect(await getComponentCard('Docmost Bridge')).toHaveTextContent('Optional integration');
   });
 });
 
@@ -141,8 +141,8 @@ function getRequestPath(input: RequestInfo | URL): string {
   return input.url.split('?')[0] ?? '';
 }
 
-function getComponentCard(label: string): HTMLElement {
-  const title = screen.getByText(label);
+async function getComponentCard(label: string): Promise<HTMLElement> {
+  const title = await screen.findByText(label);
   const card = title.closest('.ant-card');
   expect(card).not.toBeNull();
   return card as HTMLElement;

--- a/tests/integration/agent-persistent-runtime.test.ts
+++ b/tests/integration/agent-persistent-runtime.test.ts
@@ -302,6 +302,13 @@ function createRepository(initialRows: AgentSessionRow[] = []): {
       return Promise.resolve(row);
     }),
     findByConversationId: vi.fn((conversationId: string) => Promise.resolve(rows.get(conversationId))),
+    findByConversationScope: vi.fn((conversationId: string, tenantId: string, userId: string) => {
+      const row = rows.get(conversationId);
+      if (row?.tenant_id !== tenantId || row.user_id !== userId) {
+        return Promise.resolve(undefined);
+      }
+      return Promise.resolve(row);
+    }),
     updateProviderSessionId: vi.fn((conversationId: string, providerSessionId: string) => {
       const row = rows.get(conversationId);
       if (row !== undefined) {


### PR DESCRIPTION
## Summary
- Add `findByConversationScope(conversationId, tenantId, userId)` to `AgentSessionRepository` for triple-field filtered session lookup
- Update `SessionManager.getOrCreateSession()` to use the scoped method on the request-triggered restore path
- Validate in-memory sessions by tenant/user before returning them
- Deny access (return undefined) when conversation_id exists under a different tenant/user scope
- Make ownership fields (tenant_id, user_id) immutable on upsert conflict
- Add early scope check before mutex in sendTurn to prevent busy-state info leak
- Fix pre-existing flaky health-page test (async card queries)
- Internal cleanup paths (`close()`, `hasPersistedSession()`) remain on conversation-only lookup

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration & Cross-file Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `93c5bc0733e0619131eb9c8a4e734cdc650ca084`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/247#issuecomment-4415594810) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/247#issuecomment-4415594871) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/247#issuecomment-4415594952) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/247#issuecomment-4415594998)
- Key findings addressed: Cross-tenant session overwrite via upsert conflict (fixed: ownership immutable), in-memory session bypass (fixed: tenant/user validation), mutex ordering leak (fixed: early scope check)

## Test plan
- [x] Repository tests: scoped lookup returns undefined for tenant mismatch, user mismatch, and both
- [x] SessionManager tests: returns undefined without mutation when persisted row has wrong tenant or user
- [x] SessionManager tests: in-memory sessions not returned to different tenant/user
- [x] AgentService tests: sendTurn yields scope_mismatch before mutex for active cross-scope requests
- [x] Integration test: mock supports scoped lookup in end-to-end sendTurn flow
- [x] Full test suite passes (1095 tests in apps/api, 90 tests in apps/web, 0 failures)

Closes #239