### PR TITLE
feat(chat): allow adding spaces to existing sessions (#267)

### DIFF
--- a/apps/api/src/chat/__tests__/chat.service.test.ts
+++ b/apps/api/src/chat/__tests__/chat.service.test.ts
@@ -16,6 +16,7 @@ import {
 import type { ChatChunk, ChatCompletionParams, ChatProvider, EmbeddingProvider, EmbeddingProviderConfig } from '@cherrygraph/ai-core';
 import type { RetrievalResult } from '@cherrygraph/rag-core';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { validateSync } from 'class-validator';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AuditEntry, AuditService } from '../../audit/audit.service.js';
@@ -30,6 +31,7 @@ import {
 } from '../../users/__tests__/user-group-service-test-utils.js';
 import { ChatController } from '../chat.controller.js';
 import { ChatService, type ChatStreamEvent } from '../chat.service.js';
+import { UpdateSessionSpacesDto } from '../dto/chat.dto.js';
 
 type ChatSessionRow = typeof chatSessions.$inferSelect;
 type ChatSessionSpaceRow = typeof chatSessionSpaces.$inferSelect;
@@ -151,6 +153,102 @@ describe('ChatService multi-space session', () => {
       expect.objectContaining({ session_id: 'session-created', space_id: 'space-b', position: 1 }),
     ]);
   });
+
+  it('updateSessionSpaces replaces membership rows and returns space details', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createSessionRow({ id: 'session-1', space_id: 'space-a' })]);
+    db.queueSelect([createSessionSpaceInfoRow({ space_id: 'space-a', space_name: 'Space A', position: 0 })]);
+    db.queueSelect([createSpaceRow({ id: 'space-a', name: 'Space A' })]);
+    db.queueSelect([createSpaceRow({ id: 'space-b', name: 'Space B' })]);
+
+    const result = await service.updateSessionSpaces(
+      TEST_TENANT_ID,
+      'session-1',
+      TEST_USER_ID,
+      'space-a',
+      ['space-a', 'space-b'],
+      { 'space-a': ['chat:use'], 'space-b': ['chat:use'] },
+      [],
+      'viewer',
+    );
+
+    expect(result).toEqual({
+      session_id: 'session-1',
+      space_ids: ['space-a', 'space-b'],
+      space_details: [
+        { id: 'space-a', name: 'Space A' },
+        { id: 'space-b', name: 'Space B' },
+      ],
+    });
+    expect(db.deletes[0]?.table).toBe(chatSessionSpaces);
+    expect(db.inserts.at(-1)?.table).toBe(chatSessionSpaces);
+    expect(db.inserts.at(-1)?.value).toEqual([
+      expect.objectContaining({ session_id: 'session-1', space_id: 'space-a', position: 0 }),
+      expect.objectContaining({ session_id: 'session-1', space_id: 'space-b', position: 1 }),
+    ]);
+    expect(db.updates[0]?.table).toBe(chatSessions);
+  });
+
+  it('updateSessionSpaces rejects unauthorized spaces before writing', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createSessionRow({ id: 'session-1', space_id: 'space-a' })]);
+    db.queueSelect([createSessionSpaceInfoRow({ space_id: 'space-a', space_name: 'Space A', position: 0 })]);
+    db.queueSelect([createSpaceRow({ id: 'space-a', name: 'Space A' })]);
+    db.queueSelect([createSpaceRow({ id: 'space-b', name: 'Space B' })]);
+
+    const err = await getRejectedHttpException(
+      service.updateSessionSpaces(
+        TEST_TENANT_ID,
+        'session-1',
+        TEST_USER_ID,
+        'space-a',
+        ['space-a', 'space-b'],
+        { 'space-a': ['chat:use'], 'space-b': ['space:view'] },
+        [],
+        'viewer',
+      ),
+    );
+
+    expect(err.getStatus()).toBe(403);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+    expect(db.deletes).toHaveLength(0);
+    expect(db.inserts).toHaveLength(0);
+    expect(db.updates).toHaveLength(0);
+  });
+
+  it('updateSessionSpaces rejects requests missing the primary space', async () => {
+    const { service, db } = createServiceContext();
+
+    const err = await getRejectedHttpException(
+      service.updateSessionSpaces(TEST_TENANT_ID, 'session-1', TEST_USER_ID, 'space-a', ['space-b']),
+    );
+
+    expect(err.getStatus()).toBe(400);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.VALIDATION_ERROR);
+    expect(db.deletes).toHaveLength(0);
+  });
+
+  it('updateSessionSpaces rejects an empty scope', async () => {
+    const { service, db } = createServiceContext();
+
+    const err = await getRejectedHttpException(
+      service.updateSessionSpaces(TEST_TENANT_ID, 'session-1', TEST_USER_ID, 'space-a', []),
+    );
+
+    expect(err.getStatus()).toBe(400);
+    expect(getHttpExceptionCode(err)).toBe(ErrorCode.VALIDATION_ERROR);
+    expect(db.deletes).toHaveLength(0);
+  });
+
+  it('UpdateSessionSpacesDto rejects empty and oversized scope arrays', () => {
+    const emptyDto = Object.assign(new UpdateSessionSpacesDto(), { space_ids: [] });
+    const oversizedDto = Object.assign(new UpdateSessionSpacesDto(), {
+      space_ids: Array.from({ length: 11 }, (_, index) => `space-${index + 1}`),
+    });
+
+    expect(validateSync(emptyDto)).not.toHaveLength(0);
+    expect(validateSync(oversizedDto)).not.toHaveLength(0);
+  });
 });
 
 describe('Space scope normalization', () => {
@@ -233,17 +331,12 @@ describe('ChatService multi-space sessions', () => {
     expect(events.at(-1)).toEqual({ type: 'message.completed' });
   });
 
-  it('session continuation with different scope returns SESSION_SPACE_SCOPE_MISMATCH', async () => {
+  it('session continuation with different requested scope uses stored membership', async () => {
     const { service, db } = createServiceContext();
-    db.queueSelect([createModelRow({ model_type: 'chat' })]);
-    db.queueSelect([createSessionRow({ space_id: 'space-a' })]);
-    db.queueSelect([
-      createSessionSpaceRow({ space_id: 'space-a', position: 0 }),
-      createSessionSpaceRow({ space_id: 'space-b', position: 1 }),
-    ]);
+    queueExistingCompletion(db, ['space-a', 'space-b']);
 
-    const err = await getRejectedHttpException(
-      service.streamCompletion({
+    const events = await collectEvents(
+      await service.streamCompletion({
         tenantId: TEST_TENANT_ID,
         spaceId: 'space-a',
         spaceIds: ['space-a', 'space-c'],
@@ -254,9 +347,12 @@ describe('ChatService multi-space sessions', () => {
       }),
     );
 
-    expect(err.getStatus()).toBe(409);
-    expect(getHttpExceptionCode(err)).toBe(ErrorCode.SESSION_SPACE_SCOPE_MISMATCH);
-    expect(db.inserts).toHaveLength(0);
+    expect(events.at(-1)).toEqual({ type: 'message.completed' });
+    expect(
+      db.inserts.some(
+        (insert) => insert.table === chatMessages && isRecordForTest(insert.value) && insert.value.role === 'user',
+      ),
+    ).toBe(true);
   });
 
   it('session continuation with only space_id uses stored membership', async () => {
@@ -1006,6 +1102,7 @@ describe('ChatController', () => {
     expect(getPermissionsMetadata('streamCompletion')).toEqual(['chat:use']);
     expect(getPermissionsMetadata('listSessions')).toEqual(['chat:use']);
     expect(getPermissionsMetadata('getSession')).toEqual(['chat:use']);
+    expect(getPermissionsMetadata('updateSessionSpaces')).toEqual(['chat:use']);
     expect(getPermissionsMetadata('deleteSession')).toEqual(['chat:use']);
   });
 

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -1,8 +1,8 @@
-import { Body, Controller, Delete, Get, HttpException, HttpStatus, Param, Post, Query, Req, Res } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpException, HttpStatus, Param, Patch, Post, Query, Req, Res } from '@nestjs/common';
 import { Permissions, type AuthenticatedRequestUser } from '@cherrygraph/auth-core';
 import { ErrorCode } from '@cherrygraph/shared';
 
-import { ChatCompletionDto, ChatSessionsQueryDto } from './dto/chat.dto.js';
+import { ChatCompletionDto, ChatSessionsQueryDto, UpdateSessionSpacesDto } from './dto/chat.dto.js';
 import { ChatService, type ChatAuditContext, type ChatStreamEvent } from './chat.service.js';
 
 type RequestWithAuth = {
@@ -150,6 +150,29 @@ export class ChatController {
   ): ReturnType<ChatService['getSession']> {
     const user = getAuthenticatedUser(request);
     return this.chatService.getSession(user.tenant_id, sessionId, user.sub, spaceId);
+  }
+
+  @Patch('spaces/:spaceId/chat/sessions/:sessionId')
+  @Permissions('chat:use')
+  async updateSessionSpaces(
+    @Param('spaceId') spaceId: string,
+    @Param('sessionId') sessionId: string,
+    @Body() dto: UpdateSessionSpacesDto,
+    @Req() request: RequestWithAuth,
+  ): ReturnType<ChatService['updateSessionSpaces']> {
+    const user = getAuthenticatedUser(request);
+    const candidateSpacePermissions = request.space_permissions ?? user.space_permissions;
+    const spacePermissions = isSpacePermissionMap(candidateSpacePermissions) ? candidateSpacePermissions : undefined;
+    return this.chatService.updateSessionSpaces(
+      user.tenant_id,
+      sessionId,
+      user.sub,
+      spaceId,
+      dto.space_ids,
+      spacePermissions,
+      user.group_ids,
+      user.role,
+    );
   }
 
   @Delete('spaces/:spaceId/chat/sessions/:sessionId')

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -111,6 +111,15 @@ export type StreamCompletionInput = {
   auditContext?: ChatAuditContext;
 };
 
+type SpacePermissionCheckInput = {
+  tenantId: string;
+  userId: string;
+  userGroupIds: string[];
+  actorRole?: string;
+  actorPermissions?: string[];
+  spacePermissions?: Record<string, string[]>;
+};
+
 export type ChatStreamEvent =
   | { type: 'session'; session_id: string }
   | { type: 'content'; delta: string }
@@ -309,6 +318,66 @@ export class ChatService {
     });
 
     return sessionId;
+  }
+
+  async updateSessionSpaces(
+    tenantId: string,
+    sessionId: string,
+    userId: string,
+    primarySpaceId: string,
+    requestedSpaceIds: string[],
+    spacePermissions?: Record<string, string[]>,
+    userGroupIds: string[] = [],
+    actorRole?: string,
+  ): Promise<{ session_id: string; space_ids: string[]; space_details: SpaceDisplayInfo[] }> {
+    const normalizedSpaceIds = this.normalizeSpaceScope({
+      space_id: primarySpaceId,
+      space_ids: requestedSpaceIds,
+    });
+    const { session } = await this.requireSession(tenantId, sessionId, userId, primarySpaceId);
+    const spacesForScope = await this.requireSpaces(tenantId, normalizedSpaceIds);
+    await this.assertChatUseOnSpaces(
+      {
+        tenantId,
+        userId,
+        userGroupIds,
+        ...(actorRole !== undefined ? { actorRole } : {}),
+        ...(spacePermissions !== undefined ? { spacePermissions } : {}),
+      },
+      normalizedSpaceIds,
+    );
+
+    const now = new Date();
+    await this.db.transaction(async (tx) => {
+      await tx
+        .delete(chatSessionSpaces)
+        .where(and(eq(chatSessionSpaces.tenant_id, tenantId), eq(chatSessionSpaces.session_id, sessionId)));
+
+      await tx.insert(chatSessionSpaces).values(
+        normalizedSpaceIds.map((spaceId, position) => ({
+          session_id: sessionId,
+          tenant_id: tenantId,
+          space_id: spaceId,
+          position,
+          created_at: now,
+        })),
+      );
+
+      await tx
+        .update(chatSessions)
+        .set({ updated_at: now })
+        .where(and(eq(chatSessions.tenant_id, tenantId), eq(chatSessions.id, sessionId)));
+    });
+
+    const spaceById = new Map(spacesForScope.map((space) => [space.id, space]));
+    return {
+      session_id: session.id,
+      space_ids: normalizedSpaceIds,
+      space_details: normalizedSpaceIds.map((spaceId) => ({
+        id: spaceId,
+        name: spaceById.get(spaceId)?.name ?? spaceId,
+      })),
+    };
   }
 
   async listSessions(
@@ -889,11 +958,7 @@ export class ChatService {
 
     const result = await this.requireSession(tenantId, sessionId, userId, spaceId);
     if (explicitScope && !sameStringArray(result.spaceIds, requestedSpaceIds)) {
-      throwApiError(
-        ErrorCode.SESSION_SPACE_SCOPE_MISMATCH,
-        'Chat session Space scope cannot be changed',
-        HttpStatus.CONFLICT,
-      );
+      return { session: result.session, spaceIds: result.spaceIds };
     }
 
     return result;
@@ -1077,7 +1142,7 @@ export class ChatService {
     throwApiError(ErrorCode.VALIDATION_ERROR, 'At least one Space is required', HttpStatus.BAD_REQUEST);
   }
 
-  private async assertChatUseOnSpaces(input: StreamCompletionInput, spaceIds: string[]): Promise<void> {
+  private async assertChatUseOnSpaces(input: SpacePermissionCheckInput, spaceIds: string[]): Promise<void> {
     if (
       input.actorRole === undefined &&
       input.actorPermissions === undefined &&

--- a/apps/api/src/chat/dto/chat.dto.ts
+++ b/apps/api/src/chat/dto/chat.dto.ts
@@ -68,3 +68,13 @@ export class ChatSessionsQueryDto {
   @Max(100)
   limit = 20;
 }
+
+export class UpdateSessionSpacesDto {
+  @IsArray()
+  @IsString({ each: true })
+  @MinLength(1, { each: true })
+  @MaxLength(200, { each: true })
+  @ArrayMinSize(1)
+  @ArrayMaxSize(10)
+  space_ids!: string[];
+}

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
+import { message as antdMessage } from 'antd';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '../i18n';
 import i18n from '../i18n';
@@ -34,6 +35,16 @@ const testUser: AuthUser = {
 
 beforeEach(async () => {
   await i18n.changeLanguage('zh-CN');
+  window.matchMedia ??= vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
 });
 
 afterEach(() => {
@@ -209,7 +220,7 @@ describe('Space selector', () => {
       />,
     );
 
-    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.mouseDown(getSpaceSelectorCombobox());
     fireEvent.click(await screen.findByText('Space Two'));
 
     expect(onChange).toHaveBeenCalledWith(['space-1', 'space-2']);
@@ -238,7 +249,24 @@ describe('Space selector', () => {
     expect(onChange).toHaveBeenCalledWith(['space-1']);
   });
 
-  it('locks selection during an active session', () => {
+  it('does not lock selection when not streaming', () => {
+    renderWithRouter(
+      <SpaceSelector
+        availableSpaces={[{ id: 'space-1', name: 'Space One' }]}
+        selectedSpaceIds={['space-1']}
+        primarySpaceId="space-1"
+        locked={false}
+        onChange={vi.fn()}
+        onStartNewSession={vi.fn()}
+      />,
+    );
+
+    expect(document.querySelector('.chat-space-selector.ant-select-disabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('当前会话已锁定空间范围')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /新建对话以更改/ })).not.toBeInTheDocument();
+  });
+
+  it('locks selection while streaming', () => {
     renderWithRouter(
       <SpaceSelector
         availableSpaces={[{ id: 'space-1', name: 'Space One' }]}
@@ -270,7 +298,7 @@ describe('Space selector', () => {
       />,
     );
 
-    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.mouseDown(getSpaceSelectorCombobox());
 
     const extraOption = await screen.findByTitle('Space 11');
     expect(extraOption.closest('.ant-select-item-option-disabled')).not.toBeNull();
@@ -471,10 +499,11 @@ describe('Phase 3 chat controls and stream events', () => {
     fireEvent.click(await screen.findByText('Multi-space chat'));
 
     expect(await screen.findByText('Space Two')).toBeInTheDocument();
-    expect(screen.getByText('当前会话已锁定空间范围')).toBeInTheDocument();
+    expect(screen.queryByText('当前会话已锁定空间范围')).not.toBeInTheDocument();
+    expect(document.querySelector('.chat-space-selector.ant-select-disabled')).not.toBeInTheDocument();
   });
 
-  it('locks the selector after a session starts', async () => {
+  it('keeps the selector editable after a session starts', async () => {
     stubChatFetch({
       streamEvents: [
         { event: 'session', data: { session_id: 'session-started' } },
@@ -485,8 +514,69 @@ describe('Phase 3 chat controls and stream events', () => {
     renderChatRoute();
     await sendChatMessage('start a scoped session');
 
-    expect(await screen.findByText('当前会话已锁定空间范围')).toBeInTheDocument();
-    expect(document.querySelector('.chat-space-selector.ant-select-disabled')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('当前会话已锁定空间范围')).not.toBeInTheDocument());
+    expect(document.querySelector('.chat-space-selector.ant-select-disabled')).not.toBeInTheDocument();
+  });
+
+  it('rolls back selected spaces when updating an existing session fails', async () => {
+    const errorSpy = vi.spyOn(antdMessage, 'error').mockReturnValue(undefined as never);
+    const fetchState = stubChatFetch({
+      patchSessionSpacesStatus: 500,
+      sessions: [
+        {
+          id: 'session-multi',
+          title: 'Multi-space chat',
+          space_ids: ['space-1', 'space-2'],
+          space_details: [
+            { id: 'space-1', name: 'Space One' },
+            { id: 'space-2', name: 'Space Two' },
+          ],
+          created_at: '2026-05-01T10:00:00.000Z',
+          updated_at: '2026-05-01T11:00:00.000Z',
+        },
+      ],
+      sessionDetails: {
+        'session-multi': {
+          id: 'session-multi',
+          space_ids: ['space-1', 'space-2'],
+          space_details: [
+            { id: 'space-1', name: 'Space One' },
+            { id: 'space-2', name: 'Space Two' },
+          ],
+          messages: [],
+        },
+      },
+      streamEvents: [{ event: 'message.completed', data: {} }],
+    });
+
+    renderChatRoute();
+    fireEvent.click(await screen.findByText('Multi-space chat'));
+    expect(await screen.findByText('Space Two')).toBeInTheDocument();
+
+    const closeButton = document.querySelector('.chat-space-selector .ant-tag-close-icon');
+    expect(closeButton).toBeInTheDocument();
+    fireEvent.click(closeButton!);
+
+    await waitFor(() =>
+      expect(fetchState.calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: '/api/spaces/space-1/chat/sessions/session-multi',
+            body: { space_ids: ['space-1'] },
+          }),
+        ]),
+      ),
+    );
+    await waitFor(() => expect(errorSpy).toHaveBeenCalledWith('更新聊天范围失败'));
+
+    await sendChatMessage('continue with original scope');
+
+    await waitFor(() =>
+      expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({
+        session_id: 'session-multi',
+        space_ids: ['space-1', 'space-2'],
+      }),
+    );
   });
 
   it('sends enable_deep_analysis when the deep analysis toggle is on', async () => {
@@ -672,6 +762,12 @@ function renderWithRouter(element: ReactElement): void {
   render(<MemoryRouter>{element}</MemoryRouter>);
 }
 
+function getSpaceSelectorCombobox(): HTMLInputElement {
+  const combobox = document.querySelector<HTMLInputElement>('.chat-space-selector input[role="combobox"]');
+  expect(combobox).not.toBeNull();
+  return combobox!;
+}
+
 function fireTextareaKeyDown(textarea: HTMLTextAreaElement, init: KeyboardEventInit): void {
   fireEvent(textarea, new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
 }
@@ -759,12 +855,14 @@ function stubChatFetch({
   sessions = [],
   sessionDetails = {},
   streamEvents = [],
+  patchSessionSpacesStatus = 200,
 }: {
   databaseEnabled?: boolean;
   spaces?: StubSpace[];
   sessions?: StubSession[];
   sessionDetails?: Record<string, StubSessionDetail>;
   streamEvents?: StreamEvent[];
+  patchSessionSpacesStatus?: number;
 } = {}): { calls: FetchCall[] } {
   const calls: FetchCall[] = [];
 
@@ -772,7 +870,8 @@ function stubChatFetch({
     'fetch',
     vi.fn<typeof fetch>((input, init) => {
       const path = getRequestPath(input);
-      calls.push({ path, body: parseRequestBody(init?.body) });
+      const requestBody = parseRequestBody(init?.body);
+      calls.push({ path, body: requestBody });
 
       if (path === '/api/spaces') {
         return Promise.resolve(
@@ -792,6 +891,24 @@ function stubChatFetch({
       }
 
       const sessionDetailMatch = path.match(/^\/api\/spaces\/space-1\/chat\/sessions\/([^/]+)$/);
+      if (sessionDetailMatch !== null && init?.method === 'PATCH') {
+        return Promise.resolve(
+          patchSessionSpacesStatus >= 200 && patchSessionSpacesStatus < 300
+            ? jsonResponse({
+                data: {
+                  session_id: decodeURIComponent(sessionDetailMatch[1] ?? ''),
+                  space_ids: isRecord(requestBody) && Array.isArray(requestBody.space_ids) ? requestBody.space_ids : ['space-1'],
+                  space_details: spaces,
+                },
+                meta: { request_id: 'req-patch-session-spaces' },
+              })
+            : jsonResponse(
+                { error: { code: 'INTERNAL_ERROR', message: 'Failed to update chat scope' } },
+                patchSessionSpacesStatus,
+              ),
+        );
+      }
+
       if (sessionDetailMatch !== null) {
         const detail = sessionDetails[decodeURIComponent(sessionDetailMatch[1] ?? '')];
         return Promise.resolve(
@@ -880,6 +997,10 @@ function parseRequestBody(body: BodyInit | null | undefined): unknown {
   } catch {
     return null;
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function getRequestPath(input: RequestInfo | URL): string {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -916,6 +916,7 @@
     "spaceSelectorPlaceholder": "Add accessible spaces",
     "primarySpaceTag": "{{name}} (primary)",
     "scopeLocked": "Space scope is locked for this session",
+    "scopeUpdateFailed": "Failed to update chat scope",
     "spaceSelectorMax": "Maximum 10 spaces",
     "changeScopeNewChat": "New chat to change",
     "multiSpaceSelected": "{{count}} spaces selected: {{names}}",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -916,6 +916,7 @@
     "spaceSelectorPlaceholder": "添加可访问空间",
     "primarySpaceTag": "{{name}}（主）",
     "scopeLocked": "当前会话已锁定空间范围",
+    "scopeUpdateFailed": "更新聊天范围失败",
     "spaceSelectorMax": "最多选择 10 个空间",
     "changeScopeNewChat": "新建对话以更改",
     "multiSpaceSelected": "已选择 {{count}} 个空间：{{names}}",

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -395,11 +395,12 @@ export default function Chat() {
       setSelectedSpaceIds(normalizedIds);
       try {
         await patchSessionSpaces(sessionId, normalizedIds);
-        await loadSessions(true);
       } catch {
         setSelectedSpaceIds(previousIds);
         void message.error(t('chat.scopeUpdateFailed'));
+        return;
       }
+      void loadSessions(true);
       return;
     }
 

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -66,7 +66,7 @@ type SpaceSelectorProps = {
   selectedSpaceIds: string[];
   primarySpaceId: string;
   locked: boolean;
-  onChange: (spaceIds: string[]) => void;
+  onChange: (spaceIds: string[]) => Promise<void> | void;
   onStartNewSession: () => void;
 };
 
@@ -381,6 +381,31 @@ export default function Chat() {
     });
   }
 
+  async function patchSessionSpaces(nextSessionId: string, nextSpaceIds: string[]): Promise<void> {
+    await api.patch(
+      `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(nextSessionId)}`,
+      { space_ids: nextSpaceIds },
+    );
+  }
+
+  async function handleSpaceChange(nextSpaceIds: string[]): Promise<void> {
+    const normalizedIds = normalizeSelectedSpaceIds(spaceId, nextSpaceIds);
+    if (sessionId !== null) {
+      const previousIds = selectedSpaceIds;
+      setSelectedSpaceIds(normalizedIds);
+      try {
+        await patchSessionSpaces(sessionId, normalizedIds);
+        await loadSessions(true);
+      } catch {
+        setSelectedSpaceIds(previousIds);
+        void message.error(t('chat.scopeUpdateFailed'));
+      }
+      return;
+    }
+
+    setSelectedSpaceIds(normalizedIds);
+  }
+
   async function handleSend(message: string, settings: ChatSettings): Promise<void> {
     const options: SendMessageOptions = {
       sessionId,
@@ -395,7 +420,7 @@ export default function Chat() {
   }
 
   const chatErrorMessage = getChatErrorMessage(streamError, selectedSpaceIds.length);
-  const selectorLocked = isStreaming || sessionId !== null;
+  const selectorLocked = isStreaming;
 
   return (
     <div className={`chat-page${isSidebarCollapsed ? ' sidebar-collapsed' : ''}`}>
@@ -511,7 +536,7 @@ export default function Chat() {
             selectedSpaceIds={selectedSpaceIds}
             primarySpaceId={spaceId}
             locked={selectorLocked}
-            onChange={setSelectedSpaceIds}
+            onChange={handleSpaceChange}
             onStartNewSession={newChat}
           />
           <MessageInput
@@ -598,7 +623,7 @@ export function SpaceSelector({
               void message.warning(t('chat.spaceSelectorMax'));
               return;
             }
-            onChange(normalizedIds);
+            void onChange(normalizedIds);
           }}
         />
         {locked ? (


### PR DESCRIPTION
## Summary

- Unlock space selector for existing sessions (locked only during streaming)
- Add `PATCH /spaces/:spaceId/chat/sessions/:sessionId` endpoint with DTO validation
- Add transactional `updateSessionSpaces` method with `chat:use` permission check on all spaces
- Modify `resolveSession` to use stored scope instead of rejecting with `SESSION_SPACE_SCOPE_MISMATCH`
- Add optimistic UI update with error rollback (only on PATCH failure) and toast notification
- Add i18n key `chat.scopeUpdateFailed` in en + zh-CN
- Update frontend tests for new selector lock behavior
- Add 5 backend tests: happy path, unauthorized space (403), missing primary (400), empty scope (400), DTO validation

Closes #267

## Test plan

- [x] Build passes (`npm run build`)
- [x] All frontend tests pass (126 passed)
- [x] All backend tests pass (1167 passed)
- [x] Lint passes with zero warnings
- [ ] Manual: verify adding space to existing session works
- [ ] Manual: verify removing secondary space works
- [ ] Manual: verify primary space cannot be removed
- [ ] Manual: verify selector locks during streaming only

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration & Cross-file Impact Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `61a21a01c244daea3f8ae6f84abf259f6db8d844`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/279#issuecomment-4426232330) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/279#issuecomment-4426232447) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/279#issuecomment-4426232618) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/279#issuecomment-4426232763)
- Key findings addressed: PATCH rollback separated from sidebar refresh error handling to prevent client-server scope divergence