### PR TITLE
feat(web): interactive knowledge graph explorer per space

### DIFF
--- a/apps/api/src/graph/__tests__/graph-path.test.ts
+++ b/apps/api/src/graph/__tests__/graph-path.test.ts
@@ -103,6 +103,33 @@ describe('GraphController path', () => {
       { id: 'node-c', hop: 2 },
     ]);
   });
+
+  it('scopes neighbor expansion to the requested space', async () => {
+    const { controller, db } = createGraphContext();
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([createActiveSpaceRow()]);
+    db.queueExecute([
+      {
+        nodes_json: [
+          createNode({ id: 'node-a', label: 'SSO' }),
+          createNode({ id: 'node-b', label: 'Token' }),
+        ],
+        edges_json: [
+          createEdge({ id: 'edge-ab', source_node_id: 'node-a', target_node_id: 'node-b' }),
+        ],
+      },
+    ]);
+
+    const result = await controller.getNeighbors(
+      'node-a',
+      { hops: '1', space_id: TEST_SPACE_ID },
+      createRequest(),
+    );
+
+    expect(result.center_node).toMatchObject({ id: 'node-a', space_id: TEST_SPACE_ID });
+    expect(result.neighbors).toHaveLength(1);
+    expect(db.executedQueries).toHaveLength(1);
+  });
 });
 
 function createGraphContext(): { controller: GraphController; db: ScriptedDb } {

--- a/apps/api/src/graph/graph.dto.ts
+++ b/apps/api/src/graph/graph.dto.ts
@@ -21,6 +21,7 @@ export const graphPathRequestSchema = z.object({
 
 export const graphNeighborsQuerySchema = z.object({
   hops: hopsSchema,
+  space_id: optionalSpaceIdSchema,
 });
 
 export const graphCommunitiesQuerySchema = z.object({

--- a/apps/api/src/graph/graph.service.ts
+++ b/apps/api/src/graph/graph.service.ts
@@ -104,7 +104,7 @@ export class GraphService {
     input: GraphNeighborsQueryDto,
     context: GraphContext = {},
   ): Promise<GraphNeighborsResponseDto> {
-    const spaceIds = await this.resolveReadableSpaceIds(undefined, context);
+    const spaceIds = await this.resolveReadableSpaceIds(input.space_id, context);
     if (spaceIds.length === 0) {
       return { center_node: null, neighbors: [] };
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "marked": "^18.0.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-force-graph-2d": "^1.29.1",
     "react-i18next": "^17.0.7",
     "react-markdown": "^10.1.0",
     "react-router": "^7.14.2",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router';
+import { lazy, Suspense } from 'react';
 import AppShell from './components/AppShell';
 import { AuthProvider, useAuth } from './lib/auth';
 import AuditPage from './pages/admin/AuditPage';
@@ -20,6 +21,8 @@ import Wiki from './pages/Wiki';
 import UploadCenter from './pages/uploads/UploadCenter';
 import { ThemeProvider } from './theme/ThemeProvider';
 
+const SpaceGraphExplorerPage = lazy(() => import('./pages/graph/SpaceGraphExplorerPage'));
+
 export function AppRoutes() {
   return (
     <Routes>
@@ -30,6 +33,14 @@ export function AppRoutes() {
         <Route path="/spaces/:spaceId/wiki" element={<Wiki />} />
         <Route path="/spaces/:spaceId/wiki/:pageId" element={<Wiki />} />
         <Route path="/spaces/:spaceId/wiki/:pageId/history" element={<Wiki />} />
+        <Route
+          path="/spaces/:spaceId/graph"
+          element={(
+            <Suspense fallback={null}>
+              <SpaceGraphExplorerPage />
+            </Suspense>
+          )}
+        />
         <Route path="/spaces/:spaceId/graphify" element={<GraphifyRunsPage />} />
         <Route path="/spaces/:spaceId/graphify/:runId" element={<GraphifyRunDetailPage />} />
         <Route path="/spaces/:spaceId/uploads" element={<UploadCenter />} />

--- a/apps/web/src/__tests__/graph-explorer.test.tsx
+++ b/apps/web/src/__tests__/graph-explorer.test.tsx
@@ -11,6 +11,35 @@ import * as graphApi from '../lib/graphApi';
 import type { GraphCanvasData } from '../pages/graph/GraphCanvas';
 import type { GraphCommunity, GraphEdge, GraphNode } from '../lib/graphApi';
 
+type ApiGetMock = (path: string, query?: Record<string, unknown>) => Promise<unknown>;
+
+const apiMocks = vi.hoisted(() => ({
+  get: vi.fn<ApiGetMock>(),
+}));
+
+vi.mock('../lib/api', () => {
+  class ApiError extends Error {
+    readonly status: number;
+    readonly code: string;
+    readonly details: unknown;
+
+    constructor(input: { status: number; code: string; message: string; details?: unknown }) {
+      super(input.message);
+      this.name = 'ApiError';
+      this.status = input.status;
+      this.code = input.code;
+      this.details = input.details;
+    }
+  }
+
+  return {
+    ApiError,
+    api: {
+      get: apiMocks.get,
+    },
+  };
+});
+
 vi.mock('../lib/graphApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../lib/graphApi')>();
   return {
@@ -68,6 +97,15 @@ const getGraphCommunitiesMock = vi.mocked(graphApi.getGraphCommunities);
 describe('SpaceGraphExplorerPage', () => {
   beforeEach(async () => {
     await i18n.changeLanguage('en');
+    apiMocks.get.mockImplementation((path) => {
+      if (path === '/spaces/space-1') {
+        return Promise.resolve(createSpaceDetail());
+      }
+      if (path === '/spaces/space-1/stats') {
+        return Promise.resolve(createSpaceStats());
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
     getGraphCommunitiesMock.mockResolvedValue({ communities: [] });
     searchGraphNodesMock.mockResolvedValue({ nodes: [], total: 0 });
     getGraphNeighborsMock.mockResolvedValue({ center_node: null, neighbors: [] });
@@ -170,6 +208,23 @@ describe('SpaceGraphExplorerPage', () => {
     expect(await screen.findByText('No graph data loaded. Search for a node or run Graphify for this space.')).toBeInTheDocument();
   });
 
+  it('shows graphify empty state when the space has no graph nodes', async () => {
+    apiMocks.get.mockImplementation((path) => {
+      if (path === '/spaces/space-1') {
+        return Promise.resolve(createSpaceDetail({ active_graphify_run_id: null }));
+      }
+      if (path === '/spaces/space-1/stats') {
+        return Promise.resolve(createSpaceStats({ node_count: 0 }));
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('No active graph yet')).toBeInTheDocument();
+    expect(screen.getByText('Run Graphify').closest('a')).toHaveAttribute('href', '/spaces/space-1/graphify');
+  });
+
   it('shows an error state when the API fails', async () => {
     searchGraphNodesMock.mockRejectedValue(new Error('Graph API failed'));
 
@@ -186,6 +241,23 @@ describe('SpaceGraphExplorerPage', () => {
     runSearch('missing');
 
     expect(await screen.findByText('No matching nodes found.')).toBeInTheDocument();
+  });
+
+  it('preserves canvas state when neighbor expansion fails', async () => {
+    searchGraphNodesMock.mockResolvedValue({
+      nodes: [createNode({ id: 'node-a', label: 'SSO' })],
+      total: 1,
+    });
+    getGraphNeighborsMock.mockRejectedValue(new Error('Neighbor API failed'));
+
+    renderPage();
+    runSearch('SSO');
+    fireEvent.click(await screen.findByTestId('graph-node-node-a'));
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Neighbors' }));
+
+    expect(await screen.findByText('Neighbor API failed')).toBeInTheDocument();
+    expect(screen.getByTestId('graph-node-node-a')).toBeInTheDocument();
+    expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-node-count', '1');
   });
 });
 
@@ -242,6 +314,40 @@ function createCommunity(overrides: Partial<GraphCommunity> = {}): GraphCommunit
     label: 'Auth',
     summary: 'Authentication',
     node_count: 2,
+    ...overrides,
+  };
+}
+
+function createSpaceDetail(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'space-1',
+    name: 'Space 1',
+    slug: 'space-1',
+    status: 'active',
+    description: null,
+    stats: createSpaceStats(),
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    docmost_space_id: null,
+    wiki_repo_path: '',
+    active_graphify_run_id: 'run-1',
+    active_index_snapshot_id: null,
+    index_consistency_status: 'consistent',
+    strict_knowledge_only: false,
+    graphify_config: null,
+    default_publish_policy: 'draft',
+    ...overrides,
+  };
+}
+
+function createSpaceStats(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    space_id: 'space-1',
+    page_count: 0,
+    source_count: 0,
+    node_count: 2,
+    edge_count: 1,
+    index_consistency: 'consistent',
     ...overrides,
   };
 }

--- a/apps/web/src/__tests__/graph-explorer.test.tsx
+++ b/apps/web/src/__tests__/graph-explorer.test.tsx
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../i18n';
+import i18n from '../i18n';
+import { ThemeProvider } from '../theme/ThemeProvider';
+import SpaceGraphExplorerPage from '../pages/graph/SpaceGraphExplorerPage';
+import * as graphApi from '../lib/graphApi';
+import type { GraphCanvasData } from '../pages/graph/GraphCanvas';
+import type { GraphCommunity, GraphEdge, GraphNode } from '../lib/graphApi';
+
+vi.mock('../lib/graphApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/graphApi')>();
+  return {
+    ...actual,
+    searchGraphNodes: vi.fn(),
+    getGraphNeighbors: vi.fn(),
+    getGraphCommunities: vi.fn(),
+  };
+});
+
+vi.mock('../pages/graph/GraphCanvas', () => ({
+  default: ({
+    graphData,
+    activeCommunityId,
+    onNodeSelect,
+    onEdgeSelect,
+  }: {
+    graphData: GraphCanvasData;
+    activeCommunityId: string | null;
+    onNodeSelect: (nodeId: string) => void;
+    onEdgeSelect: (edgeId: string) => void;
+  }) => (
+    <div data-testid="graph-canvas" data-node-count={graphData.nodes.length} data-edge-count={graphData.links.length}>
+      {graphData.nodes.length === 0 ? <span>No graph data loaded. Search for a node or run Graphify for this space.</span> : null}
+      {graphData.nodes.map((node) => (
+        <button
+          key={node.id}
+          type="button"
+          data-testid={`graph-node-${node.id}`}
+          data-highlighted={activeCommunityId === node.community_id ? 'true' : 'false'}
+          onClick={() => onNodeSelect(node.id)}
+        >
+          {node.label}
+        </button>
+      ))}
+      {graphData.links.map((edge) => (
+        <button key={edge.id} type="button" data-testid={`graph-edge-${edge.id}`} onClick={() => onEdgeSelect(edge.id)}>
+          {edge.relationship}
+        </button>
+      ))}
+    </div>
+  ),
+  GRAPH_NODE_TYPE_COLORS: {
+    concept: '#2563eb',
+    entity: '#059669',
+    default: '#64748b',
+  },
+  getGraphNodeTypeColor: () => '#2563eb',
+}));
+
+const searchGraphNodesMock = vi.mocked(graphApi.searchGraphNodes);
+const getGraphNeighborsMock = vi.mocked(graphApi.getGraphNeighbors);
+const getGraphCommunitiesMock = vi.mocked(graphApi.getGraphCommunities);
+
+describe('SpaceGraphExplorerPage', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+    getGraphCommunitiesMock.mockResolvedValue({ communities: [] });
+    searchGraphNodesMock.mockResolvedValue({ nodes: [], total: 0 });
+    getGraphNeighborsMock.mockResolvedValue({ center_node: null, neighbors: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('search renders results and adds nodes to canvas data', async () => {
+    searchGraphNodesMock.mockResolvedValue({
+      nodes: [createNode({ id: 'node-oauth', label: 'OAuth' })],
+      total: 1,
+    });
+
+    renderPage();
+    runSearch('OAuth');
+
+    expect(await screen.findByTestId('graph-node-node-oauth')).toBeInTheDocument();
+    expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-node-count', '1');
+    expect(searchGraphNodesMock).toHaveBeenCalledWith({ spaceId: 'space-1', query: 'OAuth', limit: 20 });
+  });
+
+  it('neighbor expansion adds new nodes and edges without duplicates', async () => {
+    searchGraphNodesMock.mockResolvedValue({
+      nodes: [createNode({ id: 'node-a', label: 'SSO' })],
+      total: 1,
+    });
+    getGraphNeighborsMock.mockResolvedValue({
+      center_node: createNode({ id: 'node-a', label: 'SSO' }),
+      neighbors: [
+        {
+          node: createNode({ id: 'node-b', label: 'Token' }),
+          edge: createEdge({ id: 'edge-ab', source_node_id: 'node-a', target_node_id: 'node-b' }),
+          hop: 1,
+        },
+      ],
+    });
+
+    renderPage();
+    runSearch('SSO');
+    fireEvent.click(await screen.findByTestId('graph-node-node-a'));
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Neighbors' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-node-count', '2');
+      expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-edge-count', '1');
+    });
+
+    await waitFor(() => expect(screen.getByText('Refresh Neighbors')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Refresh Neighbors').closest('button')!);
+    await waitFor(() => {
+      expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-node-count', '2');
+      expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-edge-count', '1');
+    });
+  });
+
+  it('filters nodes from other spaces', async () => {
+    searchGraphNodesMock.mockResolvedValue({
+      nodes: [
+        createNode({ id: 'node-a', label: 'Current Space' }),
+        createNode({ id: 'node-b', label: 'Other Space', space_id: 'space-2' }),
+      ],
+      total: 2,
+    });
+
+    renderPage();
+    runSearch('space');
+
+    expect(await screen.findByTestId('graph-node-node-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('graph-node-node-b')).not.toBeInTheDocument();
+    expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-node-count', '1');
+  });
+
+  it('community selection highlights matching nodes', async () => {
+    getGraphCommunitiesMock.mockResolvedValue({
+      communities: [createCommunity({ id: 'community-auth', label: 'Auth' })],
+    });
+    searchGraphNodesMock.mockResolvedValue({
+      nodes: [
+        createNode({ id: 'node-a', label: 'OAuth', community_id: 'community-auth' }),
+        createNode({ id: 'node-b', label: 'Billing', community_id: 'community-billing' }),
+      ],
+      total: 2,
+    });
+
+    renderPage();
+    runSearch('service');
+    await screen.findByText('Auth');
+    fireEvent.click(screen.getByText('Auth').closest('button')!);
+
+    expect(screen.getByTestId('graph-node-node-a')).toHaveAttribute('data-highlighted', 'true');
+    expect(screen.getByTestId('graph-node-node-b')).toHaveAttribute('data-highlighted', 'false');
+  });
+
+  it('shows empty state when no graph data is loaded', async () => {
+    renderPage();
+
+    expect(await screen.findByText('No graph data loaded. Search for a node or run Graphify for this space.')).toBeInTheDocument();
+  });
+
+  it('shows an error state when the API fails', async () => {
+    searchGraphNodesMock.mockRejectedValue(new Error('Graph API failed'));
+
+    renderPage();
+    runSearch('OAuth');
+
+    expect(await screen.findByText('Graph API failed')).toBeInTheDocument();
+  });
+
+  it('shows no-results state for search', async () => {
+    searchGraphNodesMock.mockResolvedValue({ nodes: [], total: 0 });
+
+    renderPage();
+    runSearch('missing');
+
+    expect(await screen.findByText('No matching nodes found.')).toBeInTheDocument();
+  });
+});
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/spaces/space-1/graph']}>
+      <ThemeProvider>
+        <Routes>
+          <Route path="/spaces/:spaceId/graph" element={<SpaceGraphExplorerPage />} />
+        </Routes>
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+function runSearch(query: string): void {
+  fireEvent.change(screen.getByPlaceholderText('Search nodes'), { target: { value: query } });
+  fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+}
+
+function createNode(overrides: Partial<GraphNode> = {}): GraphNode {
+  return {
+    id: 'node-a',
+    node_key: 'node',
+    stable_key: 'space-1:concept:node',
+    label: 'Node',
+    node_type: 'concept',
+    description: null,
+    space_id: 'space-1',
+    community_id: null,
+    score: 1,
+    ...overrides,
+  };
+}
+
+function createEdge(overrides: Partial<GraphEdge> = {}): GraphEdge {
+  return {
+    id: 'edge-ab',
+    source_node_id: 'node-a',
+    target_node_id: 'node-b',
+    relationship: 'relates_to',
+    confidence_label: 'EXTRACTED',
+    effective_confidence_score: 0.9,
+    evidence_count: 1,
+    space_id: 'space-1',
+    ...overrides,
+  };
+}
+
+function createCommunity(overrides: Partial<GraphCommunity> = {}): GraphCommunity {
+  return {
+    id: 'community-auth',
+    community_key: 'auth',
+    label: 'Auth',
+    summary: 'Authentication',
+    node_count: 2,
+    ...overrides,
+  };
+}

--- a/apps/web/src/__tests__/infrastructure.test.tsx
+++ b/apps/web/src/__tests__/infrastructure.test.tsx
@@ -245,6 +245,7 @@ describe('AppShell', () => {
     expect(screen.getAllByText('Chat').length).toBeGreaterThan(0);
     expect(screen.getByText('Wiki')).toBeInTheDocument();
     expect(screen.getByText('Documents')).toBeInTheDocument();
+    expect(screen.getByText('Graph Explorer')).toBeInTheDocument();
   });
 
   it.each([

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -219,7 +219,7 @@ describe('UploadCenter', () => {
       expect(getRequestUrls(fetchMock)).toContain('/api/spaces/space-1/uploads?page=1&per_page=20&sort=-created_at');
     });
 
-    const searchInput = screen.getByPlaceholderText('Search filenames');
+    const searchInput = await screen.findByPlaceholderText('Search filenames');
     fireEvent.change(searchInput, { target: { value: 'roadmap' } });
     await waitFor(() => expect(searchInput).toHaveValue('roadmap'));
 
@@ -227,12 +227,14 @@ describe('UploadCenter', () => {
       expect(getRequestUrls(fetchMock)).toContain('/api/spaces/space-1/uploads?page=1&per_page=20&search=roadmap&sort=-created_at');
     });
 
+    await waitFor(() => getComboboxByLabel('Source type'));
     fireEvent.mouseDown(getComboboxByLabel('Source type'));
     fireEvent.click(await findSelectOption('URL'));
     await waitFor(() => {
       expect(getRequestUrls(fetchMock)).toContain('/api/spaces/space-1/uploads?page=1&per_page=20&source_type=url&search=roadmap&sort=-created_at');
     });
 
+    await waitFor(() => getComboboxByLabel('Sort by'));
     fireEvent.mouseDown(getComboboxByLabel('Sort by'));
     fireEvent.click(await findSelectOption('Recently updated'));
     await waitFor(() => {

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -209,7 +209,7 @@ describe('UploadList', () => {
 });
 
 describe('UploadCenter', () => {
-  it('loads documents with search, source type, and sort query parameters', async () => {
+  it('loads documents with search, source type, and sort query parameters', { timeout: 30000 }, async () => {
     const fetchMock = stubUploadListApi();
 
     renderUploadCenter();

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -13,6 +13,7 @@ import {
   MoonOutlined,
   NodeIndexOutlined,
   SettingOutlined,
+  ShareAltOutlined,
   SunOutlined,
   TeamOutlined,
   UserOutlined,
@@ -38,7 +39,7 @@ import { useAuth, type AuthUser } from '../lib/auth';
 import { useTheme } from '../theme/ThemeProvider';
 import './AppShell.css';
 
-type SpaceFunction = 'chat' | 'wiki' | 'uploads' | 'graphify';
+type SpaceFunction = 'chat' | 'wiki' | 'uploads' | 'graph' | 'graphify';
 type AdminRouteKey = 'users' | 'groups' | 'spaces' | 'models' | 'audit' | 'health' | 'jobs' | 'adminGraphify';
 
 const SIDER_STORAGE_KEY = 'cherrywiki.shell.collapsed';
@@ -51,6 +52,7 @@ const SPACE_FUNCTIONS: Array<{
   { key: 'chat', icon: <MessageOutlined />, translationKey: 'shell.sidebar.chat' },
   { key: 'wiki', icon: <BookOutlined />, translationKey: 'shell.sidebar.wiki' },
   { key: 'uploads', icon: <CloudUploadOutlined />, translationKey: 'shell.sidebar.documents' },
+  { key: 'graph', icon: <ShareAltOutlined />, translationKey: 'shell.sidebar.graph' },
   { key: 'graphify', icon: <NodeIndexOutlined />, translationKey: 'shell.sidebar.graphify' },
 ];
 
@@ -351,6 +353,7 @@ function getSpaceFunctionFromPath(pathname: string): SpaceFunction | null {
   if (pathname.includes('/wiki')) return 'wiki';
   if (pathname.includes('/uploads')) return 'uploads';
   if (pathname.includes('/graphify')) return 'graphify';
+  if (pathname.includes('/graph')) return 'graph';
   if (pathname.includes('/chat')) return 'chat';
   return null;
 }

--- a/apps/web/src/lib/graphApi.ts
+++ b/apps/web/src/lib/graphApi.ts
@@ -1,0 +1,79 @@
+import { api } from './api';
+
+export type GraphNode = {
+  id: string;
+  node_key: string;
+  stable_key: string;
+  label: string;
+  node_type: string | null;
+  description?: string | null;
+  space_id: string;
+  community_id: string | null;
+  score: number;
+};
+
+export type GraphEdge = {
+  id: string;
+  source_node_id: string;
+  target_node_id: string;
+  relationship: string;
+  confidence_label: string;
+  effective_confidence_score: number | null;
+  evidence_count: number;
+  space_id: string;
+};
+
+export type GraphCommunity = {
+  id: string;
+  community_key: string;
+  label: string | null;
+  summary: string | null;
+  node_count: number;
+};
+
+export type GraphSearchResponse = {
+  nodes: GraphNode[];
+  total: number;
+};
+
+export type GraphNeighborsResponse = {
+  center_node: GraphNode | null;
+  neighbors: Array<{
+    node: GraphNode;
+    edge: GraphEdge | null;
+    hop: number;
+  }>;
+};
+
+export type GraphCommunitiesResponse = {
+  communities: GraphCommunity[];
+};
+
+export function searchGraphNodes(input: {
+  spaceId: string;
+  query: string;
+  limit?: number;
+}): Promise<GraphSearchResponse> {
+  return api.get<GraphSearchResponse>('/graph/nodes', {
+    q: input.query,
+    space_id: input.spaceId,
+    top_k: input.limit ?? 20,
+  });
+}
+
+export function getGraphNeighbors(input: {
+  nodeId: string;
+  spaceId: string;
+  hops?: number;
+}): Promise<GraphNeighborsResponse> {
+  return api.get<GraphNeighborsResponse>(`/graph/nodes/${encodeURIComponent(input.nodeId)}/neighbors`, {
+    hops: input.hops ?? 1,
+    space_id: input.spaceId,
+  });
+}
+
+export function getGraphCommunities(spaceId: string): Promise<GraphCommunitiesResponse> {
+  return api.get<GraphCommunitiesResponse>('/graph/communities', {
+    space_id: spaceId,
+  });
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -73,6 +73,7 @@
       "wiki": "Wiki",
       "uploads": "Documents",
       "documents": "Documents",
+      "graph": "Graph Explorer",
       "graphify": "Graphify"
     },
     "admin": {
@@ -665,6 +666,61 @@
       "published": "Published",
       "archived": "Archived",
       "current": "Current"
+    }
+  },
+  "graph": {
+    "title": "Graph Explorer",
+    "description": "Search graph nodes, expand neighbors, and inspect relationships in this space.",
+    "search": {
+      "title": "Search",
+      "placeholder": "Search nodes"
+    },
+    "community": {
+      "title": "Communities",
+      "empty": "No communities available",
+      "clear": "Clear",
+      "nodeCount": "{{count}} nodes"
+    },
+    "canvas": {
+      "resetView": "Reset graph view"
+    },
+    "toolbar": {
+      "hops": "Hops",
+      "oneHop": "1-hop",
+      "twoHop": "2-hop"
+    },
+    "action": {
+      "expandNeighbors": "Expand Neighbors",
+      "refreshNeighbors": "Refresh Neighbors",
+      "clearGraph": "Clear Graph"
+    },
+    "state": {
+      "loading": "Loading graph...",
+      "empty": "No graph data loaded. Search for a node or run Graphify for this space.",
+      "noResults": "No matching nodes found.",
+      "truncated": "Showing the first {{limit}} nodes to keep the graph responsive."
+    },
+    "drawer": {
+      "title": "Selection Details"
+    },
+    "detail": {
+      "label": "Label",
+      "nodeType": "Node type",
+      "community": "Community",
+      "score": "Score",
+      "id": "ID",
+      "description": "Description",
+      "relationship": "Relationship",
+      "confidence": "Confidence",
+      "evidenceCount": "Evidence count",
+      "source": "Source",
+      "target": "Target"
+    },
+    "legend": {
+      "title": "Legend"
+    },
+    "nodeType": {
+      "unknown": "Unknown"
     }
   },
   "graphify": {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -698,7 +698,13 @@
       "loading": "Loading graph...",
       "empty": "No graph data loaded. Search for a node or run Graphify for this space.",
       "noResults": "No matching nodes found.",
-      "truncated": "Showing the first {{limit}} nodes to keep the graph responsive."
+      "truncated": "Showing the first {{limit}} nodes to keep the graph responsive.",
+      "edgeTruncated": "Showing the first {{limit}} edges connected to loaded nodes to keep the graph responsive."
+    },
+    "emptyGraph": {
+      "title": "No active graph yet",
+      "description": "Run Graphify to build nodes and relationships for this space before exploring the graph.",
+      "action": "Run Graphify"
     },
     "drawer": {
       "title": "Selection Details"

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -698,7 +698,13 @@
       "loading": "加载图谱中...",
       "empty": "暂无已加载的图谱数据。请搜索节点，或先为此空间运行图谱化。",
       "noResults": "没有找到匹配节点。",
-      "truncated": "为保持图谱流畅，仅展示前 {{limit}} 个节点。"
+      "truncated": "为保持图谱流畅，仅展示前 {{limit}} 个节点。",
+      "edgeTruncated": "为保持图谱流畅，仅展示与已加载节点相连的前 {{limit}} 条边。"
+    },
+    "emptyGraph": {
+      "title": "暂无可用图谱",
+      "description": "请先运行图谱化，为此空间构建节点和关系后再浏览图谱。",
+      "action": "运行图谱化"
     },
     "drawer": {
       "title": "选中详情"

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -73,6 +73,7 @@
       "wiki": "知识库",
       "uploads": "文档",
       "documents": "文档",
+      "graph": "图谱探索",
       "graphify": "图谱化"
     },
     "admin": {
@@ -665,6 +666,61 @@
       "published": "已发布",
       "archived": "已归档",
       "current": "当前"
+    }
+  },
+  "graph": {
+    "title": "图谱探索",
+    "description": "在此空间中搜索图谱节点、展开邻居并查看关系详情。",
+    "search": {
+      "title": "搜索",
+      "placeholder": "搜索节点"
+    },
+    "community": {
+      "title": "社区",
+      "empty": "暂无社区",
+      "clear": "清除",
+      "nodeCount": "{{count}} 个节点"
+    },
+    "canvas": {
+      "resetView": "重置图谱视图"
+    },
+    "toolbar": {
+      "hops": "跳数",
+      "oneHop": "1 跳",
+      "twoHop": "2 跳"
+    },
+    "action": {
+      "expandNeighbors": "展开邻居",
+      "refreshNeighbors": "刷新邻居",
+      "clearGraph": "清空图谱"
+    },
+    "state": {
+      "loading": "加载图谱中...",
+      "empty": "暂无已加载的图谱数据。请搜索节点，或先为此空间运行图谱化。",
+      "noResults": "没有找到匹配节点。",
+      "truncated": "为保持图谱流畅，仅展示前 {{limit}} 个节点。"
+    },
+    "drawer": {
+      "title": "选中详情"
+    },
+    "detail": {
+      "label": "标签",
+      "nodeType": "节点类型",
+      "community": "社区",
+      "score": "分数",
+      "id": "ID",
+      "description": "描述",
+      "relationship": "关系",
+      "confidence": "置信度",
+      "evidenceCount": "证据数",
+      "source": "源节点",
+      "target": "目标节点"
+    },
+    "legend": {
+      "title": "图例"
+    },
+    "nodeType": {
+      "unknown": "未知"
     }
   },
   "graphify": {

--- a/apps/web/src/pages/graph/GraphCanvas.tsx
+++ b/apps/web/src/pages/graph/GraphCanvas.tsx
@@ -26,6 +26,25 @@ const NODE_TYPE_COLORS: Record<string, string> = {
 };
 const DEFAULT_NODE_COLOR = '#64748b';
 
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case '\'':
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
+}
+
 type GraphCanvasProps = {
   graphData: GraphCanvasData;
   activeCommunityId: string | null;
@@ -111,10 +130,10 @@ export default function GraphCanvas({
           height={size.height}
           backgroundColor="#ffffff"
           nodeColor={getNodeColor}
-          nodeLabel={(node) => node.label}
+          nodeLabel={(node) => escapeHtml(node.label)}
           nodeRelSize={6}
           linkColor={getLinkColor}
-          linkLabel={(link) => link.relationship}
+          linkLabel={(link) => escapeHtml(link.relationship)}
           linkDirectionalArrowLength={4}
           linkDirectionalArrowRelPos={1}
           linkWidth={(link) => (link.id === selectedEdgeId ? 2.5 : 1.2)}

--- a/apps/web/src/pages/graph/GraphCanvas.tsx
+++ b/apps/web/src/pages/graph/GraphCanvas.tsx
@@ -1,0 +1,141 @@
+import { FullscreenOutlined } from '@ant-design/icons';
+import { Button, Empty, Spin, Tooltip } from 'antd';
+import ForceGraph2D, { type ForceGraphMethods, type LinkObject, type NodeObject } from 'react-force-graph-2d';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { GraphEdge, GraphNode } from '../../lib/graphApi';
+
+export type GraphLink = GraphEdge & {
+  source: string;
+  target: string;
+};
+
+export type GraphCanvasData = {
+  nodes: GraphNode[];
+  links: GraphLink[];
+};
+
+const NODE_TYPE_COLORS: Record<string, string> = {
+  concept: '#2563eb',
+  entity: '#059669',
+  document: '#d97706',
+  topic: '#7c3aed',
+  person: '#dc2626',
+  organization: '#0891b2',
+  default: '#64748b',
+};
+const DEFAULT_NODE_COLOR = '#64748b';
+
+type GraphCanvasProps = {
+  graphData: GraphCanvasData;
+  activeCommunityId: string | null;
+  selectedNodeId: string | null;
+  selectedEdgeId: string | null;
+  loading: boolean;
+  onNodeSelect: (nodeId: string) => void;
+  onEdgeSelect: (edgeId: string) => void;
+};
+
+export default function GraphCanvas({
+  graphData,
+  activeCommunityId,
+  selectedNodeId,
+  selectedEdgeId,
+  loading,
+  onNodeSelect,
+  onEdgeSelect,
+}: GraphCanvasProps) {
+  const { t } = useTranslation();
+  const graphRef = useRef<ForceGraphMethods<NodeObject<GraphNode>, LinkObject<GraphNode, GraphLink>> | undefined>(undefined);
+  const [size, setSize] = useState({ width: 720, height: 520 });
+
+  useEffect(() => {
+    const updateSize = () => {
+      const width = Math.max(360, Math.min(window.innerWidth - 520, 1120));
+      const height = Math.max(420, window.innerHeight - 260);
+      setSize({ width, height });
+    };
+
+    updateSize();
+    window.addEventListener('resize', updateSize);
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+
+  const data = useMemo(
+    () => ({
+      nodes: graphData.nodes.map((node) => ({ ...node })),
+      links: graphData.links.map((link) => ({ ...link })),
+    }),
+    [graphData.links, graphData.nodes],
+  );
+
+  function resetView(): void {
+    graphRef.current?.zoomToFit(400, 48);
+  }
+
+  function getNodeColor(node: NodeObject<GraphNode>): string {
+    if (node.id === selectedNodeId) {
+      return '#f97316';
+    }
+
+    if (activeCommunityId !== null && node.community_id === activeCommunityId) {
+      return '#16a34a';
+    }
+
+    return NODE_TYPE_COLORS[node.node_type ?? 'default'] ?? DEFAULT_NODE_COLOR;
+  }
+
+  function getLinkColor(link: LinkObject<GraphNode, GraphLink>): string {
+    return link.id === selectedEdgeId ? '#f97316' : 'rgba(71, 85, 105, 0.62)';
+  }
+
+  return (
+    <div style={{ position: 'relative', minHeight: size.height, border: '1px solid #e5e7eb', borderRadius: 8, overflow: 'hidden', background: '#ffffff' }}>
+      <div style={{ position: 'absolute', right: 12, top: 12, zIndex: 2 }}>
+        <Tooltip title={t('graph.canvas.resetView')}>
+          <Button aria-label={t('graph.canvas.resetView')} icon={<FullscreenOutlined />} onClick={resetView} />
+        </Tooltip>
+      </div>
+      {graphData.nodes.length === 0 ? (
+        <div style={{ display: 'grid', placeItems: 'center', minHeight: size.height }}>
+          {loading ? <Spin tip={t('graph.state.loading')} /> : <Empty description={t('graph.state.empty')} />}
+        </div>
+      ) : (
+        <ForceGraph2D
+          ref={graphRef}
+          graphData={data}
+          nodeId="id"
+          linkSource="source"
+          linkTarget="target"
+          width={size.width}
+          height={size.height}
+          backgroundColor="#ffffff"
+          nodeColor={getNodeColor}
+          nodeLabel={(node) => node.label}
+          nodeRelSize={6}
+          linkColor={getLinkColor}
+          linkLabel={(link) => link.relationship}
+          linkDirectionalArrowLength={4}
+          linkDirectionalArrowRelPos={1}
+          linkWidth={(link) => (link.id === selectedEdgeId ? 2.5 : 1.2)}
+          onNodeClick={(node) => {
+            if (typeof node.id === 'string') {
+              onNodeSelect(node.id);
+            }
+          }}
+          onLinkClick={(link) => {
+            if (typeof link.id === 'string') {
+              onEdgeSelect(link.id);
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export function getGraphNodeTypeColor(nodeType: string | null): string {
+  return NODE_TYPE_COLORS[nodeType ?? 'default'] ?? DEFAULT_NODE_COLOR;
+}
+
+export const GRAPH_NODE_TYPE_COLORS = NODE_TYPE_COLORS;

--- a/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
+++ b/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
@@ -16,6 +16,8 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type CSS
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { getErrorMessage } from '../../components/adminUi';
+import { api } from '../../lib/api';
+import type { AdminSpaceDetail } from '../../lib/adminTypes';
 import {
   getGraphCommunities,
   getGraphNeighbors,
@@ -29,12 +31,14 @@ import GraphCanvas, { GRAPH_NODE_TYPE_COLORS, getGraphNodeTypeColor, type GraphC
 
 const SEARCH_LIMIT = 20;
 const MAX_GRAPH_NODES = 500;
+const MAX_GRAPH_EDGES = 1000;
 
 type GraphState = {
   nodesById: Map<string, GraphNode>;
   edgesById: Map<string, GraphEdge>;
   expandedNodeIds: Set<string>;
   truncated: boolean;
+  edgeTruncated: boolean;
 };
 
 type GraphAction =
@@ -47,6 +51,11 @@ const INITIAL_GRAPH_STATE: GraphState = {
   edgesById: new Map(),
   expandedNodeIds: new Set(),
   truncated: false,
+  edgeTruncated: false,
+};
+
+type SpaceStatsResponse = {
+  node_count: number;
 };
 
 type Selection =
@@ -69,19 +78,50 @@ export default function SpaceGraphExplorerPage() {
   const [activeCommunityId, setActiveCommunityId] = useState<string | null>(null);
   const [selection, setSelection] = useState<Selection>(null);
   const [error, setError] = useState<string | null>(null);
+  const [hasEmptyGraph, setHasEmptyGraph] = useState(false);
   const searchSeqRef = useRef(0);
+  const spaceSeqRef = useRef(0);
 
   useEffect(() => {
+    const spaceSeq = ++spaceSeqRef.current;
+    searchSeqRef.current++;
     dispatch({ type: 'clear' });
     setQuery('');
     setSearchResults([]);
     setHasSearched(false);
+    setIsSearching(false);
+    setIsExpanding(false);
     setActiveCommunityId(null);
     setSelection(null);
     setError(null);
+    setHasEmptyGraph(false);
+
+    if (spaceId.length === 0) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        const [space, stats] = await Promise.all([
+          api.get<AdminSpaceDetail>(`/spaces/${encodeURIComponent(spaceId)}`),
+          api.get<SpaceStatsResponse>(`/spaces/${encodeURIComponent(spaceId)}/stats`),
+        ]);
+        if (spaceSeq !== spaceSeqRef.current) {
+          return;
+        }
+        setHasEmptyGraph(stats.node_count === 0 || space.active_graphify_run_id === null);
+      } catch (err) {
+        if (spaceSeq !== spaceSeqRef.current) {
+          return;
+        }
+        setError(getErrorMessage(err));
+        setHasEmptyGraph(false);
+      }
+    })();
   }, [spaceId]);
 
   const loadCommunities = useCallback(async () => {
+    const spaceSeq = spaceSeqRef.current;
     if (spaceId.length === 0) {
       setCommunities([]);
       setIsLoadingCommunities(false);
@@ -91,12 +131,20 @@ export default function SpaceGraphExplorerPage() {
     setIsLoadingCommunities(true);
     try {
       const response = await getGraphCommunities(spaceId);
+      if (spaceSeq !== spaceSeqRef.current) {
+        return;
+      }
       setCommunities(response.communities);
     } catch (err) {
+      if (spaceSeq !== spaceSeqRef.current) {
+        return;
+      }
       setError(getErrorMessage(err));
       setCommunities([]);
     } finally {
-      setIsLoadingCommunities(false);
+      if (spaceSeq === spaceSeqRef.current) {
+        setIsLoadingCommunities(false);
+      }
     }
   }, [spaceId]);
 
@@ -123,21 +171,23 @@ export default function SpaceGraphExplorerPage() {
 
   async function handleSearch(nextQuery: string): Promise<void> {
     const normalizedQuery = nextQuery.trim();
+    const seq = ++searchSeqRef.current;
+    const spaceSeq = spaceSeqRef.current;
     setQuery(normalizedQuery);
     setHasSearched(true);
     setSearchResults([]);
 
     if (normalizedQuery.length === 0) {
+      setIsSearching(false);
       return;
     }
 
-    const seq = ++searchSeqRef.current;
     setIsSearching(true);
     setError(null);
 
     try {
       const response = await searchGraphNodes({ spaceId, query: normalizedQuery, limit: SEARCH_LIMIT });
-      if (seq !== searchSeqRef.current) {
+      if (seq !== searchSeqRef.current || spaceSeq !== spaceSeqRef.current) {
         return;
       }
 
@@ -145,12 +195,12 @@ export default function SpaceGraphExplorerPage() {
       setSearchResults(scopedNodes);
       dispatch({ type: 'merge', spaceId, nodes: scopedNodes, edges: [] });
     } catch (err) {
-      if (seq !== searchSeqRef.current) {
+      if (seq !== searchSeqRef.current || spaceSeq !== spaceSeqRef.current) {
         return;
       }
       setError(getErrorMessage(err));
     } finally {
-      if (seq === searchSeqRef.current) {
+      if (seq === searchSeqRef.current && spaceSeq === spaceSeqRef.current) {
         setIsSearching(false);
       }
     }
@@ -161,11 +211,15 @@ export default function SpaceGraphExplorerPage() {
       return;
     }
 
+    const spaceSeq = spaceSeqRef.current;
     setIsExpanding(true);
     setError(null);
 
     try {
       const response = await getGraphNeighbors({ nodeId, spaceId, hops });
+      if (spaceSeq !== spaceSeqRef.current) {
+        return;
+      }
       const nodes = [
         ...(response.center_node === null ? [] : [response.center_node]),
         ...response.neighbors.map((neighbor) => neighbor.node),
@@ -176,9 +230,14 @@ export default function SpaceGraphExplorerPage() {
       dispatch({ type: 'merge', spaceId, nodes, edges });
       dispatch({ type: 'markExpanded', nodeId });
     } catch (err) {
+      if (spaceSeq !== spaceSeqRef.current) {
+        return;
+      }
       setError(getErrorMessage(err));
     } finally {
-      setIsExpanding(false);
+      if (spaceSeq === spaceSeqRef.current) {
+        setIsExpanding(false);
+      }
     }
   }
 
@@ -202,51 +261,69 @@ export default function SpaceGraphExplorerPage() {
       {graphState.truncated ? (
         <Alert message={t('graph.state.truncated', { limit: MAX_GRAPH_NODES })} type="warning" showIcon style={{ marginBottom: 16 }} />
       ) : null}
+      {graphState.edgeTruncated ? (
+        <Alert message={t('graph.state.edgeTruncated', { limit: MAX_GRAPH_EDGES })} type="warning" showIcon style={{ marginBottom: 16 }} />
+      ) : null}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(260px, 320px) minmax(0, 1fr)', gap: 16, alignItems: 'start' }}>
-        <Space direction="vertical" size={16} style={{ width: '100%' }}>
-          <GraphSearchPanel
-            query={query}
-            results={searchResults}
-            hasSearched={hasSearched}
-            isSearching={isSearching}
-            onQueryChange={setQuery}
-            onSearch={(value) => { void handleSearch(value); }}
-            onSelectNode={(nodeId) => setSelection({ type: 'node', id: nodeId })}
-          />
-          <GraphCommunityPanel
-            communities={communities}
-            isLoading={isLoadingCommunities}
-            activeCommunityId={activeCommunityId}
-            onSelectCommunity={setActiveCommunityId}
-          />
-        </Space>
+      {hasEmptyGraph ? (
+        <Empty
+          description={(
+            <Space direction="vertical" size={12}>
+              <Typography.Text strong>{t('graph.emptyGraph.title')}</Typography.Text>
+              <Typography.Text type="secondary">{t('graph.emptyGraph.description')}</Typography.Text>
+              <Button type="primary" href={`/spaces/${encodeURIComponent(spaceId)}/graphify`}>
+                {t('graph.emptyGraph.action')}
+              </Button>
+            </Space>
+          )}
+          style={{ marginTop: 48 }}
+        />
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(260px, 320px) minmax(0, 1fr)', gap: 16, alignItems: 'start' }}>
+          <Space direction="vertical" size={16} style={{ width: '100%' }}>
+            <GraphSearchPanel
+              query={query}
+              results={searchResults}
+              hasSearched={hasSearched}
+              isSearching={isSearching}
+              onQueryChange={setQuery}
+              onSearch={(value) => { void handleSearch(value); }}
+              onSelectNode={(nodeId) => setSelection({ type: 'node', id: nodeId })}
+            />
+            <GraphCommunityPanel
+              communities={communities}
+              isLoading={isLoadingCommunities}
+              activeCommunityId={activeCommunityId}
+              onSelectCommunity={setActiveCommunityId}
+            />
+          </Space>
 
-        <Space direction="vertical" size={12} style={{ width: '100%' }}>
-          <GraphToolbar
-            hops={hops}
-            isExpanding={isExpanding}
-            selectedNode={selectedNode}
-            alreadyExpanded={selectedNode !== null && graphState.expandedNodeIds.has(selectedNode.id)}
-            onHopsChange={setHops}
-            onExpand={(force) => {
-              if (selectedNode !== null) {
-                void expandNode(selectedNode.id, force);
-              }
-            }}
-          />
-          <GraphCanvas
-            graphData={graphData}
-            activeCommunityId={activeCommunityId}
-            selectedNodeId={selectedNode?.id ?? null}
-            selectedEdgeId={selectedEdge?.id ?? null}
-            loading={isSearching || isExpanding}
-            onNodeSelect={(nodeId) => setSelection({ type: 'node', id: nodeId })}
-            onEdgeSelect={(edgeId) => setSelection({ type: 'edge', id: edgeId })}
-          />
-          <GraphLegend />
-        </Space>
-      </div>
+          <Space direction="vertical" size={12} style={{ width: '100%' }}>
+            <GraphToolbar
+              hops={hops}
+              isExpanding={isExpanding}
+              selectedNode={selectedNode}
+              alreadyExpanded={selectedNode !== null && graphState.expandedNodeIds.has(selectedNode.id)}
+              onHopsChange={setHops}
+              onExpand={(force) => {
+                if (selectedNode !== null) {
+                  void expandNode(selectedNode.id, force);
+                }
+              }}
+            />
+            <GraphCanvas
+              graphData={graphData}
+              activeCommunityId={activeCommunityId}
+              selectedNodeId={selectedNode?.id ?? null}
+              selectedEdgeId={selectedEdge?.id ?? null}
+              loading={isSearching || isExpanding}
+              onNodeSelect={(nodeId) => setSelection({ type: 'node', id: nodeId })}
+              onEdgeSelect={(edgeId) => setSelection({ type: 'edge', id: edgeId })}
+            />
+            <GraphLegend />
+          </Space>
+        </div>
+      )}
 
       <GraphSelectionDrawer
         selectedNode={selectedNode}
@@ -490,6 +567,7 @@ function graphReducer(state: GraphState, action: GraphAction): GraphState {
       edgesById: new Map(),
       expandedNodeIds: new Set(),
       truncated: false,
+      edgeTruncated: false,
     };
   }
 
@@ -500,8 +578,9 @@ function graphReducer(state: GraphState, action: GraphAction): GraphState {
   }
 
   const nodesById = new Map(state.nodesById);
-  const edgesById = new Map(state.edgesById);
+  let edgesById = new Map(state.edgesById);
   let truncated = state.truncated;
+  let edgeTruncated = state.edgeTruncated;
 
   for (const node of action.nodes) {
     if (node.space_id !== action.spaceId) {
@@ -528,11 +607,27 @@ function graphReducer(state: GraphState, action: GraphAction): GraphState {
     edgesById.set(edge.id, edge);
   }
 
+  if (edgesById.size > MAX_GRAPH_EDGES) {
+    edgeTruncated = true;
+    const cappedEdgesById = new Map<string, GraphEdge>();
+    for (const [edgeId, edge] of edgesById) {
+      if (!nodesById.has(edge.source_node_id) || !nodesById.has(edge.target_node_id)) {
+        continue;
+      }
+      cappedEdgesById.set(edgeId, edge);
+      if (cappedEdgesById.size >= MAX_GRAPH_EDGES) {
+        break;
+      }
+    }
+    edgesById = cappedEdgesById;
+  }
+
   return {
     ...state,
     nodesById,
     edgesById,
     truncated,
+    edgeTruncated,
   };
 }
 

--- a/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
+++ b/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
@@ -1,0 +1,544 @@
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Drawer,
+  Empty,
+  Input,
+  List,
+  Select,
+  Space,
+  Spin,
+  Tag,
+  Typography,
+} from 'antd';
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type CSSProperties } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+import { getErrorMessage } from '../../components/adminUi';
+import {
+  getGraphCommunities,
+  getGraphNeighbors,
+  searchGraphNodes,
+  type GraphCommunity,
+  type GraphEdge,
+  type GraphNode,
+} from '../../lib/graphApi';
+import NotFound from '../NotFound';
+import GraphCanvas, { GRAPH_NODE_TYPE_COLORS, getGraphNodeTypeColor, type GraphCanvasData } from './GraphCanvas';
+
+const SEARCH_LIMIT = 20;
+const MAX_GRAPH_NODES = 500;
+
+type GraphState = {
+  nodesById: Map<string, GraphNode>;
+  edgesById: Map<string, GraphEdge>;
+  expandedNodeIds: Set<string>;
+  truncated: boolean;
+};
+
+type GraphAction =
+  | { type: 'clear' }
+  | { type: 'merge'; spaceId: string; nodes: GraphNode[]; edges: GraphEdge[] }
+  | { type: 'markExpanded'; nodeId: string };
+
+const INITIAL_GRAPH_STATE: GraphState = {
+  nodesById: new Map(),
+  edgesById: new Map(),
+  expandedNodeIds: new Set(),
+  truncated: false,
+};
+
+type Selection =
+  | { type: 'node'; id: string }
+  | { type: 'edge'; id: string }
+  | null;
+
+export default function SpaceGraphExplorerPage() {
+  const { t } = useTranslation();
+  const { spaceId = '' } = useParams();
+  const [graphState, dispatch] = useReducer(graphReducer, INITIAL_GRAPH_STATE);
+  const [query, setQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<GraphNode[]>([]);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isExpanding, setIsExpanding] = useState(false);
+  const [hops, setHops] = useState(1);
+  const [communities, setCommunities] = useState<GraphCommunity[]>([]);
+  const [isLoadingCommunities, setIsLoadingCommunities] = useState(true);
+  const [activeCommunityId, setActiveCommunityId] = useState<string | null>(null);
+  const [selection, setSelection] = useState<Selection>(null);
+  const [error, setError] = useState<string | null>(null);
+  const searchSeqRef = useRef(0);
+
+  useEffect(() => {
+    dispatch({ type: 'clear' });
+    setQuery('');
+    setSearchResults([]);
+    setHasSearched(false);
+    setActiveCommunityId(null);
+    setSelection(null);
+    setError(null);
+  }, [spaceId]);
+
+  const loadCommunities = useCallback(async () => {
+    if (spaceId.length === 0) {
+      setCommunities([]);
+      setIsLoadingCommunities(false);
+      return;
+    }
+
+    setIsLoadingCommunities(true);
+    try {
+      const response = await getGraphCommunities(spaceId);
+      setCommunities(response.communities);
+    } catch (err) {
+      setError(getErrorMessage(err));
+      setCommunities([]);
+    } finally {
+      setIsLoadingCommunities(false);
+    }
+  }, [spaceId]);
+
+  useEffect(() => {
+    void loadCommunities();
+  }, [loadCommunities]);
+
+  const graphData = useMemo<GraphCanvasData>(() => {
+    const nodes = [...graphState.nodesById.values()];
+    const links = [...graphState.edgesById.values()].map((edge) => ({
+      ...edge,
+      source: edge.source_node_id,
+      target: edge.target_node_id,
+    }));
+    return { nodes, links };
+  }, [graphState.edgesById, graphState.nodesById]);
+
+  const selectedNode = selection?.type === 'node' ? graphState.nodesById.get(selection.id) ?? null : null;
+  const selectedEdge = selection?.type === 'edge' ? graphState.edgesById.get(selection.id) ?? null : null;
+
+  if (spaceId.length === 0) {
+    return <NotFound />;
+  }
+
+  async function handleSearch(nextQuery: string): Promise<void> {
+    const normalizedQuery = nextQuery.trim();
+    setQuery(normalizedQuery);
+    setHasSearched(true);
+    setSearchResults([]);
+
+    if (normalizedQuery.length === 0) {
+      return;
+    }
+
+    const seq = ++searchSeqRef.current;
+    setIsSearching(true);
+    setError(null);
+
+    try {
+      const response = await searchGraphNodes({ spaceId, query: normalizedQuery, limit: SEARCH_LIMIT });
+      if (seq !== searchSeqRef.current) {
+        return;
+      }
+
+      const scopedNodes = response.nodes.filter((node) => node.space_id === spaceId);
+      setSearchResults(scopedNodes);
+      dispatch({ type: 'merge', spaceId, nodes: scopedNodes, edges: [] });
+    } catch (err) {
+      if (seq !== searchSeqRef.current) {
+        return;
+      }
+      setError(getErrorMessage(err));
+    } finally {
+      if (seq === searchSeqRef.current) {
+        setIsSearching(false);
+      }
+    }
+  }
+
+  async function expandNode(nodeId: string, force = false): Promise<void> {
+    if (!force && graphState.expandedNodeIds.has(nodeId)) {
+      return;
+    }
+
+    setIsExpanding(true);
+    setError(null);
+
+    try {
+      const response = await getGraphNeighbors({ nodeId, spaceId, hops });
+      const nodes = [
+        ...(response.center_node === null ? [] : [response.center_node]),
+        ...response.neighbors.map((neighbor) => neighbor.node),
+      ];
+      const edges = response.neighbors
+        .map((neighbor) => neighbor.edge)
+        .filter((edge): edge is GraphEdge => edge !== null);
+      dispatch({ type: 'merge', spaceId, nodes, edges });
+      dispatch({ type: 'markExpanded', nodeId });
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setIsExpanding(false);
+    }
+  }
+
+  function closeSelection(): void {
+    setSelection(null);
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'flex-start', marginBottom: 16 }}>
+        <div>
+          <Typography.Title level={4} style={{ margin: 0 }}>{t('graph.title')}</Typography.Title>
+          <Typography.Text type="secondary">{t('graph.description')}</Typography.Text>
+        </div>
+        <Button onClick={() => dispatch({ type: 'clear' })}>{t('graph.action.clearGraph')}</Button>
+      </div>
+
+      {error !== null ? (
+        <Alert message={error} type="error" showIcon closable style={{ marginBottom: 16 }} onClose={() => setError(null)} />
+      ) : null}
+      {graphState.truncated ? (
+        <Alert message={t('graph.state.truncated', { limit: MAX_GRAPH_NODES })} type="warning" showIcon style={{ marginBottom: 16 }} />
+      ) : null}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(260px, 320px) minmax(0, 1fr)', gap: 16, alignItems: 'start' }}>
+        <Space direction="vertical" size={16} style={{ width: '100%' }}>
+          <GraphSearchPanel
+            query={query}
+            results={searchResults}
+            hasSearched={hasSearched}
+            isSearching={isSearching}
+            onQueryChange={setQuery}
+            onSearch={(value) => { void handleSearch(value); }}
+            onSelectNode={(nodeId) => setSelection({ type: 'node', id: nodeId })}
+          />
+          <GraphCommunityPanel
+            communities={communities}
+            isLoading={isLoadingCommunities}
+            activeCommunityId={activeCommunityId}
+            onSelectCommunity={setActiveCommunityId}
+          />
+        </Space>
+
+        <Space direction="vertical" size={12} style={{ width: '100%' }}>
+          <GraphToolbar
+            hops={hops}
+            isExpanding={isExpanding}
+            selectedNode={selectedNode}
+            alreadyExpanded={selectedNode !== null && graphState.expandedNodeIds.has(selectedNode.id)}
+            onHopsChange={setHops}
+            onExpand={(force) => {
+              if (selectedNode !== null) {
+                void expandNode(selectedNode.id, force);
+              }
+            }}
+          />
+          <GraphCanvas
+            graphData={graphData}
+            activeCommunityId={activeCommunityId}
+            selectedNodeId={selectedNode?.id ?? null}
+            selectedEdgeId={selectedEdge?.id ?? null}
+            loading={isSearching || isExpanding}
+            onNodeSelect={(nodeId) => setSelection({ type: 'node', id: nodeId })}
+            onEdgeSelect={(edgeId) => setSelection({ type: 'edge', id: edgeId })}
+          />
+          <GraphLegend />
+        </Space>
+      </div>
+
+      <GraphSelectionDrawer
+        selectedNode={selectedNode}
+        selectedEdge={selectedEdge}
+        nodeById={graphState.nodesById}
+        onClose={closeSelection}
+      />
+    </div>
+  );
+}
+
+function GraphSearchPanel({
+  query,
+  results,
+  hasSearched,
+  isSearching,
+  onQueryChange,
+  onSearch,
+  onSelectNode,
+}: {
+  query: string;
+  results: GraphNode[];
+  hasSearched: boolean;
+  isSearching: boolean;
+  onQueryChange: (query: string) => void;
+  onSearch: (query: string) => void;
+  onSelectNode: (nodeId: string) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div style={panelStyle}>
+      <Typography.Title level={5} style={{ marginTop: 0 }}>{t('graph.search.title')}</Typography.Title>
+      <Input.Search
+        allowClear
+        enterButton={t('common.action.search')}
+        loading={isSearching}
+        onChange={(event) => onQueryChange(event.target.value)}
+        onSearch={onSearch}
+        placeholder={t('graph.search.placeholder')}
+        value={query}
+      />
+      {isSearching ? <Spin style={{ marginTop: 16 }} /> : null}
+      {!isSearching && hasSearched && results.length === 0 ? (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('graph.state.noResults')} style={{ marginTop: 16 }} />
+      ) : null}
+      {results.length > 0 ? (
+        <List
+          style={{ marginTop: 12 }}
+          size="small"
+          dataSource={results}
+          renderItem={(node) => (
+            <List.Item>
+              <Button type="link" style={{ padding: 0, height: 'auto', textAlign: 'left' }} onClick={() => onSelectNode(node.id)}>
+                {node.label}
+              </Button>
+              <Tag color={getGraphNodeTypeColor(node.node_type)}>{node.node_type ?? t('graph.nodeType.unknown')}</Tag>
+            </List.Item>
+          )}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function GraphCommunityPanel({
+  communities,
+  isLoading,
+  activeCommunityId,
+  onSelectCommunity,
+}: {
+  communities: GraphCommunity[];
+  isLoading: boolean;
+  activeCommunityId: string | null;
+  onSelectCommunity: (communityId: string | null) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div style={panelStyle}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center' }}>
+        <Typography.Title level={5} style={{ margin: 0 }}>{t('graph.community.title')}</Typography.Title>
+        {activeCommunityId !== null ? (
+          <Button size="small" onClick={() => onSelectCommunity(null)}>{t('graph.community.clear')}</Button>
+        ) : null}
+      </div>
+      {isLoading ? <Spin style={{ marginTop: 16 }} /> : null}
+      {!isLoading && communities.length === 0 ? (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('graph.community.empty')} style={{ marginTop: 16 }} />
+      ) : null}
+      {communities.length > 0 ? (
+        <List
+          style={{ marginTop: 12 }}
+          size="small"
+          dataSource={communities}
+          renderItem={(community) => {
+            const label = community.label ?? community.community_key;
+            const isActive = community.id === activeCommunityId;
+            return (
+              <List.Item>
+                <Button
+                  type={isActive ? 'primary' : 'text'}
+                  style={{ width: '100%', height: 'auto', textAlign: 'left', whiteSpace: 'normal' }}
+                  onClick={() => onSelectCommunity(isActive ? null : community.id)}
+                >
+                  <div>
+                    <span>{label}</span>
+                    <Typography.Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
+                      {t('graph.community.nodeCount', { count: community.node_count })}
+                    </Typography.Text>
+                    {community.summary !== null && community.summary.length > 0 ? (
+                      <Typography.Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
+                        {community.summary}
+                      </Typography.Text>
+                    ) : null}
+                  </div>
+                </Button>
+              </List.Item>
+            );
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function GraphToolbar({
+  hops,
+  isExpanding,
+  selectedNode,
+  alreadyExpanded,
+  onHopsChange,
+  onExpand,
+}: {
+  hops: number;
+  isExpanding: boolean;
+  selectedNode: GraphNode | null;
+  alreadyExpanded: boolean;
+  onHopsChange: (hops: number) => void;
+  onExpand: (force: boolean) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center' }}>
+      <Space>
+        <Typography.Text>{t('graph.toolbar.hops')}</Typography.Text>
+        <Select
+          value={hops}
+          style={{ width: 112 }}
+          onChange={onHopsChange}
+          options={[
+            { value: 1, label: t('graph.toolbar.oneHop') },
+            { value: 2, label: t('graph.toolbar.twoHop') },
+          ]}
+        />
+      </Space>
+      <Button
+        type="primary"
+        disabled={selectedNode === null}
+        loading={isExpanding}
+        onClick={() => onExpand(alreadyExpanded)}
+      >
+        {alreadyExpanded ? t('graph.action.refreshNeighbors') : t('graph.action.expandNeighbors')}
+      </Button>
+    </div>
+  );
+}
+
+function GraphLegend() {
+  const { t } = useTranslation();
+
+  return (
+    <Space wrap>
+      <Typography.Text type="secondary">{t('graph.legend.title')}</Typography.Text>
+      {Object.entries(GRAPH_NODE_TYPE_COLORS).map(([nodeType, color]) => (
+        <Tag key={nodeType} color={color}>{nodeType === 'default' ? t('graph.nodeType.unknown') : nodeType}</Tag>
+      ))}
+    </Space>
+  );
+}
+
+function GraphSelectionDrawer({
+  selectedNode,
+  selectedEdge,
+  nodeById,
+  onClose,
+}: {
+  selectedNode: GraphNode | null;
+  selectedEdge: GraphEdge | null;
+  nodeById: Map<string, GraphNode>;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const isOpen = selectedNode !== null || selectedEdge !== null;
+
+  return (
+    <Drawer title={t('graph.drawer.title')} open={isOpen} onClose={onClose} width={420}>
+      {selectedNode !== null ? (
+        <Descriptions column={1} size="small" bordered>
+          <Descriptions.Item label={t('graph.detail.label')}>{selectedNode.label}</Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.nodeType')}>{selectedNode.node_type ?? t('common.state.none')}</Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.community')}>{selectedNode.community_id ?? t('common.state.none')}</Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.score')}>{selectedNode.score}</Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.id')}>
+            <Typography.Text copyable>{selectedNode.id}</Typography.Text>
+          </Descriptions.Item>
+          {selectedNode.description !== undefined && selectedNode.description !== null && selectedNode.description.length > 0 ? (
+            <Descriptions.Item label={t('graph.detail.description')}>{selectedNode.description}</Descriptions.Item>
+          ) : null}
+        </Descriptions>
+      ) : null}
+
+      {selectedEdge !== null ? (
+        <Descriptions column={1} size="small" bordered>
+          <Descriptions.Item label={t('graph.detail.relationship')}>{selectedEdge.relationship}</Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.confidence')}>{selectedEdge.confidence_label}</Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.score')}>
+            {selectedEdge.effective_confidence_score ?? t('common.state.none')}
+          </Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.evidenceCount')}>{selectedEdge.evidence_count}</Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.source')}>
+            {nodeById.get(selectedEdge.source_node_id)?.label ?? selectedEdge.source_node_id}
+          </Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.target')}>
+            {nodeById.get(selectedEdge.target_node_id)?.label ?? selectedEdge.target_node_id}
+          </Descriptions.Item>
+          <Descriptions.Item label={t('graph.detail.id')}>
+            <Typography.Text copyable>{selectedEdge.id}</Typography.Text>
+          </Descriptions.Item>
+        </Descriptions>
+      ) : null}
+    </Drawer>
+  );
+}
+
+function graphReducer(state: GraphState, action: GraphAction): GraphState {
+  if (action.type === 'clear') {
+    return {
+      nodesById: new Map(),
+      edgesById: new Map(),
+      expandedNodeIds: new Set(),
+      truncated: false,
+    };
+  }
+
+  if (action.type === 'markExpanded') {
+    const expandedNodeIds = new Set(state.expandedNodeIds);
+    expandedNodeIds.add(action.nodeId);
+    return { ...state, expandedNodeIds };
+  }
+
+  const nodesById = new Map(state.nodesById);
+  const edgesById = new Map(state.edgesById);
+  let truncated = state.truncated;
+
+  for (const node of action.nodes) {
+    if (node.space_id !== action.spaceId) {
+      continue;
+    }
+
+    if (!nodesById.has(node.id) && nodesById.size >= MAX_GRAPH_NODES) {
+      truncated = true;
+      continue;
+    }
+
+    nodesById.set(node.id, node);
+  }
+
+  for (const edge of action.edges) {
+    if (
+      edge.space_id !== action.spaceId ||
+      !nodesById.has(edge.source_node_id) ||
+      !nodesById.has(edge.target_node_id)
+    ) {
+      continue;
+    }
+
+    edgesById.set(edge.id, edge);
+  }
+
+  return {
+    ...state,
+    nodesById,
+    edgesById,
+    truncated,
+  };
+}
+
+const panelStyle = {
+  border: '1px solid #e5e7eb',
+  borderRadius: 8,
+  padding: 16,
+  background: '#ffffff',
+} satisfies CSSProperties;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      react-force-graph-2d:
+        specifier: ^1.29.1
+        version: 1.29.1(react@19.2.5)
       react-i18next:
         specifier: ^17.0.7
         version: 17.0.7(i18next@26.0.10(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
@@ -2456,6 +2459,9 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tweenjs/tween.js@25.0.0':
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -2747,6 +2753,10 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  accessor-fn@1.5.3:
+    resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
+    engines: {node: '>=12'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -2900,6 +2910,9 @@ packages:
     peerDependencies:
       ajv: 4.11.8 - 8
 
+  bezier-js@6.1.4:
+    resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -2969,6 +2982,10 @@ packages:
 
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  canvas-color-tracker@1.3.2:
+    resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
+    engines: {node: '>=12'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -3173,6 +3190,82 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-binarytree@1.0.2:
+    resolution: {integrity: sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force-3d@3.0.6:
+    resolution: {integrity: sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-octree@1.1.0:
+    resolution: {integrity: sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -3626,6 +3719,14 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  float-tooltip@1.7.5:
+    resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
+    engines: {node: '>=12'}
+
+  force-graph@1.51.4:
+    resolution: {integrity: sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==}
+    engines: {node: '>=12'}
+
   foreach@2.0.6:
     resolution: {integrity: sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==}
 
@@ -3817,11 +3918,19 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  index-array-by@1.4.2:
+    resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
@@ -3902,6 +4011,10 @@ packages:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
     engines: {node: '>=6'}
 
+  jerrypick@1.1.2:
+    resolution: {integrity: sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==}
+    engines: {node: '>=12'}
+
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -3978,6 +4091,10 @@ packages:
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+
+  kapsule@1.16.3:
+    resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
+    engines: {node: '>=12'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4086,6 +4203,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -4698,6 +4818,9 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5055,6 +5178,12 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
+  react-force-graph-2d@1.29.1:
+    resolution: {integrity: sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '*'
+
   react-i18next@17.0.7:
     resolution: {integrity: sha512-rwtPXsb/zwzDafN+gytcjF5YnqGQQIRmCQ6DctBC1VSipRB8GD/MWEVrFP42vjMyuYydxWxM8CZRt+yiNuuoHg==}
     peerDependencies:
@@ -5079,6 +5208,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-kapsule@2.5.7:
+    resolution: {integrity: sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -5492,6 +5627,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
@@ -8245,6 +8383,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tweenjs/tween.js@25.0.0': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -8618,6 +8758,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  accessor-fn@1.5.3: {}
+
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -8812,6 +8954,8 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
+  bezier-js@6.1.4: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -8902,6 +9046,10 @@ snapshots:
   camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001791: {}
+
+  canvas-color-tracker@1.3.2:
+    dependencies:
+      tinycolor2: 1.6.0
 
   ccount@2.0.1: {}
 
@@ -9076,6 +9224,83 @@ snapshots:
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-binarytree@1.0.2: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-force-3d@3.0.6:
+    dependencies:
+      d3-binarytree: 1.0.2
+      d3-dispatch: 3.0.1
+      d3-octree: 1.1.0
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-octree@1.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -9551,6 +9776,30 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  float-tooltip@1.7.5:
+    dependencies:
+      d3-selection: 3.0.0
+      kapsule: 1.16.3
+      preact: 10.29.1
+
+  force-graph@1.51.4:
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      accessor-fn: 1.5.3
+      bezier-js: 6.1.4
+      canvas-color-tracker: 1.3.2
+      d3-array: 3.2.4
+      d3-drag: 3.0.0
+      d3-force-3d: 3.0.6
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      float-tooltip: 1.7.5
+      index-array-by: 1.4.2
+      kapsule: 1.16.3
+      lodash-es: 4.18.1
+
   foreach@2.0.6: {}
 
   fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.106.0(esbuild@0.27.7)):
@@ -9782,9 +10031,13 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  index-array-by@1.4.2: {}
+
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  internmap@2.0.3: {}
 
   ioredis@5.10.1:
     dependencies:
@@ -9853,6 +10106,8 @@ snapshots:
       istanbul-lib-report: 3.0.1
 
   iterare@1.2.1: {}
+
+  jerrypick@1.1.2: {}
 
   jest-worker@27.5.1:
     dependencies:
@@ -9940,6 +10195,10 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
+  kapsule@1.16.3:
+    dependencies:
+      lodash-es: 4.18.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -10023,6 +10282,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.defaults@4.2.0: {}
 
@@ -10827,6 +11088,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  preact@10.29.1: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.3: {}
@@ -11324,6 +11587,13 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
+  react-force-graph-2d@1.29.1(react@19.2.5):
+    dependencies:
+      force-graph: 1.51.4
+      prop-types: 15.8.1
+      react: 19.2.5
+      react-kapsule: 2.5.7(react@19.2.5)
+
   react-i18next@17.0.7(i18next@26.0.10(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -11340,6 +11610,11 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-kapsule@2.5.7(react@19.2.5):
+    dependencies:
+      jerrypick: 1.1.2
+      react: 19.2.5
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -11854,6 +12129,8 @@ snapshots:
   throttle-debounce@5.0.2: {}
 
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@1.1.1: {}
 


### PR DESCRIPTION
## Summary
- Add interactive graph explorer at `/spaces/:spaceId/graph` with force-directed canvas (react-force-graph-2d)
- Implement node search, 1-hop neighbor expansion, community summaries, and detail drawers for nodes/edges
- Extend backend `graphNeighborsQuery` to accept optional `space_id` scoping
- Lazy-load graph explorer page for bundle optimization (separate 201KB chunk)
- XSS-safe tooltip rendering, stale request guards, edge accumulation cap, no-active-graph empty state

Closes #232
Part of #230

## Test plan
- [x] `pnpm --filter @cherrygraph/web test` — 11 files, 105 tests pass
- [x] `pnpm --filter @cherrygraph/api test` — 1113 tests pass
- [x] `pnpm build` — clean build
- [x] `pnpm lint` — 0 warnings

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `713790653b7645f56b135fbb789dd24b9146fb97`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/252#issuecomment-4417058565) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/252#issuecomment-4417058697) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/252#issuecomment-4417058800) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/252#issuecomment-4417058901)
- Key findings addressed: XSS tooltip escaped, stale cross-space requests guarded, edge cap 1000, no-active-graph empty state, CI test async queries fixed