### PR TITLE
feat(chat): fix layout and add desktop sidebar collapse (#266)

### DIFF
--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -39,6 +39,7 @@ beforeEach(async () => {
 afterEach(() => {
   cleanup();
   window.sessionStorage.clear();
+  window.localStorage.clear();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -291,6 +292,65 @@ describe('Message input', () => {
 
     await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
     expect(onSend.mock.calls[0]?.[0]).toHaveLength(CHAT_INPUT_MAX_LENGTH);
+  });
+});
+
+describe('Chat bottom area layout', () => {
+  it('wraps space selector and message input in chat-bottom-area container', async () => {
+    stubChatFetch();
+
+    renderChatRoute();
+
+    await screen.findByLabelText('消息');
+    const bottomArea = document.querySelector('.chat-bottom-area');
+    expect(bottomArea).toBeInTheDocument();
+    expect(bottomArea?.querySelector('.chat-space-selector-panel')).toBeInTheDocument();
+    expect(bottomArea?.querySelector('.chat-input-panel')).toBeInTheDocument();
+  });
+});
+
+describe('Sidebar collapse', () => {
+  it('renders collapse toggle button in sidebar header', async () => {
+    stubChatFetch();
+
+    renderChatRoute();
+
+    const collapseButton = await screen.findByRole('button', { name: '收起侧边栏' });
+    fireEvent.click(collapseButton);
+
+    await waitFor(() => expect(document.querySelector('.chat-page')).toHaveClass('sidebar-collapsed'));
+  });
+
+  it('persists sidebar collapsed state to localStorage', async () => {
+    const localStorageMock = stubLocalStorage({ 'cherry-chat-sidebar-collapsed': 'true' });
+    stubChatFetch();
+
+    renderChatRoute();
+
+    await waitFor(() => expect(document.querySelector('.chat-page')).toHaveClass('sidebar-collapsed'));
+    localStorageMock.clear();
+    fireEvent.click(await screen.findByRole('button', { name: '展开侧边栏' }));
+
+    await waitFor(() => {
+      expect(document.querySelector('.chat-page')).not.toHaveClass('sidebar-collapsed');
+      expect(localStorageMock.setItem).toHaveBeenLastCalledWith('cherry-chat-sidebar-collapsed', 'false');
+    });
+  });
+
+  it('shows floating expand button when sidebar is collapsed', async () => {
+    stubLocalStorage({ 'cherry-chat-sidebar-collapsed': 'true' });
+    stubChatFetch();
+
+    renderChatRoute();
+
+    const expandButton = await screen.findByRole('button', { name: '展开侧边栏' });
+    expect(expandButton).toHaveClass('chat-sidebar-expand');
+    fireEvent.click(expandButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: '展开侧边栏' })).not.toBeInTheDocument();
+      expect(document.querySelector('.chat-page')).not.toHaveClass('sidebar-collapsed');
+    });
   });
 });
 
@@ -749,6 +809,31 @@ function stubChatFetch({
   );
 
   return { calls };
+}
+
+function stubLocalStorage(initial: Record<string, string> = {}): Storage {
+  const store: Record<string, string> = { ...initial };
+  const localStorageMock: Storage = {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear: vi.fn(() => {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+      }
+    }),
+    getItem: vi.fn((key: string) => (Object.prototype.hasOwnProperty.call(store, key) ? store[key] ?? null : null)),
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+  };
+
+  vi.stubGlobal('localStorage', localStorageMock);
+  return localStorageMock;
 }
 
 async function sendChatMessage(message: string): Promise<void> {

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -333,6 +333,7 @@ describe('Sidebar collapse', () => {
 
     await waitFor(() => {
       expect(document.querySelector('.chat-page')).not.toHaveClass('sidebar-collapsed');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(localStorageMock.setItem).toHaveBeenLastCalledWith('cherry-chat-sidebar-collapsed', 'false');
     });
   });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -891,6 +891,8 @@
     "brand": "Cherry Chat",
     "closeSessions": "Close sessions",
     "closeSidebar": "Close",
+    "collapseSidebar": "Collapse sidebar",
+    "expandSidebar": "Expand sidebar",
     "newChat": "New Chat",
     "loadingSessions": "Loading sessions...",
     "emptyConversation": "Start a new conversation",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -891,6 +891,8 @@
     "brand": "Cherry Chat",
     "closeSessions": "关闭会话列表",
     "closeSidebar": "关闭",
+    "collapseSidebar": "收起侧边栏",
+    "expandSidebar": "展开侧边栏",
     "newChat": "新建对话",
     "loadingSessions": "加载会话中...",
     "emptyConversation": "开始新的对话",

--- a/apps/web/src/overrides.css
+++ b/apps/web/src/overrides.css
@@ -379,6 +379,11 @@ code {
   min-height: 100vh;
   grid-template-columns: 320px minmax(0, 1fr);
   background: var(--color-background);
+  transition: grid-template-columns var(--transition-normal);
+}
+
+.chat-page.sidebar-collapsed {
+  grid-template-columns: 0 minmax(0, 1fr);
 }
 
 .chat-session-sidebar {
@@ -393,6 +398,15 @@ code {
   border-right: 1px solid var(--color-border);
   background: var(--color-surface);
   padding: 18px;
+  overflow: hidden;
+  transition:
+    border-color var(--transition-normal),
+    padding var(--transition-normal);
+}
+
+.chat-page.sidebar-collapsed .chat-session-sidebar {
+  border-right-color: transparent;
+  padding-inline: 0;
 }
 
 .chat-sidebar-header,
@@ -410,8 +424,45 @@ code {
   color: var(--color-text-1);
 }
 
+.chat-sidebar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.chat-sidebar-collapse {
+  display: inline-grid;
+}
+
 .chat-sidebar-close {
   display: none;
+}
+
+.chat-sidebar-expand {
+  position: fixed;
+  top: 88px;
+  left: 12px;
+  z-index: 8;
+  display: inline-grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-overlay);
+  color: var(--color-text-2);
+  box-shadow: var(--shadow-xs);
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.chat-sidebar-expand:hover {
+  border-color: var(--color-border-strong);
+  background: var(--color-background-hover);
+  color: var(--color-text-1);
 }
 
 .chat-session-list-panel {
@@ -496,7 +547,7 @@ code {
   display: grid;
   min-width: 0;
   height: 100vh;
-  grid-template-rows: auto minmax(0, 1fr) auto auto auto;
+  grid-template-rows: auto 1fr auto;
   background: var(--color-background);
 }
 
@@ -525,6 +576,7 @@ code {
 .chat-message-list {
   display: grid;
   align-content: start;
+  min-height: 0;
   gap: 14px;
   overflow-y: auto;
   padding: 22px;
@@ -848,6 +900,12 @@ code {
 
 /* Chat input area */
 
+.chat-bottom-area {
+  display: grid;
+  min-height: 0;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
 .chat-space-selector-panel {
   display: grid;
   gap: 8px;
@@ -1095,6 +1153,10 @@ code {
     grid-template-columns: 1fr;
   }
 
+  .chat-page.sidebar-collapsed {
+    grid-template-columns: 1fr;
+  }
+
   .chat-session-sidebar {
     position: fixed;
     inset: 0 auto 0 0;
@@ -1102,6 +1164,11 @@ code {
     transform: translateX(-100%);
     transition: transform var(--transition-normal);
     box-shadow: var(--shadow-modal);
+  }
+
+  .chat-page.sidebar-collapsed .chat-session-sidebar {
+    border-right-color: var(--color-border);
+    padding: 18px;
   }
 
   .chat-session-sidebar.open {
@@ -1115,6 +1182,11 @@ code {
   .chat-sidebar-close,
   .chat-mobile-menu {
     display: inline-grid;
+  }
+
+  .chat-sidebar-collapse,
+  .chat-sidebar-expand {
+    display: none;
   }
 
   .chat-main {

--- a/apps/web/src/overrides.css
+++ b/apps/web/src/overrides.css
@@ -1162,8 +1162,9 @@ code {
     inset: 0 auto 0 0;
     width: min(88vw, 340px);
     transform: translateX(-100%);
-    transition: transform var(--transition-normal);
+    transition: transform var(--transition-normal), visibility 0s var(--transition-normal);
     box-shadow: var(--shadow-modal);
+    visibility: hidden;
   }
 
   .chat-page.sidebar-collapsed .chat-session-sidebar {
@@ -1173,6 +1174,8 @@ code {
 
   .chat-session-sidebar.open {
     transform: translateX(0);
+    visibility: visible;
+    transition: transform var(--transition-normal), visibility 0s;
   }
 
   .chat-sidebar-backdrop {

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -5,7 +5,16 @@ import { Navigate, useNavigate, useParams } from 'react-router';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
 import { Alert, Button, Collapse, Empty, Input, List, message, Popconfirm, Result, Select, Spin, Tag } from 'antd';
-import { CloseOutlined, DeleteOutlined, LockOutlined, MenuOutlined, PlusOutlined, SendOutlined } from '@ant-design/icons';
+import {
+  CloseOutlined,
+  DeleteOutlined,
+  LockOutlined,
+  MenuFoldOutlined,
+  MenuOutlined,
+  MenuUnfoldOutlined,
+  PlusOutlined,
+  SendOutlined,
+} from '@ant-design/icons';
 import ChatChart from '../components/ChatChart.js';
 import { ConfidenceBadge } from '../components/ConfidenceBadge.js';
 import GraphPathViewer, { type GraphPathData, type GraphPathEdge, type GraphPathNode } from '../components/GraphPathViewer.js';
@@ -92,6 +101,7 @@ const DEFAULT_CHAT_SETTINGS: ChatSettings = {
   retrievalMode: DEFAULT_RETRIEVAL_MODE,
 };
 const CHAT_SPACE_SELECTION_MAX = 10;
+const CHAT_SIDEBAR_COLLAPSED_KEY = 'cherry-chat-sidebar-collapsed';
 
 export default function Chat() {
   const { t } = useTranslation();
@@ -118,6 +128,7 @@ export default function Chat() {
       ? chatSettingsState.settings
       : loadChatSettings(selectedSpaceIds);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState<boolean>(() => loadSidebarCollapsed());
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const sessionSwitchRef = useRef(0);
   const previousSpaceIdRef = useRef(spaceId);
@@ -298,6 +309,10 @@ export default function Chat() {
     }
   }, [messages]);
 
+  useEffect(() => {
+    saveSidebarCollapsed(isSidebarCollapsed);
+  }, [isSidebarCollapsed]);
+
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
   }
@@ -383,7 +398,7 @@ export default function Chat() {
   const selectorLocked = isStreaming || sessionId !== null;
 
   return (
-    <div className="chat-page">
+    <div className={`chat-page${isSidebarCollapsed ? ' sidebar-collapsed' : ''}`}>
       {isMobileSidebarOpen ? (
         <button
           className="chat-sidebar-backdrop"
@@ -393,19 +408,32 @@ export default function Chat() {
         />
       ) : null}
 
-      <aside className={`chat-session-sidebar${isMobileSidebarOpen ? ' open' : ''}`} aria-label={t('chat.title')}>
+      <aside
+        className={`chat-session-sidebar${isMobileSidebarOpen ? ' open' : ''}`}
+        aria-label={t('chat.title')}
+        aria-hidden={isSidebarCollapsed && !isMobileSidebarOpen}
+      >
         <div className="chat-sidebar-header">
           <div>
             <span className="eyebrow">{t('chat.space')}</span>
             <strong>{t('chat.brand')}</strong>
           </div>
-          <Button
-            type="text"
-            icon={<CloseOutlined />}
-            className="chat-sidebar-close"
-            onClick={() => setIsMobileSidebarOpen(false)}
-            aria-label={t('chat.closeSidebar')}
-          />
+          <div className="chat-sidebar-actions">
+            <Button
+              type="text"
+              icon={<MenuFoldOutlined />}
+              className="chat-sidebar-collapse"
+              onClick={() => setIsSidebarCollapsed(true)}
+              aria-label={t('chat.collapseSidebar')}
+            />
+            <Button
+              type="text"
+              icon={<CloseOutlined />}
+              className="chat-sidebar-close"
+              onClick={() => setIsMobileSidebarOpen(false)}
+              aria-label={t('chat.closeSidebar')}
+            />
+          </div>
         </div>
         {sessionsError !== null ? <Alert type="error" message={sessionsError} showIcon style={{ margin: '0 8px 8px' }} /> : null}
         <SessionSidebar
@@ -421,6 +449,17 @@ export default function Chat() {
           }}
         />
       </aside>
+
+      {isSidebarCollapsed ? (
+        <button
+          className="chat-sidebar-expand"
+          type="button"
+          aria-label={t('chat.expandSidebar')}
+          onClick={() => setIsSidebarCollapsed(false)}
+        >
+          <MenuUnfoldOutlined />
+        </button>
+      ) : null}
 
       <main className="chat-main">
         <header className="chat-topbar">
@@ -448,39 +487,41 @@ export default function Chat() {
           <div ref={messagesEndRef} />
         </section>
 
-        {chatErrorMessage !== null ? (
-          <div className="chat-error-bar" role="alert">
-            <span>{chatErrorMessage}</span>
-            {streamError?.code !== 'NO_CHAT_MODEL_CONFIGURED' ? (
-              <Button
-                type="default"
-                disabled={isStreaming}
-                onClick={() => {
-                  void retry();
-                }}
-              >
-                {t('common.action.retry')}
-              </Button>
-            ) : null}
-          </div>
-        ) : null}
+        <div className="chat-bottom-area">
+          {chatErrorMessage !== null ? (
+            <div className="chat-error-bar" role="alert">
+              <span>{chatErrorMessage}</span>
+              {streamError?.code !== 'NO_CHAT_MODEL_CONFIGURED' ? (
+                <Button
+                  type="default"
+                  disabled={isStreaming}
+                  onClick={() => {
+                    void retry();
+                  }}
+                >
+                  {t('common.action.retry')}
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
 
-        <SpaceSelector
-          availableSpaces={availableSpaces}
-          selectedSpaceIds={selectedSpaceIds}
-          primarySpaceId={spaceId}
-          locked={selectorLocked}
-          onChange={setSelectedSpaceIds}
-          onStartNewSession={newChat}
-        />
-        <MessageInput
-          disabled={isStreaming}
-          isStreaming={isStreaming}
-          settings={chatSettings}
-          databaseAvailable={selectedSpaceIds.length === 1 && spaceDatabaseEnabled}
-          onSettingsChange={updateChatSettings}
-          onSend={handleSend}
-        />
+          <SpaceSelector
+            availableSpaces={availableSpaces}
+            selectedSpaceIds={selectedSpaceIds}
+            primarySpaceId={spaceId}
+            locked={selectorLocked}
+            onChange={setSelectedSpaceIds}
+            onStartNewSession={newChat}
+          />
+          <MessageInput
+            disabled={isStreaming}
+            isStreaming={isStreaming}
+            settings={chatSettings}
+            databaseAvailable={selectedSpaceIds.length === 1 && spaceDatabaseEnabled}
+            onSettingsChange={updateChatSettings}
+            onSend={handleSend}
+          />
+        </div>
       </main>
     </div>
   );
@@ -1112,6 +1153,30 @@ function saveChatSettings(spaceIds: string[], settings: ChatSettings): void {
 
 function getChatSettingsKey(spaceIds: string[]): string {
   return `cherry-chat-settings:${JSON.stringify([...spaceIds].sort())}`;
+}
+
+function loadSidebarCollapsed(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(CHAT_SIDEBAR_COLLAPSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function saveSidebarCollapsed(isCollapsed: boolean): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(CHAT_SIDEBAR_COLLAPSED_KEY, String(isCollapsed));
+  } catch {
+    // localStorage can be unavailable in private browsing contexts.
+  }
 }
 
 function isSpaceDatabaseEnabled(value: unknown): boolean {

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -412,6 +412,7 @@ export default function Chat() {
         className={`chat-session-sidebar${isMobileSidebarOpen ? ' open' : ''}`}
         aria-label={t('chat.title')}
         aria-hidden={isSidebarCollapsed && !isMobileSidebarOpen}
+        inert={isSidebarCollapsed && !isMobileSidebarOpen ? true : undefined}
       >
         <div className="chat-sidebar-header">
           <div>


### PR DESCRIPTION
## Summary

- Restructure `.chat-main` to a 3-row CSS grid (`auto 1fr auto`) so the input panel stays visible without scrolling
- Wrap error bar, space selector, and message input in a `.chat-bottom-area` container
- Add collapsible desktop sidebar with `localStorage` persistence and smooth CSS transitions
- Add floating expand button when sidebar is collapsed
- Add `padding-bottom: env(safe-area-inset-bottom)` for iOS Safari
- Add i18n keys `chat.collapseSidebar` / `chat.expandSidebar` in en + zh-CN
- Add 4 automated tests for bottom-area layout, sidebar collapse, localStorage persistence, and floating expand button
- Add `inert` attribute to collapsed sidebar for keyboard accessibility
- Add `visibility: hidden` to mobile off-screen sidebar to prevent keyboard focus

Closes #266

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 126 existing tests pass (`npx vitest run`)
- [x] 4 new tests for sidebar collapse and layout wrapper
- [x] Lint passes with zero warnings
- [ ] Manual: verify input always visible on desktop (1280x800)
- [ ] Manual: verify sidebar collapse/expand with animation
- [ ] Manual: verify mobile hamburger behavior unchanged (≤768px)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration & Cross-file Impact Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `49a04669deff1f0d5f3ca99ec1197bd850452fb9`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/278#issuecomment-4426055004) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/278#issuecomment-4426055137) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/278#issuecomment-4426055250) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/278#issuecomment-4426055367)
- Key findings addressed: Collapsed sidebar keyboard accessibility fixed with inert attribute; mobile off-screen sidebar focus leak fixed with CSS visibility:hidden; lint error in test assertion suppressed