### PR TITLE
feat(graphify): add input_scope_resolved to run response

### DIFF
--- a/apps/api/src/graphify/__tests__/graphify.controller.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.controller.test.ts
@@ -224,6 +224,7 @@ function createRunResponse(
     status: 'pending',
     progress: { percent: 0, stage: 'pending' },
     input_scope: { page_ids: [], source_document_ids: [] },
+    input_scope_resolved: { source_documents: [], pages: [] },
     result: {
       nodes_created: 0,
       nodes_updated: 0,

--- a/apps/api/src/graphify/__tests__/graphify.service.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.service.test.ts
@@ -379,6 +379,54 @@ describe('GraphifyService', () => {
       expect(resolved.docMap.has('doc-deleted')).toBe(false);
     });
 
+    it('resolveInputScope resolves wiki page ids and titles', async () => {
+      const db = new ScriptedDb();
+      db.queueSelect([
+        { id: 'page-pk-1', title: 'Getting Started' },
+        { id: 'page-pk-2', title: 'API Guide' },
+      ]);
+
+      const resolved = await resolveInputScope(
+        db.asDrizzle(),
+        [
+          createRunRow({
+            stats_json: { input_scope: { page_ids: ['page-pk-1', 'page-pk-2'] } },
+          }),
+        ],
+        TEST_TENANT_ID,
+      );
+
+      expect(resolved.pageMap.get('page-pk-1')).toBe('Getting Started');
+      expect(resolved.pageMap.size).toBe(2);
+      expect(resolved.docMap.size).toBe(0);
+    });
+
+    it('resolveInputScope adds space_id filter', async () => {
+      const db = new ScriptedDb();
+      db.queueSelect([{ id: 'doc-1', filename: 'Plan.pdf' }]);
+      db.queueSelect([{ id: 'page-pk-1', title: 'Getting Started' }]);
+
+      await resolveInputScope(
+        db.asDrizzle(),
+        [
+          createRunRow({
+            stats_json: {
+              input_scope: {
+                source_document_ids: ['doc-1'],
+                page_ids: ['page-pk-1'],
+              },
+            },
+          }),
+        ],
+        TEST_TENANT_ID,
+      );
+
+      expect(db.whereClauses).toHaveLength(2);
+      expect(db.whereClauses.every((clause) => hasEncodedParam(clause, TEST_SPACE_ID, 'space_id'))).toBe(
+        true,
+      );
+    });
+
     it('toGraphifyRunResponse includes resolved source documents and pages', () => {
       const result = toGraphifyRunResponse(
         createRunRow({
@@ -459,6 +507,37 @@ function createAdminContext(): {
     actorRole: 'admin',
     userId: TEST_USER_ID,
   };
+}
+
+function hasEncodedParam(
+  value: unknown,
+  expectedValue: string,
+  expectedEncoderName: string,
+  seen = new Set<object>(),
+): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+
+  const record = value as Record<PropertyKey, unknown>;
+  const encoder = record.encoder;
+  if (
+    record.value === expectedValue &&
+    typeof encoder === 'object' &&
+    encoder !== null &&
+    (encoder as Record<PropertyKey, unknown>).name === expectedEncoderName
+  ) {
+    return true;
+  }
+
+  return Reflect.ownKeys(record).some((key) =>
+    hasEncodedParam(record[key], expectedValue, expectedEncoderName, seen),
+  );
 }
 
 function createRunRow(overrides: Partial<GraphifyRunRow> = {}): GraphifyRunRow {

--- a/apps/api/src/graphify/__tests__/graphify.service.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.service.test.ts
@@ -14,7 +14,7 @@ import {
   getRejectedHttpException,
   requireRecord,
 } from '../../users/__tests__/user-group-service-test-utils.js';
-import { GraphifyService } from '../graphify.service.js';
+import { GraphifyService, resolveInputScope, toGraphifyRunResponse } from '../graphify.service.js';
 
 type GraphifyRunRow = typeof graphifyRuns.$inferSelect;
 type GraphReportRow = typeof graphReports.$inferSelect;
@@ -332,6 +332,107 @@ describe('GraphifyService', () => {
 
     expect(err.getStatus()).toBe(403);
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+  });
+
+  describe('input_scope_resolved', () => {
+    it('resolveInputScope deduplicates source document ids across runs', async () => {
+      const db = new ScriptedDb();
+      db.queueSelect([
+        { id: 'doc-1', filename: 'Plan.pdf' },
+        { id: 'doc-2', filename: 'Notes.md' },
+      ]);
+
+      const resolved = await resolveInputScope(
+        db.asDrizzle(),
+        [
+          createRunRow({ stats_json: { input_scope: { source_document_ids: ['doc-1', 'doc-2'] } } }),
+          createRunRow({ id: 'run-2', stats_json: { input_scope: { source_document_ids: ['doc-1'] } } }),
+        ],
+        TEST_TENANT_ID,
+      );
+
+      expect(resolved.docMap).toEqual(
+        new Map([
+          ['doc-1', 'Plan.pdf'],
+          ['doc-2', 'Notes.md'],
+        ]),
+      );
+      expect(resolved.pageMap.size).toBe(0);
+      expect(db.selectFields).toHaveLength(1);
+    });
+
+    it("resolveInputScope omits document ids that don't exist", async () => {
+      const db = new ScriptedDb();
+      db.queueSelect([{ id: 'doc-existing', filename: 'Existing.pdf' }]);
+
+      const resolved = await resolveInputScope(
+        db.asDrizzle(),
+        [
+          createRunRow({
+            stats_json: { input_scope: { source_document_ids: ['doc-existing', 'doc-deleted'] } },
+          }),
+        ],
+        TEST_TENANT_ID,
+      );
+
+      expect(resolved.docMap.get('doc-existing')).toBe('Existing.pdf');
+      expect(resolved.docMap.has('doc-deleted')).toBe(false);
+    });
+
+    it('toGraphifyRunResponse includes resolved source documents and pages', () => {
+      const result = toGraphifyRunResponse(
+        createRunRow({
+          stats_json: {
+            input_scope: {
+              source_document_ids: ['doc-1', 'doc-2'],
+              page_ids: ['page-1'],
+            },
+          },
+        }),
+        {
+          docMap: new Map([
+            ['doc-1', 'Plan.pdf'],
+            ['doc-2', 'Notes.md'],
+          ]),
+          pageMap: new Map([['page-1', 'Overview']]),
+        },
+      );
+
+      expect(result.input_scope_resolved).toEqual({
+        source_documents: [
+          { id: 'doc-1', filename: 'Plan.pdf', missing: false },
+          { id: 'doc-2', filename: 'Notes.md', missing: false },
+        ],
+        pages: [{ id: 'page-1', title: 'Overview', missing: false }],
+      });
+    });
+
+    it('toGraphifyRunResponse marks unresolved source documents and pages as missing', () => {
+      const result = toGraphifyRunResponse(
+        createRunRow({
+          stats_json: {
+            input_scope: {
+              source_document_ids: ['doc-1'],
+              page_ids: ['page-1'],
+            },
+          },
+        }),
+      );
+
+      expect(result.input_scope_resolved).toEqual({
+        source_documents: [{ id: 'doc-1', filename: null, missing: true }],
+        pages: [{ id: 'page-1', title: null, missing: true }],
+      });
+    });
+
+    it('toGraphifyRunResponse returns empty resolved arrays for empty input scope', () => {
+      const result = toGraphifyRunResponse(createRunRow({ stats_json: { input_scope: {} } }));
+
+      expect(result.input_scope_resolved).toEqual({
+        source_documents: [],
+        pages: [],
+      });
+    });
   });
 });
 

--- a/apps/api/src/graphify/graphify.service.ts
+++ b/apps/api/src/graphify/graphify.service.ts
@@ -828,6 +828,8 @@ function buildRunOrder(sort: string): SQL {
   return parsed.direction === 'desc' ? desc(column) : asc(column);
 }
 
+const RESOLVE_CHUNK_SIZE = 200;
+
 export async function resolveInputScope(
   db: GraphifyDatabase,
   runs: GraphifyRunRow[],
@@ -840,55 +842,59 @@ export async function resolveInputScope(
     return { docMap, pageMap };
   }
 
-  const sourceDocumentIds = new Set<string>();
-  const pageIds = new Set<string>();
-  const spaceId = runs[0]?.space_id ?? '';
+  const spaceGroups = new Map<string, { docIds: Set<string>; pageIds: Set<string> }>();
 
   for (const run of runs) {
     const stats = asRecord(run.stats_json);
     const inputScope = readInputScope(stats.input_scope);
+    let group = spaceGroups.get(run.space_id);
+    if (group === undefined) {
+      group = { docIds: new Set(), pageIds: new Set() };
+      spaceGroups.set(run.space_id, group);
+    }
     for (const id of inputScope?.source_document_ids ?? []) {
-      sourceDocumentIds.add(id);
+      group.docIds.add(id);
     }
     for (const id of inputScope?.page_ids ?? []) {
-      pageIds.add(id);
+      group.pageIds.add(id);
     }
   }
 
-  const sourceDocumentIdList = [...sourceDocumentIds].slice(0, 200);
-  const pageIdList = [...pageIds].slice(0, 200);
-
-  if (sourceDocumentIdList.length > 0) {
-    const rows = await db
-      .select({ id: source_documents.id, filename: source_documents.filename })
-      .from(source_documents)
-      .where(
-        and(
-          eq(source_documents.tenant_id, tenantId),
-          eq(source_documents.space_id, spaceId),
-          inArray(source_documents.id, sourceDocumentIdList),
-        ),
-      );
-
-    for (const row of rows) {
-      docMap.set(row.id, row.filename);
+  for (const [spaceId, group] of spaceGroups) {
+    const docIdList = [...group.docIds];
+    for (let i = 0; i < docIdList.length; i += RESOLVE_CHUNK_SIZE) {
+      const chunk = docIdList.slice(i, i + RESOLVE_CHUNK_SIZE);
+      const rows = await db
+        .select({ id: source_documents.id, filename: source_documents.filename })
+        .from(source_documents)
+        .where(
+          and(
+            eq(source_documents.tenant_id, tenantId),
+            eq(source_documents.space_id, spaceId),
+            inArray(source_documents.id, chunk),
+          ),
+        );
+      for (const row of rows) {
+        docMap.set(row.id, row.filename);
+      }
     }
-  }
 
-  if (pageIdList.length > 0) {
-    const rows = await db
-      .select({ id: wikiPages.id, title: wikiPages.title })
-      .from(wikiPages)
-      .where(
-        and(
-          eq(wikiPages.tenant_id, tenantId),
-          eq(wikiPages.space_id, spaceId),
-          inArray(wikiPages.id, pageIdList),
-        ),
-      );
-
-    for (const row of rows) {
-      pageMap.set(row.id, row.title);
+    const pageIdList = [...group.pageIds];
+    for (let i = 0; i < pageIdList.length; i += RESOLVE_CHUNK_SIZE) {
+      const chunk = pageIdList.slice(i, i + RESOLVE_CHUNK_SIZE);
+      const rows = await db
+        .select({ id: wikiPages.id, title: wikiPages.title })
+        .from(wikiPages)
+        .where(
+          and(
+            eq(wikiPages.tenant_id, tenantId),
+            eq(wikiPages.space_id, spaceId),
+            inArray(wikiPages.id, chunk),
+          ),
+        );
+      for (const row of rows) {
+        pageMap.set(row.id, row.title);
+      }
     }
   }
 

--- a/apps/api/src/graphify/graphify.service.ts
+++ b/apps/api/src/graphify/graphify.service.ts
@@ -11,6 +11,7 @@ import {
   source_documents,
   space_permissions,
   spaces,
+  wikiPages,
   type GraphifyRunMode,
   type GraphifyRunStatus,
   type GraphifyTriggerType,
@@ -30,8 +31,8 @@ import { getApiLogger } from '../common/logger/logger.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { AuditService } from '../audit/audit.service.js';
 
-type GraphifyDatabase = NodePgDatabase;
-type GraphifyRunRow = typeof graphifyRuns.$inferSelect;
+export type GraphifyDatabase = NodePgDatabase;
+export type GraphifyRunRow = typeof graphifyRuns.$inferSelect;
 type GraphReportRow = typeof graphReports.$inferSelect;
 type SpaceRow = typeof spaces.$inferSelect;
 
@@ -90,6 +91,10 @@ export type GraphifyRunResponse = {
   input_scope: {
     page_ids: string[];
     source_document_ids: string[];
+  };
+  input_scope_resolved: {
+    source_documents: Array<{ id: string; filename: string | null; missing: boolean }>;
+    pages: Array<{ id: string; title: string | null; missing: boolean }>;
   };
   result: {
     nodes_created: number;
@@ -181,7 +186,8 @@ export class GraphifyService {
       trigger_type: input.trigger_type,
     });
 
-    return toGraphifyRunResponse(created);
+    const resolved = await resolveInputScope(this.db, [created], tenantId);
+    return toGraphifyRunResponse(created, resolved);
   }
 
   async listRuns(
@@ -209,15 +215,18 @@ export class GraphifyService {
       .offset((page - 1) * perPage);
     const [countRow] = await this.db.select({ total: count() }).from(graphifyRuns).where(where);
 
+    const resolved = await resolveInputScope(this.db, rows, tenantId);
+
     return paginatedResponse(
-      rows.map(toGraphifyRunResponse),
+      rows.map((row) => toGraphifyRunResponse(row, resolved)),
       buildPaginationMeta(page, perPage, normalizeCount(countRow?.total)),
     );
   }
 
   async getRun(runId: string, context: GraphifyContext = {}): Promise<GraphifyRunResponse> {
     const run = await this.getAccessibleRun(runId, context, 'graphify:view');
-    return toGraphifyRunResponse(run);
+    const resolved = await resolveInputScope(this.db, [run], run.tenant_id);
+    return toGraphifyRunResponse(run, resolved);
   }
 
   async cancelRun(
@@ -293,7 +302,8 @@ export class GraphifyService {
       original_run_id: run.id,
     });
 
-    return toGraphifyRunResponse(created);
+    const resolved = await resolveInputScope(this.db, [created], tenantId);
+    return toGraphifyRunResponse(created, resolved);
   }
 
   async getReport(runId: string, context: GraphifyContext = {}): Promise<GraphifyReportResponse> {
@@ -818,7 +828,62 @@ function buildRunOrder(sort: string): SQL {
   return parsed.direction === 'desc' ? desc(column) : asc(column);
 }
 
-function toGraphifyRunResponse(run: GraphifyRunRow): GraphifyRunResponse {
+export async function resolveInputScope(
+  db: GraphifyDatabase,
+  runs: GraphifyRunRow[],
+  tenantId: string,
+): Promise<{ docMap: Map<string, string>; pageMap: Map<string, string> }> {
+  const sourceDocumentIds = new Set<string>();
+  const pageIds = new Set<string>();
+
+  for (const run of runs) {
+    const stats = asRecord(run.stats_json);
+    const inputScope = readInputScope(stats.input_scope);
+    for (const id of inputScope?.source_document_ids ?? []) {
+      sourceDocumentIds.add(id);
+    }
+    for (const id of inputScope?.page_ids ?? []) {
+      pageIds.add(id);
+    }
+  }
+
+  const docMap = new Map<string, string>();
+  const pageMap = new Map<string, string>();
+  const sourceDocumentIdList = [...sourceDocumentIds];
+  const pageIdList = [...pageIds];
+
+  if (sourceDocumentIdList.length > 0) {
+    const rows = await db
+      .select({ id: source_documents.id, filename: source_documents.filename })
+      .from(source_documents)
+      .where(and(eq(source_documents.tenant_id, tenantId), inArray(source_documents.id, sourceDocumentIdList)));
+
+    for (const row of rows) {
+      docMap.set(row.id, row.filename);
+    }
+  }
+
+  if (pageIdList.length > 0) {
+    const rows = await db
+      .select({ id: wikiPages.id, title: wikiPages.title })
+      .from(wikiPages)
+      .where(and(eq(wikiPages.tenant_id, tenantId), inArray(wikiPages.id, pageIdList)));
+
+    for (const row of rows) {
+      pageMap.set(row.id, row.title);
+    }
+  }
+
+  return { docMap, pageMap };
+}
+
+export function toGraphifyRunResponse(
+  run: GraphifyRunRow,
+  resolved: { docMap: Map<string, string>; pageMap: Map<string, string> } = {
+    docMap: new Map(),
+    pageMap: new Map(),
+  },
+): GraphifyRunResponse {
   const stats = asRecord(run.stats_json);
   const inputScope = readInputScope(stats.input_scope) ?? {};
   const progress = asRecord(stats.progress);
@@ -836,6 +901,18 @@ function toGraphifyRunResponse(run: GraphifyRunRow): GraphifyRunResponse {
     input_scope: {
       page_ids: inputScope.page_ids ?? [],
       source_document_ids: inputScope.source_document_ids ?? [],
+    },
+    input_scope_resolved: {
+      source_documents: (inputScope.source_document_ids ?? []).map((id) => ({
+        id,
+        filename: resolved.docMap.get(id) ?? null,
+        missing: !resolved.docMap.has(id),
+      })),
+      pages: (inputScope.page_ids ?? []).map((id) => ({
+        id,
+        title: resolved.pageMap.get(id) ?? null,
+        missing: !resolved.pageMap.has(id),
+      })),
     },
     result: {
       nodes_created: readInteger(stats.nodes_created) ?? readInteger(stats.node_count) ?? 0,

--- a/apps/api/src/graphify/graphify.service.ts
+++ b/apps/api/src/graphify/graphify.service.ts
@@ -833,8 +833,16 @@ export async function resolveInputScope(
   runs: GraphifyRunRow[],
   tenantId: string,
 ): Promise<{ docMap: Map<string, string>; pageMap: Map<string, string> }> {
+  const docMap = new Map<string, string>();
+  const pageMap = new Map<string, string>();
+
+  if (runs.length === 0) {
+    return { docMap, pageMap };
+  }
+
   const sourceDocumentIds = new Set<string>();
   const pageIds = new Set<string>();
+  const spaceId = runs[0]?.space_id ?? '';
 
   for (const run of runs) {
     const stats = asRecord(run.stats_json);
@@ -847,16 +855,20 @@ export async function resolveInputScope(
     }
   }
 
-  const docMap = new Map<string, string>();
-  const pageMap = new Map<string, string>();
-  const sourceDocumentIdList = [...sourceDocumentIds];
-  const pageIdList = [...pageIds];
+  const sourceDocumentIdList = [...sourceDocumentIds].slice(0, 200);
+  const pageIdList = [...pageIds].slice(0, 200);
 
   if (sourceDocumentIdList.length > 0) {
     const rows = await db
       .select({ id: source_documents.id, filename: source_documents.filename })
       .from(source_documents)
-      .where(and(eq(source_documents.tenant_id, tenantId), inArray(source_documents.id, sourceDocumentIdList)));
+      .where(
+        and(
+          eq(source_documents.tenant_id, tenantId),
+          eq(source_documents.space_id, spaceId),
+          inArray(source_documents.id, sourceDocumentIdList),
+        ),
+      );
 
     for (const row of rows) {
       docMap.set(row.id, row.filename);
@@ -867,7 +879,13 @@ export async function resolveInputScope(
     const rows = await db
       .select({ id: wikiPages.id, title: wikiPages.title })
       .from(wikiPages)
-      .where(and(eq(wikiPages.tenant_id, tenantId), inArray(wikiPages.id, pageIdList)));
+      .where(
+        and(
+          eq(wikiPages.tenant_id, tenantId),
+          eq(wikiPages.space_id, spaceId),
+          inArray(wikiPages.id, pageIdList),
+        ),
+      );
 
     for (const row of rows) {
       pageMap.set(row.id, row.title);


### PR DESCRIPTION
Closes #258
Part of #257

## Summary

- Added `input_scope_resolved` field to `GraphifyRunResponse` type, resolving `source_document_ids` → `{ id, filename, missing }` and `page_ids` → `{ id, title, missing }`
- New `resolveInputScope()` helper does batch lookup against `source_documents` and `wiki_pages` tables with tenant+space isolation, per-space grouping, and chunked IN queries
- All external-facing endpoints (`createRun`, `listRuns`, `getRun`, `retryRun`) pass resolved maps; internal methods (`handleRunCompletion`) use default empty maps
- Added 7 focused unit tests covering deduplication, deleted docs, resolved output, empty maps, empty input scope, page resolution, and space filtering

## Test plan

- [x] `resolveInputScope` deduplicates IDs across multiple runs
- [x] Missing/deleted document IDs return `{ missing: true, filename: null }`
- [x] `toGraphifyRunResponse` builds correct `input_scope_resolved` structure
- [x] Empty input scope returns `{ source_documents: [], pages: [] }`
- [x] Wiki page title resolution works correctly
- [x] Space ID filtering applied to resolution queries
- [x] Full build + lint + 1146 tests passing

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `f7e7a8734a5059ad329465087b7d142f1d415ac9`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/260#issuecomment-4420363239) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/260#issuecomment-4420363447) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/260#issuecomment-4420363741) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/260#issuecomment-4420363936)
- Key findings addressed: Round 1 fixed space isolation and IN clause cap; Round 2 fixed per-space grouping and chunked queries; frontend type update deferred to #259