### PR TITLE
fix(models): real HTTP probe for model connectivity test (#263)

### DIFF
--- a/apps/api/src/models/__tests__/model-config.service.test.ts
+++ b/apps/api/src/models/__tests__/model-config.service.test.ts
@@ -289,7 +289,10 @@ describe('ModelConfigService', () => {
       expect(result.reachable).toBe(true);
       expect(result.error).toBeUndefined();
     });
-    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.openai.com/v1/embeddings');
+    const { url, init } = getFirstFetchCall(fetchMock);
+    expect(url).toBe('https://api.openai.com/v1/embeddings');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ model: 'text-embedding-3-large', input: 'test' }));
   });
 
   it('tests rerank model connectivity through the rerank endpoint', async () => {
@@ -309,7 +312,10 @@ describe('ModelConfigService', () => {
       expect(result.reachable).toBe(true);
       expect(result.error).toBeUndefined();
     });
-    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.openai.com/v1/rerank');
+    const { url, init } = getFirstFetchCall(fetchMock);
+    expect(url).toBe('https://api.openai.com/v1/rerank');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ model: 'bge-reranker-large', query: 'test', documents: ['test'] }));
   });
 
   it('returns unreachable when rerank probe returns 500', async () => {
@@ -383,6 +389,22 @@ describe('ModelConfigService', () => {
     const { service, db } = createServiceContext();
     const fetchMock = mockFetchResponse(200);
     db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: null })]);
+
+    const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        reachable: false,
+        error: 'No API key configured',
+      }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns no API key configured without fetching when key ref is empty string', async () => {
+    const { service, db } = createServiceContext();
+    const fetchMock = mockFetchResponse(200);
+    db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: '' })]);
 
     const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
 

--- a/apps/api/src/models/__tests__/model-config.service.test.ts
+++ b/apps/api/src/models/__tests__/model-config.service.test.ts
@@ -1,5 +1,5 @@
 import { ErrorCode, model_configs } from '@cherrygraph/shared';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AUDIT_EVENTS } from '../../audit/audit-events.js';
 import { ModelConfigService } from '../model-config.service.js';
@@ -17,6 +17,17 @@ import {
 type ModelConfigRow = typeof model_configs.$inferSelect;
 
 const TEST_MODEL_ID = 'model-1';
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  Object.defineProperty(globalThis, 'fetch', {
+    value: originalFetch,
+    writable: true,
+    configurable: true,
+  });
+});
 
 describe('ModelConfigService', () => {
   it('lists models with API field mapping', async () => {
@@ -198,8 +209,9 @@ describe('ModelConfigService', () => {
     expect(db.updates).toHaveLength(0);
   });
 
-  it('returns reachable when connectivity test resolves the secret', async () => {
+  it('tests chat model connectivity with valid URL and key', async () => {
     const { service, db } = createServiceContext();
+    const fetchMock = mockFetchResponse(200);
     db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: 'secret:openai_key' })]);
 
     await withEnv('OPENAI_KEY', 'test-key', async () => {
@@ -210,23 +222,196 @@ describe('ModelConfigService', () => {
       );
 
       expect(result.reachable).toBe(true);
-      expect(result.latency_ms).toBeGreaterThanOrEqual(1);
+      expect(result.latency_ms).toBeGreaterThan(0);
       expect(result.error).toBeUndefined();
+    });
+    const { url, init } = getFirstFetchCall(fetchMock);
+    expect(url).toBe('https://api.openai.com/v1/chat/completions');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({
+      Authorization: 'Bearer test-key',
+      'Content-Type': 'application/json',
+    });
+    expect(init.body).toBe(
+      JSON.stringify({
+        model: 'gpt-4.1',
+        messages: [{ role: 'user', content: 'ping' }],
+        max_tokens: 1,
+      }),
+    );
+  });
+
+  it('returns unreachable when chat model fetch hits a network error', async () => {
+    const { service, db } = createServiceContext();
+    const fetchMock = mockFetchError(new TypeError('network error'));
+    db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: 'secret:openai_key' })]);
+
+    await withEnv('OPENAI_KEY', 'test-key', async () => {
+      const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+      expect(result.reachable).toBe(false);
+      expect(result.error).toContain('network error');
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns authentication failure when chat model probe returns 401', async () => {
+    const { service, db } = createServiceContext();
+    mockFetchResponse(401);
+    db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: 'secret:openai_key' })]);
+
+    await withEnv('OPENAI_KEY', 'invalid-key', async () => {
+      const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          reachable: false,
+          error: 'Authentication failed (HTTP 401)',
+        }),
+      );
     });
   });
 
-  it('returns SECRET_NOT_FOUND when connectivity secret cannot be resolved', async () => {
+  it('tests embedding model connectivity through the embeddings endpoint', async () => {
     const { service, db } = createServiceContext();
-    db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: 'secret:missing_key' })]);
+    const fetchMock = mockFetchResponse(200);
+    db.queueSelect([
+      createModelConfigRow({
+        model_id: 'text-embedding-3-large',
+        model_type: 'embedding',
+        encrypted_api_key_ref: 'secret:openai_key',
+      }),
+    ]);
 
-    await withEnv('MISSING_KEY', undefined, async () => {
-      const err = await getRejectedHttpException(
-        service.testConnectivity(TEST_MODEL_ID, {}, createContext()),
-      );
+    await withEnv('OPENAI_KEY', 'test-key', async () => {
+      const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
 
-      expect(err.getStatus()).toBe(422);
-      expect(getHttpExceptionCode(err)).toBe(ErrorCode.SECRET_NOT_FOUND);
+      expect(result.reachable).toBe(true);
+      expect(result.error).toBeUndefined();
     });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.openai.com/v1/embeddings');
+  });
+
+  it('tests rerank model connectivity through the rerank endpoint', async () => {
+    const { service, db } = createServiceContext();
+    const fetchMock = mockFetchResponse(200);
+    db.queueSelect([
+      createModelConfigRow({
+        model_id: 'bge-reranker-large',
+        model_type: 'rerank',
+        encrypted_api_key_ref: 'secret:openai_key',
+      }),
+    ]);
+
+    await withEnv('OPENAI_KEY', 'test-key', async () => {
+      const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+      expect(result.reachable).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.openai.com/v1/rerank');
+  });
+
+  it('returns unreachable when rerank probe returns 500', async () => {
+    const { service, db } = createServiceContext();
+    mockFetchResponse(500);
+    db.queueSelect([
+      createModelConfigRow({
+        model_type: 'rerank',
+        encrypted_api_key_ref: 'secret:openai_key',
+      }),
+    ]);
+
+    await withEnv('OPENAI_KEY', 'test-key', async () => {
+      const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          reachable: false,
+          error: 'HTTP 500',
+        }),
+      );
+    });
+  });
+
+  it('falls back to MODEL_API_BASE_URL when model base_url is absent', async () => {
+    const { service, db } = createServiceContext();
+    const fetchMock = mockFetchResponse(200);
+    db.queueSelect([
+      createModelConfigRow({
+        base_url: null,
+        encrypted_api_key_ref: 'secret:openai_key',
+      }),
+    ]);
+
+    await withEnv('OPENAI_KEY', 'test-key', async () => {
+      await withEnv('MODEL_API_BASE_URL', 'https://fallback.example.com/v1', async () => {
+        const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+        expect(result.reachable).toBe(true);
+      });
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://fallback.example.com/v1/chat/completions');
+  });
+
+  it('returns no base URL configured without fetching when model and env URL are absent', async () => {
+    const { service, db } = createServiceContext();
+    const fetchMock = mockFetchResponse(200);
+    db.queueSelect([
+      createModelConfigRow({
+        base_url: null,
+        encrypted_api_key_ref: 'secret:openai_key',
+      }),
+    ]);
+
+    await withEnv('OPENAI_KEY', 'test-key', async () => {
+      await withEnv('MODEL_API_BASE_URL', undefined, async () => {
+        const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            reachable: false,
+            error: 'No base URL configured',
+          }),
+        );
+      });
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns no API key configured without fetching when key ref is null', async () => {
+    const { service, db } = createServiceContext();
+    const fetchMock = mockFetchResponse(200);
+    db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: null })]);
+
+    const result = await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        reachable: false,
+        error: 'No API key configured',
+      }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns timeout-specific error when probe aborts after 10 seconds', async () => {
+    vi.useFakeTimers();
+    const { service, db } = createServiceContext();
+    const fetchMock = mockFetchTimeout();
+    db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: 'secret:openai_key' })]);
+
+    await withEnv('OPENAI_KEY', 'test-key', async () => {
+      const resultPromise = service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+
+      await vi.advanceTimersByTimeAsync(10000);
+      const result = await resultPromise;
+
+      expect(result.reachable).toBe(false);
+      expect(result.latency_ms).toBe(10000);
+      expect(result.error).toContain('timed out');
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns MODEL_NOT_FOUND when connectivity test target is missing', async () => {
@@ -241,8 +426,9 @@ describe('ModelConfigService', () => {
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.MODEL_NOT_FOUND);
   });
 
-  it('records admin.model.test audit for connectivity tests', async () => {
+  it('records admin.model.test audit with reachable=true for successful connectivity tests', async () => {
     const { service, db, audit } = createServiceContext();
+    mockFetchResponse(200);
     db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: 'secret:openai_key' })]);
 
     await withEnv('OPENAI_KEY', 'test-key', async () => {
@@ -263,7 +449,84 @@ describe('ModelConfigService', () => {
       reachable: true,
     });
   });
+
+  it('records admin.model.test audit with reachable=false and error for failed tests', async () => {
+    const { service, db, audit } = createServiceContext();
+    mockFetchError(new TypeError('network error'));
+    db.queueSelect([createModelConfigRow({ encrypted_api_key_ref: 'secret:openai_key' })]);
+
+    await withEnv('OPENAI_KEY', 'test-key', async () => {
+      await service.testConnectivity(TEST_MODEL_ID, {}, createContext());
+    });
+
+    expect(findAuditMetadata(audit, AUDIT_EVENTS.ADMIN_MODEL_TEST, TEST_MODEL_ID)).toMatchObject({
+      model_id: 'gpt-4.1',
+      reachable: false,
+      error: 'network error',
+    });
+  });
 });
+
+type FetchMock = ReturnType<typeof vi.fn<(...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>>>;
+
+function mockFetchResponse(status: number): FetchMock {
+  const fetchMock = vi.fn<(...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>>(() =>
+    Promise.resolve(new Response(null, { status })),
+  );
+  setFetchMock(fetchMock);
+  return fetchMock;
+}
+
+function mockFetchError(error: Error): FetchMock {
+  const fetchMock = vi.fn<(...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>>(() =>
+    Promise.reject(error),
+  );
+  setFetchMock(fetchMock);
+  return fetchMock;
+}
+
+function mockFetchTimeout(): FetchMock {
+  const fetchMock = vi.fn<(...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>>(
+    (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      }),
+  );
+  setFetchMock(fetchMock);
+  return fetchMock;
+}
+
+function setFetchMock(fetchMock: FetchMock): void {
+  Object.defineProperty(globalThis, 'fetch', {
+    value: fetchMock,
+    writable: true,
+    configurable: true,
+  });
+}
+
+function getFirstFetchCall(fetchMock: FetchMock): { url: string; init: RequestInit } {
+  const firstCall = fetchMock.mock.calls[0];
+  if (firstCall === undefined) {
+    throw new Error('Expected fetch to be called');
+  }
+
+  const [input, init] = firstCall;
+  return { url: fetchInputToUrl(input), init: init ?? {} };
+}
+
+function fetchInputToUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}
 
 function createServiceContext(): {
   service: ModelConfigService;

--- a/apps/api/src/models/model-config.service.ts
+++ b/apps/api/src/models/model-config.service.ts
@@ -502,18 +502,20 @@ async function findModelById(
   return model;
 }
 
+type ProbeResult = { ok: boolean; status: number };
+
 async function probeModelEndpoint(
   baseUrl: string,
   apiKey: string,
   modelId: string,
   modelType: ModelType,
-): Promise<Response> {
+): Promise<ProbeResult> {
   const request = buildProbeRequest(modelId, modelType);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10000);
 
   try {
-    return await fetch(`${baseUrl.replace(/\/+$/, '')}${request.path}`, {
+    const response = await fetch(`${baseUrl.replace(/\/+$/, '')}${request.path}`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -522,6 +524,9 @@ async function probeModelEndpoint(
       body: JSON.stringify(request.body),
       signal: controller.signal,
     });
+    const result = { ok: response.ok, status: response.status };
+    await response.body?.cancel().catch(() => undefined);
+    return result;
   } finally {
     clearTimeout(timeout);
   }

--- a/apps/api/src/models/model-config.service.ts
+++ b/apps/api/src/models/model-config.service.ts
@@ -19,6 +19,10 @@ type ModelConfigRow = typeof model_configs.$inferSelect;
 type ModelConfigInsert = typeof model_configs.$inferInsert;
 type ModelType = 'chat' | 'embedding' | 'rerank';
 type ModelStatus = 'active' | 'disabled';
+type ProbeRequest = {
+  path: string;
+  body: unknown;
+};
 
 export type AdminContext = {
   tenantId?: string;
@@ -359,32 +363,85 @@ export class ModelConfigService {
     }
 
     const startedAt = Date.now();
+    let result: ModelConnectivityTestResponse;
+
+    let apiKey: string;
     try {
-      this.resolveApiKey(existing.encrypted_api_key_ref);
-      const result = {
-        reachable: true,
-        latency_ms: Math.max(1, Date.now() - startedAt),
+      apiKey = this.resolveApiKey(existing.encrypted_api_key_ref);
+    } catch {
+      result = {
+        reachable: false,
+        latency_ms: elapsedMs(startedAt),
+        error: 'No API key configured',
       };
 
       this.auditModelTest(tenantId, existing, result, context);
       return result;
-    } catch (err) {
-      const code = getHttpExceptionCode(err);
-      const result = {
+    }
+
+    const baseUrl = resolveModelBaseUrl(existing);
+    if (baseUrl === null) {
+      result = {
         reachable: false,
-        latency_ms: Math.max(1, Date.now() - startedAt),
-        error: code ?? (err instanceof Error ? err.message : String(err)),
+        latency_ms: elapsedMs(startedAt),
+        error: 'No base URL configured',
       };
 
       this.auditModelTest(tenantId, existing, result, context);
-      throw err;
+      return result;
     }
+
+    try {
+      const response = await probeModelEndpoint(
+        baseUrl,
+        apiKey,
+        existing.model_id,
+        normalizeModelTypeOrThrow(existing.model_type),
+      );
+      const latencyMs = elapsedMs(startedAt);
+
+      if (response.ok) {
+        result = {
+          reachable: true,
+          latency_ms: latencyMs,
+        };
+      } else if (response.status === 401 || response.status === 403) {
+        result = {
+          reachable: false,
+          latency_ms: latencyMs,
+          error: `Authentication failed (HTTP ${response.status})`,
+        };
+      } else {
+        result = {
+          reachable: false,
+          latency_ms: latencyMs,
+          error: `HTTP ${response.status}`,
+        };
+      }
+    } catch (err) {
+      if (isAbortError(err)) {
+        result = {
+          reachable: false,
+          latency_ms: 10000,
+          error: 'Request timed out (10s)',
+        };
+      } else {
+        result = {
+          reachable: false,
+          latency_ms: elapsedMs(startedAt),
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }
+
+    this.auditModelTest(tenantId, existing, result, context);
+    return result;
   }
 
   resolveApiKey(encryptedApiKeyRef: string | null): string {
     const secretName = parseSecretRef(encryptedApiKeyRef);
     const apiKey = process.env[secretName.toUpperCase()];
-    if (apiKey === undefined) {
+    if (apiKey === undefined || apiKey.trim().length === 0) {
       throwApiError(ErrorCode.SECRET_NOT_FOUND, 'Secret not found', HttpStatus.UNPROCESSABLE_ENTITY);
     }
 
@@ -443,6 +500,72 @@ async function findModelById(
     .limit(1);
 
   return model;
+}
+
+async function probeModelEndpoint(
+  baseUrl: string,
+  apiKey: string,
+  modelId: string,
+  modelType: ModelType,
+): Promise<Response> {
+  const request = buildProbeRequest(modelId, modelType);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    return await fetch(`${baseUrl.replace(/\/+$/, '')}${request.path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request.body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildProbeRequest(modelId: string, modelType: ModelType): ProbeRequest {
+  switch (modelType) {
+    case 'chat':
+      return {
+        path: '/chat/completions',
+        body: {
+          model: modelId,
+          messages: [{ role: 'user', content: 'ping' }],
+          max_tokens: 1,
+        },
+      };
+    case 'embedding':
+      return {
+        path: '/embeddings',
+        body: {
+          model: modelId,
+          input: 'test',
+        },
+      };
+    case 'rerank':
+      return {
+        path: '/rerank',
+        body: {
+          model: modelId,
+          query: 'test',
+          documents: ['test'],
+        },
+      };
+  }
+}
+
+function resolveModelBaseUrl(model: ModelConfigRow): string | null {
+  const modelBaseUrl = model.base_url?.trim();
+  if (modelBaseUrl !== undefined && modelBaseUrl.length > 0) {
+    return modelBaseUrl;
+  }
+
+  const envBaseUrl = process.env.MODEL_API_BASE_URL?.trim();
+  return envBaseUrl !== undefined && envBaseUrl.length > 0 ? envBaseUrl : null;
 }
 
 async function findModelByProviderModelId(
@@ -645,17 +768,16 @@ function normalizeCount(value: unknown): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function elapsedMs(startedAt: number): number {
+  return Math.max(1, Date.now() - startedAt);
+}
+
 function toModelStatus(enabled: boolean): ModelStatus {
   return enabled ? 'active' : 'disabled';
 }
 
-function getHttpExceptionCode(err: unknown): string | undefined {
-  if (!(err instanceof HttpException)) {
-    return undefined;
-  }
-
-  const response = err.getResponse();
-  return isRecord(response) && typeof response.code === 'string' ? response.code : undefined;
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
 }
 
 function throwModelNotFound(): never {


### PR DESCRIPTION
## Summary

- Replace fake `testConnectivity` (only checked env var existence) with real HTTP probes to model endpoints
- Probe strategy per model type: chat→`/chat/completions`, embedding→`/embeddings`, rerank→`/rerank`
- URL resolution: model `base_url` → `MODEL_API_BASE_URL` env → error
- Failures return `{ reachable: false, error }` instead of throwing HTTP exceptions
- 10s AbortController timeout with specific error message
- 13 new test scenarios covering all model types, error branches, URL fallback, timeout, and audit

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1156 tests pass (`npm test -- --run`)
- [x] Lint clean (`npm run lint`)
- [x] 13 new test cases: chat/embedding/rerank probes, 401 auth, network error, timeout, URL fallback, missing key (null + empty), audit

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `c2205235e236dbe2d0dea51e0b3026c4c6e9a01e`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/276#issuecomment-4421658434) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/276#issuecomment-4421658845) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/276#issuecomment-4421659319) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/276#issuecomment-4421662523)
- Key findings addressed: Extended embedding/rerank test assertions for POST method/body, added empty-string API key ref test, added response body drain in probeModelEndpoint. Integration URL fallback and secret casing are spec-compliant/pre-existing. SSRF hardening tracked separately.

Closes #263