### PR TITLE
feat(worker): support multi-tenant job polling (#242)

### DIFF
--- a/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
+++ b/apps/api/src/internal/__tests__/internal-jobs.service.test.ts
@@ -27,21 +27,69 @@ describe('InternalJobsService', () => {
     vi.restoreAllMocks();
   });
 
-  it('polls pending jobs by type and returns an empty array when none exist', async () => {
+  it('polls pending jobs across tenants when no tenant scope is provided', async () => {
     delete process.env.DEFAULT_TENANT_ID;
     const service = createService();
-    const findPendingByTypeSpy = vi.spyOn(JobRepository, 'findPendingByType').mockResolvedValueOnce([createJobRow()]);
+    const tenantOneJob = createJobRow({ id: 'job-1', tenant_id: 'tenant-1' });
+    const tenantTwoJob = createJobRow({ id: 'job-2', tenant_id: 'tenant-2' });
+    const findPendingByTypeSpy = vi
+      .spyOn(JobRepository, 'findPendingByType')
+      .mockResolvedValueOnce([tenantOneJob, tenantTwoJob]);
 
     await expect(service.pollPendingJobs('graphify', 2)).resolves.toEqual([
+      expect.objectContaining({ job_id: 'job-1', tenant_id: 'tenant-1' }),
+      expect.objectContaining({ job_id: 'job-2', tenant_id: 'tenant-2' }),
+    ]);
+    expect(findPendingByTypeSpy).toHaveBeenCalledWith(expect.anything(), undefined, 'graphify', 2);
+  });
+
+  it('polls pending jobs for an explicit tenant scope', async () => {
+    const service = createService();
+    const findPendingByTypeSpy = vi
+      .spyOn(JobRepository, 'findPendingByType')
+      .mockResolvedValueOnce([createJobRow({ tenant_id: 'tenant-2' })]);
+
+    await expect(service.pollPendingJobs('graphify', 1, 'tenant-2')).resolves.toEqual([
       expect.objectContaining({
         job_id: 'job-1',
+        tenant_id: 'tenant-2',
         type: 'graphify',
         status: JobStatus.PENDING,
       }),
     ]);
-    expect(findPendingByTypeSpy).toHaveBeenCalledWith(expect.anything(), 'default', 'graphify', 2);
+    expect(findPendingByTypeSpy).toHaveBeenCalledWith(expect.anything(), 'tenant-2', 'graphify', 1);
+  });
 
-    findPendingByTypeSpy.mockResolvedValueOnce([]);
+  it('does not use DEFAULT_TENANT_ID as a polling filter without an explicit tenant scope', async () => {
+    process.env.DEFAULT_TENANT_ID = 'tenant-1';
+    const service = createService();
+    const findPendingByTypeSpy = vi
+      .spyOn(JobRepository, 'findPendingByType')
+      .mockResolvedValueOnce([createJobRow({ id: 'job-2', tenant_id: 'tenant-2' })]);
+
+    await expect(service.pollPendingJobs('graphify', 10)).resolves.toEqual([
+      expect.objectContaining({ job_id: 'job-2', tenant_id: 'tenant-2' }),
+    ]);
+    expect(findPendingByTypeSpy).toHaveBeenCalledWith(expect.anything(), undefined, 'graphify', 10);
+  });
+
+  it('includes the persisted tenant_id in returned job DTOs', async () => {
+    const service = createService();
+    vi.spyOn(JobRepository, 'findPendingByType').mockResolvedValueOnce([
+      createJobRow({ id: 'job-1', tenant_id: 'tenant-alpha' }),
+      createJobRow({ id: 'job-2', tenant_id: 'tenant-beta' }),
+    ]);
+
+    await expect(service.pollPendingJobs('graphify', 2)).resolves.toEqual([
+      expect.objectContaining({ job_id: 'job-1', tenant_id: 'tenant-alpha' }),
+      expect.objectContaining({ job_id: 'job-2', tenant_id: 'tenant-beta' }),
+    ]);
+  });
+
+  it('returns an empty array when no pending jobs exist', async () => {
+    const service = createService();
+    vi.spyOn(JobRepository, 'findPendingByType').mockResolvedValueOnce([]);
+
     await expect(service.pollPendingJobs('graphify', 1)).resolves.toEqual([]);
   });
 

--- a/apps/api/src/internal/internal-jobs.controller.ts
+++ b/apps/api/src/internal/internal-jobs.controller.ts
@@ -14,7 +14,7 @@ export class InternalJobsController {
 
   @Get('pending')
   async getPendingJobs(@Query() query: PendingJobsQueryDto): Promise<JobDto[]> {
-    return this.internalJobsService.pollPendingJobs(query.type, query.limit);
+    return this.internalJobsService.pollPendingJobs(query.type, query.limit, query.tenant_id);
   }
 
   @Patch(':job_id/progress')

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -62,10 +62,10 @@ export class InternalJobsService {
     @Optional() private readonly bridgeQueueService?: BridgeQueueService,
   ) {}
 
-  async pollPendingJobs(type: string, limit: number): Promise<JobDto[]> {
+  async pollPendingJobs(type: string, limit: number, tenantId?: string): Promise<JobDto[]> {
     const pendingJobs = await JobRepository.findPendingByType(
       this.db,
-      process.env.DEFAULT_TENANT_ID ?? 'default',
+      tenantId,
       type,
       limit,
     );

--- a/apps/api/src/internal/internal.dto.ts
+++ b/apps/api/src/internal/internal.dto.ts
@@ -39,6 +39,7 @@ export class PendingJobsQueryDto {
 
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   @MaxLength(200)
   tenant_id?: string;
 }

--- a/apps/api/src/internal/internal.dto.ts
+++ b/apps/api/src/internal/internal.dto.ts
@@ -36,6 +36,11 @@ export class PendingJobsQueryDto {
   @Min(1)
   @Max(10)
   limit = 1;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  tenant_id?: string;
 }
 
 export class JobProgressUpdateDto {


### PR DESCRIPTION
## Summary
- Remove `DEFAULT_TENANT_ID` hard-code from `pollPendingJobs`
- Add optional `tenant_id` query parameter to `PendingJobsQueryDto` with `@IsNotEmpty()` validation
- When omitted: poll pending jobs across ALL tenants (multi-tenant mode)
- When provided: filter to specified tenant (single-tenant mode)
- Existing priority/created_at ordering ensures fair, deterministic distribution

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration & Cross-file Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `61208a3e0e35bb3f811e6924d79bbbffc974d97a`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/250#issuecomment-4415829135) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/250#issuecomment-4415829229) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/250#issuecomment-4415829323) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/250#issuecomment-4415829385)
- Key findings addressed: Blank tenant_id validation added to prevent silent cross-tenant polling via empty string

## Test plan
- [x] Polling without tenant_id returns jobs from multiple tenants
- [x] Polling with explicit tenant_id returns only that tenant's jobs
- [x] DEFAULT_TENANT_ID env var does NOT filter when tenant_id not in request
- [x] Returned JobDto includes tenant_id for each job
- [x] Full test suite: 1112 tests pass

Closes #242