### PR TITLE
feat(web): display document names in Graphify run lists

### DIFF
--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -191,6 +191,10 @@ function buildRun(overrides: Partial<GraphifyRun> = {}): GraphifyRun {
       page_ids: [],
       source_document_ids: [],
     },
+    input_scope_resolved: {
+      source_documents: [],
+      pages: [],
+    },
     result: {
       nodes_created: 10,
       nodes_updated: 0,

--- a/apps/web/src/__tests__/overview.test.tsx
+++ b/apps/web/src/__tests__/overview.test.tsx
@@ -252,6 +252,10 @@ function createGraphifyRun(overrides: Record<string, unknown> = {}) {
     status: 'running',
     progress: { percent: 40, stage: 'importing' },
     input_scope: {},
+    input_scope_resolved: {
+      source_documents: [],
+      pages: [],
+    },
     result: {
       nodes_created: 0,
       nodes_updated: 0,

--- a/apps/web/src/lib/graphifyApi.ts
+++ b/apps/web/src/lib/graphifyApi.ts
@@ -13,6 +13,11 @@ export type GraphifyInputScope = {
   source_document_ids?: string[];
 };
 
+export type GraphifyInputScopeResolved = {
+  source_documents: Array<{ id: string; filename: string | null; missing: boolean }>;
+  pages: Array<{ id: string; title: string | null; missing: boolean }>;
+};
+
 export type GraphifyOptions = {
   wiki?: boolean;
   no_viz?: boolean;
@@ -49,6 +54,7 @@ export type GraphifyRun = {
   status: GraphifyRunStatus;
   progress: GraphifyRunProgress | null;
   input_scope: GraphifyInputScope;
+  input_scope_resolved: GraphifyInputScopeResolved;
   result: GraphifyRunResult;
   stats_json?: unknown;
   error_json?: unknown;

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -356,10 +356,10 @@ function renderBoldMarkdown(text: string, keyPrefix: string): ReactNode[] {
 
 function formatInputScope(run: GraphifyRun, t: (key: string) => string): string {
   const sourceDocumentNames = run.input_scope_resolved.source_documents
-    .map((sourceDocument) => (sourceDocument.missing ? t('common.deleted') : sourceDocument.filename))
+    .map((sourceDocument) => (sourceDocument.missing ? t('common.status.deleted') : sourceDocument.filename))
     .filter((name): name is string => name !== null && name.length > 0);
   const pageNames = run.input_scope_resolved.pages
-    .map((page) => (page.missing ? t('common.deleted') : page.title))
+    .map((page) => (page.missing ? t('common.status.deleted') : page.title))
     .filter((name): name is string => name !== null && name.length > 0);
   const names = [...sourceDocumentNames, ...pageNames];
 

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -16,7 +16,6 @@ import {
 } from '../lib/graphifyApi';
 import {
   GraphifyStatusCell,
-  asRecord,
   formatCount,
   formatJson,
   formatRunDurationWithT,
@@ -356,21 +355,13 @@ function renderBoldMarkdown(text: string, keyPrefix: string): ReactNode[] {
 }
 
 function formatInputScope(run: GraphifyRun, t: (key: string) => string): string {
-  const inputScope = asRecord(run.input_scope);
-  const sourceDocumentIds = readStringArray(inputScope.source_document_ids);
-  const pageIds = readStringArray(inputScope.page_ids);
+  const sourceDocumentNames = run.input_scope_resolved.source_documents
+    .map((sourceDocument) => (sourceDocument.missing ? t('common.deleted') : sourceDocument.filename))
+    .filter((name): name is string => name !== null && name.length > 0);
+  const pageNames = run.input_scope_resolved.pages
+    .map((page) => (page.missing ? t('common.deleted') : page.title))
+    .filter((name): name is string => name !== null && name.length > 0);
+  const names = [...sourceDocumentNames, ...pageNames];
 
-  if (sourceDocumentIds.length > 0) {
-    return sourceDocumentIds.join(', ');
-  }
-
-  if (pageIds.length > 0) {
-    return pageIds.join(', ');
-  }
-
-  return t('graphify.space.detail.overview.allSources');
-}
-
-function readStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  return names.length > 0 ? names.join(', ') : t('graphify.space.detail.overview.allSources');
 }

--- a/apps/web/src/pages/GraphifyRunsPage.tsx
+++ b/apps/web/src/pages/GraphifyRunsPage.tsx
@@ -20,6 +20,7 @@ import {
   GraphifyStatusTabs,
   NewRunDialog,
   formatGraphifyStatsWithT,
+  formatRunLabel,
   formatRunDurationWithT,
   isGraphifyRunActive,
 } from './graphifyUi';
@@ -160,15 +161,18 @@ export default function GraphifyRunsPage() {
     {
       title: t('graphify.space.columns.run'),
       key: 'run',
-      render: (_: unknown, run: GraphifyRun) => (
-        <div>
-          <Typography.Text strong>{run.run_id}</Typography.Text>
-          <br />
-          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            {run.result.report_uri ?? t('graphify.space.noReport')}
-          </Typography.Text>
-        </div>
-      ),
+      render: (_: unknown, run: GraphifyRun) => {
+        const label = formatRunLabel(run, t);
+        return (
+          <div>
+            <Typography.Text strong>{label.primary}</Typography.Text>
+            <br />
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              {label.secondary}
+            </Typography.Text>
+          </div>
+        );
+      },
     },
     {
       title: t('graphify.space.columns.status'),

--- a/apps/web/src/pages/admin/GraphifyPage.tsx
+++ b/apps/web/src/pages/admin/GraphifyPage.tsx
@@ -17,6 +17,7 @@ import {
   GRAPHIFY_PAGE_SIZE,
   formatCount,
   getGraphifyStat,
+  formatRunLabel,
   getQuarantineType,
   isGraphifyRunActive,
   isQuarantined,
@@ -131,15 +132,18 @@ function GraphifyPage() {
     {
       title: t('admin.graphify.columns.run'),
       key: 'run',
-      render: (_: unknown, run: GraphifyRun) => (
-        <div>
-          <Typography.Text strong>{run.run_id}</Typography.Text>
-          <br />
-          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            {run.result.report_uri ?? t('admin.graphify.noReport')}
-          </Typography.Text>
-        </div>
-      ),
+      render: (_: unknown, run: GraphifyRun) => {
+        const label = formatRunLabel(run, t);
+        return (
+          <div>
+            <Typography.Text strong>{label.primary}</Typography.Text>
+            <br />
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              {label.secondary}
+            </Typography.Text>
+          </div>
+        );
+      },
     },
     {
       title: t('admin.graphify.columns.status'),

--- a/apps/web/src/pages/graphifyUi.tsx
+++ b/apps/web/src/pages/graphifyUi.tsx
@@ -1,5 +1,6 @@
 import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { Button, Form, Modal, Select, Tag } from 'antd';
+import type { TFunction } from 'i18next';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatLabel } from '../components/adminUi';
@@ -113,6 +114,28 @@ export function NewRunDialog({
 
 export function isGraphifyRunActive(run: GraphifyRun): boolean {
   return run.status === 'pending' || run.status === 'running';
+}
+
+export function formatRunLabel(run: GraphifyRun, t: TFunction): { primary: string; secondary: string } {
+  const names = [
+    ...run.input_scope_resolved.source_documents.map((sourceDocument) => (
+      sourceDocument.missing ? t('common.deleted') : sourceDocument.filename
+    )),
+    ...run.input_scope_resolved.pages.map((page) => (
+      page.missing ? t('common.deleted') : page.title
+    )),
+  ].filter((name): name is string => name !== null && name.length > 0);
+
+  const visibleNames = names.slice(0, 3);
+  const overflowCount = names.length - visibleNames.length;
+  const primary = names.length === 0
+    ? formatLabel(run.mode)
+    : `${visibleNames.join(', ')}${overflowCount > 0 ? ` +${overflowCount}` : ''}`;
+
+  return {
+    primary,
+    secondary: run.run_id,
+  };
 }
 
 export function isQuarantined(run: GraphifyRun): boolean {

--- a/apps/web/src/pages/graphifyUi.tsx
+++ b/apps/web/src/pages/graphifyUi.tsx
@@ -119,10 +119,10 @@ export function isGraphifyRunActive(run: GraphifyRun): boolean {
 export function formatRunLabel(run: GraphifyRun, t: TFunction): { primary: string; secondary: string } {
   const names = [
     ...run.input_scope_resolved.source_documents.map((sourceDocument) => (
-      sourceDocument.missing ? t('common.deleted') : sourceDocument.filename
+      sourceDocument.missing ? t('common.status.deleted') : sourceDocument.filename
     )),
     ...run.input_scope_resolved.pages.map((page) => (
-      page.missing ? t('common.deleted') : page.title
+      page.missing ? t('common.status.deleted') : page.title
     )),
   ].filter((name): name is string => name !== null && name.length > 0);
 


### PR DESCRIPTION
Closes #259
Part of #257

## Summary

- Updated `GraphifyRun` type with non-optional `input_scope_resolved` field
- Added shared `formatRunLabel()` helper in `graphifyUi.tsx` — shows filenames/page titles (max 3, then +N), falls back to mode label, marks deleted items via i18n
- Space-level and Admin Graphify run lists now display document names as primary text, run_id as secondary
- Detail page `formatInputScope` uses resolved names instead of raw UUIDs
- Fixed i18n key to `common.status.deleted`

## Test plan

- [x] Build passes with TypeScript strict checking
- [x] Lint passes with zero warnings
- [x] All 1146 tests pass
- [x] Test fixtures updated for new required field

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `19ae23e27faedbc02af3232d748a935a43ba71bb`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/261#issuecomment-4420562353) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/261#issuecomment-4420562764) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/261#issuecomment-4420563255) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/261#issuecomment-4420563577)
- Key findings addressed: Fixed i18n key from common.deleted to common.status.deleted