### PR TITLE
feat(graphify): show space name fallback in run list (#270)

### DIFF
--- a/apps/api/src/graphify/__tests__/graphify.service.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.service.test.ts
@@ -1,5 +1,5 @@
 import { JobStatus, jobs, type JobRow } from '@cherrygraph/job-core';
-import { ErrorCode, graphReports, graphifyRuns } from '@cherrygraph/shared';
+import { ErrorCode, graphReports, graphifyRuns, spaces } from '@cherrygraph/shared';
 import { describe, expect, it } from 'vitest';
 
 import type { AuditEntry } from '../../audit/audit.service.js';
@@ -80,7 +80,7 @@ describe('GraphifyService', () => {
 
   it('listRuns returns a paginated response with status filters', async () => {
     const { service, db } = createServiceContext();
-    db.queueSelect([createRunRow({ status: 'succeeded' })]);
+    db.queueSelect([{ run: createRunRow({ status: 'succeeded' }), space_name: 'Research Space' }]);
     db.queueSelect([{ total: 1 }]);
 
     const result = await service.listRuns(
@@ -91,11 +91,13 @@ describe('GraphifyService', () => {
     expect(result.data).toEqual([
       expect.objectContaining({
         run_id: 'run-1',
+        space_name: 'Research Space',
         status: 'succeeded',
       }),
     ]);
     expect(result.pagination).toEqual({ page: 1, per_page: 10, total: 1, has_next: false });
     expect(db.limitCalls).toContain(10);
+    expect(db.selectFields[0]).toEqual({ run: graphifyRuns, space_name: spaces.name });
   });
 
   it('getRun returns GRAPHIFY_RUN_NOT_FOUND for missing runs', async () => {

--- a/apps/api/src/graphify/graphify.service.ts
+++ b/apps/api/src/graphify/graphify.service.ts
@@ -81,6 +81,7 @@ export type GraphifyRunsQuery = {
 export type GraphifyRunResponse = {
   run_id: string;
   space_id: string;
+  space_name?: string;
   mode: string;
   trigger_type: string;
   status: string;
@@ -146,6 +147,7 @@ export type GraphifyCompletionPayload = {
 
 type GraphifySortField = 'created_at' | 'started_at' | 'completed_at' | 'status' | 'mode' | 'trigger_type';
 type GraphifyPermission = 'graphify:view' | 'graphify:run';
+export type GraphifyRunRowWithSpaceName = GraphifyRunRow & { space_name?: string | null };
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PER_PAGE = 20;
@@ -206,15 +208,20 @@ export class GraphifyService {
     const where = buildRunsWhere(tenantId, query, accessibleSpaceIds);
     const order = buildRunOrder(query.sort ?? '-created_at');
 
-    const rows = await this.db
-      .select()
+    const rowsWithSpaceName = await this.db
+      .select({ run: graphifyRuns, space_name: spaces.name })
       .from(graphifyRuns)
+      .leftJoin(spaces, and(eq(spaces.id, graphifyRuns.space_id), eq(spaces.tenant_id, tenantId)))
       .where(where)
       .orderBy(order)
       .limit(perPage)
       .offset((page - 1) * perPage);
     const [countRow] = await this.db.select({ total: count() }).from(graphifyRuns).where(where);
 
+    const rows: GraphifyRunRowWithSpaceName[] = rowsWithSpaceName.map((row) => ({
+      ...row.run,
+      space_name: row.space_name,
+    }));
     const resolved = await resolveInputScope(this.db, rows, tenantId);
 
     return paginatedResponse(
@@ -902,7 +909,7 @@ export async function resolveInputScope(
 }
 
 export function toGraphifyRunResponse(
-  run: GraphifyRunRow,
+  run: GraphifyRunRowWithSpaceName,
   resolved: { docMap: Map<string, string>; pageMap: Map<string, string> } = {
     docMap: new Map(),
     pageMap: new Map(),
@@ -915,6 +922,7 @@ export function toGraphifyRunResponse(
   return {
     run_id: run.id,
     space_id: run.space_id,
+    ...(run.space_name !== undefined && run.space_name !== null ? { space_name: run.space_name } : {}),
     mode: run.mode,
     trigger_type: run.trigger_type,
     status: run.status,

--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { GraphifyRun } from '../lib/graphifyApi.js';
 import GraphifyRunDetailPage from '../pages/GraphifyRunDetailPage.js';
 import GraphifyRunsPage from '../pages/GraphifyRunsPage.js';
+import { formatRunLabel } from '../pages/graphifyUi.js';
 
 type GetWrappedMock = (path: string, query?: Record<string, unknown>) => Promise<unknown>;
 type PostMock = (path: string, body?: unknown) => Promise<unknown>;
@@ -124,6 +125,39 @@ describe('GraphifyRunDetailPage', () => {
     });
     expect(screen.queryByText('Cancel Run')).not.toBeInTheDocument();
     expect(screen.queryByText('Retry Run')).not.toBeInTheDocument();
+  });
+});
+
+describe('formatRunLabel', () => {
+  const t = ((key: string) => (key === 'common.status.deleted' ? 'Deleted' : key)) as Parameters<
+    typeof formatRunLabel
+  >[1];
+
+  it('falls back to space name and mode when resolved names are empty', () => {
+    const label = formatRunLabel(buildRun({ mode: 'full' }), t, { 'space-1': 'Research Space' });
+
+    expect(label).toEqual({ primary: 'Research Space · Full', secondary: 'run-1' });
+  });
+
+  it('falls back to mode when resolved names and space name are unavailable', () => {
+    const label = formatRunLabel(buildRun({ mode: 'incremental' }), t);
+
+    expect(label).toEqual({ primary: 'Incremental', secondary: 'run-1' });
+  });
+
+  it('uses resolved document and page names ahead of the space fallback', () => {
+    const label = formatRunLabel(
+      buildRun({
+        input_scope_resolved: {
+          source_documents: [{ id: 'doc-1', filename: 'Plan.pdf', missing: false }],
+          pages: [{ id: 'page-1', title: 'Overview', missing: false }],
+        },
+      }),
+      t,
+      { 'space-1': 'Research Space' },
+    );
+
+    expect(label).toEqual({ primary: 'Plan.pdf, Overview', secondary: 'run-1' });
   });
 });
 

--- a/apps/web/src/lib/graphifyApi.ts
+++ b/apps/web/src/lib/graphifyApi.ts
@@ -49,6 +49,7 @@ export type GraphifyRunResult = {
 export type GraphifyRun = {
   run_id: string;
   space_id: string;
+  space_name?: string;
   mode: GraphifyRunMode;
   trigger_type: GraphifyTriggerType;
   status: GraphifyRunStatus;

--- a/apps/web/src/pages/admin/GraphifyPage.tsx
+++ b/apps/web/src/pages/admin/GraphifyPage.tsx
@@ -1,7 +1,7 @@
 import { ReloadOutlined } from '@ant-design/icons';
 import { Button, Input, Popconfirm, Select, Space, Table, Tabs, Tag, Typography, message } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { useCallback, useDeferredValue, useEffect, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { requireAdminPage } from '../../components/RequireAdminPage';
@@ -90,6 +90,15 @@ function GraphifyPage() {
   }, [loadRuns]);
 
   const shouldPoll = runs.some(isGraphifyRunActive) || status === 'pending' || status === 'running';
+  const spaceNameById = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const run of runs) {
+      if (run.space_name && run.space_id) {
+        map[run.space_id] = run.space_name;
+      }
+    }
+    return map;
+  }, [runs]);
 
   useEffect(() => {
     if (!shouldPoll) return;
@@ -133,7 +142,7 @@ function GraphifyPage() {
       title: t('admin.graphify.columns.run'),
       key: 'run',
       render: (_: unknown, run: GraphifyRun) => {
-        const label = formatRunLabel(run, t);
+        const label = formatRunLabel(run, t, spaceNameById);
         return (
           <div>
             <Typography.Text strong>{label.primary}</Typography.Text>

--- a/apps/web/src/pages/graphifyUi.tsx
+++ b/apps/web/src/pages/graphifyUi.tsx
@@ -116,7 +116,11 @@ export function isGraphifyRunActive(run: GraphifyRun): boolean {
   return run.status === 'pending' || run.status === 'running';
 }
 
-export function formatRunLabel(run: GraphifyRun, t: TFunction): { primary: string; secondary: string } {
+export function formatRunLabel(
+  run: GraphifyRun,
+  t: TFunction,
+  spaceNameById?: Record<string, string>,
+): { primary: string; secondary: string } {
   const names = [
     ...run.input_scope_resolved.source_documents.map((sourceDocument) => (
       sourceDocument.missing ? t('common.status.deleted') : sourceDocument.filename
@@ -128,9 +132,13 @@ export function formatRunLabel(run: GraphifyRun, t: TFunction): { primary: strin
 
   const visibleNames = names.slice(0, 3);
   const overflowCount = names.length - visibleNames.length;
-  const primary = names.length === 0
-    ? formatLabel(run.mode)
-    : `${visibleNames.join(', ')}${overflowCount > 0 ? ` +${overflowCount}` : ''}`;
+  let primary: string;
+  if (names.length > 0) {
+    primary = `${visibleNames.join(', ')}${overflowCount > 0 ? ` +${overflowCount}` : ''}`;
+  } else {
+    const spaceName = spaceNameById?.[run.space_id];
+    primary = spaceName ? `${spaceName} · ${formatLabel(run.mode)}` : formatLabel(run.mode);
+  }
 
   return {
     primary,


### PR DESCRIPTION
## Summary

- Add `space_name` field to `GraphifyRunResponse` via LEFT JOIN on spaces table
- Update `formatRunLabel` to show "Space Name · Mode" when no document/page names available
- Build `spaceNameById` map in GraphifyPage from run data
- Add frontend tests for fallback display logic (with/without space name)

Closes #270

## Test plan

- [x] Build passes
- [x] All frontend tests pass
- [x] All backend tests pass (1167)
- [ ] Manual: verify run list shows space name when no doc names

## Agent Review

- Reviewer agents used: Spec & Correctness Reviewer, Integration & Security Reviewer, Correctness Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `4e9ea8c348db0f14d90bb4621f41df56a19bf682`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/281#issuecomment-4426432524) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/281#issuecomment-4426432699) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/281#issuecomment-4426432827) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/281#issuecomment-4426432989)
- Key findings addressed: No critical or major findings; clean review