### PR TITLE
feat(bridge): auto-provision Docmost space (#273)

### DIFF
--- a/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
@@ -6,6 +6,7 @@ import {
   BRIDGE_ATTACHMENT_SYNC_QUEUE,
   BRIDGE_PAGE_SYNC_QUEUE,
   BRIDGE_PERMISSION_SYNC_QUEUE,
+  BRIDGE_SPACE_PROVISION_QUEUE,
   BridgeQueueService,
 } from '../bridge-queue.service.js';
 
@@ -105,6 +106,28 @@ describe('BridgeQueueService', () => {
     expect(queueByName(BRIDGE_PERMISSION_SYNC_QUEUE).add).toHaveBeenCalledWith(
       'permission.sync',
       { tenantId: 'tenant-1', spaceId: 'space-1' },
+      { jobId: 'tenant-1:space-1' },
+    );
+  });
+
+  it('enqueues space provision jobs with tenant-space deduplication', async () => {
+    const service = createService();
+
+    await service.enqueueSpaceProvisionJob({
+      tenantId: 'tenant-1',
+      spaceId: 'space-1',
+      spaceName: 'Research',
+      spaceSlug: 'research',
+    });
+
+    expect(queueByName(BRIDGE_SPACE_PROVISION_QUEUE).add).toHaveBeenCalledWith(
+      'space.provision',
+      {
+        tenantId: 'tenant-1',
+        spaceId: 'space-1',
+        spaceName: 'Research',
+        spaceSlug: 'research',
+      },
       { jobId: 'tenant-1:space-1' },
     );
   });

--- a/apps/api/src/bridge/bridge-queue.service.ts
+++ b/apps/api/src/bridge/bridge-queue.service.ts
@@ -11,12 +11,14 @@ export const BRIDGE_PAGE_SYNC_QUEUE = 'bridge-page-sync';
 export const BRIDGE_PERMISSION_SYNC_QUEUE = 'bridge-permission-sync';
 export const BRIDGE_ATTACHMENT_SYNC_QUEUE = 'bridge-attachment-sync';
 export const BRIDGE_DOCMOST_PUSH_QUEUE = 'bridge-docmost-push';
+export const BRIDGE_SPACE_PROVISION_QUEUE = 'bridge-space-provision';
 
 export type BridgeQueueName =
   | typeof BRIDGE_PAGE_SYNC_QUEUE
   | typeof BRIDGE_PERMISSION_SYNC_QUEUE
   | typeof BRIDGE_ATTACHMENT_SYNC_QUEUE
-  | typeof BRIDGE_DOCMOST_PUSH_QUEUE;
+  | typeof BRIDGE_DOCMOST_PUSH_QUEUE
+  | typeof BRIDGE_SPACE_PROVISION_QUEUE;
 
 export type BridgeQueueJobData = {
   bridgeEventId: string;
@@ -37,6 +39,13 @@ export type PermissionSyncJobData = {
   tenantId: string;
 };
 
+export type SpaceProvisionJobData = {
+  spaceId: string;
+  tenantId: string;
+  spaceName: string;
+  spaceSlug: string;
+};
+
 const DEFAULT_JOB_OPTIONS: JobsOptions = {
   attempts: 3,
   backoff: {
@@ -53,7 +62,7 @@ export class BridgeQueueService implements OnModuleDestroy {
   private readonly ownsConnection: boolean;
   private readonly disabled: boolean;
   private readonly queues: Partial<
-    Record<BridgeQueueName, Queue<BridgeQueueJobData | DocmostPushJobData | PermissionSyncJobData>>
+    Record<BridgeQueueName, Queue<BridgeQueueJobData | DocmostPushJobData | PermissionSyncJobData | SpaceProvisionJobData>>
   >;
 
   constructor(@Optional() @Inject(REDIS_CLIENT) redis?: OptionalRedisClient) {
@@ -88,6 +97,10 @@ export class BridgeQueueService implements OnModuleDestroy {
         defaultJobOptions: DEFAULT_JOB_OPTIONS,
       }),
       [BRIDGE_DOCMOST_PUSH_QUEUE]: new Queue(BRIDGE_DOCMOST_PUSH_QUEUE, {
+        connection,
+        defaultJobOptions: DEFAULT_JOB_OPTIONS,
+      }),
+      [BRIDGE_SPACE_PROVISION_QUEUE]: new Queue(BRIDGE_SPACE_PROVISION_QUEUE, {
         connection,
         defaultJobOptions: DEFAULT_JOB_OPTIONS,
       }),
@@ -135,6 +148,20 @@ export class BridgeQueueService implements OnModuleDestroy {
     });
   }
 
+  async enqueueSpaceProvisionJob(jobData: SpaceProvisionJobData): Promise<void> {
+    if (this.disabled) {
+      getApiLogger().warn(
+        { redis_configured: false },
+        'BullMQ dispatch disabled — no Redis configured',
+      );
+      return;
+    }
+
+    await this.getQueue(BRIDGE_SPACE_PROVISION_QUEUE).add('space.provision', jobData, {
+      jobId: `${jobData.tenantId}:${jobData.spaceId}`,
+    });
+  }
+
   async onModuleDestroy(): Promise<void> {
     if (this.disabled) {
       return;
@@ -156,7 +183,7 @@ export class BridgeQueueService implements OnModuleDestroy {
 
   private getQueue(
     queueName: BridgeQueueName,
-  ): Queue<BridgeQueueJobData | DocmostPushJobData | PermissionSyncJobData> {
+  ): Queue<BridgeQueueJobData | DocmostPushJobData | PermissionSyncJobData | SpaceProvisionJobData> {
     const queue = this.queues[queueName];
     if (queue === undefined) {
       throw new Error(`Bridge queue is not initialized: ${queueName}`);

--- a/apps/api/src/spaces/__tests__/space-provision.spec.ts
+++ b/apps/api/src/spaces/__tests__/space-provision.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  TEST_ACTOR_ID,
+  TEST_TENANT_ID,
+  ScriptedDb,
+  createAuditMock,
+  createRedisMock,
+} from '../../users/__tests__/user-group-service-test-utils.js';
+import { SpaceService } from '../space.service.js';
+
+describe('SpaceService Docmost space provision', () => {
+  it('calls enqueueSpaceProvisionJob after insert', async () => {
+    const db = new ScriptedDb();
+    const audit = createAuditMock();
+    const bridgeQueue = {
+      enqueueSpaceProvisionJob: vi.fn(() => Promise.resolve()),
+    };
+    const service = new SpaceService(
+      db.asDrizzle(),
+      audit.service,
+      createRedisMock(),
+      bridgeQueue as never,
+    );
+    db.queueSelect([]);
+
+    const created = await service.createSpace(
+      { name: 'Research', slug: 'research' },
+      {
+        tenantId: TEST_TENANT_ID,
+        actorUserId: TEST_ACTOR_ID,
+        userId: TEST_ACTOR_ID,
+        actorRole: 'admin',
+      },
+    );
+
+    expect(bridgeQueue.enqueueSpaceProvisionJob).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      spaceId: created.id,
+      spaceName: 'Research',
+      spaceSlug: 'research',
+    });
+  });
+});

--- a/apps/api/src/spaces/space.module.ts
+++ b/apps/api/src/spaces/space.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 
+import { BridgeModule } from '../bridge/bridge.module.js';
 import { GroupModule } from '../groups/group.module.js';
 import { SpaceController } from './space.controller.js';
 import { SpacePermissionController } from './space-permission.controller.js';
 import { SpaceService } from './space.service.js';
 
 @Module({
-  imports: [GroupModule],
+  imports: [GroupModule, BridgeModule],
   controllers: [SpaceController, SpacePermissionController],
   providers: [SpaceService],
   exports: [SpaceService],

--- a/apps/api/src/spaces/space.service.ts
+++ b/apps/api/src/spaces/space.service.ts
@@ -27,6 +27,7 @@ import {
 import { getApiLogger } from '../common/logger/logger.module.js';
 import { REDIS_CLIENT } from '../common/redis/redis.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
+import { BridgeQueueService } from '../bridge/bridge-queue.service.js';
 import {
   databaseConfigStorageValue,
   maskSpaceDatabaseConfig,
@@ -124,6 +125,7 @@ export class SpaceService {
     @Inject(DRIZZLE) private readonly db: SpaceDatabase,
     private readonly auditService: AuditService,
     @Optional() @Inject(REDIS_CLIENT) private readonly redis?: RedisPublisher,
+    @Optional() private readonly bridgeQueueService?: BridgeQueueService,
   ) {}
 
   async listSpaces(
@@ -209,6 +211,18 @@ export class SpaceService {
           name: created.name,
           slug: created.slug,
         },
+      });
+
+      void this.bridgeQueueService?.enqueueSpaceProvisionJob({
+        spaceId: created.id,
+        tenantId,
+        spaceName: created.name,
+        spaceSlug: created.slug,
+      }).catch((err: unknown) => {
+        getApiLogger().warn(
+          { err: toSafeErrorMessage(err), space_id: created.id },
+          'Docmost space provision enqueue failed',
+        );
       });
 
       return toSpaceDetail(created);
@@ -771,6 +785,10 @@ function escapeLikePattern(value: string): string {
 
 function normalizeSlug(slug: string): string {
   return slug.trim();
+}
+
+function toSafeErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function normalizePage(value: number | undefined): number {

--- a/apps/wiki-sync-worker/src/__tests__/health.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/health.test.ts
@@ -13,6 +13,7 @@ describe('wiki-sync-worker health server', () => {
         'permission-sync': { getWaitingCount: vi.fn(() => Promise.resolve(1)) },
         'attachment-sync': { getWaitingCount: vi.fn(() => Promise.resolve(4)) },
         'docmost-push': { getWaitingCount: vi.fn(() => Promise.resolve(3)) },
+        'space-provision': { getWaitingCount: vi.fn(() => Promise.resolve(5)) },
       },
       0,
     );
@@ -32,6 +33,7 @@ describe('wiki-sync-worker health server', () => {
           'permission-sync': 1,
           'attachment-sync': 4,
           'docmost-push': 3,
+          'space-provision': 5,
         },
       });
     } finally {

--- a/apps/wiki-sync-worker/src/bridge-client.ts
+++ b/apps/wiki-sync-worker/src/bridge-client.ts
@@ -1,5 +1,8 @@
+import { createHash, createHmac, randomUUID } from 'node:crypto';
+
 import type { DocmostPushBridgeClient } from './processors/docmost-push.processor.js';
 import type { PermissionSyncBridgeClient } from './processors/permission-sync.processor.js';
+import type { SpaceProvisionBridgeClient } from './processors/space-provision.processor.js';
 
 export class BridgeClientHttpError extends Error {
   constructor(
@@ -14,25 +17,58 @@ export class BridgeClientHttpError extends Error {
 export function createBridgeClient(
   baseUrl: string,
   secret: string,
-): DocmostPushBridgeClient & PermissionSyncBridgeClient {
+): DocmostPushBridgeClient & PermissionSyncBridgeClient & SpaceProvisionBridgeClient {
   const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
-  const headers = secret.length > 0 ? { Authorization: `Bearer ${secret}` } : {};
 
   return {
+    async provisionSpace(input) {
+      const path = '/api/internal/bridge/spaces';
+      const body = JSON.stringify({
+        name: input.name,
+        slug: input.slug,
+        cherry_space_id: input.cherry_space_id,
+      });
+      const response = await fetch(`${normalizedBaseUrl}${path}`, {
+        method: 'POST',
+        headers: {
+          ...createBridgeHeaders(secret, 'POST', path, body),
+          'content-type': 'application/json',
+        },
+        body,
+      });
+
+      if (!response.ok) {
+        throw new BridgeClientHttpError(
+          `Bridge space provision failed for Cherry space ${input.cherry_space_id}: HTTP ${response.status}`,
+          response.status,
+        );
+      }
+
+      const payload = readRecord(await response.json());
+      const docmostSpaceId = readString(payload.docmost_space_id);
+      if (docmostSpaceId === undefined) {
+        throw new Error('Bridge space provision response did not include docmost_space_id');
+      }
+
+      return { docmost_space_id: docmostSpaceId };
+    },
+
     async importPage(pageId, markdown, opts) {
+      const path = `/api/internal/bridge/pages/${encodeURIComponent(pageId)}/import`;
+      const body = JSON.stringify({
+        markdown,
+        overwrite_policy: opts.overwritePolicy,
+        ...(opts.expectedHash !== undefined ? { expected_hash: opts.expectedHash } : {}),
+      });
       const response = await fetch(
-        `${normalizedBaseUrl}/api/internal/bridge/pages/${encodeURIComponent(pageId)}/import`,
+        `${normalizedBaseUrl}${path}`,
         {
           method: 'PUT',
           headers: {
-            ...headers,
+            ...createBridgeHeaders(secret, 'PUT', path, body),
             'content-type': 'application/json',
           },
-          body: JSON.stringify({
-            markdown,
-            overwrite_policy: opts.overwritePolicy,
-            ...(opts.expectedHash !== undefined ? { expected_hash: opts.expectedHash } : {}),
-          }),
+          body,
         },
       );
 
@@ -54,9 +90,10 @@ export function createBridgeClient(
     },
 
     async exportPage(pageId) {
+      const path = `/api/internal/bridge/pages/${encodeURIComponent(pageId)}/export?format=markdown`;
       const response = await fetch(
-        `${normalizedBaseUrl}/api/internal/bridge/pages/${encodeURIComponent(pageId)}/export?format=markdown`,
-        { headers },
+        `${normalizedBaseUrl}${path}`,
+        { headers: createBridgeHeaders(secret, 'GET', path, '') },
       );
 
       if (!response.ok) {
@@ -76,15 +113,17 @@ export function createBridgeClient(
     },
 
     async pushPermissions(docmostSpaceId, members) {
+      const path = `/api/internal/bridge/spaces/${encodeURIComponent(docmostSpaceId)}/permissions`;
+      const body = JSON.stringify({ members });
       const response = await fetch(
-        `${normalizedBaseUrl}/api/internal/bridge/spaces/${encodeURIComponent(docmostSpaceId)}/permissions`,
+        `${normalizedBaseUrl}${path}`,
         {
           method: 'PUT',
           headers: {
-            ...headers,
+            ...createBridgeHeaders(secret, 'PUT', path, body),
             'content-type': 'application/json',
           },
-          body: JSON.stringify({ members }),
+          body,
         },
       );
 
@@ -97,9 +136,10 @@ export function createBridgeClient(
     },
 
     async getPermissions(docmostSpaceId) {
+      const path = `/api/internal/bridge/spaces/${encodeURIComponent(docmostSpaceId)}/permissions`;
       const response = await fetch(
-        `${normalizedBaseUrl}/api/internal/bridge/spaces/${encodeURIComponent(docmostSpaceId)}/permissions`,
-        { headers },
+        `${normalizedBaseUrl}${path}`,
+        { headers: createBridgeHeaders(secret, 'GET', path, '') },
       );
 
       if (!response.ok) {
@@ -113,6 +153,30 @@ export function createBridgeClient(
       const rawMembers = Array.isArray(payload) ? payload : readArray(readRecord(payload).members);
       return rawMembers.flatMap(readPermissionMember);
     },
+  };
+}
+
+function createBridgeHeaders(
+  secret: string,
+  method: string,
+  path: string,
+  body: string,
+): Record<string, string> {
+  if (secret.length === 0) {
+    return {};
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const nonce = randomUUID();
+  const bodyHash = createHash('sha256').update(body).digest('hex');
+  const payload = [timestamp, nonce, method.toUpperCase(), path, bodyHash].join('\n');
+  const signature = createHmac('sha256', secret).update(payload).digest('hex');
+
+  return {
+    Authorization: `Bearer ${secret}`,
+    'X-Bridge-Timestamp': timestamp,
+    'X-Bridge-Nonce': nonce,
+    'X-Bridge-Signature': `sha256=${signature}`,
   };
 }
 

--- a/apps/wiki-sync-worker/src/health.ts
+++ b/apps/wiki-sync-worker/src/health.ts
@@ -9,6 +9,7 @@ export type WikiSyncHealthQueues = {
   'permission-sync': PendingQueue;
   'attachment-sync': PendingQueue;
   'docmost-push': PendingQueue;
+  'space-provision': PendingQueue;
 };
 
 export type WikiSyncHealthPayload = {
@@ -18,6 +19,7 @@ export type WikiSyncHealthPayload = {
     'permission-sync': number;
     'attachment-sync': number;
     'docmost-push': number;
+    'space-provision': number;
   };
 };
 
@@ -42,11 +44,12 @@ export function createHealthServer(queues: WikiSyncHealthQueues): Server {
 }
 
 export async function buildHealthPayload(queues: WikiSyncHealthQueues): Promise<WikiSyncHealthPayload> {
-  const [pageSync, permissionSync, attachmentSync, docmostPush] = await Promise.all([
+  const [pageSync, permissionSync, attachmentSync, docmostPush, spaceProvision] = await Promise.all([
     queues['page-sync'].getWaitingCount(),
     queues['permission-sync'].getWaitingCount(),
     queues['attachment-sync'].getWaitingCount(),
     queues['docmost-push'].getWaitingCount(),
+    queues['space-provision'].getWaitingCount(),
   ]);
 
   return {
@@ -56,6 +59,7 @@ export async function buildHealthPayload(queues: WikiSyncHealthQueues): Promise<
       'permission-sync': permissionSync,
       'attachment-sync': attachmentSync,
       'docmost-push': docmostPush,
+      'space-provision': spaceProvision,
     },
   };
 }

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -11,6 +11,7 @@ import { createBridgeClient } from './bridge-client.js';
 import { closeHealthServer, startHealthServer } from './health.js';
 import { reconcileOnStartup, type ReconciliationDb } from './reconciliation.js';
 import { reconcilePermissions } from './reconciliation/permission-reconcile.js';
+import { reconcileSpaces } from './reconciliation/space-reconcile.js';
 import {
   createDocmostPushProcessor,
   type DocmostPushDeps,
@@ -24,6 +25,11 @@ import {
   createPermissionSyncProcessor,
   type PermissionSyncDeps,
 } from './processors/permission-sync.processor.js';
+import {
+  BRIDGE_SPACE_PROVISION_QUEUE,
+  createSpaceProvisionProcessor,
+  type SpaceProvisionDeps,
+} from './processors/space-provision.processor.js';
 
 const WORKER_NAME = 'wiki-sync-worker';
 const PAGE_SYNC_QUEUE = 'bridge-page-sync';
@@ -60,12 +66,14 @@ type BridgeWorkerQueues = {
   permissionSync: BullQueue;
   attachmentSync: BullQueue;
   docmostPush: BullQueue;
+  spaceProvision: BullQueue;
 };
 
 type BridgeWorkers = {
   pageSync: BullWorker;
   permissionSync: BullWorker;
   docmostPush: BullWorker;
+  spaceProvision: BullWorker;
 };
 
 export async function bootstrap(): Promise<void> {
@@ -86,6 +94,7 @@ export async function bootstrap(): Promise<void> {
   const queues = createQueues(connection);
 
   await reconcileOnStartup(db as unknown as ReconciliationDb, queues);
+  await reconcileSpaces(db as SpaceProvisionDeps['db'], queues.spaceProvision);
 
   const bridgeBaseUrl = process.env.DOCMOST_BRIDGE_BASE_URL ?? process.env.DOCMOST_BASE_URL ?? 'http://localhost:3000';
   const bridgeSecret = process.env.DOCMOST_BRIDGE_SECRET ?? process.env.DOCMOST_BRIDGE_TOKEN ?? '';
@@ -107,6 +116,10 @@ export async function bootstrap(): Promise<void> {
       db,
       bridgeClient,
     },
+    spaceProvision: {
+      db,
+      bridgeClient,
+    },
   });
   const permissionReconcileTimer = startPermissionReconcileTimer(db, bridgeClient);
 
@@ -116,6 +129,7 @@ export async function bootstrap(): Promise<void> {
       'permission-sync': queues.permissionSync,
       'attachment-sync': queues.attachmentSync,
       'docmost-push': queues.docmostPush,
+      'space-provision': queues.spaceProvision,
     },
     healthPort,
   );
@@ -132,12 +146,18 @@ function createQueues(connection: IORedis): BridgeWorkerQueues {
     permissionSync: new Queue(PERMISSION_SYNC_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
     attachmentSync: new Queue(ATTACHMENT_SYNC_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
     docmostPush: new Queue(DOCMOST_PUSH_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
+    spaceProvision: new Queue(BRIDGE_SPACE_PROVISION_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
   };
 }
 
 function createWorkers(
   connection: IORedis,
-  deps: { pageSync: PageSyncDeps; permissionSync: PermissionSyncDeps; docmostPush: DocmostPushDeps },
+  deps: {
+    pageSync: PageSyncDeps;
+    permissionSync: PermissionSyncDeps;
+    docmostPush: DocmostPushDeps;
+    spaceProvision: SpaceProvisionDeps;
+  },
 ): BridgeWorkers {
   const pageSync = new Worker(PAGE_SYNC_QUEUE, createPageSyncProcessor(deps.pageSync), {
     connection,
@@ -159,6 +179,14 @@ function createWorkers(
       concurrency: 1,
     },
   );
+  const spaceProvision = new Worker(
+    BRIDGE_SPACE_PROVISION_QUEUE,
+    createSpaceProvisionProcessor(deps.spaceProvision),
+    {
+      connection,
+      concurrency: 1,
+    },
+  );
 
   pageSync.on('error', (error) => {
     console.error(`${WORKER_NAME}: page-sync worker error`, error);
@@ -169,8 +197,11 @@ function createWorkers(
   permissionSync.on('error', (error) => {
     console.error(`${WORKER_NAME}: permission-sync worker error`, error);
   });
+  spaceProvision.on('error', (error) => {
+    console.error(`${WORKER_NAME}: space-provision worker error`, error);
+  });
 
-  return { pageSync, permissionSync, docmostPush };
+  return { pageSync, permissionSync, docmostPush, spaceProvision };
 }
 
 function startPermissionReconcileTimer(
@@ -226,8 +257,19 @@ async function shutdown(
   permissionReconcileTimer: ReturnType<typeof setInterval>,
 ): Promise<void> {
   let shutdownFailed = false;
-  const queueList = [queues.pageSync, queues.permissionSync, queues.attachmentSync, queues.docmostPush];
-  const workerList = [workers.pageSync, workers.permissionSync, workers.docmostPush];
+  const queueList = [
+    queues.pageSync,
+    queues.permissionSync,
+    queues.attachmentSync,
+    queues.docmostPush,
+    queues.spaceProvision,
+  ];
+  const workerList = [
+    workers.pageSync,
+    workers.permissionSync,
+    workers.docmostPush,
+    workers.spaceProvision,
+  ];
 
   try {
     console.log(`${WORKER_NAME}: shutting down`);

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -231,10 +231,22 @@ function startSpaceReconcileTimer(
   db: SpaceProvisionDeps['db'],
   queue: BridgeWorkerQueues['spaceProvision'],
 ): ReturnType<typeof setInterval> {
+  let isReconciling = false;
+
   return setInterval(() => {
-    void reconcileSpaces(db, queue).catch((error: unknown) => {
-      console.error(`${WORKER_NAME}: space reconcile failed`, error);
-    });
+    if (isReconciling) {
+      console.warn(`${WORKER_NAME}: skipped space reconcile; previous run still active`);
+      return;
+    }
+
+    isReconciling = true;
+    void reconcileSpaces(db, queue)
+      .catch((error: unknown) => {
+        console.error(`${WORKER_NAME}: space reconcile failed`, error);
+      })
+      .finally(() => {
+        isReconciling = false;
+      });
   }, 10 * 60 * 1000);
 }
 

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -122,6 +122,10 @@ export async function bootstrap(): Promise<void> {
     },
   });
   const permissionReconcileTimer = startPermissionReconcileTimer(db, bridgeClient);
+  const spaceReconcileTimer = startSpaceReconcileTimer(
+    db as SpaceProvisionDeps['db'],
+    queues.spaceProvision,
+  );
 
   const healthServer = await startHealthServer(
     {
@@ -134,7 +138,15 @@ export async function bootstrap(): Promise<void> {
     healthPort,
   );
 
-  const shutdown = createShutdownHandler(queues, workers, connection, pool, healthServer, permissionReconcileTimer);
+  const shutdown = createShutdownHandler(
+    queues,
+    workers,
+    connection,
+    pool,
+    healthServer,
+    permissionReconcileTimer,
+    spaceReconcileTimer,
+  );
   process.once('SIGTERM', shutdown);
   process.once('SIGINT', shutdown);
   console.log(`${WORKER_NAME}: started`, { healthPort });
@@ -215,6 +227,17 @@ function startPermissionReconcileTimer(
   }, 60 * 60 * 1000);
 }
 
+function startSpaceReconcileTimer(
+  db: SpaceProvisionDeps['db'],
+  queue: BridgeWorkerQueues['spaceProvision'],
+): ReturnType<typeof setInterval> {
+  return setInterval(() => {
+    void reconcileSpaces(db, queue).catch((error: unknown) => {
+      console.error(`${WORKER_NAME}: space reconcile failed`, error);
+    });
+  }, 10 * 60 * 1000);
+}
+
 function parseHealthPort(value: string | undefined): number {
   if (value === undefined || value.trim() === '') {
     return 9090;
@@ -235,6 +258,7 @@ function createShutdownHandler(
   pool: PgPool,
   healthServer: Server,
   permissionReconcileTimer: ReturnType<typeof setInterval>,
+  spaceReconcileTimer: ReturnType<typeof setInterval>,
 ): () => void {
   let shuttingDown = false;
 
@@ -244,7 +268,15 @@ function createShutdownHandler(
     }
 
     shuttingDown = true;
-    void shutdown(queues, workers, connection, pool, healthServer, permissionReconcileTimer);
+    void shutdown(
+      queues,
+      workers,
+      connection,
+      pool,
+      healthServer,
+      permissionReconcileTimer,
+      spaceReconcileTimer,
+    );
   };
 }
 
@@ -255,6 +287,7 @@ async function shutdown(
   pool: PgPool,
   healthServer: Server,
   permissionReconcileTimer: ReturnType<typeof setInterval>,
+  spaceReconcileTimer: ReturnType<typeof setInterval>,
 ): Promise<void> {
   let shutdownFailed = false;
   const queueList = [
@@ -274,6 +307,7 @@ async function shutdown(
   try {
     console.log(`${WORKER_NAME}: shutting down`);
     clearInterval(permissionReconcileTimer);
+    clearInterval(spaceReconcileTimer);
     const results = await Promise.allSettled([
       ...workerList.map((worker) => worker.close()),
       ...queueList.map((queue) => queue.close()),

--- a/apps/wiki-sync-worker/src/processors/__tests__/space-provision.processor.spec.ts
+++ b/apps/wiki-sync-worker/src/processors/__tests__/space-provision.processor.spec.ts
@@ -67,7 +67,7 @@ describe('space-provision processor', () => {
         createSpace({ id: 'space-3', docmost_space_id: null, status: 'archived' }),
       ],
     });
-    const queue = { add: vi.fn(() => Promise.resolve()) };
+    const queue = createSpaceProvisionQueue();
 
     await expect(reconcileSpaces(db.asDb(), queue)).resolves.toBe(1);
 
@@ -92,12 +92,38 @@ describe('space-provision processor', () => {
       }),
     );
     const db = new SpaceProvisionTestDb({ spaces: unmappedSpaces });
-    const queue = { add: vi.fn(() => Promise.resolve()) };
+    const queue = createSpaceProvisionQueue();
 
     await expect(reconcileSpaces(db.asDb(), queue)).resolves.toBe(51);
 
     expect(queue.add).toHaveBeenCalledTimes(51);
     expect(db.selectPageCount).toBe(3);
+  });
+
+  it('reconcileSpaces removes failed existing jobs before re-enqueueing', async () => {
+    const db = new SpaceProvisionTestDb();
+    const existingJob = createSpaceProvisionJob({ failed: true });
+    const queue = createSpaceProvisionQueue(existingJob);
+
+    await expect(reconcileSpaces(db.asDb(), queue)).resolves.toBe(1);
+
+    expect(existingJob.remove).toHaveBeenCalledOnce();
+    expect(queue.add).toHaveBeenCalledWith(
+      'space.provision',
+      expect.objectContaining({ spaceId: 'space-1', tenantId: 'tenant-1' }),
+      { jobId: 'tenant-1:space-1' },
+    );
+  });
+
+  it('reconcileSpaces skips non-failed existing jobs', async () => {
+    const db = new SpaceProvisionTestDb();
+    const existingJob = createSpaceProvisionJob({ failed: false });
+    const queue = createSpaceProvisionQueue(existingJob);
+
+    await expect(reconcileSpaces(db.asDb(), queue)).resolves.toBe(0);
+
+    expect(existingJob.remove).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
   });
 });
 
@@ -223,6 +249,20 @@ function createBridgeClient(error?: Error): SpaceProvisionBridgeClient {
         ? Promise.resolve({ docmost_space_id: 'docmost-space-1' })
         : Promise.reject(error),
     ),
+  };
+}
+
+function createSpaceProvisionQueue(existingJob?: ReturnType<typeof createSpaceProvisionJob>) {
+  return {
+    add: vi.fn(() => Promise.resolve()),
+    getJob: vi.fn(() => Promise.resolve(existingJob)),
+  };
+}
+
+function createSpaceProvisionJob(options: { failed: boolean }) {
+  return {
+    isFailed: vi.fn(() => Promise.resolve(options.failed)),
+    remove: vi.fn(() => Promise.resolve()),
   };
 }
 

--- a/apps/wiki-sync-worker/src/processors/__tests__/space-provision.processor.spec.ts
+++ b/apps/wiki-sync-worker/src/processors/__tests__/space-provision.processor.spec.ts
@@ -28,6 +28,28 @@ describe('space-provision processor', () => {
     ]);
   });
 
+  it('treats an already-mapped space as successful writeback', async () => {
+    const db = new SpaceProvisionTestDb({
+      spaces: [createSpace({ docmost_space_id: 'docmost-space-existing' })],
+    });
+    const bridgeClient = createBridgeClient();
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    await runProcessor(db, bridgeClient);
+
+    expect(db.spaceUpdates).toHaveLength(0);
+    expect(info).toHaveBeenCalledWith(
+      'space-provision: skipped docmost_space_id writeback; mapping already exists',
+      expect.objectContaining({
+        spaceId: 'space-1',
+        tenantId: 'tenant-1',
+        docmostSpaceId: 'docmost-space-1',
+      }),
+    );
+
+    info.mockRestore();
+  });
+
   it('throws on bridge failure', async () => {
     const db = new SpaceProvisionTestDb();
     const bridgeClient = createBridgeClient(new Error('upstream down'));
@@ -60,6 +82,23 @@ describe('space-provision processor', () => {
       { jobId: 'tenant-1:space-1' },
     );
   });
+
+  it('reconcileSpaces enqueues unmapped spaces in batches', async () => {
+    const unmappedSpaces = Array.from({ length: 51 }, (_, index) =>
+      createSpace({
+        id: `space-${String(index + 1).padStart(2, '0')}`,
+        docmost_space_id: null,
+        status: 'active',
+      }),
+    );
+    const db = new SpaceProvisionTestDb({ spaces: unmappedSpaces });
+    const queue = { add: vi.fn(() => Promise.resolve()) };
+
+    await expect(reconcileSpaces(db.asDb(), queue)).resolves.toBe(51);
+
+    expect(queue.add).toHaveBeenCalledTimes(51);
+    expect(db.selectPageCount).toBe(3);
+  });
 });
 
 type SpaceRow = typeof spaces.$inferSelect;
@@ -67,6 +106,7 @@ type SpaceRow = typeof spaces.$inferSelect;
 class SpaceProvisionTestDb {
   spaces: SpaceRow[];
   spaceUpdates: Array<Partial<typeof spaces.$inferInsert>> = [];
+  selectPageCount = 0;
 
   constructor(options: Partial<{ spaces: SpaceRow[] }> = {}) {
     this.spaces = options.spaces ?? [createSpace()];
@@ -75,16 +115,21 @@ class SpaceProvisionTestDb {
   select(): unknown {
     return {
       from: (table: unknown) => {
-        const resolveRows = (): unknown[] => {
+        const resolveRows = (limit?: number): unknown[] => {
           if (table === spaces) {
-            return this.spaces
+            const rows = this.spaces
               .filter((space) => space.status === 'active' && space.docmost_space_id === null)
+              .sort((left, right) => left.id.localeCompare(right.id))
               .map((space) => ({
                 spaceId: space.id,
                 tenantId: space.tenant_id,
                 spaceName: space.name,
                 spaceSlug: space.slug,
               }));
+
+            const offset = this.selectPageCount * (limit ?? rows.length);
+            this.selectPageCount += 1;
+            return rows.slice(offset, limit === undefined ? undefined : offset + limit);
           }
 
           return [];
@@ -98,12 +143,25 @@ class SpaceProvisionTestDb {
   update(table: unknown): unknown {
     return {
       set: (values: Partial<typeof spaces.$inferInsert>) => ({
-        where: (): Promise<void> => {
-          if (table === spaces) {
-            this.spaceUpdates.push(values);
-          }
-          return Promise.resolve();
-        },
+        where: () => ({
+          returning: (): Promise<Array<{ id: string }>> => {
+            const space = this.spaces.find(
+              (candidate) =>
+                candidate.id === 'space-1' &&
+                candidate.tenant_id === 'tenant-1' &&
+                candidate.docmost_space_id === null,
+            );
+
+            if (table === spaces && space !== undefined) {
+              this.spaceUpdates.push(values);
+              space.docmost_space_id = values.docmost_space_id ?? null;
+              space.updated_at = values.updated_at ?? space.updated_at;
+              return Promise.resolve([{ id: space.id }]);
+            }
+
+            return Promise.resolve([]);
+          },
+        }),
       }),
     };
   }
@@ -114,9 +172,20 @@ class SpaceProvisionTestDb {
 }
 
 class SelectBuilder {
-  constructor(private readonly resolveRows: () => unknown[]) {}
+  private limitValue: number | undefined;
+
+  constructor(private readonly resolveRows: (limit?: number) => unknown[]) {}
 
   where(): this {
+    return this;
+  }
+
+  orderBy(): this {
+    return this;
+  }
+
+  limit(value: number): this {
+    this.limitValue = value;
     return this;
   }
 
@@ -124,7 +193,7 @@ class SelectBuilder {
     onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2> {
-    return Promise.resolve(this.resolveRows()).then(onfulfilled, onrejected);
+    return Promise.resolve(this.resolveRows(this.limitValue)).then(onfulfilled, onrejected);
   }
 }
 

--- a/apps/wiki-sync-worker/src/processors/__tests__/space-provision.processor.spec.ts
+++ b/apps/wiki-sync-worker/src/processors/__tests__/space-provision.processor.spec.ts
@@ -1,0 +1,182 @@
+import type { Job } from 'bullmq';
+import { describe, expect, it, vi } from 'vitest';
+
+import { spaces } from '@cherrygraph/shared';
+
+import { reconcileSpaces } from '../../reconciliation/space-reconcile.js';
+import {
+  createSpaceProvisionProcessor,
+  type DrizzleDatabase,
+  type SpaceProvisionBridgeClient,
+  type SpaceProvisionJobData,
+} from '../space-provision.processor.js';
+
+describe('space-provision processor', () => {
+  it('calls bridge and updates docmost_space_id', async () => {
+    const db = new SpaceProvisionTestDb();
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.provisionSpace).toHaveBeenCalledWith({
+      name: 'Research',
+      slug: 'research',
+      cherry_space_id: 'space-1',
+    });
+    expect(db.spaceUpdates).toEqual([
+      expect.objectContaining({ docmost_space_id: 'docmost-space-1' }),
+    ]);
+  });
+
+  it('throws on bridge failure', async () => {
+    const db = new SpaceProvisionTestDb();
+    const bridgeClient = createBridgeClient(new Error('upstream down'));
+
+    await expect(runProcessor(db, bridgeClient)).rejects.toThrow('upstream down');
+
+    expect(db.spaceUpdates).toHaveLength(0);
+  });
+
+  it('reconcileSpaces enqueues jobs for unmapped active spaces', async () => {
+    const db = new SpaceProvisionTestDb({
+      spaces: [
+        createSpace({ id: 'space-1', docmost_space_id: null, status: 'active' }),
+        createSpace({ id: 'space-2', docmost_space_id: 'docmost-space-2', status: 'active' }),
+        createSpace({ id: 'space-3', docmost_space_id: null, status: 'archived' }),
+      ],
+    });
+    const queue = { add: vi.fn(() => Promise.resolve()) };
+
+    await expect(reconcileSpaces(db.asDb(), queue)).resolves.toBe(1);
+
+    expect(queue.add).toHaveBeenCalledWith(
+      'space.provision',
+      {
+        spaceId: 'space-1',
+        tenantId: 'tenant-1',
+        spaceName: 'Research',
+        spaceSlug: 'research',
+      },
+      { jobId: 'tenant-1:space-1' },
+    );
+  });
+});
+
+type SpaceRow = typeof spaces.$inferSelect;
+
+class SpaceProvisionTestDb {
+  spaces: SpaceRow[];
+  spaceUpdates: Array<Partial<typeof spaces.$inferInsert>> = [];
+
+  constructor(options: Partial<{ spaces: SpaceRow[] }> = {}) {
+    this.spaces = options.spaces ?? [createSpace()];
+  }
+
+  select(): unknown {
+    return {
+      from: (table: unknown) => {
+        const resolveRows = (): unknown[] => {
+          if (table === spaces) {
+            return this.spaces
+              .filter((space) => space.status === 'active' && space.docmost_space_id === null)
+              .map((space) => ({
+                spaceId: space.id,
+                tenantId: space.tenant_id,
+                spaceName: space.name,
+                spaceSlug: space.slug,
+              }));
+          }
+
+          return [];
+        };
+
+        return new SelectBuilder(resolveRows);
+      },
+    };
+  }
+
+  update(table: unknown): unknown {
+    return {
+      set: (values: Partial<typeof spaces.$inferInsert>) => ({
+        where: (): Promise<void> => {
+          if (table === spaces) {
+            this.spaceUpdates.push(values);
+          }
+          return Promise.resolve();
+        },
+      }),
+    };
+  }
+
+  asDb(): DrizzleDatabase {
+    return this as unknown as DrizzleDatabase;
+  }
+}
+
+class SelectBuilder {
+  constructor(private readonly resolveRows: () => unknown[]) {}
+
+  where(): this {
+    return this;
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.resolveRows()).then(onfulfilled, onrejected);
+  }
+}
+
+async function runProcessor(
+  db: SpaceProvisionTestDb,
+  bridgeClient: SpaceProvisionBridgeClient,
+): Promise<void> {
+  const processor = createSpaceProvisionProcessor({
+    db: db.asDb(),
+    bridgeClient,
+  });
+
+  await processor({
+    data: {
+      tenantId: 'tenant-1',
+      spaceId: 'space-1',
+      spaceName: 'Research',
+      spaceSlug: 'research',
+    },
+  } as Job<SpaceProvisionJobData>);
+}
+
+function createBridgeClient(error?: Error): SpaceProvisionBridgeClient {
+  return {
+    provisionSpace: vi.fn<SpaceProvisionBridgeClient['provisionSpace']>(() =>
+      error === undefined
+        ? Promise.resolve({ docmost_space_id: 'docmost-space-1' })
+        : Promise.reject(error),
+    ),
+  };
+}
+
+function createSpace(overrides: Partial<SpaceRow> = {}): SpaceRow {
+  return {
+    id: 'space-1',
+    tenant_id: 'tenant-1',
+    name: 'Research',
+    slug: 'research',
+    description: null,
+    status: 'active',
+    docmost_space_id: null,
+    wiki_repo_path: '/tmp/wiki',
+    active_graphify_run_id: null,
+    active_index_snapshot_id: null,
+    index_consistency_status: 'healthy',
+    permission_version: 1,
+    strict_knowledge_only: true,
+    graphify_config: {},
+    database_config: { enabled: false },
+    default_publish_policy: 'editor_publish',
+    created_at: new Date('2026-05-05T10:00:00.000Z'),
+    updated_at: new Date('2026-05-05T10:00:00.000Z'),
+    ...overrides,
+  };
+}

--- a/apps/wiki-sync-worker/src/processors/space-provision.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/space-provision.processor.ts
@@ -1,5 +1,5 @@
 import type { Job } from 'bullmq';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
 import { spaces } from '@cherrygraph/shared';
@@ -49,10 +49,25 @@ async function writeBackDocmostSpaceId(
   data: SpaceProvisionJobData,
   docmostSpaceId: string,
 ): Promise<void> {
-  await db
+  const updated = await db
     .update(spaces)
     .set({ docmost_space_id: docmostSpaceId, updated_at: new Date() })
-    .where(and(eq(spaces.id, data.spaceId), eq(spaces.tenant_id, data.tenantId)));
+    .where(
+      and(
+        eq(spaces.id, data.spaceId),
+        eq(spaces.tenant_id, data.tenantId),
+        isNull(spaces.docmost_space_id),
+      ),
+    )
+    .returning({ id: spaces.id });
+
+  if (updated.length === 0) {
+    console.info('space-provision: skipped docmost_space_id writeback; mapping already exists', {
+      spaceId: data.spaceId,
+      tenantId: data.tenantId,
+      docmostSpaceId,
+    });
+  }
 }
 
 function readJobData(data: unknown): SpaceProvisionJobData {

--- a/apps/wiki-sync-worker/src/processors/space-provision.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/space-provision.processor.ts
@@ -1,0 +1,85 @@
+import type { Job } from 'bullmq';
+import { and, eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { spaces } from '@cherrygraph/shared';
+
+export const BRIDGE_SPACE_PROVISION_QUEUE = 'bridge-space-provision';
+
+export type DrizzleDatabase = NodePgDatabase;
+type DatabaseClient = Pick<DrizzleDatabase, 'update'>;
+
+export interface SpaceProvisionDeps {
+  db: DrizzleDatabase;
+  bridgeClient: SpaceProvisionBridgeClient;
+}
+
+export interface SpaceProvisionBridgeClient {
+  provisionSpace(input: {
+    name: string;
+    slug: string;
+    cherry_space_id: string;
+  }): Promise<{ docmost_space_id: string }>;
+}
+
+export type SpaceProvisionJobData = {
+  spaceId: string;
+  tenantId: string;
+  spaceName: string;
+  spaceSlug: string;
+};
+
+export function createSpaceProvisionProcessor(
+  deps: SpaceProvisionDeps,
+): (job: Job<SpaceProvisionJobData>) => Promise<void> {
+  return async (job) => {
+    const data = readJobData(job.data);
+    const result = await deps.bridgeClient.provisionSpace({
+      name: data.spaceName,
+      slug: data.spaceSlug,
+      cherry_space_id: data.spaceId,
+    });
+
+    await writeBackDocmostSpaceId(deps.db, data, result.docmost_space_id);
+  };
+}
+
+async function writeBackDocmostSpaceId(
+  db: DatabaseClient,
+  data: SpaceProvisionJobData,
+  docmostSpaceId: string,
+): Promise<void> {
+  await db
+    .update(spaces)
+    .set({ docmost_space_id: docmostSpaceId, updated_at: new Date() })
+    .where(and(eq(spaces.id, data.spaceId), eq(spaces.tenant_id, data.tenantId)));
+}
+
+function readJobData(data: unknown): SpaceProvisionJobData {
+  const record = readRecord(data);
+  const spaceId = readString(record.spaceId);
+  const tenantId = readString(record.tenantId);
+  const spaceName = readString(record.spaceName);
+  const spaceSlug = readString(record.spaceSlug);
+
+  if (
+    spaceId === undefined ||
+    tenantId === undefined ||
+    spaceName === undefined ||
+    spaceSlug === undefined
+  ) {
+    throw new Error('space-provision job is missing spaceId, tenantId, spaceName, or spaceSlug');
+  }
+
+  return { spaceId, tenantId, spaceName, spaceSlug };
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/apps/wiki-sync-worker/src/reconciliation/space-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/space-reconcile.ts
@@ -21,6 +21,8 @@ export type SpaceProvisionQueue = {
 type SpaceProvisionJob = {
   isFailed: () => Promise<boolean>;
   remove: () => Promise<void>;
+  attemptsMade?: number;
+  finishedOn?: number;
 };
 
 type UnmappedSpaceRow = {
@@ -83,6 +85,9 @@ async function loadUnmappedSpaces(
     .limit(SPACE_RECONCILE_BATCH_SIZE);
 }
 
+const MAX_RECONCILE_RETRIES = 10;
+const MIN_RETRY_AGE_MS = 5 * 60 * 1000;
+
 async function enqueueSpaceProvision(
   queue: SpaceProvisionQueue,
   space: UnmappedSpaceRow,
@@ -92,11 +97,22 @@ async function enqueueSpaceProvision(
 
   if (existing !== null && existing !== undefined) {
     const isFailed = await existing.isFailed();
-    if (isFailed) {
-      await existing.remove();
-    } else {
+    if (!isFailed) {
       return false;
     }
+
+    if ((existing.attemptsMade ?? 0) >= MAX_RECONCILE_RETRIES) {
+      return false;
+    }
+
+    const failedAge = existing.finishedOn
+      ? Date.now() - existing.finishedOn
+      : Infinity;
+    if (failedAge < MIN_RETRY_AGE_MS) {
+      return false;
+    }
+
+    await existing.remove();
   }
 
   await queue.add('space.provision', space, {

--- a/apps/wiki-sync-worker/src/reconciliation/space-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/space-reconcile.ts
@@ -15,6 +15,12 @@ export type SpaceProvisionQueue = {
     data: SpaceProvisionJobData,
     opts: { jobId: string },
   ) => Promise<unknown>;
+  getJob: (jobId: string) => Promise<SpaceProvisionJob | null | undefined>;
+};
+
+type SpaceProvisionJob = {
+  isFailed: () => Promise<boolean>;
+  remove: () => Promise<void>;
 };
 
 type UnmappedSpaceRow = {
@@ -42,7 +48,10 @@ export async function reconcileSpaces(
     const results = await Promise.allSettled(
       unmappedSpaces.map((space) => enqueueSpaceProvision(queue, space)),
     );
-    enqueuedCount += results.filter((result) => result.status === 'fulfilled').length;
+    enqueuedCount += results.filter(
+      (result): result is PromiseFulfilledResult<true> =>
+        result.status === 'fulfilled' && result.value,
+    ).length;
 
     cursor = unmappedSpaces[unmappedSpaces.length - 1]?.spaceId;
   }
@@ -77,8 +86,21 @@ async function loadUnmappedSpaces(
 async function enqueueSpaceProvision(
   queue: SpaceProvisionQueue,
   space: UnmappedSpaceRow,
-): Promise<void> {
+): Promise<boolean> {
+  const jobId = `${space.tenantId}:${space.spaceId}`;
+  const existing = await queue.getJob(jobId);
+
+  if (existing !== null && existing !== undefined) {
+    const isFailed = await existing.isFailed();
+    if (isFailed) {
+      await existing.remove();
+    } else {
+      return false;
+    }
+  }
+
   await queue.add('space.provision', space, {
-    jobId: `${space.tenantId}:${space.spaceId}`,
+    jobId,
   });
+  return true;
 }

--- a/apps/wiki-sync-worker/src/reconciliation/space-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/space-reconcile.ts
@@ -1,0 +1,58 @@
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { spaces } from '@cherrygraph/shared';
+
+import type {
+  DrizzleDatabase,
+  SpaceProvisionJobData,
+} from '../processors/space-provision.processor.js';
+
+type DatabaseClient = Pick<DrizzleDatabase, 'select'>;
+
+export type SpaceProvisionQueue = {
+  add: (
+    name: string,
+    data: SpaceProvisionJobData,
+    opts: { jobId: string },
+  ) => Promise<unknown>;
+};
+
+type UnmappedSpaceRow = {
+  spaceId: string;
+  tenantId: string;
+  spaceName: string;
+  spaceSlug: string;
+};
+
+export async function reconcileSpaces(
+  db: DrizzleDatabase,
+  queue: SpaceProvisionQueue,
+): Promise<number> {
+  const unmappedSpaces = await loadUnmappedSpaces(db);
+  const results = await Promise.allSettled(
+    unmappedSpaces.map((space) => enqueueSpaceProvision(queue, space)),
+  );
+
+  return results.filter((result) => result.status === 'fulfilled').length;
+}
+
+async function loadUnmappedSpaces(db: DatabaseClient): Promise<UnmappedSpaceRow[]> {
+  return db
+    .select({
+      spaceId: spaces.id,
+      tenantId: spaces.tenant_id,
+      spaceName: spaces.name,
+      spaceSlug: spaces.slug,
+    })
+    .from(spaces)
+    .where(and(eq(spaces.status, 'active'), isNull(spaces.docmost_space_id)));
+}
+
+async function enqueueSpaceProvision(
+  queue: SpaceProvisionQueue,
+  space: UnmappedSpaceRow,
+): Promise<void> {
+  await queue.add('space.provision', space, {
+    jobId: `${space.tenantId}:${space.spaceId}`,
+  });
+}

--- a/apps/wiki-sync-worker/src/reconciliation/space-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/space-reconcile.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, asc, eq, gt, isNull } from 'drizzle-orm';
 
 import { spaces } from '@cherrygraph/shared';
 
@@ -24,19 +24,43 @@ type UnmappedSpaceRow = {
   spaceSlug: string;
 };
 
+const SPACE_RECONCILE_BATCH_SIZE = 50;
+
 export async function reconcileSpaces(
   db: DrizzleDatabase,
   queue: SpaceProvisionQueue,
 ): Promise<number> {
-  const unmappedSpaces = await loadUnmappedSpaces(db);
-  const results = await Promise.allSettled(
-    unmappedSpaces.map((space) => enqueueSpaceProvision(queue, space)),
-  );
+  let enqueuedCount = 0;
+  let cursor: string | undefined;
 
-  return results.filter((result) => result.status === 'fulfilled').length;
+  for (;;) {
+    const unmappedSpaces = await loadUnmappedSpaces(db, cursor);
+    if (unmappedSpaces.length === 0) {
+      return enqueuedCount;
+    }
+
+    const results = await Promise.allSettled(
+      unmappedSpaces.map((space) => enqueueSpaceProvision(queue, space)),
+    );
+    enqueuedCount += results.filter((result) => result.status === 'fulfilled').length;
+
+    cursor = unmappedSpaces[unmappedSpaces.length - 1]?.spaceId;
+  }
 }
 
-async function loadUnmappedSpaces(db: DatabaseClient): Promise<UnmappedSpaceRow[]> {
+async function loadUnmappedSpaces(
+  db: DatabaseClient,
+  afterSpaceId?: string,
+): Promise<UnmappedSpaceRow[]> {
+  const predicates = [
+    eq(spaces.status, 'active'),
+    isNull(spaces.docmost_space_id),
+  ];
+
+  if (afterSpaceId !== undefined) {
+    predicates.push(gt(spaces.id, afterSpaceId));
+  }
+
   return db
     .select({
       spaceId: spaces.id,
@@ -45,7 +69,9 @@ async function loadUnmappedSpaces(db: DatabaseClient): Promise<UnmappedSpaceRow[
       spaceSlug: spaces.slug,
     })
     .from(spaces)
-    .where(and(eq(spaces.status, 'active'), isNull(spaces.docmost_space_id)));
+    .where(and(...predicates))
+    .orderBy(asc(spaces.id))
+    .limit(SPACE_RECONCILE_BATCH_SIZE);
 }
 
 async function enqueueSpaceProvision(

--- a/openspec/changes/docmost-auto-sync/tasks.md
+++ b/openspec/changes/docmost-auto-sync/tasks.md
@@ -31,7 +31,17 @@
 - [ ] 2.6 Wiki-sync worker: `main.ts` 注册 `bridge-space-provision` 队列常量、Queue 实例、Worker 实例，加入 health/shutdown 流程
 - [ ] 2.7 Wiki-sync worker: 新增 `space-provision.processor.ts`，消费队列：调用 Docmost Bridge 创建 Space → 更新 `spaces.docmost_space_id`
 - [ ] 2.8 Wiki-sync worker: `reconcileOnStartup` 增加 Space 对账：查找 `docmost_space_id = null` 的 active Space → 逐个入队
-- [ ] 2.9 测试：创建 Space → docmost_space_id 自动回填 → Docmost 中可见；启动对账回填已有 Space
+- [ ] 2.9 测试（Docmost Fork 端）：
+  - [ ] 2.9.1 POST /api/internal/bridge/spaces 成功创建 Space（返回 201 + docmost_space_id）
+  - [ ] 2.9.2 POST /api/internal/bridge/spaces 已存在 slug 时返回现有 Space（幂等性）
+  - [ ] 2.9.3 POST /api/internal/bridge/spaces 缺少必填字段返回 400
+- [ ] 2.10 测试（Cherry API 端）：
+  - [ ] 2.10.1 SpaceService.createSpace() 成功后 enqueue space-provision job
+  - [ ] 2.10.2 BridgeQueueService.enqueueSpaceProvisionJob() 正确入队
+- [ ] 2.11 测试（Wiki-sync worker 端）：
+  - [ ] 2.11.1 space-provision processor 调用 Bridge 创建 Space → 更新 docmost_space_id
+  - [ ] 2.11.2 space-provision processor Bridge 不可达时重试
+  - [ ] 2.11.3 reconcileOnStartup 查找 unmapped spaces 并逐个入队
 
 ## graphify-docmost-push-trigger
 


### PR DESCRIPTION
## Summary

- Docmost Fork: `POST /api/internal/bridge/spaces` — find-or-create space by slug with unique constraint race handling
- Cherry API: `bridge-space-provision` queue + `enqueueSpaceProvisionJob()` in BridgeQueueService
- Cherry API: `SpaceService.createSpace()` fire-and-forget enqueues provision job
- Wiki-sync worker: space-provision processor with IS NULL guard on docmost_space_id update
- Wiki-sync worker: periodic reconciliation (10min) with batching (50), retry cap (10), cooldown (5min)
- Wiki-sync worker: in-flight guard prevents overlapping reconciliation runs
- Tests: 4 Jest (Docmost) + 9 Vitest (API + worker)

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] API tests pass (1185 tests)
- [x] Wiki-sync worker typecheck passes
- [x] Docmost bridge tests pass (4 new)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `c556e52bf0bcc04633ee5552165d2f65a10dd951`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/283#issuecomment-4427805167) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/283#issuecomment-4427805339) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/283#issuecomment-4427805491) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/283#issuecomment-4427805769)
- Key findings addressed: periodic reconciliation with retry cap, IS NULL guard on docmost_space_id update, unique constraint race handling, batched reconciliation, in-flight guard, failed BullMQ job removal before re-enqueue

Closes #273