### PR TITLE
fix(admin): real Docmost health probe instead of hardcoded status (#264)

### DIFF
--- a/apps/api/src/admin/__tests__/admin-health.test.ts
+++ b/apps/api/src/admin/__tests__/admin-health.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AdminHealthController } from '../admin-health.controller.js';
-import type { HealthComponent } from '../admin-health.controller.js';
+import type { AdminSystemHealthResponse, HealthComponent } from '../admin-health.controller.js';
 import type { StorageService } from '../../storage/storage.service.js';
 
 type DbQuery = ReturnType<typeof vi.fn<(queryText: string) => Promise<unknown>>>;
@@ -11,13 +11,14 @@ type StorageHealthCheck = ReturnType<typeof vi.fn<() => Promise<HealthComponent>
 
 describe('AdminHealthController', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
   it('returns healthy when configured components are healthy', async () => {
     const { controller, dbQuery, redisPing, storageHealthCheck } = createController();
 
-    const result = await controller.getHealth();
+    const result = await getHealthWithDocmostUnset(controller);
 
     expect(result.status).toBe('healthy');
     expect(result.components.database.status).toBe('healthy');
@@ -35,7 +36,7 @@ describe('AdminHealthController', () => {
     });
     expect(result.components.docmost_bridge).toEqual({
       status: 'not_configured',
-      details: expect.stringMatching(/optional/i) as unknown,
+      details: 'DOCMOST_BASE_URL not set',
     });
     expect(result.uptime).toBeGreaterThanOrEqual(1);
     expect(dbQuery).toHaveBeenCalledWith('select 1');
@@ -48,7 +49,7 @@ describe('AdminHealthController', () => {
       redisPing: vi.fn<() => Promise<unknown>>(() => Promise.reject(new Error('redis down'))),
     });
 
-    const result = await controller.getHealth();
+    const result = await getHealthWithDocmostUnset(controller);
 
     expect(result.status).toBe('degraded');
     expect(result.components.database.status).toBe('healthy');
@@ -65,7 +66,7 @@ describe('AdminHealthController', () => {
       dbQuery: vi.fn<(queryText: string) => Promise<unknown>>(() => Promise.reject(new Error('db down'))),
     });
 
-    const result = await controller.getHealth();
+    const result = await getHealthWithDocmostUnset(controller);
 
     expect(result.status).toBe('unhealthy');
     expect(result.components.database).toEqual(
@@ -81,7 +82,7 @@ describe('AdminHealthController', () => {
       dbQuery: vi.fn<(queryText: string) => Promise<unknown>>(() => Promise.reject(new Error('db down'))),
     });
 
-    const result = await controller.getHealth();
+    const result = await getHealthWithDocmostUnset(controller);
 
     expect(result.status).toBe('unhealthy');
     expect(result.components.vector_store).toEqual({
@@ -99,7 +100,7 @@ describe('AdminHealthController', () => {
   it('marks undeployed or absent components as not_configured', async () => {
     const { controller } = createController({ redisPing: undefined, storageConfigured: vi.fn(() => false) });
 
-    const result = await controller.getHealth();
+    const result = await getHealthWithDocmostUnset(controller);
 
     expect(result.status).toBe('healthy');
     expect(result.components.redis).toEqual({ status: 'not_configured' });
@@ -116,20 +117,109 @@ describe('AdminHealthController', () => {
     });
     expect(result.components.docmost_bridge).toEqual({
       status: 'not_configured',
-      details: expect.stringMatching(/optional/i) as unknown,
+      details: 'DOCMOST_BASE_URL not set',
     });
   });
 
   it('keeps the optional docmost bridge neutral when it is not configured', async () => {
     const { controller } = createController();
 
-    const result = await controller.getHealth();
+    const result = await getHealthWithDocmostUnset(controller);
 
     expect(result.status).toBe('healthy');
     expect(result.components.docmost_bridge).toEqual({
       status: 'not_configured',
-      details: expect.stringMatching(/optional/i) as unknown,
+      details: 'DOCMOST_BASE_URL not set',
     });
+  });
+
+  it('reports Docmost healthy when the health endpoint returns 200', async () => {
+    const { controller } = createController();
+    const fetchMock = mockFetchResponse(200);
+
+    const result = await withEnv('DOCMOST_BASE_URL', 'https://docmost.example.com/', () => controller.getHealth());
+
+    expect(result.status).toBe('healthy');
+    expect(result.components.docmost_bridge).toEqual({
+      status: 'healthy',
+      latency_ms: expect.any(Number) as unknown,
+    });
+    expect(result.components.docmost_bridge.latency_ms).toBeGreaterThan(0);
+    expect(fetchMock).toHaveBeenCalledWith('https://docmost.example.com/api/health', {
+      method: 'GET',
+      signal: expect.any(AbortSignal) as unknown,
+    });
+  });
+
+  it('reports Docmost unhealthy when the health endpoint is unreachable', async () => {
+    const { controller } = createController();
+    mockFetchError(new TypeError('network error'));
+
+    const result = await withEnv('DOCMOST_BASE_URL', 'https://docmost.example.com', () => controller.getHealth());
+
+    expect(result.status).toBe('degraded');
+    expect(result.components.docmost_bridge).toEqual(
+      expect.objectContaining({
+        status: 'unhealthy',
+        error: 'network error',
+      }),
+    );
+  });
+
+  it('reports Docmost not_configured when DOCMOST_BASE_URL is unset', async () => {
+    const { controller } = createController();
+    const fetchMock = mockFetchResponse(200);
+
+    const result = await getHealthWithDocmostUnset(controller);
+
+    expect(result.status).toBe('healthy');
+    expect(result.components.docmost_bridge).toEqual({
+      status: 'not_configured',
+      details: 'DOCMOST_BASE_URL not set',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports Docmost unhealthy when the health check times out', async () => {
+    vi.useFakeTimers();
+    const { controller } = createController();
+    const fetchMock = mockFetchTimeout();
+
+    await withEnv('DOCMOST_BASE_URL', 'https://docmost.example.com', async () => {
+      const resultPromise = controller.getHealth();
+
+      await vi.advanceTimersByTimeAsync(5000);
+      const result = await resultPromise;
+
+      expect(result.status).toBe('degraded');
+      expect(result.components.docmost_bridge).toEqual({
+        status: 'unhealthy',
+        latency_ms: 5000,
+        error: 'Health check timed out (5s)',
+      });
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns degraded overall when Docmost is unhealthy and database is healthy', async () => {
+    const { controller } = createController();
+    mockFetchError(new TypeError('docmost down'));
+
+    const result = await withEnv('DOCMOST_BASE_URL', 'https://docmost.example.com', () => controller.getHealth());
+
+    expect(result.components.database.status).toBe('healthy');
+    expect(result.components.docmost_bridge.status).toBe('unhealthy');
+    expect(result.status).toBe('degraded');
+  });
+
+  it('returns healthy overall when Docmost is not configured and database is healthy', async () => {
+    const { controller } = createController();
+
+    const result = await getHealthWithDocmostUnset(controller);
+
+    expect(result.components.database.status).toBe('healthy');
+    expect(result.components.docmost_bridge.status).toBe('not_configured');
+    expect(result.status).toBe('healthy');
   });
 });
 
@@ -174,4 +264,53 @@ function createController(
     storageConfigured,
     storageHealthCheck,
   };
+}
+
+function mockFetchResponse(status: number) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    status,
+    body: {
+      cancel: vi.fn(() => Promise.resolve(undefined)),
+    },
+  } as unknown as Response);
+}
+
+function mockFetchError(error: Error) {
+  return vi.spyOn(globalThis, 'fetch').mockRejectedValue(error);
+}
+
+function mockFetchTimeout() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(
+    (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted.');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      }),
+  );
+}
+
+async function getHealthWithDocmostUnset(controller: AdminHealthController): Promise<AdminSystemHealthResponse> {
+  return withEnv('DOCMOST_BASE_URL', undefined, () => controller.getHealth());
+}
+
+async function withEnv<T>(name: string, value: string | undefined, callback: () => Promise<T>): Promise<T> {
+  const previous = process.env[name];
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+
+  try {
+    return await callback();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previous;
+    }
+  }
 }

--- a/apps/api/src/admin/admin-health.controller.ts
+++ b/apps/api/src/admin/admin-health.controller.ts
@@ -43,14 +43,19 @@ export class AdminHealthController {
 
   @Get('health')
   async getHealth(): Promise<AdminSystemHealthResponse> {
-    const [database, redis, minio] = await Promise.all([this.checkDatabase(), this.checkRedis(), this.checkStorage()]);
+    const [database, redis, minio, docmost] = await Promise.all([
+      this.checkDatabase(),
+      this.checkRedis(),
+      this.checkStorage(),
+      this.checkDocmost(),
+    ]);
     const components: Record<ComponentName, HealthComponent> = {
       database,
       redis,
       minio,
       vector_store: postgresBackedComponent(database, 'Postgres-backed vector store'),
       graph_store: postgresBackedComponent(database, 'Postgres-backed graph store'),
-      docmost_bridge: { status: 'not_configured', details: 'Optional integration' },
+      docmost_bridge: docmost,
     };
 
     return {
@@ -82,6 +87,46 @@ export class AdminHealthController {
     }
 
     return this.storage.healthCheck();
+  }
+
+  private async checkDocmost(): Promise<HealthComponent> {
+    const baseUrl = process.env.DOCMOST_BASE_URL?.trim();
+    if (baseUrl === undefined || baseUrl.length === 0) {
+      return { status: 'not_configured', details: 'DOCMOST_BASE_URL not set' };
+    }
+
+    const startedAt = performance.now();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    try {
+      const response = await fetch(`${baseUrl.replace(/\/+$/, '')}/api/health`, {
+        method: 'GET',
+        signal: controller.signal,
+      });
+      const result: HealthComponent =
+        response.status === 200
+          ? { status: 'healthy', latency_ms: elapsedMs(startedAt) }
+          : { status: 'unhealthy', latency_ms: elapsedMs(startedAt), error: `HTTP ${response.status}` };
+      await response.body?.cancel().catch(() => undefined);
+      return result;
+    } catch (err) {
+      if (isAbortError(err)) {
+        return {
+          status: 'unhealthy',
+          latency_ms: 5000,
+          error: 'Health check timed out (5s)',
+        };
+      }
+
+      return {
+        status: 'unhealthy',
+        latency_ms: elapsedMs(startedAt),
+        error: toSafeErrorMessage(err),
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 }
 
@@ -141,4 +186,8 @@ function elapsedMs(startedAt: number): number {
 
 function toSafeErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded `docmost_bridge: { status: 'not_configured' }` with real HTTP probe to `DOCMOST_BASE_URL/api/health`
- 5s AbortController timeout, response body cleanup
- Docmost unhealthy → overall `degraded`; Docmost not_configured → overall `healthy`
- 6 new test scenarios + updated existing tests for new behavior

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1162 tests pass (`npm test -- --run`)
- [x] Lint clean (`npm run lint`)
- [x] 6 new Docmost probe tests: healthy, unreachable, not configured, timeout, overall status degraded/healthy

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `5c431548ab7a97626975499816b956d32a1173d3`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/277#issuecomment-4422152212) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/277#issuecomment-4422152437) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/277#issuecomment-4422152672) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/277#issuecomment-4422152962)
- Key findings addressed: Tightened timeout test assertion to exact match. Docker DOCMOST_BASE_URL config and SSRF hardening noted as separate concerns.

Closes #264