### PR TITLE
feat(api): implement internal search and pages endpoints (#240)

### DIFF
--- a/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
@@ -252,11 +252,11 @@ function createPayload(
 
 function getResponseData(response: Response): TestResponseData {
   const body = parseResponseBody(response);
-  if (!isRecord(body.data)) {
-    throw new Error('Expected response body to include data object');
+  if (body.accepted !== true || typeof body.event_id !== 'string' || typeof body.deduplicated !== 'boolean') {
+    throw new Error('Expected raw bridge response body');
   }
 
-  return body.data as TestResponseData;
+  return body as TestResponseData;
 }
 
 function getErrorCode(response: Response): unknown {

--- a/apps/api/src/common/interceptors/__tests__/response-wrapper.interceptor.test.ts
+++ b/apps/api/src/common/interceptors/__tests__/response-wrapper.interceptor.test.ts
@@ -24,8 +24,16 @@ class WrapperTestController {
   }
 }
 
+@Controller('internal')
+class InternalTestController {
+  @Get('wrapper-test')
+  getValue(): { results: unknown[] } {
+    return { results: [] };
+  }
+}
+
 @Module({
-  controllers: [WrapperTestController],
+  controllers: [WrapperTestController, InternalTestController],
 })
 class WrapperTestModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {
@@ -75,6 +83,17 @@ describe('ResponseWrapperInterceptor', () => {
         },
       },
     });
+  });
+
+  it('does not wrap internal endpoint responses', async () => {
+    app = await createTestApp();
+
+    const response = await request(app.getHttpAdapter().getInstance().server)
+      .get('/api/internal/wrapper-test')
+      .set('X-Request-Id', REQUEST_ID)
+      .expect(200);
+
+    expect(parseJsonObject(response.text)).toEqual({ results: [] });
   });
 });
 

--- a/apps/api/src/common/interceptors/response-wrapper.interceptor.ts
+++ b/apps/api/src/common/interceptors/response-wrapper.interceptor.ts
@@ -25,7 +25,7 @@ type RequestLike = {
 export class ResponseWrapperInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context.switchToHttp().getRequest<RequestLike>();
-    if (isHealthRequest(request) || isChatCompletionStreamRequest(request)) {
+    if (isHealthRequest(request) || isChatCompletionStreamRequest(request) || isInternalRequest(request)) {
       return next.handle();
     }
 
@@ -69,4 +69,10 @@ function isChatCompletionStreamRequest(request: RequestLike): boolean {
     path === '/api/chat/completions' ||
     path === '/api/chat/completions/'
   );
+}
+
+function isInternalRequest(request: RequestLike): boolean {
+  const url = request.url ?? request.raw?.url ?? '';
+  const path = url.split('?')[0] ?? '';
+  return path.startsWith('/internal/') || path.startsWith('/api/internal/');
 }

--- a/apps/api/src/internal/__tests__/internal-wiki.test.ts
+++ b/apps/api/src/internal/__tests__/internal-wiki.test.ts
@@ -1,0 +1,314 @@
+import 'reflect-metadata';
+
+import { HttpException, type ExecutionContext } from '@nestjs/common';
+import { ErrorCode } from '@cherrygraph/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { DrizzleDatabase } from '../../database/drizzle.module.js';
+import {
+  ScriptedDb,
+  TEST_TENANT_ID,
+  getHttpExceptionCode,
+  getRejectedHttpException,
+} from '../../users/__tests__/user-group-service-test-utils.js';
+import { AgentTokenGuard, type AgentAuthenticatedRequest } from '../agent-token.guard.js';
+import { InternalWikiController } from '../internal-wiki.controller.js';
+
+const originalAgentToken = process.env.CHERRY_AGENT_TOKEN;
+const originalDefaultTenantId = process.env.DEFAULT_TENANT_ID;
+
+describe('AgentTokenGuard', () => {
+  afterEach(() => {
+    restoreEnvironment();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects a missing bearer token with 401', () => {
+    process.env.CHERRY_AGENT_TOKEN = 'agent-secret';
+    const guard = new AgentTokenGuard();
+    const { context } = createGuardContext();
+
+    expect(() => guard.canActivate(context)).toThrowError(HttpException);
+
+    try {
+      guard.canActivate(context);
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpException);
+      expect((error as HttpException).getStatus()).toBe(401);
+      expect(getHttpExceptionCode(error)).toBe(ErrorCode.UNAUTHENTICATED);
+    }
+  });
+
+  it('rejects an invalid bearer token with 401', () => {
+    process.env.CHERRY_AGENT_TOKEN = 'agent-secret';
+    const guard = new AgentTokenGuard();
+    const { context } = createGuardContext('Bearer wrong-secret');
+
+    expect(() => guard.canActivate(context)).toThrowError(HttpException);
+
+    try {
+      guard.canActivate(context);
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpException);
+      expect((error as HttpException).getStatus()).toBe(401);
+      expect(getHttpExceptionCode(error)).toBe(ErrorCode.UNAUTHENTICATED);
+    }
+  });
+
+  it('accepts a valid bearer token and attaches Agent context', () => {
+    process.env.CHERRY_AGENT_TOKEN = 'agent-secret';
+    const guard = new AgentTokenGuard();
+    const { context, request } = createGuardContext('Bearer agent-secret');
+
+    expect(guard.canActivate(context)).toBe(true);
+    expect(request.agent).toEqual({
+      authenticated: true,
+      auth_method: 'static',
+    });
+  });
+});
+
+describe('InternalWikiController', () => {
+  afterEach(() => {
+    restoreEnvironment();
+  });
+
+  it('rejects an empty search query with 400', async () => {
+    const { controller } = createControllerContext();
+
+    const error = await getRejectedHttpException(controller.search({ query: '   ' }));
+
+    expect(error.getStatus()).toBe(400);
+    expect(getHttpExceptionCode(error)).toBe(ErrorCode.VALIDATION_ERROR);
+  });
+
+  it('returns search results with the CLI response shape', async () => {
+    const { controller, db } = createControllerContext();
+    db.queueExecute({
+      rows: [
+        {
+          page_id: 'page-1',
+          space_id: 'space-a',
+          title: 'Auth Guide',
+          section_id: 'overview',
+          section_title: 'Overview',
+          content: 'Authentication overview content',
+          score: '0.72',
+        },
+      ],
+    });
+
+    const result = await controller.search({ query: 'auth', top_k: '5' });
+
+    expect(result).toEqual({
+      results: [
+        {
+          page_id: 'page-1',
+          space_id: 'space-a',
+          title: 'Auth Guide',
+          section_id: 'overview',
+          section_title: 'Overview',
+          content: 'Authentication overview content',
+          score: 0.72,
+        },
+      ],
+    });
+    expect(db.executedQueries).toHaveLength(1);
+  });
+
+  it('applies requested space_ids to the search query', async () => {
+    const { controller, db } = createControllerContext();
+    db.queueExecute({
+      rows: [
+        {
+          page_id: 'page-2',
+          space_id: 'space-b',
+          title: 'Space B Guide',
+          section_id: null,
+          section_title: null,
+          content: 'Space-specific authentication content',
+          score: 1,
+        },
+      ],
+    });
+
+    const result = await controller.search({ query: 'auth', space_ids: 'space-b, space-c' });
+
+    expect(result.results).toEqual([
+      expect.objectContaining({
+        page_id: 'page-2',
+        space_id: 'space-b',
+      }),
+    ]);
+    expect(flattenSqlValues(db.executedQueries[0])).toEqual(
+      expect.arrayContaining([TEST_TENANT_ID, 'space-b', 'space-c']),
+    );
+  });
+
+  it('returns 404 when a page is not found', async () => {
+    const { controller, db } = createControllerContext();
+    db.queueSelect([]);
+
+    const error = await getRejectedHttpException(controller.getPage('missing-page', {}));
+
+    expect(error.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(error)).toBe(ErrorCode.WIKI_PAGE_NOT_FOUND);
+  });
+
+  it('returns current page content and sections', async () => {
+    const { controller, db } = createControllerContext();
+    const content = '# Auth Guide\n\nIntro text.\n\n## Overview\nAuthentication overview content.\n';
+    const sectionStart = content.indexOf('## Overview');
+    db.queueSelect([createPageRow()]);
+    db.queueSelect([
+      {
+        id: 'version-1',
+        contentMarkdown: content,
+      },
+    ]);
+    db.queueSelect([
+      {
+        id: 'section-pk-1',
+        sectionId: 'overview',
+        heading: 'Overview',
+        startOffset: sectionStart,
+        endOffset: content.length,
+      },
+    ]);
+
+    const result = await controller.getPage('page-1', { space_id: 'space-a' });
+
+    expect(result).toEqual({
+      page_id: 'page-1',
+      space_id: 'space-a',
+      title: 'Auth Guide',
+      content,
+      sections: [
+        {
+          id: 'section-pk-1',
+          section_id: 'overview',
+          title: 'Overview',
+          content: '## Overview\nAuthentication overview content.\n',
+        },
+      ],
+    });
+  });
+
+  it('requires space_id when page_id matches multiple spaces', async () => {
+    const { controller, db } = createControllerContext();
+    db.queueSelect([
+      createPageRow({ spaceId: 'space-a' }),
+      createPageRow({ id: 'wiki-page-pk-2', spaceId: 'space-b' }),
+    ]);
+
+    const error = await getRejectedHttpException(controller.getPage('page-1', {}));
+
+    expect(error.getStatus()).toBe(400);
+    expect(error.message).toBe('space_id required for disambiguation');
+  });
+
+  it('returns the selected section content when section matches', async () => {
+    const { controller, db } = createControllerContext();
+    const content = '# Auth Guide\n\nIntro text.\n\n## Overview\nAuthentication overview content.\n';
+    const sectionStart = content.indexOf('## Overview');
+    db.queueSelect([createPageRow()]);
+    db.queueSelect([{ id: 'version-1', contentMarkdown: content }]);
+    db.queueSelect([
+      {
+        id: 'section-pk-1',
+        sectionId: 'overview',
+        heading: 'Overview',
+        startOffset: sectionStart,
+        endOffset: content.length,
+      },
+    ]);
+
+    const result = await controller.getPage('page-1', { space_id: 'space-a', section: 'overview' });
+
+    expect(result.content).toBe('## Overview\nAuthentication overview content.\n');
+    expect(result.sections).toHaveLength(1);
+  });
+});
+
+function createControllerContext(): { controller: InternalWikiController; db: ScriptedDb } {
+  process.env.DEFAULT_TENANT_ID = TEST_TENANT_ID;
+  const db = new ScriptedDb();
+  return {
+    controller: new InternalWikiController(db.asDrizzle() as unknown as DrizzleDatabase),
+    db,
+  };
+}
+
+function createGuardContext(authorization?: string): {
+  context: ExecutionContext;
+  request: AgentAuthenticatedRequest;
+} {
+  const request: AgentAuthenticatedRequest = {
+    headers: authorization === undefined ? {} : { Authorization: authorization },
+  };
+
+  return {
+    request,
+    context: {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext,
+  };
+}
+
+function createPageRow(overrides: Partial<{
+  id: string;
+  pageId: string;
+  spaceId: string;
+  title: string;
+  currentVersionId: string | null;
+}> = {}) {
+  return {
+    id: 'wiki-page-pk-1',
+    pageId: 'page-1',
+    spaceId: 'space-a',
+    title: 'Auth Guide',
+    currentVersionId: 'version-1',
+    ...overrides,
+  };
+}
+
+function flattenSqlValues(value: unknown): string[] {
+  if (typeof value === 'string' || typeof value === 'number') {
+    return [String(value)];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => flattenSqlValues(item));
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return [];
+  }
+
+  const record = value as { queryChunks?: unknown[]; value?: unknown };
+  if (Array.isArray(record.queryChunks)) {
+    return flattenSqlValues(record.queryChunks);
+  }
+
+  if (record.value !== undefined) {
+    return flattenSqlValues(record.value);
+  }
+
+  return [];
+}
+
+function restoreEnvironment(): void {
+  if (originalAgentToken === undefined) {
+    delete process.env.CHERRY_AGENT_TOKEN;
+  } else {
+    process.env.CHERRY_AGENT_TOKEN = originalAgentToken;
+  }
+
+  if (originalDefaultTenantId === undefined) {
+    delete process.env.DEFAULT_TENANT_ID;
+  } else {
+    process.env.DEFAULT_TENANT_ID = originalDefaultTenantId;
+  }
+}

--- a/apps/api/src/internal/__tests__/internal-wiki.test.ts
+++ b/apps/api/src/internal/__tests__/internal-wiki.test.ts
@@ -55,6 +55,14 @@ describe('AgentTokenGuard', () => {
     }
   });
 
+  it('rejects a bearer token header with extra content', () => {
+    process.env.CHERRY_AGENT_TOKEN = 'agent-secret';
+    const guard = new AgentTokenGuard();
+    const { context } = createGuardContext('Bearer agent-secret extra');
+
+    expect(() => guard.canActivate(context)).toThrowError(HttpException);
+  });
+
   it('accepts a valid bearer token and attaches Agent context', () => {
     process.env.CHERRY_AGENT_TOKEN = 'agent-secret';
     const guard = new AgentTokenGuard();

--- a/apps/api/src/internal/agent-token.guard.ts
+++ b/apps/api/src/internal/agent-token.guard.ts
@@ -1,0 +1,123 @@
+import { CanActivate, ExecutionContext, HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { ErrorCode } from '@cherrygraph/shared';
+import * as crypto from 'node:crypto';
+import type { IncomingHttpHeaders } from 'node:http';
+
+import { getApiLogger } from '../common/logger/logger.module.js';
+
+export type AgentAuthenticatedRequest = RequestLike & {
+  agent?: {
+    authenticated: true;
+    auth_method: 'static';
+  };
+};
+
+type RequestLike = {
+  headers?: IncomingHttpHeaders | Record<string, string | string[] | undefined>;
+  raw?: {
+    headers?: IncomingHttpHeaders | Record<string, string | string[] | undefined>;
+  };
+};
+
+@Injectable()
+export class AgentTokenGuard implements CanActivate {
+  constructor() {
+    if (typeof process.env.CHERRY_AGENT_TOKEN !== 'string' || process.env.CHERRY_AGENT_TOKEN.length === 0) {
+      getApiLogger().warn(
+        { cherry_agent_token_present: false },
+        'CHERRY_AGENT_TOKEN is not configured; internal Agent wiki endpoints will reject all requests',
+      );
+    }
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<AgentAuthenticatedRequest>();
+    const expectedToken = process.env.CHERRY_AGENT_TOKEN;
+    const providedToken = parseBearerToken(getHeaderValue(request, 'authorization'));
+
+    if (
+      typeof expectedToken !== 'string' ||
+      expectedToken.length === 0 ||
+      !hasMatchingAgentToken(expectedToken, providedToken)
+    ) {
+      throw new HttpException(
+        {
+          code: ErrorCode.UNAUTHENTICATED,
+          message: 'Invalid Agent token',
+        },
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    request.agent = {
+      authenticated: true,
+      auth_method: 'static',
+    };
+
+    return true;
+  }
+}
+
+function getHeaderValue(request: RequestLike, name: string): string | undefined {
+  return getHeaderFromRecord(request.headers, name) ?? getHeaderFromRecord(request.raw?.headers, name);
+}
+
+function getHeaderFromRecord(
+  headers: IncomingHttpHeaders | Record<string, string | string[] | undefined> | undefined,
+  name: string,
+): string | undefined {
+  if (headers === undefined) {
+    return undefined;
+  }
+
+  const normalizedName = name.toLowerCase();
+  const directValue = normalizeHeaderValue(headers[name] ?? headers[normalizedName]);
+  if (directValue !== undefined) {
+    return directValue;
+  }
+
+  for (const [headerName, headerValue] of Object.entries(headers)) {
+    if (headerName.toLowerCase() === normalizedName) {
+      return normalizeHeaderValue(headerValue);
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const first = value.find((entry) => typeof entry === 'string' && entry.trim().length > 0);
+    return first?.trim();
+  }
+
+  return undefined;
+}
+
+function parseBearerToken(authorization: string | undefined): string | undefined {
+  if (authorization === undefined) {
+    return undefined;
+  }
+
+  const [scheme, token] = authorization.split(/\s+/, 2);
+  if (scheme?.toLowerCase() !== 'bearer' || token === undefined || token.length === 0) {
+    return undefined;
+  }
+
+  return token;
+}
+
+function hasMatchingAgentToken(expectedToken: string, providedToken: string | undefined): boolean {
+  const expectedBuffer = Buffer.from(expectedToken);
+  const providedBuffer = Buffer.from(providedToken ?? '');
+  const normalizedProvidedBuffer =
+    providedBuffer.length === expectedBuffer.length ? providedBuffer : Buffer.alloc(expectedBuffer.length);
+  const tokensMatch = crypto.timingSafeEqual(expectedBuffer, normalizedProvidedBuffer);
+
+  return providedBuffer.length === expectedBuffer.length && tokensMatch;
+}

--- a/apps/api/src/internal/agent-token.guard.ts
+++ b/apps/api/src/internal/agent-token.guard.ts
@@ -104,12 +104,12 @@ function parseBearerToken(authorization: string | undefined): string | undefined
     return undefined;
   }
 
-  const [scheme, token] = authorization.split(/\s+/, 2);
-  if (scheme?.toLowerCase() !== 'bearer' || token === undefined || token.length === 0) {
+  const match = /^Bearer\s+(\S+)$/i.exec(authorization);
+  if (match === null) {
     return undefined;
   }
 
-  return token;
+  return match[1];
 }
 
 function hasMatchingAgentToken(expectedToken: string, providedToken: string | undefined): boolean {

--- a/apps/api/src/internal/internal-wiki.controller.ts
+++ b/apps/api/src/internal/internal-wiki.controller.ts
@@ -1,0 +1,404 @@
+import { Controller, Get, HttpException, HttpStatus, Inject, Param, Query, UseGuards } from '@nestjs/common';
+import { Public } from '@cherrygraph/auth-core';
+import { ErrorCode, wikiPages, wikiPageVersions, wikiSections } from '@cherrygraph/shared';
+import { and, asc, eq, sql, type SQL } from 'drizzle-orm';
+
+import { DRIZZLE } from '../database/drizzle.constants.js';
+import type { DrizzleDatabase } from '../database/drizzle.module.js';
+import { AgentTokenGuard } from './agent-token.guard.js';
+
+const DEFAULT_SEARCH_LIMIT = 10;
+const MAX_SEARCH_LIMIT = 50;
+
+type QueryValue = string | string[] | number | undefined;
+
+type InternalSearchQuery = {
+  query?: QueryValue;
+  q?: QueryValue;
+  space_ids?: QueryValue;
+  top_k?: QueryValue;
+};
+
+type InternalPageQuery = {
+  space_id?: QueryValue;
+  section?: QueryValue;
+};
+
+type InternalSearchRow = {
+  page_id: string | null;
+  space_id: string;
+  title: string | null;
+  section_id: string | null;
+  section_title: string | null;
+  content: string;
+  score: string | number | null;
+};
+
+type SqlQueryResult<TRow> = {
+  rows: TRow[];
+};
+
+type InternalSearchResult = {
+  page_id: string;
+  space_id: string;
+  title: string;
+  section_id: string | null;
+  section_title: string | null;
+  content: string;
+  score: number;
+};
+
+type InternalSearchResponse = {
+  results: InternalSearchResult[];
+};
+
+type WikiPageRow = {
+  id: string;
+  pageId: string;
+  spaceId: string;
+  title: string;
+  currentVersionId: string | null;
+};
+
+type WikiPageVersionRow = {
+  id: string;
+  contentMarkdown: string;
+};
+
+type WikiSectionRow = {
+  id: string;
+  sectionId: string;
+  heading: string;
+  startOffset: number | null;
+  endOffset: number | null;
+};
+
+type InternalPageSection = {
+  id: string;
+  section_id: string;
+  title: string;
+  content: string;
+};
+
+type InternalPageResponse = {
+  page_id: string;
+  space_id: string;
+  title: string;
+  content: string;
+  sections: InternalPageSection[];
+};
+
+@Public()
+@UseGuards(AgentTokenGuard)
+@Controller('internal')
+export class InternalWikiController {
+  constructor(@Inject(DRIZZLE) private readonly db: DrizzleDatabase) {}
+
+  @Get('search')
+  async search(@Query() query: InternalSearchQuery): Promise<InternalSearchResponse> {
+    const searchQuery = normalizeSearchQuery(query.query, query.q);
+    const tsQuery = toSimpleTsQuery(searchQuery);
+    if (tsQuery.length === 0) {
+      throwValidationError('query must contain searchable terms');
+    }
+
+    const tenantId = getTenantId();
+    const spaceIds = parseSpaceIds(query.space_ids);
+    const topK = normalizePositiveInt(query.top_k, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT);
+    const spaceFilter = spaceIds.length > 0 ? sql`AND wc.space_id = ANY(${toPgTextArray(spaceIds)})` : sql``;
+    const result = await this.db.execute<InternalSearchRow>(sql`
+      SELECT wp.page_id,
+             wc.space_id,
+             wp.title,
+             ws.section_id,
+             ws.heading AS section_title,
+             wc.content,
+             ts_rank_cd(to_tsvector('simple', wc.content), to_tsquery('simple', ${tsQuery})) AS score
+      FROM wiki_chunks wc
+      JOIN wiki_pages wp ON wp.id = wc.wiki_page_pk
+      LEFT JOIN wiki_sections ws ON ws.id = wc.section_id
+      WHERE wc.tenant_id = ${tenantId}
+        AND wp.tenant_id = ${tenantId}
+        AND wp.status = 'published'
+        ${spaceFilter}
+        AND to_tsvector('simple', wc.content) @@ to_tsquery('simple', ${tsQuery})
+      ORDER BY score DESC
+      LIMIT ${topK}
+    `);
+
+    return {
+      results: normalizeSearchRows(result),
+    };
+  }
+
+  @Get('pages/:page_id')
+  async getPage(
+    @Param('page_id') pageId: string,
+    @Query() query: InternalPageQuery,
+  ): Promise<InternalPageResponse> {
+    const tenantId = getTenantId();
+    const spaceId = getOptionalQueryString(query.space_id);
+    const pages = await this.findPages(tenantId, pageId, spaceId);
+
+    if (pages.length === 0) {
+      throw new HttpException(
+        {
+          code: ErrorCode.WIKI_PAGE_NOT_FOUND,
+          message: 'Wiki page not found',
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    if (pages.length > 1 && spaceId === undefined) {
+      throwValidationError('space_id required for disambiguation');
+    }
+
+    const page = pages[0];
+    if (page === undefined || page.currentVersionId === null) {
+      throw new HttpException(
+        {
+          code: ErrorCode.VERSION_NOT_FOUND,
+          message: 'Current page version not found',
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const version = await this.findCurrentVersion(tenantId, page);
+    const sections = await this.findSections(tenantId, page, version.id);
+    const responseSections = sections.map((section) => toPageSection(section, version.contentMarkdown));
+    const sectionSelector = getOptionalQueryString(query.section);
+    const selectedSection =
+      sectionSelector === undefined ? undefined : findMatchingSection(responseSections, sectionSelector);
+
+    return {
+      page_id: page.pageId,
+      space_id: page.spaceId,
+      title: page.title,
+      content: selectedSection?.content ?? version.contentMarkdown,
+      sections: selectedSection === undefined ? responseSections : [selectedSection],
+    };
+  }
+
+  private findPages(tenantId: string, pageId: string, spaceId: string | undefined): Promise<WikiPageRow[]> {
+    const conditions: SQL[] = [
+      eq(wikiPages.tenant_id, tenantId),
+      eq(wikiPages.page_id, pageId),
+      eq(wikiPages.status, 'published'),
+    ];
+    if (spaceId !== undefined) {
+      conditions.push(eq(wikiPages.space_id, spaceId));
+    }
+
+    return this.db
+      .select({
+        id: wikiPages.id,
+        pageId: wikiPages.page_id,
+        spaceId: wikiPages.space_id,
+        title: wikiPages.title,
+        currentVersionId: wikiPages.current_version_id,
+      })
+      .from(wikiPages)
+      .where(and(...conditions))
+      .limit(2);
+  }
+
+  private async findCurrentVersion(tenantId: string, page: WikiPageRow): Promise<WikiPageVersionRow> {
+    const versions = await this.db
+      .select({
+        id: wikiPageVersions.id,
+        contentMarkdown: wikiPageVersions.content_markdown,
+      })
+      .from(wikiPageVersions)
+      .where(
+        and(
+          eq(wikiPageVersions.id, page.currentVersionId ?? ''),
+          eq(wikiPageVersions.tenant_id, tenantId),
+          eq(wikiPageVersions.space_id, page.spaceId),
+          eq(wikiPageVersions.wiki_page_pk, page.id),
+        ),
+      )
+      .limit(1);
+    const version = versions[0];
+
+    if (version === undefined) {
+      throw new HttpException(
+        {
+          code: ErrorCode.VERSION_NOT_FOUND,
+          message: 'Current page version not found',
+        },
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    return version;
+  }
+
+  private findSections(tenantId: string, page: WikiPageRow, versionId: string): Promise<WikiSectionRow[]> {
+    return this.db
+      .select({
+        id: wikiSections.id,
+        sectionId: wikiSections.section_id,
+        heading: wikiSections.heading,
+        startOffset: wikiSections.start_offset,
+        endOffset: wikiSections.end_offset,
+      })
+      .from(wikiSections)
+      .where(
+        and(
+          eq(wikiSections.tenant_id, tenantId),
+          eq(wikiSections.space_id, page.spaceId),
+          eq(wikiSections.wiki_page_pk, page.id),
+          eq(wikiSections.page_version_id, versionId),
+        ),
+      )
+      .orderBy(asc(wikiSections.section_index));
+  }
+}
+
+function normalizeSearchQuery(queryValue: QueryValue, qValue: QueryValue): string {
+  const query = getOptionalQueryString(queryValue) ?? getOptionalQueryString(qValue);
+  if (query === undefined) {
+    throwValidationError('query is required');
+  }
+
+  return query;
+}
+
+function getOptionalQueryString(value: QueryValue): string | undefined {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+  if (rawValue === undefined) {
+    return undefined;
+  }
+
+  const normalized = String(rawValue).trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function parseSpaceIds(value: QueryValue): string[] {
+  const rawValue = getOptionalQueryString(value);
+  if (rawValue === undefined) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      rawValue
+        .split(',')
+        .map((spaceId) => spaceId.trim())
+        .filter((spaceId) => spaceId.length > 0),
+    ),
+  );
+}
+
+function normalizePositiveInt(value: QueryValue, fallback: number, max: number): number {
+  const rawValue = getOptionalQueryString(value);
+  if (rawValue === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return Math.min(parsed, max);
+}
+
+function normalizeSearchRows(result: SqlQueryResult<InternalSearchRow>): InternalSearchResult[] {
+  return result.rows.map((row) => ({
+    page_id: row.page_id ?? '',
+    space_id: row.space_id,
+    title: row.title ?? 'Untitled',
+    section_id: row.section_id,
+    section_title: row.section_title,
+    content: row.content,
+    score: normalizeScore(row.score),
+  }));
+}
+
+function normalizeScore(value: string | number | null): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
+function toPageSection(section: WikiSectionRow, contentMarkdown: string): InternalPageSection {
+  return {
+    id: section.id,
+    section_id: section.sectionId,
+    title: section.heading,
+    content: sliceSectionContent(contentMarkdown, section.startOffset, section.endOffset),
+  };
+}
+
+function sliceSectionContent(content: string, startOffset: number | null, endOffset: number | null): string {
+  if (
+    typeof startOffset !== 'number' ||
+    typeof endOffset !== 'number' ||
+    startOffset < 0 ||
+    endOffset <= startOffset ||
+    startOffset >= content.length
+  ) {
+    return '';
+  }
+
+  return content.slice(startOffset, Math.min(endOffset, content.length));
+}
+
+function findMatchingSection(
+  sections: InternalPageSection[],
+  selector: string,
+): InternalPageSection | undefined {
+  const normalizedSelector = selector.toLowerCase();
+  return sections.find(
+    (section) =>
+      section.id === selector ||
+      section.section_id === selector ||
+      section.title === selector ||
+      section.id.toLowerCase() === normalizedSelector ||
+      section.section_id.toLowerCase() === normalizedSelector ||
+      section.title.toLowerCase() === normalizedSelector,
+  );
+}
+
+function toSimpleTsQuery(query: string): string {
+  return query
+    .split(/[^\p{L}\p{N}_]+/u)
+    .map((term) => term.trim())
+    .filter((term) => term.length > 0)
+    .map((term) => term.replace(/[':*!&|()]/g, ''))
+    .filter((term) => term.length > 0)
+    .join(' & ');
+}
+
+function toPgTextArray(values: string[]): SQL {
+  if (values.length === 0) {
+    return sql`ARRAY[]::text[]`;
+  }
+
+  return sql`ARRAY[${sql.join(values.map((value) => sql`${value}`), sql`, `)}]::text[]`;
+}
+
+function getTenantId(): string {
+  const tenantId = process.env.DEFAULT_TENANT_ID?.trim();
+  return tenantId !== undefined && tenantId.length > 0 ? tenantId : 'default';
+}
+
+function throwValidationError(message: string): never {
+  throw new HttpException(
+    {
+      code: ErrorCode.VALIDATION_ERROR,
+      message,
+    },
+    HttpStatus.BAD_REQUEST,
+  );
+}

--- a/apps/api/src/internal/internal-wiki.controller.ts
+++ b/apps/api/src/internal/internal-wiki.controller.ts
@@ -107,18 +107,23 @@ export class InternalWikiController {
     const topK = normalizePositiveInt(query.top_k, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT);
     const spaceFilter = spaceIds.length > 0 ? sql`AND wc.space_id = ANY(${toPgTextArray(spaceIds)})` : sql``;
     const result = await this.db.execute<InternalSearchRow>(sql`
-      SELECT wp.page_id,
+      SELECT wc.id,
+             wc.content,
+             wc.wiki_page_pk,
+             wp.page_id,
+             wc.section_id,
              wc.space_id,
              wp.title,
-             ws.section_id,
              ws.heading AS section_title,
-             wc.content,
+             ws.section_id AS section_slug,
              ts_rank_cd(to_tsvector('simple', wc.content), to_tsquery('simple', ${tsQuery})) AS score
       FROM wiki_chunks wc
-      JOIN wiki_pages wp ON wp.id = wc.wiki_page_pk
+      JOIN spaces s ON s.id = wc.space_id AND s.tenant_id = wc.tenant_id
+      LEFT JOIN wiki_pages wp ON wp.id = wc.wiki_page_pk
       LEFT JOIN wiki_sections ws ON ws.id = wc.section_id
       WHERE wc.tenant_id = ${tenantId}
-        AND wp.tenant_id = ${tenantId}
+        AND wc.index_snapshot_id = s.active_index_snapshot_id
+        AND wc.index_status = 'indexed'
         AND wp.status = 'published'
         ${spaceFilter}
         AND to_tsvector('simple', wc.content) @@ to_tsquery('simple', ${tsQuery})

--- a/apps/api/src/internal/internal.module.ts
+++ b/apps/api/src/internal/internal.module.ts
@@ -7,12 +7,14 @@ import { GraphifyModule } from '../graphify/graphify.module.js';
 import { UploadsModule } from '../uploads/uploads.module.js';
 import { InternalJobsController } from './internal-jobs.controller.js';
 import { InternalJobsService } from './internal-jobs.service.js';
+import { InternalWikiController } from './internal-wiki.controller.js';
 import { InternalWorkersController } from './internal-workers.controller.js';
+import { AgentTokenGuard } from './agent-token.guard.js';
 import { WorkerApiKeyGuard } from './worker-api-key.guard.js';
 
 @Module({
   imports: [ScheduleModule.forRoot(), UploadsModule, AuditModule, GraphifyModule, BridgeModule],
-  controllers: [InternalJobsController, InternalWorkersController],
-  providers: [InternalJobsService, WorkerApiKeyGuard],
+  controllers: [InternalJobsController, InternalWorkersController, InternalWikiController],
+  providers: [InternalJobsService, WorkerApiKeyGuard, AgentTokenGuard],
 })
 export class InternalModule {}


### PR DESCRIPTION
## Summary
- Add `AgentTokenGuard` with timing-safe CHERRY_AGENT_TOKEN Bearer validation and strict parsing
- Implement `GET /api/internal/search` — BM25 full-text search over wiki_chunks with active snapshot + tenant + space filtering
- Implement `GET /api/internal/pages/:page_id` — wiki page content with section selection and page_id disambiguation
- Exempt `/api/internal/*` routes from ResponseWrapperInterceptor (CLI expects raw body)
- Register controller and guard in InternalModule
- Comprehensive test suite covering auth, validation, search shape, page content, disambiguation, section filtering

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration & Cross-file Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `d764a9853ba82df92237754a9fad8792f06576a3`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/248#issuecomment-4415698312) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/248#issuecomment-4415698502) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/248#issuecomment-4415698588) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/248#issuecomment-4415698683)
- Key findings addressed: ResponseWrapperInterceptor bypass for CLI compatibility, active snapshot filtering for search correctness, strict bearer parsing

## Test plan
- [x] Guard tests: missing token → 401, invalid token → 401, malformed bearer → 401, valid token passes
- [x] Search tests: empty query → 400, valid search returns results with correct shape
- [x] Search tests: space_ids parameter filters results, active snapshot constraint
- [x] Page tests: not found → 404, valid page returns content + sections
- [x] Page tests: ambiguous page_id without space_id → 400
- [x] Page tests: section parameter returns selected section content
- [x] Response wrapper bypass: internal routes return raw body
- [x] Full test suite: 1107 tests pass

Closes #240