### PR TITLE
feat(bridge): auto-bootstrap Docmost workspace (#272)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,8 @@ DOCMOST_BASE_URL=http://localhost:3000
 DOCMOST_APP_SECRET=dev-docmost-app-secret-minimum-32-chars
 DOCMOST_DB_PASSWORD=docmost_dev
 DOCMOST_BRIDGE_SECRET=dev-docmost-bridge-secret
+DOCMOST_ADMIN_EMAIL=admin@cherrywiki.local
+DOCMOST_ADMIN_PASSWORD=changeme-initial-setup
 DOCMOST_FORK_BUILD=true
 
 # --- MCP Gateway (Phase 4 — not used in Phase 1) ---

--- a/apps/api/src/bridge/__tests__/docmost-bootstrap.service.spec.ts
+++ b/apps/api/src/bridge/__tests__/docmost-bootstrap.service.spec.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getApiLogger } from '../../common/logger/logger.module.js';
+import { BridgeModule } from '../bridge.module.js';
+import { DocmostBootstrapService } from '../docmost-bootstrap.service.js';
+
+const originalEnv = {
+  DOCMOST_BASE_URL: process.env.DOCMOST_BASE_URL,
+  DOCMOST_BRIDGE_SECRET: process.env.DOCMOST_BRIDGE_SECRET,
+  DOCMOST_ADMIN_EMAIL: process.env.DOCMOST_ADMIN_EMAIL,
+  DOCMOST_ADMIN_PASSWORD: process.env.DOCMOST_ADMIN_PASSWORD,
+  CHERRY_TENANT_NAME: process.env.CHERRY_TENANT_NAME,
+};
+
+describe('DocmostBootstrapService', () => {
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(() => {
+    getApiLogger().level = 'silent';
+    setBootstrapEnv();
+    fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    restoreEnv();
+  });
+
+  it('calls the bootstrap endpoint when workspace_initialized is false', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ workspace_initialized: false }))
+      .mockResolvedValueOnce(jsonResponse({ workspace_id: 'workspace-1', user_id: 'user-1' }));
+    const service = new DocmostBootstrapService();
+
+    await expect(service.bootstrapIfNeeded()).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchCall(fetchMock, 0)[0]).toBe(
+      'https://docmost.example.com/api/internal/bridge/health',
+    );
+    expect(fetchCall(fetchMock, 1)[0]).toBe(
+      'https://docmost.example.com/api/internal/bridge/bootstrap',
+    );
+    const bootstrapInit = fetchCall(fetchMock, 1)[1] as RequestInit;
+    expect(bootstrapInit.method).toBe('POST');
+    if (typeof bootstrapInit.body !== 'string') {
+      throw new Error('Expected JSON bootstrap request body');
+    }
+    expect(JSON.parse(bootstrapInit.body)).toEqual({
+      workspaceName: 'CherryWiki',
+      name: 'Admin',
+      email: 'admin@cherrywiki.local',
+      password: 'changeme-initial-setup',
+    });
+  });
+
+  it('skips bootstrap when workspace_initialized is true', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ workspace_initialized: true }));
+    const service = new DocmostBootstrapService();
+
+    await expect(service.bootstrapIfNeeded()).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchCall(fetchMock, 0)[0]).toBe(
+      'https://docmost.example.com/api/internal/bridge/health',
+    );
+  });
+
+  it("logs warn and doesn't throw when Docmost is unreachable", async () => {
+    const warn = vi.spyOn(getApiLogger(), 'warn').mockImplementation(() => undefined);
+    fetchMock.mockRejectedValueOnce(new Error('connection refused'));
+    const service = new DocmostBootstrapService();
+
+    await expect(service.bootstrapIfNeeded()).resolves.toBe(false);
+
+    expect(warn).toHaveBeenCalledWith(
+      { err: 'connection refused' },
+      'Docmost workspace bootstrap skipped',
+    );
+  });
+});
+
+describe('BridgeModule Docmost bootstrap lifecycle', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('calls bootstrapIfNeeded and catches errors', async () => {
+    const bootstrapIfNeeded = vi.fn().mockRejectedValue(new Error('boom'));
+    const service = { bootstrapIfNeeded } as Pick<
+      DocmostBootstrapService,
+      'bootstrapIfNeeded'
+    >;
+    const module = new BridgeModule(service as DocmostBootstrapService);
+
+    await expect(module.onApplicationBootstrap()).resolves.toBeUndefined();
+    module.onModuleDestroy();
+
+    expect(bootstrapIfNeeded).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after the initial bootstrap failure', async () => {
+    vi.useFakeTimers();
+    const bootstrapIfNeeded = vi.fn().mockResolvedValue(false);
+    const service = { bootstrapIfNeeded } as Pick<
+      DocmostBootstrapService,
+      'bootstrapIfNeeded'
+    >;
+    const module = new BridgeModule(service as DocmostBootstrapService);
+
+    await module.onApplicationBootstrap();
+    expect(bootstrapIfNeeded).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(bootstrapIfNeeded).toHaveBeenCalledTimes(2);
+    module.onModuleDestroy();
+  });
+});
+
+function jsonResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(payload),
+    body: { cancel: vi.fn().mockResolvedValue(undefined) },
+  } as unknown as Response;
+}
+
+function fetchCall(
+  fetchMock: ReturnType<typeof vi.fn<typeof fetch>>,
+  index: number,
+): Parameters<typeof fetch> {
+  const call = fetchMock.mock.calls[index];
+  if (call === undefined) {
+    throw new Error(`Expected fetch call ${index}`);
+  }
+
+  return call;
+}
+
+function setBootstrapEnv(): void {
+  process.env.DOCMOST_BASE_URL = 'https://docmost.example.com/';
+  process.env.DOCMOST_BRIDGE_SECRET = 'bridge-secret';
+  process.env.DOCMOST_ADMIN_EMAIL = 'admin@cherrywiki.local';
+  process.env.DOCMOST_ADMIN_PASSWORD = 'changeme-initial-setup';
+  delete process.env.CHERRY_TENANT_NAME;
+}
+
+function restoreEnv(): void {
+  restoreEnvValue('DOCMOST_BASE_URL', originalEnv.DOCMOST_BASE_URL);
+  restoreEnvValue('DOCMOST_BRIDGE_SECRET', originalEnv.DOCMOST_BRIDGE_SECRET);
+  restoreEnvValue('DOCMOST_ADMIN_EMAIL', originalEnv.DOCMOST_ADMIN_EMAIL);
+  restoreEnvValue('DOCMOST_ADMIN_PASSWORD', originalEnv.DOCMOST_ADMIN_PASSWORD);
+  restoreEnvValue('CHERRY_TENANT_NAME', originalEnv.CHERRY_TENANT_NAME);
+}
+
+function restoreEnvValue(name: keyof typeof originalEnv, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/apps/api/src/bridge/__tests__/docmost-bootstrap.service.spec.ts
+++ b/apps/api/src/bridge/__tests__/docmost-bootstrap.service.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getApiLogger } from '../../common/logger/logger.module.js';
+import type { UserService } from '../../users/user.service.js';
 import { BridgeModule } from '../bridge.module.js';
 import { DocmostBootstrapService } from '../docmost-bootstrap.service.js';
 
@@ -23,6 +24,7 @@ describe('DocmostBootstrapService', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     restoreEnv();
@@ -44,6 +46,10 @@ describe('DocmostBootstrapService', () => {
       'https://docmost.example.com/api/internal/bridge/bootstrap',
     );
     const bootstrapInit = fetchCall(fetchMock, 1)[1] as RequestInit;
+    expect((fetchCall(fetchMock, 0)[1] as RequestInit).signal).toBeInstanceOf(
+      AbortSignal,
+    );
+    expect(bootstrapInit.signal).toBeInstanceOf(AbortSignal);
     expect(bootstrapInit.method).toBe('POST');
     if (typeof bootstrapInit.body !== 'string') {
       throw new Error('Expected JSON bootstrap request body');
@@ -80,6 +86,80 @@ describe('DocmostBootstrapService', () => {
       'Docmost workspace bootstrap skipped',
     );
   });
+
+  it('aborts a stalled health check and returns false', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockImplementationOnce((_url, init) => {
+      const signal = (init as RequestInit).signal;
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('This operation was aborted', 'AbortError'));
+        });
+      });
+    });
+    const service = new DocmostBootstrapService();
+
+    const result = service.bootstrapIfNeeded();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(result).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const healthInit = fetchCall(fetchMock, 0)[1] as RequestInit;
+    expect(healthInit.signal?.aborted).toBe(true);
+  });
+
+  it('aborts a stalled bootstrap POST and returns false', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ workspace_initialized: false }))
+      .mockImplementationOnce((_url, init) => {
+        const signal = (init as RequestInit).signal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => {
+            reject(new DOMException('This operation was aborted', 'AbortError'));
+          });
+        });
+      });
+    const service = new DocmostBootstrapService();
+
+    const result = service.bootstrapIfNeeded();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(result).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const bootstrapInit = fetchCall(fetchMock, 1)[1] as RequestInit;
+    expect(bootstrapInit.signal?.aborted).toBe(true);
+  });
+
+  it('uses the first Cherry admin user when DOCMOST_ADMIN_EMAIL is unset', async () => {
+    delete process.env.DOCMOST_ADMIN_EMAIL;
+    const userService = {
+      findFirstAdminUser: vi.fn().mockResolvedValue({
+        id: 'admin-1',
+        email: 'owner@cherrywiki.local',
+        name: 'Owner',
+        role: 'owner',
+      }),
+    };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ workspace_initialized: false }))
+      .mockResolvedValueOnce(jsonResponse({ workspace_id: 'workspace-1', user_id: 'user-1' }));
+    const service = new DocmostBootstrapService(userService as unknown as UserService);
+
+    await expect(service.bootstrapIfNeeded()).resolves.toBe(true);
+
+    expect(userService.findFirstAdminUser).toHaveBeenCalledTimes(1);
+    const bootstrapInit = fetchCall(fetchMock, 1)[1] as RequestInit;
+    if (typeof bootstrapInit.body !== 'string') {
+      throw new Error('Expected JSON bootstrap request body');
+    }
+    expect(JSON.parse(bootstrapInit.body)).toEqual({
+      workspaceName: 'CherryWiki',
+      name: 'Admin',
+      email: 'owner@cherrywiki.local',
+      password: 'changeme-initial-setup',
+    });
+  });
 });
 
 describe('BridgeModule Docmost bootstrap lifecycle', () => {
@@ -102,7 +182,7 @@ describe('BridgeModule Docmost bootstrap lifecycle', () => {
     expect(bootstrapIfNeeded).toHaveBeenCalledTimes(1);
   });
 
-  it('retries after the initial bootstrap failure', async () => {
+  it('retries with bounded backoff after the initial bootstrap failure', async () => {
     vi.useFakeTimers();
     const bootstrapIfNeeded = vi.fn().mockResolvedValue(false);
     const service = { bootstrapIfNeeded } as Pick<
@@ -116,6 +196,40 @@ describe('BridgeModule Docmost bootstrap lifecycle', () => {
 
     await vi.advanceTimersByTimeAsync(60_000);
     expect(bootstrapIfNeeded).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(bootstrapIfNeeded).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect(bootstrapIfNeeded).toHaveBeenCalledTimes(4);
+    module.onModuleDestroy();
+  });
+
+  it('continues retrying past the previous retry cap', async () => {
+    vi.useFakeTimers();
+    const bootstrapIfNeeded = vi.fn().mockResolvedValue(false);
+    const service = { bootstrapIfNeeded } as Pick<
+      DocmostBootstrapService,
+      'bootstrapIfNeeded'
+    >;
+    const module = new BridgeModule(service as DocmostBootstrapService);
+
+    await module.onApplicationBootstrap();
+    for (const delay of [
+      60_000,
+      120_000,
+      240_000,
+      300_000,
+      300_000,
+      300_000,
+      300_000,
+      300_000,
+      300_000,
+      300_000,
+      300_000,
+    ]) {
+      await vi.advanceTimersByTimeAsync(delay);
+    }
+
+    expect(bootstrapIfNeeded).toHaveBeenCalledTimes(12);
     module.onModuleDestroy();
   });
 });

--- a/apps/api/src/bridge/bridge.module.ts
+++ b/apps/api/src/bridge/bridge.module.ts
@@ -1,6 +1,7 @@
 import { Module, type OnApplicationBootstrap, type OnModuleDestroy } from '@nestjs/common';
 
 import { AuditModule } from '../audit/audit.module.js';
+import { UserModule } from '../users/user.module.js';
 import { BridgeAuthGuard } from './bridge-auth.guard.js';
 import { BridgeEventController } from './bridge-event.controller.js';
 import { BridgeEventService } from './bridge-event.service.js';
@@ -9,10 +10,10 @@ import { BridgeRateLimitGuard } from './bridge-rate-limit.guard.js';
 import { DocmostBootstrapService } from './docmost-bootstrap.service.js';
 
 const DOCMOST_BOOTSTRAP_RETRY_INTERVAL_MS = 60_000;
-const DOCMOST_BOOTSTRAP_MAX_RETRIES = 10;
+const DOCMOST_BOOTSTRAP_MAX_RETRY_INTERVAL_MS = 300_000;
 
 @Module({
-  imports: [AuditModule],
+  imports: [AuditModule, UserModule],
   controllers: [BridgeEventController],
   providers: [
     BridgeAuthGuard,
@@ -25,7 +26,9 @@ const DOCMOST_BOOTSTRAP_MAX_RETRIES = 10;
 })
 export class BridgeModule implements OnApplicationBootstrap, OnModuleDestroy {
   private retryTimer: NodeJS.Timeout | undefined;
-  private retryCount = 0;
+  private retryDelayMs = DOCMOST_BOOTSTRAP_RETRY_INTERVAL_MS;
+  private isBootstrapping = false;
+  private isDestroyed = false;
 
   constructor(private readonly docmostBootstrapService: DocmostBootstrapService) {}
 
@@ -37,25 +40,53 @@ export class BridgeModule implements OnApplicationBootstrap, OnModuleDestroy {
   }
 
   onModuleDestroy(): void {
+    this.isDestroyed = true;
     this.clearRetryTimer();
   }
 
   private startRetryTimer(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+
     if (this.retryTimer !== undefined) {
       return;
     }
 
-    this.retryTimer = setInterval(() => {
+    this.retryTimer = setTimeout(() => {
       void this.runRetry();
-    }, DOCMOST_BOOTSTRAP_RETRY_INTERVAL_MS);
+    }, this.retryDelayMs);
   }
 
   private async runRetry(): Promise<void> {
-    this.retryCount += 1;
-    const completed = await this.tryBootstrap();
-    if (completed || this.retryCount >= DOCMOST_BOOTSTRAP_MAX_RETRIES) {
-      this.clearRetryTimer();
+    this.retryTimer = undefined;
+    if (this.isBootstrapping) {
+      this.startRetryTimer();
+      return;
     }
+
+    this.isBootstrapping = true;
+    let completed = false;
+    try {
+      completed = await this.tryBootstrap();
+    } finally {
+      this.isBootstrapping = false;
+    }
+
+    if (completed) {
+      this.retryDelayMs = DOCMOST_BOOTSTRAP_RETRY_INTERVAL_MS;
+      return;
+    }
+
+    if (this.isDestroyed) {
+      return;
+    }
+
+    this.retryDelayMs = Math.min(
+      this.retryDelayMs * 2,
+      DOCMOST_BOOTSTRAP_MAX_RETRY_INTERVAL_MS,
+    );
+    this.startRetryTimer();
   }
 
   private async tryBootstrap(): Promise<boolean> {
@@ -71,7 +102,7 @@ export class BridgeModule implements OnApplicationBootstrap, OnModuleDestroy {
       return;
     }
 
-    clearInterval(this.retryTimer);
+    clearTimeout(this.retryTimer);
     this.retryTimer = undefined;
   }
 }

--- a/apps/api/src/bridge/bridge.module.ts
+++ b/apps/api/src/bridge/bridge.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, type OnApplicationBootstrap, type OnModuleDestroy } from '@nestjs/common';
 
 import { AuditModule } from '../audit/audit.module.js';
 import { BridgeAuthGuard } from './bridge-auth.guard.js';
@@ -6,11 +6,72 @@ import { BridgeEventController } from './bridge-event.controller.js';
 import { BridgeEventService } from './bridge-event.service.js';
 import { BridgeQueueService } from './bridge-queue.service.js';
 import { BridgeRateLimitGuard } from './bridge-rate-limit.guard.js';
+import { DocmostBootstrapService } from './docmost-bootstrap.service.js';
+
+const DOCMOST_BOOTSTRAP_RETRY_INTERVAL_MS = 60_000;
+const DOCMOST_BOOTSTRAP_MAX_RETRIES = 10;
 
 @Module({
   imports: [AuditModule],
   controllers: [BridgeEventController],
-  providers: [BridgeAuthGuard, BridgeRateLimitGuard, BridgeEventService, BridgeQueueService],
+  providers: [
+    BridgeAuthGuard,
+    BridgeRateLimitGuard,
+    BridgeEventService,
+    BridgeQueueService,
+    DocmostBootstrapService,
+  ],
   exports: [BridgeQueueService],
 })
-export class BridgeModule {}
+export class BridgeModule implements OnApplicationBootstrap, OnModuleDestroy {
+  private retryTimer: NodeJS.Timeout | undefined;
+  private retryCount = 0;
+
+  constructor(private readonly docmostBootstrapService: DocmostBootstrapService) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    const completed = await this.tryBootstrap();
+    if (!completed) {
+      this.startRetryTimer();
+    }
+  }
+
+  onModuleDestroy(): void {
+    this.clearRetryTimer();
+  }
+
+  private startRetryTimer(): void {
+    if (this.retryTimer !== undefined) {
+      return;
+    }
+
+    this.retryTimer = setInterval(() => {
+      void this.runRetry();
+    }, DOCMOST_BOOTSTRAP_RETRY_INTERVAL_MS);
+  }
+
+  private async runRetry(): Promise<void> {
+    this.retryCount += 1;
+    const completed = await this.tryBootstrap();
+    if (completed || this.retryCount >= DOCMOST_BOOTSTRAP_MAX_RETRIES) {
+      this.clearRetryTimer();
+    }
+  }
+
+  private async tryBootstrap(): Promise<boolean> {
+    try {
+      return await this.docmostBootstrapService.bootstrapIfNeeded();
+    } catch {
+      return false;
+    }
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer === undefined) {
+      return;
+    }
+
+    clearInterval(this.retryTimer);
+    this.retryTimer = undefined;
+  }
+}

--- a/apps/api/src/bridge/docmost-bootstrap.service.ts
+++ b/apps/api/src/bridge/docmost-bootstrap.service.ts
@@ -95,7 +95,7 @@ export class DocmostBootstrapService {
 
       if (bootstrapResponse.ok) {
         getApiLogger().info(
-          { email: config.adminEmail, workspace_name: payload.workspaceName },
+          { workspace_name: payload.workspaceName },
           'Docmost workspace bootstrap completed',
         );
         return true;
@@ -223,13 +223,8 @@ function isWorkspaceInitialized(health: BridgeHealthResponse): boolean {
 
 async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), DOCMOST_BOOTSTRAP_FETCH_TIMEOUT_MS);
-
-  try {
-    return await fetch(input, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
+  setTimeout(() => controller.abort(), DOCMOST_BOOTSTRAP_FETCH_TIMEOUT_MS);
+  return fetch(input, { ...init, signal: controller.signal });
 }
 
 function generateBootstrapPassword(): string {

--- a/apps/api/src/bridge/docmost-bootstrap.service.ts
+++ b/apps/api/src/bridge/docmost-bootstrap.service.ts
@@ -1,0 +1,188 @@
+import { Injectable } from '@nestjs/common';
+import { createHash, createHmac, randomUUID } from 'node:crypto';
+
+import { getApiLogger } from '../common/logger/logger.module.js';
+
+type BridgeHealthResponse = {
+  workspace_initialized?: unknown;
+  workspace_count?: unknown;
+};
+
+type BootstrapPayload = {
+  workspaceName: string;
+  name: string;
+  email: string;
+  password: string;
+};
+
+@Injectable()
+export class DocmostBootstrapService {
+  async bootstrapIfNeeded(): Promise<boolean> {
+    const config = this.getConfig();
+    if (config === undefined) {
+      return true;
+    }
+
+    try {
+      const healthPath = '/api/internal/bridge/health';
+      const healthResponse = await fetch(`${config.baseUrl}${healthPath}`, {
+        method: 'GET',
+        headers: createBridgeHeaders({
+          secret: config.secret,
+          method: 'GET',
+          path: healthPath,
+          body: '',
+        }),
+      });
+
+      if (!healthResponse.ok) {
+        await healthResponse.body?.cancel().catch(() => undefined);
+        getApiLogger().warn(
+          { status: healthResponse.status },
+          'Docmost workspace bootstrap health check failed',
+        );
+        return false;
+      }
+
+      const health = readHealthResponse(await healthResponse.json());
+      if (isWorkspaceInitialized(health)) {
+        return true;
+      }
+
+      const payload: BootstrapPayload = {
+        workspaceName: process.env.CHERRY_TENANT_NAME?.trim() || 'CherryWiki',
+        name: 'Admin',
+        email: config.adminEmail,
+        password: config.adminPassword,
+      };
+      const body = JSON.stringify(payload);
+      const bootstrapPath = '/api/internal/bridge/bootstrap';
+      const bootstrapResponse = await fetch(`${config.baseUrl}${bootstrapPath}`, {
+        method: 'POST',
+        headers: {
+          ...createBridgeHeaders({
+            secret: config.secret,
+            method: 'POST',
+            path: bootstrapPath,
+            body,
+          }),
+          'content-type': 'application/json',
+        },
+        body,
+      });
+
+      if (bootstrapResponse.ok) {
+        getApiLogger().info(
+          { email: config.adminEmail, workspace_name: payload.workspaceName },
+          'Docmost workspace bootstrap completed',
+        );
+        return true;
+      }
+
+      await bootstrapResponse.body?.cancel().catch(() => undefined);
+      if (bootstrapResponse.status === 409) {
+        getApiLogger().info('Docmost workspace already initialized');
+        return true;
+      }
+
+      getApiLogger().warn(
+        { status: bootstrapResponse.status },
+        'Docmost workspace bootstrap failed',
+      );
+      return false;
+    } catch (err) {
+      getApiLogger().warn(
+        { err: toSafeErrorMessage(err) },
+        'Docmost workspace bootstrap skipped',
+      );
+      return false;
+    }
+  }
+
+  private getConfig():
+    | {
+        baseUrl: string;
+        secret: string;
+        adminEmail: string;
+        adminPassword: string;
+      }
+    | undefined {
+    const baseUrl = process.env.DOCMOST_BASE_URL?.trim().replace(/\/+$/, '');
+    const secret = process.env.DOCMOST_BRIDGE_SECRET?.trim();
+    const adminEmail = process.env.DOCMOST_ADMIN_EMAIL?.trim();
+    const adminPassword = process.env.DOCMOST_ADMIN_PASSWORD?.trim();
+
+    if (!baseUrl) {
+      return undefined;
+    }
+
+    if (!secret || !adminEmail || !adminPassword) {
+      getApiLogger().warn(
+        {
+          docmost_bridge_secret_present: Boolean(secret),
+          docmost_admin_email_present: Boolean(adminEmail),
+          docmost_admin_password_present: Boolean(adminPassword),
+        },
+        'Docmost workspace bootstrap is not configured',
+      );
+      return undefined;
+    }
+
+    return { baseUrl, secret, adminEmail, adminPassword };
+  }
+}
+
+export function createBridgeHeaders(opts: {
+  secret: string;
+  method: string;
+  path: string;
+  body: string;
+}): Record<string, string> {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const nonce = randomUUID();
+  const bodyHash = createHash('sha256').update(opts.body).digest('hex');
+  const signaturePayload = [
+    timestamp,
+    nonce,
+    opts.method.toUpperCase(),
+    opts.path,
+    bodyHash,
+  ].join('\n');
+  const signature = createHmac('sha256', opts.secret)
+    .update(signaturePayload)
+    .digest('hex');
+
+  return {
+    Authorization: `Bearer ${opts.secret}`,
+    'X-Bridge-Timestamp': timestamp,
+    'X-Bridge-Nonce': nonce,
+    'X-Bridge-Signature': `sha256=${signature}`,
+  };
+}
+
+function readHealthResponse(value: unknown): BridgeHealthResponse {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+function isWorkspaceInitialized(health: BridgeHealthResponse): boolean {
+  if (typeof health.workspace_initialized === 'boolean') {
+    return health.workspace_initialized;
+  }
+
+  if (typeof health.workspace_count === 'number') {
+    return health.workspace_count > 0;
+  }
+
+  if (typeof health.workspace_count === 'string') {
+    const parsed = Number(health.workspace_count);
+    return Number.isFinite(parsed) && parsed > 0;
+  }
+
+  return false;
+}
+
+function toSafeErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/apps/api/src/bridge/docmost-bootstrap.service.ts
+++ b/apps/api/src/bridge/docmost-bootstrap.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { createHash, createHmac, randomUUID } from 'node:crypto';
+import { createHash, createHmac, randomBytes, randomUUID } from 'node:crypto';
 
 import { getApiLogger } from '../common/logger/logger.module.js';
+import { UserService } from '../users/user.service.js';
+
+const DOCMOST_BOOTSTRAP_FETCH_TIMEOUT_MS = 10_000;
 
 type BridgeHealthResponse = {
   workspace_initialized?: unknown;
@@ -15,17 +18,36 @@ type BootstrapPayload = {
   password: string;
 };
 
+type BootstrapConfig = {
+  baseUrl: string;
+  secret: string;
+  adminEmail: string;
+  adminPassword: string;
+};
+
+type ConfigResolution =
+  | { status: 'ready'; config: BootstrapConfig }
+  | { status: 'disabled' }
+  | { status: 'pending' };
+
 @Injectable()
 export class DocmostBootstrapService {
+  constructor(private readonly userService?: UserService) {}
+
   async bootstrapIfNeeded(): Promise<boolean> {
-    const config = this.getConfig();
-    if (config === undefined) {
+    const configResolution = await this.getConfig();
+    if (configResolution.status === 'disabled') {
       return true;
     }
 
+    if (configResolution.status === 'pending') {
+      return false;
+    }
+
+    const config = configResolution.config;
     try {
       const healthPath = '/api/internal/bridge/health';
-      const healthResponse = await fetch(`${config.baseUrl}${healthPath}`, {
+      const healthResponse = await fetchWithTimeout(`${config.baseUrl}${healthPath}`, {
         method: 'GET',
         headers: createBridgeHeaders({
           secret: config.secret,
@@ -57,7 +79,7 @@ export class DocmostBootstrapService {
       };
       const body = JSON.stringify(payload);
       const bootstrapPath = '/api/internal/bridge/bootstrap';
-      const bootstrapResponse = await fetch(`${config.baseUrl}${bootstrapPath}`, {
+      const bootstrapResponse = await fetchWithTimeout(`${config.baseUrl}${bootstrapPath}`, {
         method: 'POST',
         headers: {
           ...createBridgeHeaders({
@@ -99,36 +121,52 @@ export class DocmostBootstrapService {
     }
   }
 
-  private getConfig():
-    | {
-        baseUrl: string;
-        secret: string;
-        adminEmail: string;
-        adminPassword: string;
-      }
-    | undefined {
+  private async getConfig(): Promise<ConfigResolution> {
     const baseUrl = process.env.DOCMOST_BASE_URL?.trim().replace(/\/+$/, '');
     const secret = process.env.DOCMOST_BRIDGE_SECRET?.trim();
     const adminEmail = process.env.DOCMOST_ADMIN_EMAIL?.trim();
-    const adminPassword = process.env.DOCMOST_ADMIN_PASSWORD?.trim();
+    const adminPassword =
+      process.env.DOCMOST_ADMIN_PASSWORD?.trim() || generateBootstrapPassword();
 
-    if (!baseUrl) {
-      return undefined;
-    }
-
-    if (!secret || !adminEmail || !adminPassword) {
+    if (!baseUrl || !secret) {
       getApiLogger().warn(
         {
+          docmost_base_url_present: Boolean(baseUrl),
           docmost_bridge_secret_present: Boolean(secret),
-          docmost_admin_email_present: Boolean(adminEmail),
-          docmost_admin_password_present: Boolean(adminPassword),
         },
         'Docmost workspace bootstrap is not configured',
       );
-      return undefined;
+      return { status: 'disabled' };
     }
 
-    return { baseUrl, secret, adminEmail, adminPassword };
+    const resolvedAdminEmail = adminEmail || (await this.getFirstAdminEmail());
+    if (!resolvedAdminEmail) {
+      getApiLogger().warn(
+        {
+          docmost_admin_email_present: Boolean(adminEmail),
+          cherry_admin_user_present: false,
+        },
+        'Docmost workspace bootstrap is waiting for a Cherry admin user',
+      );
+      return { status: 'pending' };
+    }
+
+    return {
+      status: 'ready',
+      config: { baseUrl, secret, adminEmail: resolvedAdminEmail, adminPassword },
+    };
+  }
+
+  private async getFirstAdminEmail(): Promise<string | undefined> {
+    try {
+      return (await this.userService?.findFirstAdminUser())?.email;
+    } catch (err) {
+      getApiLogger().warn(
+        { err: toSafeErrorMessage(err) },
+        'Docmost workspace bootstrap admin fallback lookup failed',
+      );
+      return undefined;
+    }
   }
 }
 
@@ -181,6 +219,21 @@ function isWorkspaceInitialized(health: BridgeHealthResponse): boolean {
   }
 
   return false;
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DOCMOST_BOOTSTRAP_FETCH_TIMEOUT_MS);
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function generateBootstrapPassword(): string {
+  return randomBytes(32).toString('base64url');
 }
 
 function toSafeErrorMessage(err: unknown): string {

--- a/apps/api/src/users/user.service.ts
+++ b/apps/api/src/users/user.service.ts
@@ -65,6 +65,13 @@ export type AdminUserResponse = {
   created_at: Date;
 };
 
+export type AdminUserIdentity = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+};
+
 type UserSortField = keyof Pick<
   typeof users,
   'created_at' | 'email' | 'display_name' | 'role' | 'status' | 'last_login_at'
@@ -353,6 +360,29 @@ export class UserService {
         email: existing.email,
       },
     });
+  }
+
+  async findFirstAdminUser(context: AdminContext = {}): Promise<AdminUserIdentity | undefined> {
+    const tenantId = await this.resolveTenantId(context);
+    const [user] = await this.db
+      .select({
+        id: users.id,
+        email: users.email,
+        name: users.display_name,
+        role: users.role,
+      })
+      .from(users)
+      .where(
+        and(
+          eq(users.tenant_id, tenantId),
+          inArray(users.role, [ROLES.OWNER, ROLES.ADMIN]),
+          eq(users.status, 'active'),
+        ),
+      )
+      .orderBy(asc(users.created_at))
+      .limit(1);
+
+    return user;
   }
 
   private async getUserGroupIds(tenantId: string, userIds: string[]): Promise<Map<string, string[]>> {

--- a/apps/web/src/__tests__/overview.test.tsx
+++ b/apps/web/src/__tests__/overview.test.tsx
@@ -97,10 +97,10 @@ describe('SpaceOverviewPage', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
-    expect(await screen.findByText('13')).toBeInTheDocument();
     await waitFor(() => {
+      expect(screen.getByText('13')).toBeInTheDocument();
       expect(countRequests(fetchMock, '/api/spaces/space-1/stats')).toBeGreaterThanOrEqual(2);
-    });
+    }, { timeout: 5000 });
   });
 
   it('renders quick actions with the expected routes', async () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,11 @@ services:
       MODEL_API_KEY: ${MODEL_API_KEY:-dev-model-key}
       DEFAULT_CHAT_MODEL: ${DEFAULT_CHAT_MODEL:-gpt-4.1}
       DEFAULT_EMBEDDING_MODEL: ${DEFAULT_EMBEDDING_MODEL:-text-embedding-3-large}
-      DOCMOST_BASE_URL: ${DOCMOST_BASE_URL:-http://localhost:3000}
+      DOCMOST_BASE_URL: ${DOCMOST_BASE_URL:-http://docmost:3000}
       DOCMOST_BRIDGE_SECRET: ${DOCMOST_BRIDGE_SECRET:-dev-docmost-bridge-secret}
       DOCMOST_BRIDGE_SECRET_NEXT: ${DOCMOST_BRIDGE_SECRET_NEXT:-}
+      DOCMOST_ADMIN_EMAIL: ${DOCMOST_ADMIN_EMAIL:-admin@cherrywiki.local}
+      DOCMOST_ADMIN_PASSWORD: ${DOCMOST_ADMIN_PASSWORD:-changeme-initial-setup}
       AGENT_ANTHROPIC_API_KEY: ${AGENT_ANTHROPIC_API_KEY:-}
       AGENT_ANTHROPIC_BASE_URL: ${AGENT_ANTHROPIC_BASE_URL:-}
       AGENT_ANTHROPIC_MODEL: ${AGENT_ANTHROPIC_MODEL:-deepseek-v4-flash}
@@ -479,7 +481,7 @@ services:
     restart: unless-stopped
     working_dir: /app
     command: >-
-      sh -c "corepack enable && pnpm install --frozen-lockfile && pnpm build && node apps/wiki-sync-worker/dist/main.js"
+      sh -c "corepack enable && pnpm install --frozen-lockfile && pnpm --filter @cherrygraph/shared --filter @cherrygraph/wiki-core --filter wiki-sync-worker build && node apps/wiki-sync-worker/dist/main.js"
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://cherrygraph:cherrygraph_dev@postgres:5432/cherrygraph}
       REDIS_URL: ${COMPOSE_REDIS_URL:-redis://redis:6379}

--- a/openspec/changes/docmost-auto-sync/tasks.md
+++ b/openspec/changes/docmost-auto-sync/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Docmost Auto Sync
+
+## docmost-workspace-bootstrap
+
+- [ ] 1.1 Docmost Fork: 新增 `workspace-bootstrap.controller.ts`，实现 `POST /api/internal/bridge/bootstrap`，接受 `{ workspaceName, name, email, password }`（与 `CreateAdminUserDto` 对齐），调用 `SignupService.initialSetup()`
+- [ ] 1.2 Docmost Fork: `bridge.module.ts` 注册 WorkspaceBootstrapController + `imports: [AuthModule]`（提供 SignupService）
+- [ ] 1.3 Docmost Fork: bridge/health 端点返回值增加 `workspace_initialized: boolean` 字段
+- [ ] 1.4 Cherry API: 新增 `apps/api/src/bridge/docmost-bootstrap.service.ts`，实现 `bootstrapIfNeeded()`：检查 bridge/health 的 workspace_initialized → 为 false 时调用 bootstrap 端点；失败时 warn 日志，不阻塞启动
+- [ ] 1.5 Cherry API: 在 `BridgeModule.onApplicationBootstrap()` 中调用 `bootstrapIfNeeded()`（catch 全部错误）；同时注册定时重试（如 Docmost 启动后）
+- [ ] 1.6 `.env.example` 增加 `DOCMOST_ADMIN_EMAIL` 和 `DOCMOST_ADMIN_PASSWORD` 变量说明
+- [ ] 1.7 测试（Docmost Fork 端）：
+  - [ ] 1.7.1 POST /api/internal/bridge/bootstrap 成功创建 workspace + admin user（验证返回 201 + workspace_id/user_id）
+  - [ ] 1.7.2 POST /api/internal/bridge/bootstrap 在 workspace 已存在时返回 409（幂等性）
+  - [ ] 1.7.3 POST /api/internal/bridge/bootstrap 缺少必填字段返回 400
+  - [ ] 1.7.4 GET /api/internal/bridge/health 返回 workspace_initialized: true/false
+  - [ ] 1.7.5 BridgeAuthGuard 拒绝无签名请求
+- [ ] 1.8 测试（Cherry API 端）：
+  - [ ] 1.8.1 bootstrapIfNeeded() 当 health 返回 workspace_initialized=false 时调用 bootstrap 端点
+  - [ ] 1.8.2 bootstrapIfNeeded() 当 health 返回 workspace_initialized=true 时跳过（无调用）
+  - [ ] 1.8.3 bootstrapIfNeeded() 当 Docmost 不可达时 warn 日志不抛异常
+  - [ ] 1.8.4 onApplicationBootstrap 调用 bootstrapIfNeeded 并 catch 全部错误
+  - [ ] 1.8.5 定时重试：首次失败后在下次定时触发时重新尝试
+
+## space-auto-provision
+
+- [ ] 2.1 Docmost Fork: 新增 `space-provision.controller.ts`，实现 `POST /api/internal/bridge/spaces`，接受 `{ name, slug, cherry_space_id }`，使用 SpaceService 创建或查找 Space
+- [ ] 2.2 Docmost Fork: `bridge.module.ts` 注册 SpaceProvisionController + `imports: [SpaceModule]`（提供 SpaceService）
+- [ ] 2.3 Cherry API: `BridgeQueueService` 增加 `enqueueSpaceProvisionJob({ spaceId, tenantId })` 方法 + `bridge-space-provision` 队列常量
+- [ ] 2.4 Cherry API: `SpaceModule` 添加 `imports: [BridgeModule]`，使 BridgeQueueService 可在 SpaceService 中注入
+- [ ] 2.5 Cherry API: `SpaceService.createSpace()` 成功后调用 `bridgeQueueService.enqueueSpaceProvisionJob()`
+- [ ] 2.6 Wiki-sync worker: `main.ts` 注册 `bridge-space-provision` 队列常量、Queue 实例、Worker 实例，加入 health/shutdown 流程
+- [ ] 2.7 Wiki-sync worker: 新增 `space-provision.processor.ts`，消费队列：调用 Docmost Bridge 创建 Space → 更新 `spaces.docmost_space_id`
+- [ ] 2.8 Wiki-sync worker: `reconcileOnStartup` 增加 Space 对账：查找 `docmost_space_id = null` 的 active Space → 逐个入队
+- [ ] 2.9 测试：创建 Space → docmost_space_id 自动回填 → Docmost 中可见；启动对账回填已有 Space
+
+## graphify-docmost-push-trigger
+
+- [ ] 3.1 在 `InternalJobsService.handleGraphifyCompletion()` 中（已有 enqueue 调用处），增加 `spaces.docmost_space_id` 检查：仅在非 null 时 enqueue docmost-push
+- [ ] 3.2 确保 InternalJobsService 已注入 SpaceService 或可查询 spaces 表获取 docmost_space_id
+- [ ] 3.3 测试：Graphify 完成（mapped space）→ docmost-push 队列有任务 → Docmost 中出现 wiki 页面；Graphify 完成（unmapped space）→ 无 push 任务
+
+## user-permission-sync
+
+- [ ] 4.1 Docmost Fork: 新增 `user-sync.controller.ts`，实现 `POST /api/internal/bridge/users`，接受 `{ email, name, cherry_user_id }`，使用 UserService 查找/创建用户（生成随机密码，关联默认 workspace+group）
+- [ ] 4.2 Docmost Fork: `bridge.module.ts` 注册 UserSyncController + `imports: [UserModule, WorkspaceModule]`
+- [ ] 4.3 Cherry API: 在用户创建后通过 BridgeQueueService 推入 `bridge-user-sync` 队列；UserModule 添加 `imports: [BridgeModule]`
+- [ ] 4.4 Wiki-sync worker: `main.ts` 注册 `bridge-user-sync` 队列 + Worker + health/shutdown
+- [ ] 4.5 Wiki-sync worker: 新增 `user-sync.processor.ts`，消费队列调用 Docmost Bridge 创建用户
+- [ ] 4.6 **修复权限同步契约不匹配**：Cherry worker 发送 `{ members: [...] }` 格式（admin|writer|reader），Docmost 端点期望 `{ groups: [...], version, source }` 格式（view|edit|admin）。统一为一方：要么 Cherry 侧 `bridge-client.ts` 改为 Docmost 期望的格式，要么 Docmost `permissions.controller.ts` 适配 Cherry 格式
+- [ ] 4.7 Cherry API: `bridge-permission-hooks.ts` 当前仅是 helper 函数，未接入任何 mutation 路径。在 `GroupService` 成员变更和 `SpaceService` 权限变更的 commit 后显式调用 `BridgeQueueService.enqueuePermissionSyncJob()`
+- [ ] 4.8 Cherry API: `GroupModule` 和 `SpaceModule` 添加 `imports: [BridgeModule]`
+- [ ] 4.9 Wiki-sync worker: 修改 `reconcilePermissions` 在 worker 启动时立即执行一次（当前仅 hourly timer）
+- [ ] 4.10 测试：创建用户 → Docmost 可见；Group 成员变更 → Docmost Space 权限更新；启动时权限对账

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,14 @@ export default defineConfig({
     ],
   },
   test: {
-    include: ['packages/**/src/**/*.test.ts', 'apps/**/src/**/*.test.ts', 'apps/**/src/**/*.test.tsx', 'tests/**/*.test.ts'],
+    name: 'api',
+    include: [
+      'packages/**/src/**/*.test.ts',
+      'apps/**/src/**/*.test.ts',
+      'apps/**/src/**/*.spec.ts',
+      'apps/**/src/**/*.test.tsx',
+      'tests/**/*.test.ts',
+    ],
     exclude: runsExplicitWebTest ? configDefaults.exclude : [...configDefaults.exclude, 'apps/web/**'],
     passWithNoTests: true,
     coverage: {


### PR DESCRIPTION
## Summary

- Docmost Fork: `POST /api/internal/bridge/bootstrap` endpoint for automated workspace + admin user creation with HMAC auth
- Docmost Fork: `GET /api/internal/bridge/health` now returns `workspace_initialized` field
- Cherry API: `DocmostBootstrapService.bootstrapIfNeeded()` with signed bridge requests, 10s fetch timeout
- Cherry API: `BridgeModule.onApplicationBootstrap()` with exponential backoff retry, in-flight guard
- Cherry API: Admin email fallback to first Cherry admin user when env var absent
- Docmost: Atomic workspace bootstrap with `pg_advisory_xact_lock`
- `.env.example` + `docker-compose.yml`: `DOCMOST_ADMIN_EMAIL` and `DOCMOST_ADMIN_PASSWORD`
- Tests: 5 Jest (Docmost) + 9 Vitest (Cherry API)
- Fix: stabilize flaky overview refresh test

## Test plan

- [x] Build passes (`pnpm --filter @cherrygraph/api build`)
- [x] Lint passes (`pnpm --filter @cherrygraph/api lint`)
- [x] API tests pass (1176 tests, 9 new for bootstrap)
- [x] Docmost bridge tests pass (5 new for bootstrap/health)
- [x] Web tests pass (134 tests, flaky test fixed)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `5861350042b009a28c84a6953b193ceb83b1b743`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/282#issuecomment-4427511750) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/282#issuecomment-4427511877) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/282#issuecomment-4427511990) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/282#issuecomment-4427512133)
- Key findings addressed: fetch timeout extended through body consumption, retry cap replaced with exponential backoff, atomic workspace bootstrap with advisory lock, admin email fallback, docker-compose env mapping, overlapping retry guard, admin email removed from logs

Closes #272