### PR TITLE
feat(web): space overview dashboard with document/wiki/graph stats

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import UploadCenter from './pages/uploads/UploadCenter';
 import { ThemeProvider } from './theme/ThemeProvider';
 
 const SpaceGraphExplorerPage = lazy(() => import('./pages/graph/SpaceGraphExplorerPage'));
+const SpaceOverviewPage = lazy(() => import('./pages/space/SpaceOverviewPage'));
 
 export function AppRoutes() {
   return (
@@ -29,6 +30,15 @@ export function AppRoutes() {
       <Route path="/login" element={<Login />} />
       <Route element={<ProtectedShell />}>
         <Route path="/" element={<Home />} />
+        <Route path="/spaces/:spaceId" element={<Navigate to="overview" replace />} />
+        <Route
+          path="/spaces/:spaceId/overview"
+          element={(
+            <Suspense fallback={null}>
+              <SpaceOverviewPage />
+            </Suspense>
+          )}
+        />
         <Route path="/spaces/:spaceId/chat" element={<Chat />} />
         <Route path="/spaces/:spaceId/wiki" element={<Wiki />} />
         <Route path="/spaces/:spaceId/wiki/:pageId" element={<Wiki />} />

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -78,10 +78,10 @@ describe('App routing', () => {
     expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
   });
 
-  it('redirects authenticated admin with spaces to first space overview', async () => {
+  it('redirects authenticated admin with spaces to first space overview', { timeout: 30000 }, async () => {
     mockOverviewApi();
     renderRoute('/', ADMIN_USER);
-    expect(await screen.findByRole('heading', { name: '空间概览' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '空间概览' }, { timeout: 15000 })).toBeInTheDocument();
   });
 
   it('redirects authenticated admin without spaces to /admin/spaces', async () => {
@@ -117,10 +117,10 @@ describe('App routing', () => {
     expect(screen.getByRole('heading', { name: '登录' })).toBeInTheDocument();
   });
 
-  it('redirects non-admin from admin routes to /', async () => {
+  it('redirects non-admin from admin routes to /', { timeout: 30000 }, async () => {
     mockOverviewApi();
     renderRoute('/admin/users', VIEWER_USER);
-    expect(await screen.findByRole('heading', { name: '空间概览' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '空间概览' }, { timeout: 15000 })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: '用户管理' })).not.toBeInTheDocument();
   });
 
@@ -429,6 +429,10 @@ function mockOverviewApi(): void {
           data: { communities: [] },
           meta: { request_id: 'req-communities' },
         }));
+      }
+
+      if (path === '/api/spaces/space-main/graphify/runs') {
+        return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-runs' } }));
       }
 
       return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -78,11 +78,10 @@ describe('App routing', () => {
     expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
   });
 
-  it('redirects authenticated admin with spaces to first space chat', async () => {
-    mockChatSessionsApi();
+  it('redirects authenticated admin with spaces to first space overview', async () => {
+    mockOverviewApi();
     renderRoute('/', ADMIN_USER);
-    // Admin with spaces should go to /spaces/space-main/chat
-    expect(await screen.findByRole('heading', { name: '聊天' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '空间概览' })).toBeInTheDocument();
   });
 
   it('redirects authenticated admin without spaces to /admin/spaces', async () => {
@@ -119,9 +118,9 @@ describe('App routing', () => {
   });
 
   it('redirects non-admin from admin routes to /', async () => {
-    mockChatSessionsApi();
+    mockOverviewApi();
     renderRoute('/admin/users', VIEWER_USER);
-    expect(await screen.findByRole('heading', { name: '聊天' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '空间概览' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: '用户管理' })).not.toBeInTheDocument();
   });
 
@@ -374,6 +373,61 @@ function mockChatSessionsApi(): void {
               has_next: false,
             },
           },
+        }));
+      }
+
+      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+    }),
+  );
+}
+
+function mockOverviewApi(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/spaces/space-main') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            id: 'space-main',
+            name: 'Main Space',
+            slug: 'main-space',
+            status: 'active',
+            description: null,
+            active_graphify_run_id: null,
+            active_index_snapshot_id: null,
+            index_consistency_status: 'consistent',
+            strict_knowledge_only: true,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+          meta: { request_id: 'req-space' },
+        }));
+      }
+
+      if (path === '/api/spaces/space-main/stats') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            space_id: 'space-main',
+            source_count: 0,
+            page_count: 0,
+            node_count: 0,
+            edge_count: 0,
+            index_consistency: 'consistent',
+          },
+          meta: { request_id: 'req-stats' },
+        }));
+      }
+
+      if (path === '/api/spaces/space-main/uploads' || path === '/api/spaces/space-main/wiki/pages') {
+        return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-list' } }));
+      }
+
+      if (path === '/api/graph/communities') {
+        return Promise.resolve(jsonResponse({
+          data: { communities: [] },
+          meta: { request_id: 'req-communities' },
         }));
       }
 

--- a/apps/web/src/__tests__/infrastructure.test.tsx
+++ b/apps/web/src/__tests__/infrastructure.test.tsx
@@ -242,6 +242,7 @@ describe('AppShell', () => {
       </MemoryRouter>,
     );
 
+    expect(screen.getByText('Overview')).toBeInTheDocument();
     expect(screen.getAllByText('Chat').length).toBeGreaterThan(0);
     expect(screen.getByText('Wiki')).toBeInTheDocument();
     expect(screen.getByText('Documents')).toBeInTheDocument();

--- a/apps/web/src/__tests__/overview.test.tsx
+++ b/apps/web/src/__tests__/overview.test.tsx
@@ -40,7 +40,40 @@ describe('SpaceOverviewPage', () => {
     renderPage();
 
     expect(await screen.findByText('No documents in this space yet.')).toBeInTheDocument();
-    expect(screen.getByText('No wiki pages in this space yet.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add documents' }).closest('a')).toHaveAttribute(
+      'href',
+      '/spaces/space-1/uploads',
+    );
+    expect(screen.getByText('Wiki pages appear after document ingestion or Graphify generation.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run Graphify' }).closest('a')).toHaveAttribute(
+      'href',
+      '/spaces/space-1/graphify',
+    );
+  });
+
+  it('shows the latest pending graphify run when no active run is set', async () => {
+    stubOverviewApi({
+      space: { active_graphify_run_id: null },
+      latestGraphifyRuns: [createGraphifyRun({ run_id: 'run-latest', status: 'pending' })],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('View run').closest('a')).toHaveAttribute(
+      'href',
+      '/spaces/space-1/graphify/run-latest',
+    );
+  });
+
+  it('shows remediation links when index consistency is unhealthy', async () => {
+    stubOverviewApi({ space: { index_consistency_status: 'stale' } });
+
+    renderPage();
+
+    expect(await screen.findByText('Index consistency is Stale.')).toBeInTheDocument();
+    expect(screen.getByText('Review wiki').closest('a')).toHaveAttribute('href', '/spaces/space-1/wiki');
+    expect(screen.getByText('Run Graphify').closest('a')).toHaveAttribute('href', '/spaces/space-1/graphify');
   });
 
   it('keeps recent documents visible when stats fail', async () => {
@@ -108,6 +141,8 @@ function renderPage(): void {
 function stubOverviewApi(options: {
   documents?: unknown[];
   wikiPages?: unknown[];
+  space?: Record<string, unknown>;
+  latestGraphifyRuns?: unknown[];
   failStats?: boolean;
   statsSequence?: number[];
 } = {}) {
@@ -116,7 +151,7 @@ function stubOverviewApi(options: {
     const path = getRequestPath(input);
 
     if (path === '/api/spaces/space-1') {
-      return Promise.resolve(jsonResponse({ data: createSpaceDetail() }));
+      return Promise.resolve(jsonResponse({ data: createSpaceDetail(options.space) }));
     }
 
     if (path === '/api/spaces/space-1/stats') {
@@ -136,6 +171,10 @@ function stubOverviewApi(options: {
       return Promise.resolve(jsonResponse({ data: options.wikiPages ?? [createWikiPage()] }));
     }
 
+    if (path === '/api/spaces/space-1/graphify/runs') {
+      return Promise.resolve(jsonResponse({ data: options.latestGraphifyRuns ?? [] }));
+    }
+
     if (path === '/api/graph/communities') {
       return Promise.resolve(jsonResponse({ data: { communities: [{ id: 'community-1' }] } }));
     }
@@ -151,7 +190,7 @@ function stubOverviewApi(options: {
   return fetchMock;
 }
 
-function createSpaceDetail() {
+function createSpaceDetail(overrides: Record<string, unknown> = {}) {
   return {
     id: 'space-1',
     name: 'Space 1',
@@ -164,6 +203,7 @@ function createSpaceDetail() {
     strict_knowledge_only: true,
     created_at: '2026-01-01T00:00:00.000Z',
     updated_at: '2026-01-02T00:00:00.000Z',
+    ...overrides,
   };
 }
 
@@ -203,7 +243,7 @@ function createWikiPage(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function createGraphifyRun() {
+function createGraphifyRun(overrides: Record<string, unknown> = {}) {
   return {
     run_id: 'run-1',
     space_id: 'space-1',
@@ -224,6 +264,7 @@ function createGraphifyRun() {
     created_at: '2026-01-01T00:00:00.000Z',
     started_at: '2026-01-01T00:01:00.000Z',
     completed_at: null,
+    ...overrides,
   };
 }
 

--- a/apps/web/src/__tests__/overview.test.tsx
+++ b/apps/web/src/__tests__/overview.test.tsx
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../i18n';
+import i18n from '../i18n';
+import { ThemeProvider } from '../theme/ThemeProvider';
+import SpaceOverviewPage from '../pages/space/SpaceOverviewPage';
+
+describe('SpaceOverviewPage', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows loaded stats cards with correct values', async () => {
+    stubOverviewApi();
+
+    renderPage();
+
+    expect(await screen.findByText('Space Overview')).toBeInTheDocument();
+    expect((await screen.findAllByText('Documents')).length).toBeGreaterThan(0);
+    expect(screen.getByText('Wiki Pages')).toBeInTheDocument();
+    expect(screen.getByText('Graph Nodes')).toBeInTheDocument();
+    expect(screen.getByText('Graph Edges')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+    expect(screen.getByText('340')).toBeInTheDocument();
+  });
+
+  it('shows empty states when there are no recent documents or wiki pages', async () => {
+    stubOverviewApi({ documents: [], wikiPages: [] });
+
+    renderPage();
+
+    expect(await screen.findByText('No documents in this space yet.')).toBeInTheDocument();
+    expect(screen.getByText('No wiki pages in this space yet.')).toBeInTheDocument();
+  });
+
+  it('keeps recent documents visible when stats fail', async () => {
+    stubOverviewApi({ failStats: true });
+
+    renderPage();
+
+    expect(await screen.findByText('Stats unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Stats broken')).toBeInTheDocument();
+    expect(await screen.findByText('policy.md')).toBeInTheDocument();
+  });
+
+  it('reloads overview data when refresh is clicked', async () => {
+    const fetchMock = stubOverviewApi({ statsSequence: [12, 13] });
+
+    renderPage();
+
+    expect(await screen.findByText('12')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Refresh' })).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect(await screen.findByText('13')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(countRequests(fetchMock, '/api/spaces/space-1/stats')).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('renders quick actions with the expected routes', async () => {
+    stubOverviewApi();
+
+    renderPage();
+
+    expect(await screen.findByText('Quick Actions')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Documents' }).closest('a')).toHaveAttribute(
+      'href',
+      '/spaces/space-1/uploads',
+    );
+    expect(screen.getByRole('button', { name: 'Wiki' }).closest('a')).toHaveAttribute('href', '/spaces/space-1/wiki');
+    expect(screen.getByRole('button', { name: 'Graph Explorer' }).closest('a')).toHaveAttribute(
+      'href',
+      '/spaces/space-1/graph',
+    );
+    expect(screen.getByRole('button', { name: 'Graphify' }).closest('a')).toHaveAttribute(
+      'href',
+      '/spaces/space-1/graphify',
+    );
+    expect(screen.getByRole('button', { name: 'Chat' }).closest('a')).toHaveAttribute('href', '/spaces/space-1/chat');
+  });
+});
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/spaces/space-1/overview']}>
+      <ThemeProvider>
+        <Routes>
+          <Route path="/spaces/:spaceId/overview" element={<SpaceOverviewPage />} />
+        </Routes>
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+function stubOverviewApi(options: {
+  documents?: unknown[];
+  wikiPages?: unknown[];
+  failStats?: boolean;
+  statsSequence?: number[];
+} = {}) {
+  let statsCall = 0;
+  const fetchMock = vi.fn<typeof fetch>((input) => {
+    const path = getRequestPath(input);
+
+    if (path === '/api/spaces/space-1') {
+      return Promise.resolve(jsonResponse({ data: createSpaceDetail() }));
+    }
+
+    if (path === '/api/spaces/space-1/stats') {
+      if (options.failStats === true) {
+        return Promise.resolve(jsonResponse({ error: { code: 'STATS_FAILED', message: 'Stats broken' } }, 500));
+      }
+      const sourceCount = options.statsSequence?.[Math.min(statsCall, options.statsSequence.length - 1)] ?? 12;
+      statsCall += 1;
+      return Promise.resolve(jsonResponse({ data: createStats({ source_count: sourceCount }) }));
+    }
+
+    if (path === '/api/spaces/space-1/uploads') {
+      return Promise.resolve(jsonResponse({ data: options.documents ?? [createDocument()] }));
+    }
+
+    if (path === '/api/spaces/space-1/wiki/pages') {
+      return Promise.resolve(jsonResponse({ data: options.wikiPages ?? [createWikiPage()] }));
+    }
+
+    if (path === '/api/graph/communities') {
+      return Promise.resolve(jsonResponse({ data: { communities: [{ id: 'community-1' }] } }));
+    }
+
+    if (path === '/api/graphify/runs/run-1') {
+      return Promise.resolve(jsonResponse({ data: createGraphifyRun() }));
+    }
+
+    return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: `Unexpected path: ${path}` } }, 404));
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function createSpaceDetail() {
+  return {
+    id: 'space-1',
+    name: 'Space 1',
+    slug: 'space-1',
+    status: 'active',
+    description: null,
+    active_graphify_run_id: 'run-1',
+    active_index_snapshot_id: 'snapshot-1',
+    index_consistency_status: 'consistent',
+    strict_knowledge_only: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-02T00:00:00.000Z',
+  };
+}
+
+function createStats(overrides: Record<string, unknown> = {}) {
+  return {
+    space_id: 'space-1',
+    source_count: 12,
+    page_count: 8,
+    node_count: 120,
+    edge_count: 340,
+    index_consistency: 'consistent',
+    ...overrides,
+  };
+}
+
+function createDocument(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'doc-1',
+    filename: 'policy.md',
+    mime_type: 'text/markdown',
+    source_type: 'upload',
+    status: 'parsed',
+    updated_at: '2026-01-03T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createWikiPage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wiki-row-1',
+    page_id: 'policy',
+    space_id: 'space-1',
+    title: 'Policy',
+    status: 'published',
+    updated_at: '2026-01-04T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createGraphifyRun() {
+  return {
+    run_id: 'run-1',
+    space_id: 'space-1',
+    mode: 'full',
+    trigger_type: 'manual',
+    status: 'running',
+    progress: { percent: 40, stage: 'importing' },
+    input_scope: {},
+    result: {
+      nodes_created: 0,
+      nodes_updated: 0,
+      edges_created: 0,
+      wiki_pages_generated: 0,
+      schema_version: 'v1',
+      graph_json_uri: null,
+      report_uri: null,
+    },
+    created_at: '2026-01-01T00:00:00.000Z',
+    started_at: '2026-01-01T00:01:00.000Z',
+    completed_at: null,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function getRequestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input.split('?')[0] ?? input;
+  }
+
+  if (input instanceof URL) {
+    return input.pathname;
+  }
+
+  return input.url.split('?')[0] ?? input.url;
+}
+
+function countRequests(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, path: string): number {
+  return fetchMock.mock.calls.filter((call) => getRequestPath(call[0]) === path).length;
+}

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import {
   AuditOutlined,
   BookOutlined,
   CloudUploadOutlined,
+  DashboardOutlined,
   DatabaseOutlined,
   HeartOutlined,
   HistoryOutlined,
@@ -39,7 +40,7 @@ import { useAuth, type AuthUser } from '../lib/auth';
 import { useTheme } from '../theme/ThemeProvider';
 import './AppShell.css';
 
-type SpaceFunction = 'chat' | 'wiki' | 'uploads' | 'graph' | 'graphify';
+type SpaceFunction = 'overview' | 'chat' | 'wiki' | 'uploads' | 'graph' | 'graphify';
 type AdminRouteKey = 'users' | 'groups' | 'spaces' | 'models' | 'audit' | 'health' | 'jobs' | 'adminGraphify';
 
 const SIDER_STORAGE_KEY = 'cherrywiki.shell.collapsed';
@@ -49,6 +50,7 @@ const SPACE_FUNCTIONS: Array<{
   icon: ReactNode;
   translationKey: string;
 }> = [
+  { key: 'overview', icon: <DashboardOutlined />, translationKey: 'shell.sidebar.overview' },
   { key: 'chat', icon: <MessageOutlined />, translationKey: 'shell.sidebar.chat' },
   { key: 'wiki', icon: <BookOutlined />, translationKey: 'shell.sidebar.wiki' },
   { key: 'uploads', icon: <CloudUploadOutlined />, translationKey: 'shell.sidebar.documents' },
@@ -174,7 +176,7 @@ export default function AppShell() {
 
   function handleSpaceChange(nextSpaceId: string): void {
     try {
-      const nextFunction = selectedSpaceFunction ?? 'chat';
+      const nextFunction = selectedSpaceFunction ?? 'overview';
       void navigate(`/spaces/${encodeURIComponent(nextSpaceId)}/${nextFunction}`);
     } catch {
       // Keep the current route if navigation fails.
@@ -350,11 +352,13 @@ function isSpaceFunction(key: string): key is SpaceFunction {
 
 function getSpaceFunctionFromPath(pathname: string): SpaceFunction | null {
   if (pathname.startsWith('/admin')) return null;
+  if (pathname.includes('/overview')) return 'overview';
   if (pathname.includes('/wiki')) return 'wiki';
   if (pathname.includes('/uploads')) return 'uploads';
   if (pathname.includes('/graphify')) return 'graphify';
   if (pathname.includes('/graph')) return 'graph';
   if (pathname.includes('/chat')) return 'chat';
+  if (/^\/spaces\/[^/]+\/?$/.test(pathname)) return 'overview';
   return null;
 }
 

--- a/apps/web/src/lib/spaceApi.ts
+++ b/apps/web/src/lib/spaceApi.ts
@@ -1,0 +1,63 @@
+import { api, type ApiWrappedResponse } from './api';
+
+export type SpaceDetail = {
+  id: string;
+  name: string;
+  slug: string;
+  status: string;
+  description: string | null;
+  active_graphify_run_id: string | null;
+  active_index_snapshot_id: string | null;
+  index_consistency_status: string;
+  strict_knowledge_only: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type SpaceStats = {
+  space_id?: string;
+  source_count: number;
+  page_count: number;
+  node_count: number;
+  edge_count: number;
+  index_consistency: string;
+};
+
+export type RecentDocument = {
+  id: string;
+  filename: string;
+  mime_type: string | null;
+  source_type: string;
+  status: string;
+  updated_at: string;
+};
+
+export type RecentWikiPage = {
+  id: string;
+  page_id: string;
+  space_id: string;
+  title: string;
+  status: string;
+  updated_at: string;
+};
+
+export function getSpace(spaceId: string): Promise<SpaceDetail> {
+  return api.get<SpaceDetail>(`/spaces/${encodeURIComponent(spaceId)}`);
+}
+
+export function getSpaceStats(spaceId: string): Promise<SpaceStats> {
+  return api.get<SpaceStats>(`/spaces/${encodeURIComponent(spaceId)}/stats`);
+}
+
+export function getRecentDocuments(spaceId: string): Promise<ApiWrappedResponse<RecentDocument[]>> {
+  return api.getWrapped<RecentDocument[]>(`/spaces/${encodeURIComponent(spaceId)}/uploads`, {
+    per_page: 5,
+    sort: '-updated_at',
+  });
+}
+
+export function getRecentWikiPages(spaceId: string): Promise<ApiWrappedResponse<RecentWikiPage[]>> {
+  return api.getWrapped<RecentWikiPage[]>(`/spaces/${encodeURIComponent(spaceId)}/wiki/pages`, {
+    per_page: 5,
+  });
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -69,6 +69,7 @@
     },
     "sidebar": {
       "spaceFunctions": "Space Functions",
+      "overview": "Overview",
       "chat": "Chat",
       "wiki": "Wiki",
       "uploads": "Documents",
@@ -460,6 +461,53 @@
         "notStarted": "Not started",
         "unavailable": "Unavailable"
       }
+    }
+  },
+  "overview": {
+    "title": "Space Overview",
+    "description": "Review knowledge coverage, graph readiness, and recent activity for this space.",
+    "stats": {
+      "documents": "Documents",
+      "wikiPages": "Wiki Pages",
+      "graphNodes": "Graph Nodes",
+      "graphEdges": "Graph Edges"
+    },
+    "status": {
+      "title": "Knowledge Status",
+      "indexConsistency": "Index consistency",
+      "indexWarning": "Index consistency is {{status}}.",
+      "strictMode": "Strict knowledge mode",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "graphAvailability": "Graph availability",
+      "graphAvailable": "Available in Graph Explorer",
+      "graphUnavailable": "No graph nodes yet",
+      "communities": "Communities",
+      "activeRun": "Active Graphify run",
+      "noActiveRun": "No active run",
+      "viewRun": "View run"
+    },
+    "recentDocuments": {
+      "title": "Recent Documents",
+      "empty": "No documents in this space yet."
+    },
+    "recentWikiPages": {
+      "title": "Recent Wiki Pages",
+      "empty": "No wiki pages in this space yet."
+    },
+    "quickActions": {
+      "title": "Quick Actions",
+      "documents": "Documents",
+      "wiki": "Wiki",
+      "graph": "Graph Explorer",
+      "graphify": "Graphify",
+      "chat": "Chat"
+    },
+    "action": {
+      "viewAll": "View all"
+    },
+    "error": {
+      "stats": "Stats unavailable"
     }
   },
   "upload": {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -485,7 +485,9 @@
       "communities": "Communities",
       "activeRun": "Active Graphify run",
       "noActiveRun": "No active run",
-      "viewRun": "View run"
+      "viewRun": "View run",
+      "reviewWiki": "Review wiki",
+      "runGraphify": "Run Graphify"
     },
     "recentDocuments": {
       "title": "Recent Documents",
@@ -493,7 +495,7 @@
     },
     "recentWikiPages": {
       "title": "Recent Wiki Pages",
-      "empty": "No wiki pages in this space yet."
+      "empty": "Wiki pages appear after document ingestion or Graphify generation."
     },
     "quickActions": {
       "title": "Quick Actions",
@@ -504,7 +506,9 @@
       "chat": "Chat"
     },
     "action": {
-      "viewAll": "View all"
+      "viewAll": "View all",
+      "addDocuments": "Add documents",
+      "runGraphify": "Run Graphify"
     },
     "error": {
       "stats": "Stats unavailable"

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -69,6 +69,7 @@
     },
     "sidebar": {
       "spaceFunctions": "空间功能",
+      "overview": "概览",
       "chat": "聊天",
       "wiki": "知识库",
       "uploads": "文档",
@@ -460,6 +461,53 @@
         "notStarted": "未开始",
         "unavailable": "不可用"
       }
+    }
+  },
+  "overview": {
+    "title": "空间概览",
+    "description": "查看此空间的知识覆盖、图谱可用性和最近活动。",
+    "stats": {
+      "documents": "文档",
+      "wikiPages": "知识库页面",
+      "graphNodes": "图谱节点",
+      "graphEdges": "图谱边"
+    },
+    "status": {
+      "title": "知识状态",
+      "indexConsistency": "索引一致性",
+      "indexWarning": "索引一致性为 {{status}}。",
+      "strictMode": "严格知识模式",
+      "enabled": "已启用",
+      "disabled": "已禁用",
+      "graphAvailability": "图谱可用性",
+      "graphAvailable": "可在图谱探索中查看",
+      "graphUnavailable": "暂无图谱节点",
+      "communities": "社区",
+      "activeRun": "活跃 Graphify 运行",
+      "noActiveRun": "暂无活跃运行",
+      "viewRun": "查看运行"
+    },
+    "recentDocuments": {
+      "title": "最近文档",
+      "empty": "此空间还没有文档。"
+    },
+    "recentWikiPages": {
+      "title": "最近知识库页面",
+      "empty": "此空间尚无知识库页面。"
+    },
+    "quickActions": {
+      "title": "快捷操作",
+      "documents": "文档",
+      "wiki": "知识库",
+      "graph": "图谱探索",
+      "graphify": "图谱化",
+      "chat": "聊天"
+    },
+    "action": {
+      "viewAll": "查看全部"
+    },
+    "error": {
+      "stats": "统计不可用"
     }
   },
   "upload": {

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -485,7 +485,9 @@
       "communities": "社区",
       "activeRun": "活跃 Graphify 运行",
       "noActiveRun": "暂无活跃运行",
-      "viewRun": "查看运行"
+      "viewRun": "查看运行",
+      "reviewWiki": "查看知识库",
+      "runGraphify": "运行图谱化"
     },
     "recentDocuments": {
       "title": "最近文档",
@@ -493,7 +495,7 @@
     },
     "recentWikiPages": {
       "title": "最近知识库页面",
-      "empty": "此空间尚无知识库页面。"
+      "empty": "知识库页面会在文档摄取或图谱化生成后显示。"
     },
     "quickActions": {
       "title": "快捷操作",
@@ -504,7 +506,9 @@
       "chat": "聊天"
     },
     "action": {
-      "viewAll": "查看全部"
+      "viewAll": "查看全部",
+      "addDocuments": "添加文档",
+      "runGraphify": "运行图谱化"
     },
     "error": {
       "stats": "统计不可用"

--- a/apps/web/src/pages/Home.tsx
+++ b/apps/web/src/pages/Home.tsx
@@ -9,7 +9,7 @@ export default function Home() {
   const firstSpace = user?.spaces?.[0];
 
   if (firstSpace !== undefined) {
-    return <Navigate to={`/spaces/${encodeURIComponent(firstSpace.id)}/chat`} replace />;
+    return <Navigate to={`/spaces/${encodeURIComponent(firstSpace.id)}/overview`} replace />;
   }
 
   if (isAdmin) {

--- a/apps/web/src/pages/space/SpaceOverviewPage.tsx
+++ b/apps/web/src/pages/space/SpaceOverviewPage.tsx
@@ -26,6 +26,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 import { formatDate, formatLabel, getErrorMessage } from '../../components/adminUi';
+import { api } from '../../lib/api';
 import { getGraphCommunities } from '../../lib/graphApi';
 import { getGraphifyRun, type GraphifyRun } from '../../lib/graphifyApi';
 import {
@@ -80,6 +81,11 @@ export default function SpaceOverviewPage() {
     const seq = ++requestSeqRef.current;
     setIsLoading(true);
     setErrors(EMPTY_ERRORS);
+    setSpace(null);
+    setStats(null);
+    setDocuments([]);
+    setWikiPages([]);
+    setCommunityCount(0);
     setActiveRun(null);
 
     const setError = (key: keyof OverviewErrors, error: unknown): void => {
@@ -93,6 +99,19 @@ export default function SpaceOverviewPage() {
           if (seq !== requestSeqRef.current) return;
           setSpace(nextSpace);
           if (nextSpace.active_graphify_run_id === null) {
+            try {
+              const latestRuns = await api.get<GraphifyRun[]>(
+                `/spaces/${encodeURIComponent(spaceId)}/graphify/runs`,
+                { per_page: 1, sort: '-created_at' },
+              );
+              if (seq !== requestSeqRef.current) return;
+              const latestRun = latestRuns[0];
+              if (latestRun?.status === 'pending' || latestRun?.status === 'running') {
+                setActiveRun(latestRun);
+              }
+            } catch (err) {
+              setError('graphifyRun', err);
+            }
             return;
           }
           try {
@@ -103,7 +122,11 @@ export default function SpaceOverviewPage() {
             setError('graphifyRun', err);
           }
         })
-        .catch((err) => setError('space', err)),
+        .catch((err) => {
+          if (seq !== requestSeqRef.current) return;
+          setSpace(null);
+          setError('space', err);
+        }),
       getSpaceStats(spaceId)
         .then((nextStats) => {
           if (seq !== requestSeqRef.current) return;
@@ -267,6 +290,16 @@ function KnowledgeStatusPanel({
             type="warning"
             showIcon
             message={t('overview.status.indexWarning', { status: formatLabel(indexConsistency) })}
+            description={(
+              <Space size={12} wrap>
+                <Link to={`/spaces/${encodeURIComponent(spaceId)}/wiki`}>
+                  {t('overview.status.reviewWiki')}
+                </Link>
+                <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify`}>
+                  {t('overview.status.runGraphify')}
+                </Link>
+              </Space>
+            )}
           />
         ) : null}
         {errors.communities !== null ? <Alert type="warning" showIcon message={errors.communities} /> : null}
@@ -337,7 +370,11 @@ function RecentDocumentsList({
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
               description={t('overview.recentDocuments.empty')}
-            />
+            >
+              <Link to={`/spaces/${encodeURIComponent(spaceId)}/uploads`}>
+                <Button type="primary">{t('overview.action.addDocuments')}</Button>
+              </Link>
+            </Empty>
           ),
         }}
         renderItem={(document) => (
@@ -383,7 +420,11 @@ function RecentWikiPagesList({
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
               description={t('overview.recentWikiPages.empty')}
-            />
+            >
+              <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify`}>
+                <Button>{t('overview.action.runGraphify')}</Button>
+              </Link>
+            </Empty>
           ),
         }}
         renderItem={(page) => (

--- a/apps/web/src/pages/space/SpaceOverviewPage.tsx
+++ b/apps/web/src/pages/space/SpaceOverviewPage.tsx
@@ -1,0 +1,486 @@
+import {
+  BookOutlined,
+  CloudUploadOutlined,
+  MessageOutlined,
+  NodeIndexOutlined,
+  ReloadOutlined,
+  ShareAltOutlined,
+} from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Descriptions,
+  Empty,
+  List,
+  Progress,
+  Row,
+  Space,
+  Spin,
+  Statistic,
+  Tag,
+  Typography,
+} from 'antd';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+import { formatDate, formatLabel, getErrorMessage } from '../../components/adminUi';
+import { getGraphCommunities } from '../../lib/graphApi';
+import { getGraphifyRun, type GraphifyRun } from '../../lib/graphifyApi';
+import {
+  getRecentDocuments,
+  getRecentWikiPages,
+  getSpace,
+  getSpaceStats,
+  type RecentDocument,
+  type RecentWikiPage,
+  type SpaceDetail,
+  type SpaceStats,
+} from '../../lib/spaceApi';
+import NotFound from '../NotFound';
+
+type OverviewErrors = {
+  space: string | null;
+  stats: string | null;
+  documents: string | null;
+  wikiPages: string | null;
+  communities: string | null;
+  graphifyRun: string | null;
+};
+
+const EMPTY_ERRORS: OverviewErrors = {
+  space: null,
+  stats: null,
+  documents: null,
+  wikiPages: null,
+  communities: null,
+  graphifyRun: null,
+};
+
+export default function SpaceOverviewPage() {
+  const { t } = useTranslation();
+  const { spaceId = '' } = useParams();
+  const [space, setSpace] = useState<SpaceDetail | null>(null);
+  const [stats, setStats] = useState<SpaceStats | null>(null);
+  const [documents, setDocuments] = useState<RecentDocument[]>([]);
+  const [wikiPages, setWikiPages] = useState<RecentWikiPage[]>([]);
+  const [communityCount, setCommunityCount] = useState<number | null>(null);
+  const [activeRun, setActiveRun] = useState<GraphifyRun | null>(null);
+  const [errors, setErrors] = useState<OverviewErrors>(EMPTY_ERRORS);
+  const [isLoading, setIsLoading] = useState(true);
+  const requestSeqRef = useRef(0);
+
+  const loadOverview = useCallback(async () => {
+    if (spaceId.length === 0) {
+      setIsLoading(false);
+      return;
+    }
+
+    const seq = ++requestSeqRef.current;
+    setIsLoading(true);
+    setErrors(EMPTY_ERRORS);
+    setActiveRun(null);
+
+    const setError = (key: keyof OverviewErrors, error: unknown): void => {
+      if (seq !== requestSeqRef.current) return;
+      setErrors((current) => ({ ...current, [key]: getErrorMessage(error) }));
+    };
+
+    await Promise.allSettled([
+      getSpace(spaceId)
+        .then(async (nextSpace) => {
+          if (seq !== requestSeqRef.current) return;
+          setSpace(nextSpace);
+          if (nextSpace.active_graphify_run_id === null) {
+            return;
+          }
+          try {
+            const response = await getGraphifyRun(nextSpace.active_graphify_run_id);
+            if (seq !== requestSeqRef.current) return;
+            setActiveRun(response.data);
+          } catch (err) {
+            setError('graphifyRun', err);
+          }
+        })
+        .catch((err) => setError('space', err)),
+      getSpaceStats(spaceId)
+        .then((nextStats) => {
+          if (seq !== requestSeqRef.current) return;
+          setStats(nextStats);
+        })
+        .catch((err) => {
+          if (seq !== requestSeqRef.current) return;
+          setStats(null);
+          setError('stats', err);
+        }),
+      getRecentDocuments(spaceId)
+        .then((response) => {
+          if (seq !== requestSeqRef.current) return;
+          setDocuments(response.data);
+        })
+        .catch((err) => {
+          if (seq !== requestSeqRef.current) return;
+          setDocuments([]);
+          setError('documents', err);
+        }),
+      getRecentWikiPages(spaceId)
+        .then((response) => {
+          if (seq !== requestSeqRef.current) return;
+          setWikiPages(response.data);
+        })
+        .catch((err) => {
+          if (seq !== requestSeqRef.current) return;
+          setWikiPages([]);
+          setError('wikiPages', err);
+        }),
+      getGraphCommunities(spaceId)
+        .then((response) => {
+          if (seq !== requestSeqRef.current) return;
+          setCommunityCount(response.communities.length);
+        })
+        .catch((err) => {
+          if (seq !== requestSeqRef.current) return;
+          setCommunityCount(null);
+          setError('communities', err);
+        }),
+    ]);
+
+    if (seq === requestSeqRef.current) {
+      setIsLoading(false);
+    }
+  }, [spaceId]);
+
+  useEffect(() => {
+    void loadOverview();
+  }, [loadOverview]);
+
+  if (spaceId.length === 0) {
+    return <NotFound />;
+  }
+
+  return (
+    <Spin spinning={isLoading && space === null && stats === null}>
+      <Space direction="vertical" size={16} style={{ width: '100%' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'flex-start' }}>
+          <div>
+            <Typography.Title level={4} style={{ margin: 0 }}>
+              {t('overview.title')}
+            </Typography.Title>
+            <Typography.Text type="secondary">{space?.name ?? t('overview.description')}</Typography.Text>
+          </div>
+          <Button
+            aria-label={t('common.action.refresh')}
+            icon={<ReloadOutlined />}
+            onClick={() => { void loadOverview(); }}
+            loading={isLoading}
+          >
+            {t('common.action.refresh')}
+          </Button>
+        </div>
+
+        {errors.space !== null ? <Alert type="warning" showIcon message={errors.space} /> : null}
+
+        <SpaceStatsStrip stats={stats} error={errors.stats} />
+
+        <KnowledgeStatusPanel
+          spaceId={spaceId}
+          space={space}
+          stats={stats}
+          communityCount={communityCount}
+          activeRun={activeRun}
+          errors={errors}
+        />
+
+        <Row gutter={[16, 16]}>
+          <Col xs={24} lg={12}>
+            <RecentDocumentsList spaceId={spaceId} documents={documents} error={errors.documents} />
+          </Col>
+          <Col xs={24} lg={12}>
+            <RecentWikiPagesList spaceId={spaceId} pages={wikiPages} error={errors.wikiPages} />
+          </Col>
+        </Row>
+
+        <KnowledgeQuickActions spaceId={spaceId} />
+      </Space>
+    </Spin>
+  );
+}
+
+function SpaceStatsStrip({ stats, error }: { stats: SpaceStats | null; error: string | null }) {
+  const { t } = useTranslation();
+
+  if (error !== null) {
+    return (
+      <Card>
+        <Alert type="error" showIcon message={t('overview.error.stats')} description={error} />
+      </Card>
+    );
+  }
+
+  const cards = [
+    { key: 'documents', title: t('overview.stats.documents'), value: stats?.source_count ?? 0 },
+    { key: 'wikiPages', title: t('overview.stats.wikiPages'), value: stats?.page_count ?? 0 },
+    { key: 'graphNodes', title: t('overview.stats.graphNodes'), value: stats?.node_count ?? 0 },
+    { key: 'graphEdges', title: t('overview.stats.graphEdges'), value: stats?.edge_count ?? 0 },
+  ];
+
+  return (
+    <Row gutter={[16, 16]}>
+      {cards.map((card) => (
+        <Col key={card.key} xs={24} sm={12} lg={6}>
+          <Card>
+            <Statistic title={card.title} value={card.value} />
+          </Card>
+        </Col>
+      ))}
+    </Row>
+  );
+}
+
+function KnowledgeStatusPanel({
+  spaceId,
+  space,
+  stats,
+  communityCount,
+  activeRun,
+  errors,
+}: {
+  spaceId: string;
+  space: SpaceDetail | null;
+  stats: SpaceStats | null;
+  communityCount: number | null;
+  activeRun: GraphifyRun | null;
+  errors: OverviewErrors;
+}) {
+  const { t } = useTranslation();
+  const indexConsistency = space?.index_consistency_status ?? stats?.index_consistency ?? 'unavailable';
+  const indexHealthy = isHealthyIndex(indexConsistency);
+  const graphAvailable = (stats?.node_count ?? 0) > 0;
+  const activeRunIsProcessing = activeRun?.status === 'pending' || activeRun?.status === 'running';
+
+  return (
+    <Card title={t('overview.status.title')}>
+      <Space direction="vertical" size={12} style={{ width: '100%' }}>
+        {!indexHealthy ? (
+          <Alert
+            type="warning"
+            showIcon
+            message={t('overview.status.indexWarning', { status: formatLabel(indexConsistency) })}
+          />
+        ) : null}
+        {errors.communities !== null ? <Alert type="warning" showIcon message={errors.communities} /> : null}
+        {errors.graphifyRun !== null ? <Alert type="warning" showIcon message={errors.graphifyRun} /> : null}
+        <Descriptions column={{ xs: 1, sm: 2, lg: 3 }} size="small">
+          <Descriptions.Item label={t('overview.status.indexConsistency')}>
+            <Tag color={indexHealthy ? 'success' : 'warning'}>{formatLabel(indexConsistency)}</Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label={t('overview.status.strictMode')}>
+            <Tag color={space?.strict_knowledge_only ? 'blue' : 'default'}>
+              {space?.strict_knowledge_only ? t('overview.status.enabled') : t('overview.status.disabled')}
+            </Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label={t('overview.status.graphAvailability')}>
+            {graphAvailable ? (
+              <Link to={`/spaces/${encodeURIComponent(spaceId)}/graph`}>{t('overview.status.graphAvailable')}</Link>
+            ) : (
+              <Typography.Text type="secondary">{t('overview.status.graphUnavailable')}</Typography.Text>
+            )}
+          </Descriptions.Item>
+          <Descriptions.Item label={t('overview.status.communities')}>
+            {communityCount ?? t('common.state.unavailable')}
+          </Descriptions.Item>
+          <Descriptions.Item label={t('overview.status.activeRun')} span={2}>
+            {activeRun === null ? (
+              <Typography.Text type="secondary">{t('overview.status.noActiveRun')}</Typography.Text>
+            ) : (
+              <Space wrap>
+                <Tag color={activeRunIsProcessing ? 'processing' : statusColor(activeRun.status)}>
+                  {formatLabel(activeRun.status)}
+                </Tag>
+                {activeRun.progress !== null ? (
+                  <Progress percent={activeRun.progress.percent} size="small" style={{ width: 120 }} />
+                ) : null}
+                <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify/${encodeURIComponent(activeRun.run_id)}`}>
+                  {t('overview.status.viewRun')}
+                </Link>
+              </Space>
+            )}
+          </Descriptions.Item>
+        </Descriptions>
+      </Space>
+    </Card>
+  );
+}
+
+function RecentDocumentsList({
+  spaceId,
+  documents,
+  error,
+}: {
+  spaceId: string;
+  documents: RecentDocument[];
+  error: string | null;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Card
+      title={t('overview.recentDocuments.title')}
+      extra={<Link to={`/spaces/${encodeURIComponent(spaceId)}/uploads`}>{t('overview.action.viewAll')}</Link>}
+    >
+      {error !== null ? <Alert type="error" showIcon message={error} style={{ marginBottom: 12 }} /> : null}
+      <List
+        dataSource={documents}
+        locale={{
+          emptyText: (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={t('overview.recentDocuments.empty')}
+            />
+          ),
+        }}
+        renderItem={(document) => (
+          <List.Item>
+            <List.Item.Meta
+              title={<Link to={`/spaces/${encodeURIComponent(spaceId)}/uploads`}>{document.filename}</Link>}
+              description={(
+                <Space size={8} wrap>
+                  <Tag>{formatLabel(document.source_type)}</Tag>
+                  <StatusTag status={document.status} />
+                  <Typography.Text type="secondary">{formatDate(document.updated_at)}</Typography.Text>
+                </Space>
+              )}
+            />
+          </List.Item>
+        )}
+      />
+    </Card>
+  );
+}
+
+function RecentWikiPagesList({
+  spaceId,
+  pages,
+  error,
+}: {
+  spaceId: string;
+  pages: RecentWikiPage[];
+  error: string | null;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Card
+      title={t('overview.recentWikiPages.title')}
+      extra={<Link to={`/spaces/${encodeURIComponent(spaceId)}/wiki`}>{t('overview.action.viewAll')}</Link>}
+    >
+      {error !== null ? <Alert type="error" showIcon message={error} style={{ marginBottom: 12 }} /> : null}
+      <List
+        dataSource={pages}
+        locale={{
+          emptyText: (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={t('overview.recentWikiPages.empty')}
+            />
+          ),
+        }}
+        renderItem={(page) => (
+          <List.Item>
+            <List.Item.Meta
+              title={(
+                <Link to={`/spaces/${encodeURIComponent(spaceId)}/wiki/${encodeURIComponent(page.page_id)}`}>
+                  {page.title}
+                </Link>
+              )}
+              description={(
+                <Space size={8} wrap>
+                  <StatusTag status={page.status} />
+                  <Typography.Text type="secondary">{formatDate(page.updated_at)}</Typography.Text>
+                </Space>
+              )}
+            />
+          </List.Item>
+        )}
+      />
+    </Card>
+  );
+}
+
+function KnowledgeQuickActions({ spaceId }: { spaceId: string }) {
+  const { t } = useTranslation();
+  const actions: Array<{ key: string; label: string; to: string; icon: ReactNode }> = [
+    {
+      key: 'documents',
+      label: t('overview.quickActions.documents'),
+      to: `/spaces/${encodeURIComponent(spaceId)}/uploads`,
+      icon: <CloudUploadOutlined />,
+    },
+    {
+      key: 'wiki',
+      label: t('overview.quickActions.wiki'),
+      to: `/spaces/${encodeURIComponent(spaceId)}/wiki`,
+      icon: <BookOutlined />,
+    },
+    {
+      key: 'graph',
+      label: t('overview.quickActions.graph'),
+      to: `/spaces/${encodeURIComponent(spaceId)}/graph`,
+      icon: <ShareAltOutlined />,
+    },
+    {
+      key: 'graphify',
+      label: t('overview.quickActions.graphify'),
+      to: `/spaces/${encodeURIComponent(spaceId)}/graphify`,
+      icon: <NodeIndexOutlined />,
+    },
+    {
+      key: 'chat',
+      label: t('overview.quickActions.chat'),
+      to: `/spaces/${encodeURIComponent(spaceId)}/chat`,
+      icon: <MessageOutlined />,
+    },
+  ];
+
+  return (
+    <Card title={t('overview.quickActions.title')}>
+      <Space wrap>
+        {actions.map((action) => (
+          <Link key={action.key} to={action.to}>
+            <Button aria-label={action.label} icon={action.icon}>{action.label}</Button>
+          </Link>
+        ))}
+      </Space>
+    </Card>
+  );
+}
+
+function StatusTag({ status }: { status: string }) {
+  return <Tag color={statusColor(status)}>{formatLabel(status)}</Tag>;
+}
+
+function statusColor(status: string): string {
+  if (status === 'healthy' || status === 'consistent' || status === 'parsed' || status === 'published' || status === 'succeeded') {
+    return 'success';
+  }
+
+  if (status === 'pending' || status === 'running' || status === 'uploaded' || status === 'parsing') {
+    return 'processing';
+  }
+
+  if (status === 'failed' || status === 'parse_failed' || status === 'security_rejected') {
+    return 'error';
+  }
+
+  if (status === 'stale' || status === 'degraded') {
+    return 'warning';
+  }
+
+  return 'default';
+}
+
+function isHealthyIndex(status: string): boolean {
+  const normalized = status.toLowerCase();
+  return normalized === 'healthy' || normalized === 'consistent';
+}


### PR DESCRIPTION
## Summary
- Add Space overview dashboard at /spaces/:spaceId/overview as default Space landing page
- Stats cards, knowledge status panel, recent documents/wiki, quick actions
- Stale state clearing, Graphify run fallback, remediation links

Closes #233
Part of #230

## Test plan
- [x] pnpm --filter @cherrygraph/web test — 12 files, 112 tests pass
- [x] pnpm build — clean build
- [x] pnpm lint — 0 warnings

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `5fdbc9bd8d4de4547f075e827ac4a447ff4055c9`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/253#issuecomment-4417167898) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/253#issuecomment-4417168142) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/253#issuecomment-4417168303) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/253#issuecomment-4417168452)
- Key findings addressed: Stale space data cleared on navigation, Graphify fallback, index links, empty state actions