### PR TITLE
feat(bridge): auto-sync users and permissions to Docmost (#275)

### DIFF
--- a/apps/api/src/auth/__tests__/auth-test-utils.ts
+++ b/apps/api/src/auth/__tests__/auth-test-utils.ts
@@ -168,6 +168,7 @@ export function createUser(passwordHash: string, overrides: Partial<UserRow> = {
     password_hash: passwordHash,
     role: 'editor',
     status: 'active',
+    docmost_user_id: null,
     permission_version: 1,
     last_login_at: null,
     created_at: new Date('2026-04-01T00:00:00.000Z'),

--- a/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
@@ -99,16 +99,18 @@ describe('BridgeQueueService', () => {
     });
   });
 
-  it('enqueues direct permission sync jobs with tenant-space deduplication', async () => {
+  it('enqueues direct permission sync jobs with versioned job IDs', async () => {
     const service = createService();
 
     await service.enqueuePermissionSyncJob({ tenantId: 'tenant-1', spaceId: 'space-1' });
 
-    expect(queueByName(BRIDGE_PERMISSION_SYNC_QUEUE).add).toHaveBeenCalledWith(
-      'permission.sync',
-      { tenantId: 'tenant-1', spaceId: 'space-1' },
-      { jobId: 'tenant-1:space-1' },
-    );
+    const addCalls = queueByName(BRIDGE_PERMISSION_SYNC_QUEUE).add.mock.calls as Array<
+      [string, { tenantId: string; spaceId: string }, { jobId: string }]
+    >;
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0]?.[0]).toBe('permission.sync');
+    expect(addCalls[0]?.[1]).toEqual({ tenantId: 'tenant-1', spaceId: 'space-1' });
+    expect(addCalls[0]?.[2].jobId).toMatch(/^tenant-1:space-1:[0-9a-f-]+$/);
   });
 
   it('enqueues space provision jobs with tenant-space deduplication', async () => {

--- a/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-queue.service.test.ts
@@ -7,6 +7,7 @@ import {
   BRIDGE_PAGE_SYNC_QUEUE,
   BRIDGE_PERMISSION_SYNC_QUEUE,
   BRIDGE_SPACE_PROVISION_QUEUE,
+  BRIDGE_USER_SYNC_QUEUE,
   BridgeQueueService,
 } from '../bridge-queue.service.js';
 
@@ -129,6 +130,28 @@ describe('BridgeQueueService', () => {
         spaceSlug: 'research',
       },
       { jobId: 'tenant-1:space-1' },
+    );
+  });
+
+  it('enqueues user sync jobs with tenant-user deduplication', async () => {
+    const service = createService();
+
+    await service.enqueueUserSyncJob({
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      email: 'user@example.com',
+      name: 'Test User',
+    });
+
+    expect(queueByName(BRIDGE_USER_SYNC_QUEUE).add).toHaveBeenCalledWith(
+      'user.sync',
+      {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        email: 'user@example.com',
+        name: 'Test User',
+      },
+      { jobId: 'tenant-1:user-1' },
     );
   });
 

--- a/apps/api/src/bridge/bridge-queue.service.ts
+++ b/apps/api/src/bridge/bridge-queue.service.ts
@@ -12,13 +12,15 @@ export const BRIDGE_PERMISSION_SYNC_QUEUE = 'bridge-permission-sync';
 export const BRIDGE_ATTACHMENT_SYNC_QUEUE = 'bridge-attachment-sync';
 export const BRIDGE_DOCMOST_PUSH_QUEUE = 'bridge-docmost-push';
 export const BRIDGE_SPACE_PROVISION_QUEUE = 'bridge-space-provision';
+export const BRIDGE_USER_SYNC_QUEUE = 'bridge-user-sync';
 
 export type BridgeQueueName =
   | typeof BRIDGE_PAGE_SYNC_QUEUE
   | typeof BRIDGE_PERMISSION_SYNC_QUEUE
   | typeof BRIDGE_ATTACHMENT_SYNC_QUEUE
   | typeof BRIDGE_DOCMOST_PUSH_QUEUE
-  | typeof BRIDGE_SPACE_PROVISION_QUEUE;
+  | typeof BRIDGE_SPACE_PROVISION_QUEUE
+  | typeof BRIDGE_USER_SYNC_QUEUE;
 
 export type BridgeQueueJobData = {
   bridgeEventId: string;
@@ -46,6 +48,13 @@ export type SpaceProvisionJobData = {
   spaceSlug: string;
 };
 
+export type UserSyncJobData = {
+  userId: string;
+  email: string;
+  name: string;
+  tenantId: string;
+};
+
 const DEFAULT_JOB_OPTIONS: JobsOptions = {
   attempts: 3,
   backoff: {
@@ -62,7 +71,16 @@ export class BridgeQueueService implements OnModuleDestroy {
   private readonly ownsConnection: boolean;
   private readonly disabled: boolean;
   private readonly queues: Partial<
-    Record<BridgeQueueName, Queue<BridgeQueueJobData | DocmostPushJobData | PermissionSyncJobData | SpaceProvisionJobData>>
+    Record<
+      BridgeQueueName,
+      Queue<
+        | BridgeQueueJobData
+        | DocmostPushJobData
+        | PermissionSyncJobData
+        | SpaceProvisionJobData
+        | UserSyncJobData
+      >
+    >
   >;
 
   constructor(@Optional() @Inject(REDIS_CLIENT) redis?: OptionalRedisClient) {
@@ -101,6 +119,10 @@ export class BridgeQueueService implements OnModuleDestroy {
         defaultJobOptions: DEFAULT_JOB_OPTIONS,
       }),
       [BRIDGE_SPACE_PROVISION_QUEUE]: new Queue(BRIDGE_SPACE_PROVISION_QUEUE, {
+        connection,
+        defaultJobOptions: DEFAULT_JOB_OPTIONS,
+      }),
+      [BRIDGE_USER_SYNC_QUEUE]: new Queue(BRIDGE_USER_SYNC_QUEUE, {
         connection,
         defaultJobOptions: DEFAULT_JOB_OPTIONS,
       }),
@@ -162,6 +184,20 @@ export class BridgeQueueService implements OnModuleDestroy {
     });
   }
 
+  async enqueueUserSyncJob(jobData: UserSyncJobData): Promise<void> {
+    if (this.disabled) {
+      getApiLogger().warn(
+        { redis_configured: false },
+        'BullMQ dispatch disabled — no Redis configured',
+      );
+      return;
+    }
+
+    await this.getQueue(BRIDGE_USER_SYNC_QUEUE).add('user.sync', jobData, {
+      jobId: `${jobData.tenantId}:${jobData.userId}`,
+    });
+  }
+
   async onModuleDestroy(): Promise<void> {
     if (this.disabled) {
       return;
@@ -183,7 +219,13 @@ export class BridgeQueueService implements OnModuleDestroy {
 
   private getQueue(
     queueName: BridgeQueueName,
-  ): Queue<BridgeQueueJobData | DocmostPushJobData | PermissionSyncJobData | SpaceProvisionJobData> {
+  ): Queue<
+    | BridgeQueueJobData
+    | DocmostPushJobData
+    | PermissionSyncJobData
+    | SpaceProvisionJobData
+    | UserSyncJobData
+  > {
     const queue = this.queues[queueName];
     if (queue === undefined) {
       throw new Error(`Bridge queue is not initialized: ${queueName}`);

--- a/apps/api/src/bridge/bridge-queue.service.ts
+++ b/apps/api/src/bridge/bridge-queue.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Optional, type OnModuleDestroy } from '@nestjs/common';
 import { Queue, type JobsOptions } from 'bullmq';
 import { Redis, type Redis as IORedis } from 'ioredis';
+import { randomUUID } from 'node:crypto';
 
 import type { BridgeEventType } from '@cherrygraph/shared';
 
@@ -166,7 +167,7 @@ export class BridgeQueueService implements OnModuleDestroy {
     }
 
     await this.getQueue(BRIDGE_PERMISSION_SYNC_QUEUE).add('permission.sync', jobData, {
-      jobId: `${jobData.tenantId}:${jobData.spaceId}`,
+      jobId: `${jobData.tenantId}:${jobData.spaceId}:${randomUUID()}`,
     });
   }
 

--- a/apps/api/src/bridge/bridge.module.ts
+++ b/apps/api/src/bridge/bridge.module.ts
@@ -1,4 +1,4 @@
-import { Module, type OnApplicationBootstrap, type OnModuleDestroy } from '@nestjs/common';
+import { forwardRef, Module, type OnApplicationBootstrap, type OnModuleDestroy } from '@nestjs/common';
 
 import { AuditModule } from '../audit/audit.module.js';
 import { UserModule } from '../users/user.module.js';
@@ -13,7 +13,7 @@ const DOCMOST_BOOTSTRAP_RETRY_INTERVAL_MS = 60_000;
 const DOCMOST_BOOTSTRAP_MAX_RETRY_INTERVAL_MS = 300_000;
 
 @Module({
-  imports: [AuditModule, UserModule],
+  imports: [AuditModule, forwardRef(() => UserModule)],
   controllers: [BridgeEventController],
   providers: [
     BridgeAuthGuard,

--- a/apps/api/src/bridge/docmost-bootstrap.service.ts
+++ b/apps/api/src/bridge/docmost-bootstrap.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { createHash, createHmac, randomBytes, randomUUID } from 'node:crypto';
 
 import { getApiLogger } from '../common/logger/logger.module.js';
@@ -32,7 +32,7 @@ type ConfigResolution =
 
 @Injectable()
 export class DocmostBootstrapService {
-  constructor(private readonly userService?: UserService) {}
+  constructor(@Optional() private readonly userService?: UserService) {}
 
   async bootstrapIfNeeded(): Promise<boolean> {
     const configResolution = await this.getConfig();

--- a/apps/api/src/groups/__tests__/group.service.test.ts
+++ b/apps/api/src/groups/__tests__/group.service.test.ts
@@ -97,6 +97,7 @@ describe('GroupService', () => {
     db.queueSelect([createGroupRow()]);
     db.queueSelect([{ id: TEST_USER_ID }, { id: 'user-2' }]);
     db.queueSelect([{ user_id: TEST_USER_ID }]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID, permission: 'space:view' }]);
     db.queueSelect([createGroupRow()]);
     db.queueSelect([{ group_id: TEST_GROUP_ID, member_count: 2 }]);
     db.queueSelect([]);
@@ -132,6 +133,7 @@ describe('GroupService', () => {
     db.queueSelect([createGroupRow()]);
     db.queueSelect([{ id: TEST_USER_ID }, { id: 'user-2' }]);
     db.queueSelect([{ user_id: TEST_USER_ID }]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID, permission: 'space:view' }]);
     db.queueSelect([createGroupRow()]);
     db.queueSelect([{ group_id: TEST_GROUP_ID, member_count: 2 }]);
     db.queueSelect([]);
@@ -163,6 +165,7 @@ describe('GroupService', () => {
     db.queueSelect([createGroupRow()]);
     db.queueSelect([{ id: TEST_USER_ID }]);
     db.queueSelect([{ user_id: TEST_USER_ID }, { user_id: 'user-2' }]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID, permission: 'space:view' }]);
     db.queueSelect([createGroupRow()]);
     db.queueSelect([{ group_id: TEST_GROUP_ID, member_count: 1 }]);
     db.queueSelect([]);
@@ -216,6 +219,31 @@ describe('GroupService', () => {
         space_id: TEST_SPACE_ID,
       }),
     );
+  });
+
+  it('enqueues permission sync after group member changes for affected spaces', async () => {
+    const bridgeQueue = {
+      enqueuePermissionSyncJob: vi.fn(() => Promise.resolve()),
+    };
+    const { service, db } = createServiceContext({ bridgeQueue });
+    db.queueSelect([createGroupRow()]);
+    db.queueSelect([{ id: TEST_USER_ID }, { id: 'user-2' }]);
+    db.queueSelect([{ user_id: TEST_USER_ID }]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID, permission: 'space:view' }]);
+    db.queueSelect([createGroupRow()]);
+    db.queueSelect([{ group_id: TEST_GROUP_ID, member_count: 2 }]);
+    db.queueSelect([]);
+
+    await service.updateGroup(
+      TEST_GROUP_ID,
+      { member_ids: [TEST_USER_ID, 'user-2'] },
+      createContext(),
+    );
+
+    expect(bridgeQueue.enqueuePermissionSyncJob).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      spaceId: TEST_SPACE_ID,
+    });
   });
 
   it('updates a group by removing a space permission with revoke trail', async () => {
@@ -365,7 +393,9 @@ describe('GroupService', () => {
   });
 });
 
-function createServiceContext(): {
+function createServiceContext(
+  overrides: { bridgeQueue?: { enqueuePermissionSyncJob: ReturnType<typeof vi.fn> } } = {},
+): {
   service: GroupService;
   db: ScriptedDb;
   audit: ReturnType<typeof createAuditMock>;
@@ -374,7 +404,12 @@ function createServiceContext(): {
   const db = new ScriptedDb();
   const audit = createAuditMock();
   const redis = createRedisMock();
-  const service = new GroupService(db.asDrizzle(), audit.service, redis);
+  const service = new GroupService(
+    db.asDrizzle(),
+    audit.service,
+    redis,
+    overrides.bridgeQueue as never,
+  );
 
   return { service, db, audit, redis };
 }

--- a/apps/api/src/groups/group.module.ts
+++ b/apps/api/src/groups/group.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 
+import { BridgeModule } from '../bridge/bridge.module.js';
 import { GroupController } from './group.controller.js';
 import { GroupService } from './group.service.js';
 
 @Module({
+  imports: [BridgeModule],
   controllers: [GroupController],
   providers: [GroupService],
   exports: [GroupService],

--- a/apps/api/src/groups/group.service.ts
+++ b/apps/api/src/groups/group.service.ts
@@ -25,6 +25,8 @@ import {
 import { getApiLogger } from '../common/logger/logger.module.js';
 import { REDIS_CLIENT } from '../common/redis/redis.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
+import { BridgeQueueService } from '../bridge/bridge-queue.service.js';
+import { enqueuePermissionSync } from '../bridge/bridge-permission-hooks.js';
 
 type GroupDatabase = NodePgDatabase;
 type GroupRow = typeof groups.$inferSelect;
@@ -112,6 +114,7 @@ export class GroupService {
     @Inject(DRIZZLE) private readonly db: GroupDatabase,
     private readonly auditService: AuditService,
     @Optional() @Inject(REDIS_CLIENT) private readonly redis?: RedisPublisher,
+    @Optional() private readonly bridgeQueueService?: BridgeQueueService,
   ) {}
 
   async listGroups(
@@ -256,6 +259,7 @@ export class GroupService {
     const now = new Date();
     const memberChanges: MemberChange[] = [];
     const permissionChanges: PermissionChange[] = [];
+    const memberChangeAffectedSpaceIds = new Set<string>();
 
     try {
       await this.db.transaction(async (tx) => {
@@ -276,6 +280,10 @@ export class GroupService {
           const diff = diffMembers(currentMemberIds, nextMemberIds);
           memberChanges.push(...diff);
           if (diff.length > 0) {
+            const groupPermissions = await getGroupSpacePermissionMap(txDb, tenantId, groupId);
+            for (const spaceId of groupPermissions.keys()) {
+              memberChangeAffectedSpaceIds.add(spaceId);
+            }
             await replaceGroupMembers(txDb, tenantId, groupId, nextMemberIds, now);
             await incrementUsersPermissionVersion(
               txDb,
@@ -363,6 +371,11 @@ export class GroupService {
       });
     }
 
+    this.enqueuePermissionSyncForSpaces(tenantId, [
+      ...memberChangeAffectedSpaceIds,
+      ...permissionChanges.map((change) => change.spaceId),
+    ]);
+
     return this.getGroupResponse(tenantId, groupId);
   }
 
@@ -413,6 +426,7 @@ export class GroupService {
     for (const spaceId of affectedSpaceIds) {
       await this.publishSpacePermissionChanged(tenantId, spaceId);
     }
+    this.enqueuePermissionSyncForSpaces(tenantId, affectedSpaceIds);
 
     for (const memberId of memberIds) {
       await this.publishUserPermissionChanged(tenantId, memberId);
@@ -491,6 +505,7 @@ export class GroupService {
 
     if (permissionChanges.length > 0) {
       await this.publishSpacePermissionChanged(tenantId, spaceId);
+      this.enqueuePermissionSyncForSpaces(tenantId, [spaceId]);
     }
 
     for (const change of permissionChanges) {
@@ -650,6 +665,28 @@ export class GroupService {
     } catch (err) {
       getApiLogger().warn({ err, redis_channel: channel }, 'Redis publish failed');
     }
+  }
+
+  private enqueuePermissionSyncForSpaces(tenantId: string, spaceIds: string[]): void {
+    if (this.bridgeQueueService === undefined) {
+      return;
+    }
+
+    const uniqueSpaceIds = [...new Set(spaceIds)].filter((spaceId) => spaceId.length > 0);
+    if (uniqueSpaceIds.length === 0) {
+      return;
+    }
+
+    void Promise.all(
+      uniqueSpaceIds.map((spaceId) =>
+        enqueuePermissionSync(this.bridgeQueueService as BridgeQueueService, spaceId, tenantId),
+      ),
+    ).catch((err: unknown) => {
+      getApiLogger().warn(
+        { err: toSafeErrorMessage(err), space_ids: uniqueSpaceIds },
+        'Docmost permission sync enqueue failed',
+      );
+    });
   }
 }
 
@@ -1189,6 +1226,10 @@ function normalizePerPage(value: number | undefined): number {
 function normalizeCount(value: unknown): number {
   const parsed = typeof value === 'bigint' ? Number(value) : Number(value ?? 0);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function toSafeErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function isUniqueViolation(err: unknown, constraint: string): boolean {

--- a/apps/api/src/groups/group.service.ts
+++ b/apps/api/src/groups/group.service.ts
@@ -216,6 +216,7 @@ export class GroupService {
       for (const spaceId of affectedSpaces) {
         await this.publishSpacePermissionChanged(tenantId, spaceId);
       }
+      this.enqueuePermissionSyncForSpaces(tenantId, affectedSpaces);
 
       this.auditService.push({
         tenant_id: tenantId,

--- a/apps/api/src/spaces/__tests__/space-permission.service.test.ts
+++ b/apps/api/src/spaces/__tests__/space-permission.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { AUDIT_EVENTS } from '../../audit/audit-events.js';
 import { GroupService } from '../../groups/group.service.js';
@@ -69,6 +69,28 @@ describe('Space permission management', () => {
     );
   });
 
+  it('enqueues permission sync after replacing space permissions', async () => {
+    const bridgeQueue = {
+      enqueuePermissionSyncJob: vi.fn(() => Promise.resolve()),
+    };
+    const { service, db } = createServiceContext({ bridgeQueue });
+    db.queueSelect([{ id: TEST_SPACE_ID }]);
+    db.queueSelect([{ id: TEST_GROUP_ID }]);
+    db.queueSelect([]);
+    db.queueSelect([{ group_id: TEST_GROUP_ID, name: 'Editors', permission: 'space:view' }]);
+
+    await service.replaceSpacePermissions(
+      TEST_SPACE_ID,
+      { permissions: [{ group_id: TEST_GROUP_ID, permissions: ['space:view'] }] },
+      createContext(),
+    );
+
+    expect(bridgeQueue.enqueuePermissionSyncJob).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      spaceId: TEST_SPACE_ID,
+    });
+  });
+
   it('replaces space permissions to revoke a group and writes revoke trail', async () => {
     const { service, db, audit, redis } = createServiceContext();
     db.queueSelect([{ id: TEST_SPACE_ID }]);
@@ -103,7 +125,9 @@ describe('Space permission management', () => {
   });
 });
 
-function createServiceContext(): {
+function createServiceContext(
+  overrides: { bridgeQueue?: { enqueuePermissionSyncJob: ReturnType<typeof vi.fn> } } = {},
+): {
   service: GroupService;
   db: ScriptedDb;
   audit: ReturnType<typeof createAuditMock>;
@@ -112,7 +136,12 @@ function createServiceContext(): {
   const db = new ScriptedDb();
   const audit = createAuditMock();
   const redis = createRedisMock();
-  const service = new GroupService(db.asDrizzle(), audit.service, redis);
+  const service = new GroupService(
+    db.asDrizzle(),
+    audit.service,
+    redis,
+    overrides.bridgeQueue as never,
+  );
 
   return { service, db, audit, redis };
 }

--- a/apps/api/src/users/__tests__/user-group-service-test-utils.ts
+++ b/apps/api/src/users/__tests__/user-group-service-test-utils.ts
@@ -239,6 +239,7 @@ export function createUserRow(overrides: Partial<UserRow> = {}): UserRow {
     password_hash: 'password-hash',
     role: 'viewer',
     status: 'active',
+    docmost_user_id: null,
     permission_version: 1,
     last_login_at: null,
     created_at: new Date('2026-04-01T00:00:00.000Z'),

--- a/apps/api/src/users/__tests__/user.service.test.ts
+++ b/apps/api/src/users/__tests__/user.service.test.ts
@@ -1,6 +1,6 @@
 import { group_members, ErrorCode, sessions, users } from '@cherrygraph/shared';
 import { inspect } from 'node:util';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { AUDIT_EVENTS } from '../../audit/audit-events.js';
 import { UserService } from '../user.service.js';
@@ -90,6 +90,31 @@ describe('UserService', () => {
         resource_type: 'user',
       }),
     );
+  });
+
+  it('enqueues user sync after creating a user', async () => {
+    const bridgeQueue = {
+      enqueueUserSyncJob: vi.fn(() => Promise.resolve()),
+    };
+    const { service, db } = createServiceContext({ bridgeQueue });
+
+    await service.createUser(
+      {
+        email: 'USER@example.com ',
+        name: 'Test User',
+        password: 'Correct1!',
+        role: 'editor',
+      },
+      createContext(),
+    );
+
+    const insertedUserId = String(requireRecord(db.inserts[0]?.value).id);
+    expect(bridgeQueue.enqueueUserSyncJob).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      userId: insertedUserId,
+      email: 'user@example.com',
+      name: 'Test User',
+    });
   });
 
   it('maps duplicate user email to USER_EMAIL_CONFLICT', async () => {
@@ -337,7 +362,9 @@ describe('UserService', () => {
   });
 });
 
-function createServiceContext(): {
+function createServiceContext(
+  overrides: { bridgeQueue?: { enqueueUserSyncJob: ReturnType<typeof vi.fn> } } = {},
+): {
   service: UserService;
   db: ScriptedDb;
   audit: ReturnType<typeof createAuditMock>;
@@ -348,7 +375,13 @@ function createServiceContext(): {
   const audit = createAuditMock();
   const session = createSessionMock();
   const redis = createRedisMock();
-  const service = new UserService(db.asDrizzle(), audit.service, session.service, redis);
+  const service = new UserService(
+    db.asDrizzle(),
+    audit.service,
+    session.service,
+    redis,
+    overrides.bridgeQueue as never,
+  );
 
   return { service, db, audit, session, redis };
 }

--- a/apps/api/src/users/__tests__/user.service.test.ts
+++ b/apps/api/src/users/__tests__/user.service.test.ts
@@ -7,6 +7,7 @@ import { UserService } from '../user.service.js';
 import {
   TEST_ACTOR_ID,
   TEST_GROUP_ID,
+  TEST_SPACE_ID,
   TEST_TENANT_ID,
   TEST_USER_ID,
   ScriptedDb,
@@ -93,9 +94,7 @@ describe('UserService', () => {
   });
 
   it('enqueues user sync after creating a user', async () => {
-    const bridgeQueue = {
-      enqueueUserSyncJob: vi.fn(() => Promise.resolve()),
-    };
+    const bridgeQueue = createBridgeQueueMock();
     const { service, db } = createServiceContext({ bridgeQueue });
 
     await service.createUser(
@@ -254,6 +253,24 @@ describe('UserService', () => {
     );
   });
 
+  it('enqueues permission sync for spaces affected by a disabled user', async () => {
+    const bridgeQueue = createBridgeQueueMock();
+    const { service, db } = createServiceContext({ bridgeQueue });
+    db.queueSelect([createUserRow({ status: 'active' })]);
+    db.queueUpdate([createUserRow({ status: 'disabled' })]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID }]);
+    db.queueSelect([]);
+
+    await service.updateUser(TEST_USER_ID, { status: 'disabled' }, createContext());
+
+    await vi.waitFor(() => {
+      expect(bridgeQueue.enqueuePermissionSyncJob).toHaveBeenCalledWith({
+        tenantId: TEST_TENANT_ID,
+        spaceId: TEST_SPACE_ID,
+      });
+    });
+  });
+
   it('re-enables a user and records admin.user.update', async () => {
     const { service, db, audit, session, redis } = createServiceContext();
     db.queueSelect([createUserRow({ status: 'disabled' })]);
@@ -315,6 +332,21 @@ describe('UserService', () => {
     );
   });
 
+  it('enqueues permission sync for spaces affected by a deleted user', async () => {
+    const bridgeQueue = createBridgeQueueMock();
+    const { service, db } = createServiceContext({ bridgeQueue });
+    db.queueSelect([createUserRow({ status: 'active' })]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID }]);
+    db.queueUpdate([createUserRow({ status: 'deleted', permission_version: 2 })]);
+
+    await service.deleteUser(TEST_USER_ID, createContext());
+
+    expect(bridgeQueue.enqueuePermissionSyncJob).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      spaceId: TEST_SPACE_ID,
+    });
+  });
+
   it('denies deleting yourself', async () => {
     const { service, db } = createServiceContext();
     db.queueSelect([createUserRow({ id: TEST_ACTOR_ID })]);
@@ -363,7 +395,7 @@ describe('UserService', () => {
 });
 
 function createServiceContext(
-  overrides: { bridgeQueue?: { enqueueUserSyncJob: ReturnType<typeof vi.fn> } } = {},
+  overrides: { bridgeQueue?: ReturnType<typeof createBridgeQueueMock> } = {},
 ): {
   service: UserService;
   db: ScriptedDb;
@@ -384,6 +416,16 @@ function createServiceContext(
   );
 
   return { service, db, audit, session, redis };
+}
+
+function createBridgeQueueMock(): {
+  enqueueUserSyncJob: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  enqueuePermissionSyncJob: ReturnType<typeof vi.fn<() => Promise<void>>>;
+} {
+  return {
+    enqueueUserSyncJob: vi.fn(() => Promise.resolve()),
+    enqueuePermissionSyncJob: vi.fn(() => Promise.resolve()),
+  };
 }
 
 function createContext(

--- a/apps/api/src/users/user.module.ts
+++ b/apps/api/src/users/user.module.ts
@@ -1,11 +1,12 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module.js';
+import { BridgeModule } from '../bridge/bridge.module.js';
 import { UserController } from './user.controller.js';
 import { UserService } from './user.service.js';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, forwardRef(() => BridgeModule)],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/apps/api/src/users/user.service.ts
+++ b/apps/api/src/users/user.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
 import { ROLES, hashPassword, normalizeRole, type Role } from '@cherrygraph/auth-core';
-import { ErrorCode, group_members, groups, sessions, tenants, users } from '@cherrygraph/shared';
+import { ErrorCode, group_members, groups, sessions, space_permissions, tenants, users } from '@cherrygraph/shared';
 import { and, asc, count, desc, eq, ilike, inArray, or, sql, type SQL } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { randomUUID } from 'node:crypto';
@@ -18,6 +18,7 @@ import { REDIS_CLIENT } from '../common/redis/redis.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { SessionService } from '../auth/session.service.js';
 import { BridgeQueueService } from '../bridge/bridge-queue.service.js';
+import { enqueuePermissionSync } from '../bridge/bridge-permission-hooks.js';
 
 type UserDatabase = NodePgDatabase;
 type UserRow = typeof users.$inferSelect;
@@ -203,6 +204,7 @@ export class UserService {
           'Docmost user sync enqueue failed',
         );
       });
+      this.enqueuePermissionSyncForGroups(tenantId, groupIds);
 
       return toAdminUserResponse(created, groupIds);
     } catch (err) {
@@ -447,6 +449,45 @@ export class UserService {
     } catch (err) {
       getApiLogger().warn({ err, redis_channel: channel }, 'Redis publish failed');
     }
+  }
+
+  private enqueuePermissionSyncForGroups(tenantId: string, groupIds: string[]): void {
+    if (this.bridgeQueueService === undefined) {
+      return;
+    }
+
+    const uniqueGroupIds = [...new Set(groupIds)].filter((groupId) => groupId.length > 0);
+    if (uniqueGroupIds.length === 0) {
+      return;
+    }
+
+    void this.getSpaceIdsForGroups(tenantId, uniqueGroupIds)
+      .then((spaceIds) =>
+        Promise.all(
+          spaceIds.map((spaceId) =>
+            enqueuePermissionSync(this.bridgeQueueService as BridgeQueueService, spaceId, tenantId),
+          ),
+        ),
+      )
+      .catch((err: unknown) => {
+        getApiLogger().warn(
+          { err: toSafeErrorMessage(err), group_ids: uniqueGroupIds },
+          'Docmost permission sync enqueue failed',
+        );
+      });
+  }
+
+  private async getSpaceIdsForGroups(tenantId: string, groupIds: string[]): Promise<string[]> {
+    if (groupIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db
+      .select({ space_id: space_permissions.space_id })
+      .from(space_permissions)
+      .where(and(eq(space_permissions.tenant_id, tenantId), inArray(space_permissions.group_id, groupIds)));
+
+    return [...new Set(rows.map((row) => row.space_id))];
   }
 }
 

--- a/apps/api/src/users/user.service.ts
+++ b/apps/api/src/users/user.service.ts
@@ -303,6 +303,10 @@ export class UserService {
       await this.publishUserPermissionChanged(tenantId, userId);
     }
 
+    if (changedFields.includes('status')) {
+      this.enqueuePermissionSyncForUserSpaces(tenantId, userId);
+    }
+
     this.auditService.push({
       tenant_id: tenantId,
       ...(context.actorUserId !== undefined ? { actor_user_id: context.actorUserId } : {}),
@@ -336,6 +340,7 @@ export class UserService {
     }
 
     const now = new Date();
+    const affectedSpaceIds = await this.getSpaceIdsForUserGroups(tenantId, userId);
     await this.db.transaction(async (tx) => {
       const txDb = tx as UserDatabase;
       const [deleted] = await txDb
@@ -362,6 +367,7 @@ export class UserService {
     });
 
     await this.publishUserPermissionChanged(tenantId, userId);
+    this.enqueuePermissionSyncForSpaces(tenantId, affectedSpaceIds);
 
     this.auditService.push({
       tenant_id: tenantId,
@@ -477,6 +483,43 @@ export class UserService {
       });
   }
 
+  private enqueuePermissionSyncForUserSpaces(tenantId: string, userId: string): void {
+    if (this.bridgeQueueService === undefined) {
+      return;
+    }
+
+    void this.getSpaceIdsForUserGroups(tenantId, userId)
+      .then((spaceIds) => this.enqueuePermissionSyncForSpaces(tenantId, spaceIds))
+      .catch((err: unknown) => {
+        getApiLogger().warn(
+          { err: toSafeErrorMessage(err), user_id: userId },
+          'Docmost permission sync enqueue failed',
+        );
+      });
+  }
+
+  private enqueuePermissionSyncForSpaces(tenantId: string, spaceIds: string[]): void {
+    if (this.bridgeQueueService === undefined) {
+      return;
+    }
+
+    const uniqueSpaceIds = [...new Set(spaceIds)].filter((spaceId) => spaceId.length > 0);
+    if (uniqueSpaceIds.length === 0) {
+      return;
+    }
+
+    void Promise.all(
+      uniqueSpaceIds.map((spaceId) =>
+        enqueuePermissionSync(this.bridgeQueueService as BridgeQueueService, spaceId, tenantId),
+      ),
+    ).catch((err: unknown) => {
+      getApiLogger().warn(
+        { err: toSafeErrorMessage(err), space_ids: uniqueSpaceIds },
+        'Docmost permission sync enqueue failed',
+      );
+    });
+  }
+
   private async getSpaceIdsForGroups(tenantId: string, groupIds: string[]): Promise<string[]> {
     if (groupIds.length === 0) {
       return [];
@@ -486,6 +529,22 @@ export class UserService {
       .select({ space_id: space_permissions.space_id })
       .from(space_permissions)
       .where(and(eq(space_permissions.tenant_id, tenantId), inArray(space_permissions.group_id, groupIds)));
+
+    return [...new Set(rows.map((row) => row.space_id))];
+  }
+
+  private async getSpaceIdsForUserGroups(tenantId: string, userId: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ space_id: space_permissions.space_id })
+      .from(group_members)
+      .innerJoin(
+        space_permissions,
+        and(
+          eq(group_members.tenant_id, space_permissions.tenant_id),
+          eq(group_members.group_id, space_permissions.group_id),
+        ),
+      )
+      .where(and(eq(group_members.tenant_id, tenantId), eq(group_members.user_id, userId)));
 
     return [...new Set(rows.map((row) => row.space_id))];
   }

--- a/apps/api/src/users/user.service.ts
+++ b/apps/api/src/users/user.service.ts
@@ -17,6 +17,7 @@ import { getApiLogger } from '../common/logger/logger.module.js';
 import { REDIS_CLIENT } from '../common/redis/redis.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { SessionService } from '../auth/session.service.js';
+import { BridgeQueueService } from '../bridge/bridge-queue.service.js';
 
 type UserDatabase = NodePgDatabase;
 type UserRow = typeof users.$inferSelect;
@@ -97,6 +98,7 @@ export class UserService {
     private readonly auditService: AuditService,
     private readonly sessionService: SessionService,
     @Optional() @Inject(REDIS_CLIENT) private readonly redis?: RedisPublisher,
+    @Optional() private readonly bridgeQueueService?: BridgeQueueService,
   ) {}
 
   async listUsers(
@@ -188,6 +190,18 @@ export class UserService {
           role: created.role,
           groups: groupIds,
         },
+      });
+
+      void this.bridgeQueueService?.enqueueUserSyncJob({
+        userId: created.id,
+        email: created.email,
+        name: created.display_name,
+        tenantId,
+      }).catch((err: unknown) => {
+        getApiLogger().warn(
+          { err: toSafeErrorMessage(err), user_id: created.id },
+          'Docmost user sync enqueue failed',
+        );
       });
 
       return toAdminUserResponse(created, groupIds);
@@ -607,6 +621,10 @@ function normalizeStatusOrThrow(status: string): string {
 
 function normalizeEmail(email: string): string {
   return email.trim().toLowerCase();
+}
+
+function toSafeErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function normalizeIdList(values: string[]): string[] {

--- a/apps/wiki-sync-worker/src/__tests__/health.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/health.test.ts
@@ -14,6 +14,7 @@ describe('wiki-sync-worker health server', () => {
         'attachment-sync': { getWaitingCount: vi.fn(() => Promise.resolve(4)) },
         'docmost-push': { getWaitingCount: vi.fn(() => Promise.resolve(3)) },
         'space-provision': { getWaitingCount: vi.fn(() => Promise.resolve(5)) },
+        'user-sync': { getWaitingCount: vi.fn(() => Promise.resolve(6)) },
       },
       0,
     );
@@ -34,6 +35,7 @@ describe('wiki-sync-worker health server', () => {
           'attachment-sync': 4,
           'docmost-push': 3,
           'space-provision': 5,
+          'user-sync': 6,
         },
       });
     } finally {

--- a/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
@@ -29,19 +29,20 @@ describe('permission-sync processor', () => {
   it('pushes collapsed space permissions to Docmost', async () => {
     const db = new PermissionSyncTestDb();
     db.permissionRows = [
-      { userId: 'user-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
-      { userId: 'user-writer', email: 'writer@example.com', cherryRole: 'space:edit' },
-      { userId: 'user-reader', email: 'reader@example.com', cherryRole: 'space:view' },
-      { userId: 'user-writer', email: 'writer@example.com', cherryRole: 'space:view' },
+      { userId: 'docmost-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
+      { userId: 'docmost-writer', email: 'writer@example.com', cherryRole: 'space:edit' },
+      { userId: 'docmost-reader', email: 'reader@example.com', cherryRole: 'space:view' },
+      { userId: 'docmost-writer', email: 'writer@example.com', cherryRole: 'space:view' },
+      { userId: null, email: 'unsynced@example.com', cherryRole: 'space:admin' },
     ];
     const bridgeClient = createBridgeClient();
 
     await runProcessor(db, bridgeClient);
 
     expect(bridgeClient.pushPermissions).toHaveBeenCalledWith('docmost-space-1', [
-      { userId: 'user-admin', email: 'admin@example.com', role: 'admin' },
-      { userId: 'user-reader', email: 'reader@example.com', role: 'reader' },
-      { userId: 'user-writer', email: 'writer@example.com', role: 'writer' },
+      { userId: 'docmost-admin', email: 'admin@example.com', role: 'admin' },
+      { userId: 'docmost-reader', email: 'reader@example.com', role: 'reader' },
+      { userId: 'docmost-writer', email: 'writer@example.com', role: 'writer' },
     ], { version: 1, source: 'cherry_api' });
   });
 
@@ -101,7 +102,7 @@ describe('permission-sync processor', () => {
     await expect(reconcilePermissions(db.asDb(), bridgeClient)).resolves.toEqual({ fixed: 1, errors: 0 });
 
     expect(bridgeClient.pushPermissions).toHaveBeenCalledWith('docmost-space-1', [
-      { userId: 'user-admin', email: 'admin@example.com', role: 'admin' },
+      { userId: 'docmost-admin', email: 'admin@example.com', role: 'admin' },
     ], { version: 1, source: 'cherry_api' });
     expect(db.auditRows.at(-1)).toMatchObject({ action: 'permission_consistency_fixed' });
   });
@@ -112,7 +113,7 @@ describe('permission-sync processor', () => {
       pushPermissions: vi.fn<PermissionSyncBridgeClient['pushPermissions']>(() => Promise.resolve()),
       getPermissions: vi.fn(() =>
         Promise.resolve<PermissionMember[]>([
-          { userId: 'user-admin', email: 'admin@example.com', role: 'admin' },
+          { userId: 'docmost-admin', email: 'admin@example.com', role: 'admin' },
         ]),
       ),
     };
@@ -129,8 +130,8 @@ type AuditLogInsert = typeof audit_logs.$inferInsert;
 
 class PermissionSyncTestDb {
   spaces: SpaceRow[];
-  permissionRows: Array<{ userId: string; email: string; cherryRole: string }> = [
-    { userId: 'user-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
+  permissionRows: Array<{ userId: string | null; email: string; cherryRole: string }> = [
+    { userId: 'docmost-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
   ];
   auditRows: AuditLogInsert[] = [];
 

--- a/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
@@ -33,7 +33,6 @@ describe('permission-sync processor', () => {
       { userId: 'docmost-writer', email: 'writer@example.com', cherryRole: 'space:edit' },
       { userId: 'docmost-reader', email: 'reader@example.com', cherryRole: 'space:view' },
       { userId: 'docmost-writer', email: 'writer@example.com', cherryRole: 'space:view' },
-      { userId: null, email: 'unsynced@example.com', cherryRole: 'space:admin' },
     ];
     const bridgeClient = createBridgeClient();
 
@@ -44,6 +43,19 @@ describe('permission-sync processor', () => {
       { userId: 'docmost-reader', email: 'reader@example.com', role: 'reader' },
       { userId: 'docmost-writer', email: 'writer@example.com', role: 'writer' },
     ], { version: 1, source: 'cherry_api' });
+  });
+
+  it('defers permission pushes while active users are pending Docmost sync', async () => {
+    const db = new PermissionSyncTestDb();
+    db.permissionRows = [
+      { userId: 'docmost-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
+      { userId: null, email: 'unsynced@example.com', cherryRole: 'space:view' },
+    ];
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    expect(bridgeClient.pushPermissions).not.toHaveBeenCalled();
   });
 
   it('skips spaces that have not been synced to Docmost', async () => {

--- a/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
@@ -42,7 +42,7 @@ describe('permission-sync processor', () => {
       { userId: 'user-admin', email: 'admin@example.com', role: 'admin' },
       { userId: 'user-reader', email: 'reader@example.com', role: 'reader' },
       { userId: 'user-writer', email: 'writer@example.com', role: 'writer' },
-    ]);
+    ], { version: 1, source: 'cherry_api' });
   });
 
   it('skips spaces that have not been synced to Docmost', async () => {
@@ -102,7 +102,7 @@ describe('permission-sync processor', () => {
 
     expect(bridgeClient.pushPermissions).toHaveBeenCalledWith('docmost-space-1', [
       { userId: 'user-admin', email: 'admin@example.com', role: 'admin' },
-    ]);
+    ], { version: 1, source: 'cherry_api' });
     expect(db.auditRows.at(-1)).toMatchObject({ action: 'permission_consistency_fixed' });
   });
 
@@ -150,13 +150,18 @@ class PermissionSyncTestDb {
                   spaceId: space.id,
                   tenantId: space.tenant_id,
                   docmostSpaceId: space.docmost_space_id,
+                  permissionVersion: space.permission_version,
                 }));
             }
 
             const space = this.spaces.find((row) => row.id === 'space-1');
             return space === undefined
               ? []
-              : [{ tenantId: space.tenant_id, docmostSpaceId: space.docmost_space_id }];
+              : [{
+                  tenantId: space.tenant_id,
+                  docmostSpaceId: space.docmost_space_id,
+                  permissionVersion: space.permission_version,
+                }];
           }
 
           if (table === space_permissions) {

--- a/apps/wiki-sync-worker/src/__tests__/user-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/user-sync.test.ts
@@ -15,7 +15,8 @@ describe('user-sync processor', () => {
         Promise.resolve({ docmost_user_id: 'docmost-user-1' }),
       ),
     };
-    const processor = createUserSyncProcessor({ bridgeClient });
+    const db = createDb();
+    const processor = createUserSyncProcessor({ db: db as never, bridgeClient });
 
     await processor({
       data: {
@@ -31,8 +32,21 @@ describe('user-sync processor', () => {
       name: 'Test User',
       cherry_user_id: 'user-1',
     });
+    expect(db.update).toHaveBeenCalled();
   });
 });
+
+function createDb(): { update: ReturnType<typeof vi.fn> } {
+  return {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(() => Promise.resolve([{ id: 'user-1' }])),
+        })),
+      })),
+    })),
+  };
+}
 
 describe('worker startup reconciliation', () => {
   it('runs permission reconciliation immediately at startup', async () => {

--- a/apps/wiki-sync-worker/src/__tests__/user-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/user-sync.test.ts
@@ -1,0 +1,55 @@
+import type { Job } from 'bullmq';
+import { describe, expect, it, vi } from 'vitest';
+
+import { runStartupPermissionReconciliation } from '../main.js';
+import {
+  createUserSyncProcessor,
+  type UserSyncBridgeClient,
+  type UserSyncJobData,
+} from '../processors/user-sync.processor.js';
+
+describe('user-sync processor', () => {
+  it('calls bridge to create or find a Docmost user', async () => {
+    const bridgeClient = {
+      syncUser: vi.fn<UserSyncBridgeClient['syncUser']>(() =>
+        Promise.resolve({ docmost_user_id: 'docmost-user-1' }),
+      ),
+    };
+    const processor = createUserSyncProcessor({ bridgeClient });
+
+    await processor({
+      data: {
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        email: 'user@example.com',
+        name: 'Test User',
+      },
+    } as Job<UserSyncJobData>);
+
+    expect(bridgeClient.syncUser).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      name: 'Test User',
+      cherry_user_id: 'user-1',
+    });
+  });
+});
+
+describe('worker startup reconciliation', () => {
+  it('runs permission reconciliation immediately at startup', async () => {
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve([])),
+        })),
+      })),
+    };
+    const bridgeClient = {
+      pushPermissions: vi.fn(() => Promise.resolve()),
+      getPermissions: vi.fn(() => Promise.resolve([])),
+    };
+
+    await runStartupPermissionReconciliation(db as never, bridgeClient);
+
+    expect(db.select).toHaveBeenCalled();
+  });
+});

--- a/apps/wiki-sync-worker/src/bridge-client.ts
+++ b/apps/wiki-sync-worker/src/bridge-client.ts
@@ -3,6 +3,7 @@ import { createHash, createHmac, randomUUID } from 'node:crypto';
 import type { DocmostPushBridgeClient } from './processors/docmost-push.processor.js';
 import type { PermissionSyncBridgeClient } from './processors/permission-sync.processor.js';
 import type { SpaceProvisionBridgeClient } from './processors/space-provision.processor.js';
+import type { UserSyncBridgeClient } from './processors/user-sync.processor.js';
 
 export class BridgeClientHttpError extends Error {
   constructor(
@@ -17,10 +18,42 @@ export class BridgeClientHttpError extends Error {
 export function createBridgeClient(
   baseUrl: string,
   secret: string,
-): DocmostPushBridgeClient & PermissionSyncBridgeClient & SpaceProvisionBridgeClient {
+): DocmostPushBridgeClient & PermissionSyncBridgeClient & SpaceProvisionBridgeClient & UserSyncBridgeClient {
   const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
 
   return {
+    async syncUser(input) {
+      const path = '/api/internal/bridge/users';
+      const body = JSON.stringify({
+        email: input.email,
+        name: input.name,
+        cherry_user_id: input.cherry_user_id,
+      });
+      const response = await fetch(`${normalizedBaseUrl}${path}`, {
+        method: 'POST',
+        headers: {
+          ...createBridgeHeaders(secret, 'POST', path, body),
+          'content-type': 'application/json',
+        },
+        body,
+      });
+
+      if (!response.ok) {
+        throw new BridgeClientHttpError(
+          `Bridge user sync failed for Cherry user ${input.cherry_user_id}: HTTP ${response.status}`,
+          response.status,
+        );
+      }
+
+      const payload = readRecord(await response.json());
+      const docmostUserId = readString(payload.docmost_user_id);
+      if (docmostUserId === undefined) {
+        throw new Error('Bridge user sync response did not include docmost_user_id');
+      }
+
+      return { docmost_user_id: docmostUserId };
+    },
+
     async provisionSpace(input) {
       const path = '/api/internal/bridge/spaces';
       const body = JSON.stringify({
@@ -112,9 +145,16 @@ export function createBridgeClient(
       return { markdown };
     },
 
-    async pushPermissions(docmostSpaceId, members) {
+    async pushPermissions(docmostSpaceId, members, opts) {
       const path = `/api/internal/bridge/spaces/${encodeURIComponent(docmostSpaceId)}/permissions`;
-      const body = JSON.stringify({ members });
+      const body = JSON.stringify({
+        groups: members.map((member) => ({
+          group_id: member.userId,
+          permissions: [docmostRoleToPermission(member.role)],
+        })),
+        version: opts?.version ?? Date.now(),
+        source: opts?.source ?? 'cherry_api',
+      });
       const response = await fetch(
         `${normalizedBaseUrl}${path}`,
         {
@@ -209,4 +249,14 @@ function readPermissionMember(value: unknown): Array<{ userId: string; email: st
 
 function readPermissionRole(value: unknown): 'admin' | 'writer' | 'reader' | undefined {
   return value === 'admin' || value === 'writer' || value === 'reader' ? value : undefined;
+}
+
+function docmostRoleToPermission(role: 'admin' | 'writer' | 'reader'): 'admin' | 'edit' | 'view' {
+  if (role === 'admin') {
+    return 'admin';
+  }
+  if (role === 'writer') {
+    return 'edit';
+  }
+  return 'view';
 }

--- a/apps/wiki-sync-worker/src/health.ts
+++ b/apps/wiki-sync-worker/src/health.ts
@@ -10,6 +10,7 @@ export type WikiSyncHealthQueues = {
   'attachment-sync': PendingQueue;
   'docmost-push': PendingQueue;
   'space-provision': PendingQueue;
+  'user-sync': PendingQueue;
 };
 
 export type WikiSyncHealthPayload = {
@@ -20,6 +21,7 @@ export type WikiSyncHealthPayload = {
     'attachment-sync': number;
     'docmost-push': number;
     'space-provision': number;
+    'user-sync': number;
   };
 };
 
@@ -44,12 +46,13 @@ export function createHealthServer(queues: WikiSyncHealthQueues): Server {
 }
 
 export async function buildHealthPayload(queues: WikiSyncHealthQueues): Promise<WikiSyncHealthPayload> {
-  const [pageSync, permissionSync, attachmentSync, docmostPush, spaceProvision] = await Promise.all([
+  const [pageSync, permissionSync, attachmentSync, docmostPush, spaceProvision, userSync] = await Promise.all([
     queues['page-sync'].getWaitingCount(),
     queues['permission-sync'].getWaitingCount(),
     queues['attachment-sync'].getWaitingCount(),
     queues['docmost-push'].getWaitingCount(),
     queues['space-provision'].getWaitingCount(),
+    queues['user-sync'].getWaitingCount(),
   ]);
 
   return {
@@ -60,6 +63,7 @@ export async function buildHealthPayload(queues: WikiSyncHealthQueues): Promise<
       'attachment-sync': attachmentSync,
       'docmost-push': docmostPush,
       'space-provision': spaceProvision,
+      'user-sync': userSync,
     },
   };
 }

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -12,6 +12,7 @@ import { closeHealthServer, startHealthServer } from './health.js';
 import { reconcileOnStartup, type ReconciliationDb } from './reconciliation.js';
 import { reconcilePermissions } from './reconciliation/permission-reconcile.js';
 import { reconcileSpaces } from './reconciliation/space-reconcile.js';
+import { reconcileUsers } from './reconciliation/user-reconcile.js';
 import {
   createDocmostPushProcessor,
   type DocmostPushDeps,
@@ -41,6 +42,8 @@ const PAGE_SYNC_QUEUE = 'bridge-page-sync';
 const PERMISSION_SYNC_QUEUE = 'bridge-permission-sync';
 const ATTACHMENT_SYNC_QUEUE = 'bridge-attachment-sync';
 const DOCMOST_PUSH_QUEUE = 'bridge-docmost-push';
+const STARTUP_USER_SYNC_DRAIN_TIMEOUT_MS = 30_000;
+const STARTUP_USER_SYNC_DRAIN_POLL_MS = 1_000;
 
 const PAGE_SYNC_BACKOFF = {
   type: 'custom',
@@ -106,7 +109,7 @@ export async function bootstrap(): Promise<void> {
   const bridgeBaseUrl = process.env.DOCMOST_BRIDGE_BASE_URL ?? process.env.DOCMOST_BASE_URL ?? 'http://localhost:3000';
   const bridgeSecret = process.env.DOCMOST_BRIDGE_SECRET ?? process.env.DOCMOST_BRIDGE_TOKEN ?? '';
   const bridgeClient = createBridgeClient(bridgeBaseUrl, bridgeSecret);
-  await runStartupPermissionReconciliation(db as PermissionSyncDeps['db'], bridgeClient);
+  await queues.permissionSync.pause();
   const workers = createWorkers(connection, {
     pageSync: {
       db,
@@ -133,6 +136,20 @@ export async function bootstrap(): Promise<void> {
       bridgeClient,
     },
   });
+
+  try {
+    const userReconcileCount = await reconcileUsers(db as UserSyncDeps['db'], queues.userSync);
+    if (userReconcileCount > 0) {
+      console.log(`${WORKER_NAME}: enqueued user reconciliation jobs`, {
+        count: userReconcileCount,
+      });
+    }
+    await waitForUserSyncQueueToDrain(queues.userSync);
+    await runStartupPermissionReconciliation(db as PermissionSyncDeps['db'], bridgeClient);
+  } finally {
+    await queues.permissionSync.resume();
+  }
+
   const permissionReconcileTimer = startPermissionReconcileTimer(db, bridgeClient);
   const spaceReconcileTimer = startSpaceReconcileTimer(
     db as SpaceProvisionDeps['db'],
@@ -163,6 +180,42 @@ export async function bootstrap(): Promise<void> {
   process.once('SIGTERM', shutdown);
   process.once('SIGINT', shutdown);
   console.log(`${WORKER_NAME}: started`, { healthPort });
+}
+
+async function waitForUserSyncQueueToDrain(queue: BridgeWorkerQueues['userSync']): Promise<void> {
+  const deadline = Date.now() + STARTUP_USER_SYNC_DRAIN_TIMEOUT_MS;
+
+  for (;;) {
+    const pending = await getPendingUserSyncJobCount(queue);
+    if (pending === 0) {
+      return;
+    }
+
+    if (Date.now() >= deadline) {
+      console.warn(`${WORKER_NAME}: continuing startup with pending user-sync jobs`, {
+        pending,
+      });
+      return;
+    }
+
+    await sleep(STARTUP_USER_SYNC_DRAIN_POLL_MS);
+  }
+}
+
+async function getPendingUserSyncJobCount(queue: BridgeWorkerQueues['userSync']): Promise<number> {
+  const counts = await queue.getJobCounts('waiting', 'active', 'delayed', 'prioritized');
+  return (
+    (counts.waiting ?? 0) +
+    (counts.active ?? 0) +
+    (counts.delayed ?? 0) +
+    (counts.prioritized ?? 0)
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 function createQueues(connection: IORedis): BridgeWorkerQueues {

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -129,6 +129,7 @@ export async function bootstrap(): Promise<void> {
       bridgeClient,
     },
     userSync: {
+      db,
       bridgeClient,
     },
   });

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -30,6 +30,11 @@ import {
   createSpaceProvisionProcessor,
   type SpaceProvisionDeps,
 } from './processors/space-provision.processor.js';
+import {
+  BRIDGE_USER_SYNC_QUEUE,
+  createUserSyncProcessor,
+  type UserSyncDeps,
+} from './processors/user-sync.processor.js';
 
 const WORKER_NAME = 'wiki-sync-worker';
 const PAGE_SYNC_QUEUE = 'bridge-page-sync';
@@ -67,6 +72,7 @@ type BridgeWorkerQueues = {
   attachmentSync: BullQueue;
   docmostPush: BullQueue;
   spaceProvision: BullQueue;
+  userSync: BullQueue;
 };
 
 type BridgeWorkers = {
@@ -74,6 +80,7 @@ type BridgeWorkers = {
   permissionSync: BullWorker;
   docmostPush: BullWorker;
   spaceProvision: BullWorker;
+  userSync: BullWorker;
 };
 
 export async function bootstrap(): Promise<void> {
@@ -99,6 +106,7 @@ export async function bootstrap(): Promise<void> {
   const bridgeBaseUrl = process.env.DOCMOST_BRIDGE_BASE_URL ?? process.env.DOCMOST_BASE_URL ?? 'http://localhost:3000';
   const bridgeSecret = process.env.DOCMOST_BRIDGE_SECRET ?? process.env.DOCMOST_BRIDGE_TOKEN ?? '';
   const bridgeClient = createBridgeClient(bridgeBaseUrl, bridgeSecret);
+  await runStartupPermissionReconciliation(db as PermissionSyncDeps['db'], bridgeClient);
   const workers = createWorkers(connection, {
     pageSync: {
       db,
@@ -120,6 +128,9 @@ export async function bootstrap(): Promise<void> {
       db,
       bridgeClient,
     },
+    userSync: {
+      bridgeClient,
+    },
   });
   const permissionReconcileTimer = startPermissionReconcileTimer(db, bridgeClient);
   const spaceReconcileTimer = startSpaceReconcileTimer(
@@ -134,6 +145,7 @@ export async function bootstrap(): Promise<void> {
       'attachment-sync': queues.attachmentSync,
       'docmost-push': queues.docmostPush,
       'space-provision': queues.spaceProvision,
+      'user-sync': queues.userSync,
     },
     healthPort,
   );
@@ -159,6 +171,7 @@ function createQueues(connection: IORedis): BridgeWorkerQueues {
     attachmentSync: new Queue(ATTACHMENT_SYNC_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
     docmostPush: new Queue(DOCMOST_PUSH_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
     spaceProvision: new Queue(BRIDGE_SPACE_PROVISION_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
+    userSync: new Queue(BRIDGE_USER_SYNC_QUEUE, { connection, defaultJobOptions: DEFAULT_JOB_OPTIONS }),
   };
 }
 
@@ -169,6 +182,7 @@ function createWorkers(
     permissionSync: PermissionSyncDeps;
     docmostPush: DocmostPushDeps;
     spaceProvision: SpaceProvisionDeps;
+    userSync: UserSyncDeps;
   },
 ): BridgeWorkers {
   const pageSync = new Worker(PAGE_SYNC_QUEUE, createPageSyncProcessor(deps.pageSync), {
@@ -199,6 +213,14 @@ function createWorkers(
       concurrency: 1,
     },
   );
+  const userSync = new Worker(
+    BRIDGE_USER_SYNC_QUEUE,
+    createUserSyncProcessor(deps.userSync),
+    {
+      connection,
+      concurrency: 1,
+    },
+  );
 
   pageSync.on('error', (error) => {
     console.error(`${WORKER_NAME}: page-sync worker error`, error);
@@ -212,8 +234,22 @@ function createWorkers(
   spaceProvision.on('error', (error) => {
     console.error(`${WORKER_NAME}: space-provision worker error`, error);
   });
+  userSync.on('error', (error) => {
+    console.error(`${WORKER_NAME}: user-sync worker error`, error);
+  });
 
-  return { pageSync, permissionSync, docmostPush, spaceProvision };
+  return { pageSync, permissionSync, docmostPush, spaceProvision, userSync };
+}
+
+export async function runStartupPermissionReconciliation(
+  db: PermissionSyncDeps['db'],
+  bridgeClient: PermissionSyncDeps['bridgeClient'],
+): Promise<void> {
+  try {
+    await reconcilePermissions(db, bridgeClient);
+  } catch (error) {
+    console.error(`${WORKER_NAME}: startup permission reconcile failed`, error);
+  }
 }
 
 function startPermissionReconcileTimer(
@@ -308,12 +344,14 @@ async function shutdown(
     queues.attachmentSync,
     queues.docmostPush,
     queues.spaceProvision,
+    queues.userSync,
   ];
   const workerList = [
     workers.pageSync,
     workers.permissionSync,
     workers.docmostPush,
     workers.spaceProvision,
+    workers.userSync,
   ];
 
   try {

--- a/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
@@ -45,7 +45,7 @@ export type PermissionSyncJobData = {
 };
 
 type SpacePermissionRow = {
-  userId: string;
+  userId: string | null;
   email: string;
   cherryRole: string;
 };
@@ -123,7 +123,7 @@ export async function loadSpacePermissionMembers(
 ): Promise<PermissionMember[]> {
   const rows = await db
     .select({
-      userId: users.id,
+      userId: users.docmost_user_id,
       email: users.email,
       cherryRole: space_permissions.permission,
     })
@@ -195,7 +195,7 @@ function collapsePermissionRows(rows: SpacePermissionRow[]): PermissionMember[] 
   const membersByUserId = new Map<string, PermissionMember>();
 
   for (const row of rows) {
-    if (row.email.length === 0) {
+    if (row.userId === null || row.email.length === 0) {
       continue;
     }
 

--- a/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
@@ -50,11 +50,18 @@ type SpacePermissionRow = {
   cherryRole: string;
 };
 
+export type SpacePermissionMemberState = {
+  members: PermissionMember[];
+  pendingDocmostUserCount: number;
+};
+
 type PushSpacePermissionsResult = {
   pushed: boolean;
+  deferred?: boolean;
   tenantId?: string;
   docmostSpaceId?: string;
   version?: number;
+  pendingDocmostUserCount?: number;
   members: PermissionMember[];
 };
 
@@ -99,10 +106,27 @@ export async function pushSpacePermissions(
     return { pushed: false, members: [] };
   }
 
-  const members = await loadSpacePermissionMembers(db, {
+  const memberState = await loadSpacePermissionMemberState(db, {
     spaceId: data.spaceId,
     tenantId: space.tenantId,
   });
+  if (memberState.pendingDocmostUserCount > 0) {
+    console.info(`Permission sync deferred: ${memberState.pendingDocmostUserCount} users pending Docmost sync`, {
+      spaceId: data.spaceId,
+      tenantId: space.tenantId,
+    });
+    return {
+      pushed: false,
+      deferred: true,
+      tenantId: space.tenantId,
+      docmostSpaceId: space.docmostSpaceId,
+      version: space.permissionVersion,
+      pendingDocmostUserCount: memberState.pendingDocmostUserCount,
+      members: memberState.members,
+    };
+  }
+
+  const members = memberState.members;
   await bridgeClient.pushPermissions(space.docmostSpaceId, members, {
     version: space.permissionVersion,
     source: 'cherry_api',
@@ -121,6 +145,13 @@ export async function loadSpacePermissionMembers(
   db: DatabaseClient,
   data: { spaceId: string; tenantId: string },
 ): Promise<PermissionMember[]> {
+  return (await loadSpacePermissionMemberState(db, data)).members;
+}
+
+export async function loadSpacePermissionMemberState(
+  db: DatabaseClient,
+  data: { spaceId: string; tenantId: string },
+): Promise<SpacePermissionMemberState> {
   const rows = await db
     .select({
       userId: users.docmost_user_id,
@@ -143,6 +174,7 @@ export async function loadSpacePermissionMembers(
       and(
         eq(space_permissions.tenant_id, data.tenantId),
         eq(space_permissions.space_id, data.spaceId),
+        eq(users.status, 'active'),
       ),
     );
 
@@ -191,11 +223,17 @@ async function loadPermissionSyncSpace(
   return space;
 }
 
-function collapsePermissionRows(rows: SpacePermissionRow[]): PermissionMember[] {
+function collapsePermissionRows(rows: SpacePermissionRow[]): SpacePermissionMemberState {
   const membersByUserId = new Map<string, PermissionMember>();
+  const pendingDocmostUserIds = new Set<string>();
 
   for (const row of rows) {
-    if (row.userId === null || row.email.length === 0) {
+    if (row.userId === null) {
+      pendingDocmostUserIds.add(row.email);
+      continue;
+    }
+
+    if (row.email.length === 0) {
       continue;
     }
 
@@ -212,7 +250,10 @@ function collapsePermissionRows(rows: SpacePermissionRow[]): PermissionMember[] 
     });
   }
 
-  return [...membersByUserId.values()].sort((left, right) => left.email.localeCompare(right.email));
+  return {
+    members: [...membersByUserId.values()].sort((left, right) => left.email.localeCompare(right.email)),
+    pendingDocmostUserCount: pendingDocmostUserIds.size,
+  };
 }
 
 function normalizeCherryRole(permission: string): string {

--- a/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
@@ -20,9 +20,18 @@ export interface PermissionSyncDeps {
 }
 
 export interface PermissionSyncBridgeClient {
-  pushPermissions(docmostSpaceId: string, members: PermissionMember[]): Promise<void>;
+  pushPermissions(
+    docmostSpaceId: string,
+    members: PermissionMember[],
+    opts?: PermissionPushOptions,
+  ): Promise<void>;
   getPermissions?(docmostSpaceId: string): Promise<PermissionMember[]>;
 }
+
+export type PermissionPushOptions = {
+  version: number;
+  source: 'cherry_api';
+};
 
 export interface PermissionMember {
   userId: string;
@@ -45,6 +54,7 @@ type PushSpacePermissionsResult = {
   pushed: boolean;
   tenantId?: string;
   docmostSpaceId?: string;
+  version?: number;
   members: PermissionMember[];
 };
 
@@ -93,12 +103,16 @@ export async function pushSpacePermissions(
     spaceId: data.spaceId,
     tenantId: space.tenantId,
   });
-  await bridgeClient.pushPermissions(space.docmostSpaceId, members);
+  await bridgeClient.pushPermissions(space.docmostSpaceId, members, {
+    version: space.permissionVersion,
+    source: 'cherry_api',
+  });
 
   return {
     pushed: true,
     tenantId: space.tenantId,
     docmostSpaceId: space.docmostSpaceId,
+    version: space.permissionVersion,
     members,
   };
 }
@@ -159,13 +173,17 @@ export async function logPermissionAuditEvent(
 async function loadPermissionSyncSpace(
   db: DatabaseClient,
   data: PermissionSyncJobData,
-): Promise<{ tenantId: string; docmostSpaceId: string | null } | undefined> {
+): Promise<{ tenantId: string; docmostSpaceId: string | null; permissionVersion: number } | undefined> {
   const where =
     data.tenantId === undefined
       ? eq(spaces.id, data.spaceId)
       : and(eq(spaces.id, data.spaceId), eq(spaces.tenant_id, data.tenantId));
   const [space] = await db
-    .select({ tenantId: spaces.tenant_id, docmostSpaceId: spaces.docmost_space_id })
+    .select({
+      tenantId: spaces.tenant_id,
+      docmostSpaceId: spaces.docmost_space_id,
+      permissionVersion: spaces.permission_version,
+    })
     .from(spaces)
     .where(where)
     .limit(1);

--- a/apps/wiki-sync-worker/src/processors/user-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/user-sync.processor.ts
@@ -1,0 +1,70 @@
+import type { Job } from 'bullmq';
+
+export const BRIDGE_USER_SYNC_QUEUE = 'bridge-user-sync';
+
+export interface UserSyncDeps {
+  bridgeClient: UserSyncBridgeClient;
+}
+
+export interface UserSyncBridgeClient {
+  syncUser(input: {
+    email: string;
+    name: string;
+    cherry_user_id: string;
+  }): Promise<{ docmost_user_id: string }>;
+}
+
+export type UserSyncJobData = {
+  userId: string;
+  email: string;
+  name: string;
+  tenantId: string;
+};
+
+export function createUserSyncProcessor(
+  deps: UserSyncDeps,
+): (job: Job<UserSyncJobData>) => Promise<void> {
+  return async (job) => {
+    const data = readJobData(job.data);
+    const result = await deps.bridgeClient.syncUser({
+      email: data.email,
+      name: data.name,
+      cherry_user_id: data.userId,
+    });
+
+    console.info('user-sync: user synced to Docmost', {
+      userId: data.userId,
+      tenantId: data.tenantId,
+      docmostUserId: result.docmost_user_id,
+    });
+  };
+}
+
+function readJobData(data: unknown): UserSyncJobData {
+  const record = readRecord(data);
+  const userId = readString(record.userId);
+  const email = readString(record.email);
+  const name = readString(record.name);
+  const tenantId = readString(record.tenantId);
+
+  if (
+    userId === undefined ||
+    email === undefined ||
+    name === undefined ||
+    tenantId === undefined
+  ) {
+    throw new Error('user-sync job is missing userId, email, name, or tenantId');
+  }
+
+  return { userId, email, name, tenantId };
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/apps/wiki-sync-worker/src/processors/user-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/user-sync.processor.ts
@@ -1,8 +1,16 @@
 import type { Job } from 'bullmq';
+import { and, eq, isNull } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { users } from '@cherrygraph/shared';
 
 export const BRIDGE_USER_SYNC_QUEUE = 'bridge-user-sync';
 
+export type DrizzleDatabase = NodePgDatabase;
+type DatabaseClient = Pick<DrizzleDatabase, 'update'>;
+
 export interface UserSyncDeps {
+  db: DrizzleDatabase;
   bridgeClient: UserSyncBridgeClient;
 }
 
@@ -32,12 +40,40 @@ export function createUserSyncProcessor(
       cherry_user_id: data.userId,
     });
 
+    await writeBackDocmostUserId(deps.db, data, result.docmost_user_id);
+
     console.info('user-sync: user synced to Docmost', {
       userId: data.userId,
       tenantId: data.tenantId,
       docmostUserId: result.docmost_user_id,
     });
   };
+}
+
+async function writeBackDocmostUserId(
+  db: DatabaseClient,
+  data: UserSyncJobData,
+  docmostUserId: string,
+): Promise<void> {
+  const updated = await db
+    .update(users)
+    .set({ docmost_user_id: docmostUserId, updated_at: new Date() })
+    .where(
+      and(
+        eq(users.id, data.userId),
+        eq(users.tenant_id, data.tenantId),
+        isNull(users.docmost_user_id),
+      ),
+    )
+    .returning({ id: users.id });
+
+  if (updated.length === 0) {
+    console.info('user-sync: skipped docmost_user_id writeback; mapping already exists', {
+      userId: data.userId,
+      tenantId: data.tenantId,
+      docmostUserId,
+    });
+  }
 }
 
 function readJobData(data: unknown): UserSyncJobData {

--- a/apps/wiki-sync-worker/src/reconciliation/permission-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/permission-reconcile.ts
@@ -3,7 +3,7 @@ import { isNotNull } from 'drizzle-orm';
 import { spaces } from '@cherrygraph/shared';
 
 import {
-  loadSpacePermissionMembers,
+  loadSpacePermissionMemberState,
   logPermissionAuditEvent,
   type DrizzleDatabase,
   type PermissionMember,
@@ -52,10 +52,19 @@ async function runPermissionReconcile(
     }
 
     try {
-      const expected = await loadSpacePermissionMembers(db, {
+      const expectedState = await loadSpacePermissionMemberState(db, {
         spaceId: space.spaceId,
         tenantId: space.tenantId,
       });
+      if (expectedState.pendingDocmostUserCount > 0) {
+        console.info(`Permission sync deferred: ${expectedState.pendingDocmostUserCount} users pending Docmost sync`, {
+          spaceId: space.spaceId,
+          tenantId: space.tenantId,
+        });
+        continue;
+      }
+
+      const expected = expectedState.members;
       const actual = await bridgeClient.getPermissions?.(space.docmostSpaceId);
       if (actual !== undefined && permissionMembersEqual(expected, actual)) {
         continue;

--- a/apps/wiki-sync-worker/src/reconciliation/permission-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/permission-reconcile.ts
@@ -20,6 +20,7 @@ type ReconcileSpaceRow = {
   spaceId: string;
   tenantId: string;
   docmostSpaceId: string | null;
+  permissionVersion: number;
 };
 
 export async function reconcilePermissions(
@@ -60,7 +61,10 @@ async function runPermissionReconcile(
         continue;
       }
 
-      await bridgeClient.pushPermissions(space.docmostSpaceId, expected);
+      await bridgeClient.pushPermissions(space.docmostSpaceId, expected, {
+        version: space.permissionVersion,
+        source: 'cherry_api',
+      });
       fixed += 1;
       await logPermissionAuditEvent(db, {
         tenantId: space.tenantId,
@@ -97,6 +101,7 @@ async function loadSyncedSpaces(db: DatabaseClient): Promise<ReconcileSpaceRow[]
       spaceId: spaces.id,
       tenantId: spaces.tenant_id,
       docmostSpaceId: spaces.docmost_space_id,
+      permissionVersion: spaces.permission_version,
     })
     .from(spaces)
     .where(isNotNull(spaces.docmost_space_id));

--- a/apps/wiki-sync-worker/src/reconciliation/user-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/user-reconcile.ts
@@ -1,0 +1,121 @@
+import { and, asc, eq, gt, isNull } from 'drizzle-orm';
+
+import { users } from '@cherrygraph/shared';
+
+import type {
+  DrizzleDatabase,
+  UserSyncJobData,
+} from '../processors/user-sync.processor.js';
+
+type DatabaseClient = Pick<DrizzleDatabase, 'select'>;
+
+export type UserSyncQueue = {
+  add: (
+    name: string,
+    data: UserSyncJobData,
+    opts: { jobId: string },
+  ) => Promise<unknown>;
+  getJob: (jobId: string) => Promise<UserSyncJob | null | undefined>;
+};
+
+type UserSyncJob = {
+  isFailed: () => Promise<boolean>;
+  remove: () => Promise<void>;
+  attemptsMade?: number;
+  finishedOn?: number;
+};
+
+type UnmappedUserRow = {
+  userId: string;
+  tenantId: string;
+  email: string;
+  name: string;
+};
+
+const USER_RECONCILE_BATCH_SIZE = 50;
+const MAX_RECONCILE_RETRIES = 10;
+const MIN_RETRY_AGE_MS = 5 * 60 * 1000;
+
+export async function reconcileUsers(
+  db: DrizzleDatabase,
+  queue: UserSyncQueue,
+): Promise<number> {
+  let enqueuedCount = 0;
+  let cursor: string | undefined;
+
+  for (;;) {
+    const unmappedUsers = await loadUnmappedUsers(db, cursor);
+    if (unmappedUsers.length === 0) {
+      return enqueuedCount;
+    }
+
+    const results = await Promise.allSettled(
+      unmappedUsers.map((user) => enqueueUserSync(queue, user)),
+    );
+    enqueuedCount += results.filter(
+      (result): result is PromiseFulfilledResult<true> =>
+        result.status === 'fulfilled' && result.value,
+    ).length;
+
+    cursor = unmappedUsers[unmappedUsers.length - 1]?.userId;
+  }
+}
+
+async function loadUnmappedUsers(
+  db: DatabaseClient,
+  afterUserId?: string,
+): Promise<UnmappedUserRow[]> {
+  const predicates = [
+    eq(users.status, 'active'),
+    isNull(users.docmost_user_id),
+  ];
+
+  if (afterUserId !== undefined) {
+    predicates.push(gt(users.id, afterUserId));
+  }
+
+  return db
+    .select({
+      userId: users.id,
+      tenantId: users.tenant_id,
+      email: users.email,
+      name: users.display_name,
+    })
+    .from(users)
+    .where(and(...predicates))
+    .orderBy(asc(users.id))
+    .limit(USER_RECONCILE_BATCH_SIZE);
+}
+
+async function enqueueUserSync(
+  queue: UserSyncQueue,
+  user: UnmappedUserRow,
+): Promise<boolean> {
+  const jobId = `${user.tenantId}:${user.userId}`;
+  const existing = await queue.getJob(jobId);
+
+  if (existing !== null && existing !== undefined) {
+    const isFailed = await existing.isFailed();
+    if (!isFailed) {
+      return false;
+    }
+
+    if ((existing.attemptsMade ?? 0) >= MAX_RECONCILE_RETRIES) {
+      return false;
+    }
+
+    const failedAge = existing.finishedOn
+      ? Date.now() - existing.finishedOn
+      : Infinity;
+    if (failedAge < MIN_RETRY_AGE_MS) {
+      return false;
+    }
+
+    await existing.remove();
+  }
+
+  await queue.add('user.sync', user, {
+    jobId,
+  });
+  return true;
+}

--- a/openspec/changes/docmost-auto-sync/tasks.md
+++ b/openspec/changes/docmost-auto-sync/tasks.md
@@ -63,4 +63,14 @@
 - [ ] 4.7 Cherry API: `bridge-permission-hooks.ts` 当前仅是 helper 函数，未接入任何 mutation 路径。在 `GroupService` 成员变更和 `SpaceService` 权限变更的 commit 后显式调用 `BridgeQueueService.enqueuePermissionSyncJob()`
 - [ ] 4.8 Cherry API: `GroupModule` 和 `SpaceModule` 添加 `imports: [BridgeModule]`
 - [ ] 4.9 Wiki-sync worker: 修改 `reconcilePermissions` 在 worker 启动时立即执行一次（当前仅 hourly timer）
-- [ ] 4.10 测试：创建用户 → Docmost 可见；Group 成员变更 → Docmost Space 权限更新；启动时权限对账
+- [ ] 4.10 测试（Docmost Fork 端）：
+  - [ ] 4.10.1 POST /api/internal/bridge/users 创建新用户（返回 201 + docmost_user_id）
+  - [ ] 4.10.2 POST /api/internal/bridge/users 已存在 email → 返回现有用户（幂等）
+  - [ ] 4.10.3 POST /api/internal/bridge/users 缺少 email → 400
+- [ ] 4.11 测试（Cherry API 端）：
+  - [ ] 4.11.1 用户创建后 enqueue user-sync job
+  - [ ] 4.11.2 GroupService 成员变更后 enqueue permission-sync job
+  - [ ] 4.11.3 SpaceService 权限变更后 enqueue permission-sync job
+- [ ] 4.12 测试（Wiki-sync worker 端）：
+  - [ ] 4.12.1 user-sync processor 调用 Bridge 创建用户
+  - [ ] 4.12.2 reconcilePermissions 在启动时立即执行

--- a/packages/shared/src/schema/core.ts
+++ b/packages/shared/src/schema/core.ts
@@ -52,6 +52,7 @@ export const users = pgTable(
     password_hash: text('password_hash').notNull(),
     role: text('role').notNull().default('viewer'),
     status: text('status').notNull().default('active'),
+    docmost_user_id: text('docmost_user_id'),
     permission_version: bigint('permission_version', { mode: 'number' }).notNull().default(1),
     last_login_at: timestamp('last_login_at', { withTimezone: true }),
     created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/schemas/migrations/0016_bored_lethal_legion.sql
+++ b/schemas/migrations/0016_bored_lethal_legion.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "docmost_user_id" text;

--- a/schemas/migrations/meta/0016_snapshot.json
+++ b/schemas/migrations/meta/0016_snapshot.json
@@ -1,0 +1,6819 @@
+{
+  "id": "ee610dc9-34fa-4c87-b108-f78f27827e02",
+  "prevId": "89bf434e-9b35-4183-b2f5-d780f27a7d2d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_dir": {
+          "name": "work_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_home": {
+          "name": "agent_home",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options_hash": {
+          "name": "options_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owned_by_instance": {
+          "name": "owned_by_instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "process_started_at": {
+          "name": "process_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "process_stopped_at": {
+          "name": "process_stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_status": {
+          "name": "idx_agent_sessions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_instance": {
+          "name": "idx_agent_sessions_instance",
+          "columns": [
+            {
+              "expression": "owned_by_instance",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_conversation_id_chat_sessions_id_fk": {
+          "name": "agent_sessions_conversation_id_chat_sessions_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "chat_sessions",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_tenant_id_tenants_id_fk": {
+          "name": "agent_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_space_id_spaces_id_fk": {
+          "name": "agent_sessions_space_id_spaces_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_user_id_users_id_fk": {
+          "name": "agent_sessions_user_id_users_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.answer_citations": {
+      "name": "answer_citations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relevance_score": {
+          "name": "relevance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_chain_json": {
+          "name": "source_chain_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_text": {
+          "name": "display_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_answer_citations_message": {
+          "name": "idx_answer_citations_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_answer_citations_page": {
+          "name": "idx_answer_citations_page",
+          "columns": [
+            {
+              "expression": "wiki_page_pk",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_answer_citations_space": {
+          "name": "idx_answer_citations_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "answer_citations_message_id_chat_messages_id_fk": {
+          "name": "answer_citations_message_id_chat_messages_id_fk",
+          "tableFrom": "answer_citations",
+          "tableTo": "chat_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "answer_citations_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "answer_citations_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "answer_citations",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "answer_citations_space_id_spaces_id_fk": {
+          "name": "answer_citations_space_id_spaces_id_fk",
+          "tableFrom": "answer_citations",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "answer_citations_section_id_wiki_sections_id_fk": {
+          "name": "answer_citations_section_id_wiki_sections_id_fk",
+          "tableFrom": "answer_citations",
+          "tableTo": "wiki_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "answer_citations_chunk_id_wiki_chunks_id_fk": {
+          "name": "answer_citations_chunk_id_wiki_chunks_id_fk",
+          "tableFrom": "answer_citations",
+          "tableTo": "wiki_chunks",
+          "columnsFrom": [
+            "chunk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_user": {
+          "name": "idx_api_tokens_user",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_tokens\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_tenant_id_tenants_id_fk": {
+          "name": "api_tokens_tenant_id_tenants_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_tenant_time": {
+          "name": "idx_audit_logs_tenant_time",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_tenant_id_tenants_id_fk": {
+          "name": "audit_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_actor_user_id_users_id_fk": {
+          "name": "audit_logs_actor_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bridge_events": {
+      "name": "bridge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'docmost'"
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bridge_events_space_type_received": {
+          "name": "idx_bridge_events_space_type_received",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bridge_events_pending": {
+          "name": "idx_bridge_events_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"bridge_events\".\"status\" IN ('received', 'processing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bridge_events_event_id_unique": {
+          "name": "bridge_events_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations_json": {
+          "name": "citations_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_messages_session_created": {
+          "name": "idx_chat_messages_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_session_id_chat_sessions_id_fk": {
+          "name": "chat_messages_session_id_chat_sessions_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_spaces": {
+      "name": "chat_session_spaces",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_session_spaces_tenant_space": {
+          "name": "idx_chat_session_spaces_tenant_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_spaces_position": {
+          "name": "idx_chat_session_spaces_position",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_spaces_session_id_chat_sessions_id_fk": {
+          "name": "chat_session_spaces_session_id_chat_sessions_id_fk",
+          "tableFrom": "chat_session_spaces",
+          "tableTo": "chat_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_spaces_space_id_spaces_id_fk": {
+          "name": "chat_session_spaces_space_id_spaces_id_fk",
+          "tableFrom": "chat_session_spaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_session_spaces_session_id_space_id_pk": {
+          "name": "chat_session_spaces_session_id_space_id_pk",
+          "columns": [
+            "session_id",
+            "space_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_sessions": {
+      "name": "chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_sessions_tenant_space_user": {
+          "name": "idx_chat_sessions_tenant_space_user",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_sessions_user_updated": {
+          "name": "idx_chat_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_sessions_tenant_id_tenants_id_fk": {
+          "name": "chat_sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_sessions_space_id_spaces_id_fk": {
+          "name": "chat_sessions_space_id_spaces_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_sessions_user_id_users_id_fk": {
+          "name": "chat_sessions_user_id_users_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.embeddings": {
+      "name": "embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_embeddings_model": {
+          "name": "idx_embeddings_model",
+          "columns": [
+            {
+              "expression": "model_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embeddings_tenant_id_tenants_id_fk": {
+          "name": "embeddings_tenant_id_tenants_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "embeddings_space_id_spaces_id_fk": {
+          "name": "embeddings_space_id_spaces_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "embeddings_chunk_id_wiki_chunks_id_fk": {
+          "name": "embeddings_chunk_id_wiki_chunks_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "wiki_chunks",
+          "columnsFrom": [
+            "chunk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "embeddings_model_config_id_model_configs_id_fk": {
+          "name": "embeddings_model_config_id_model_configs_id_fk",
+          "tableFrom": "embeddings",
+          "tableTo": "model_configs",
+          "columnsFrom": [
+            "model_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_items": {
+      "name": "feedback_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_items_tenant_id_tenants_id_fk": {
+          "name": "feedback_items_tenant_id_tenants_id_fk",
+          "tableFrom": "feedback_items",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_items_user_id_users_id_fk": {
+          "name": "feedback_items_user_id_users_id_fk",
+          "tableFrom": "feedback_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_items_message_id_chat_messages_id_fk": {
+          "name": "feedback_items_message_id_chat_messages_id_fk",
+          "tableFrom": "feedback_items",
+          "tableTo": "chat_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_items_space_id_spaces_id_fk": {
+          "name": "feedback_items_space_id_spaces_id_fk",
+          "tableFrom": "feedback_items",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_items_resolved_by_users_id_fk": {
+          "name": "feedback_items_resolved_by_users_id_fk",
+          "tableFrom": "feedback_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_blobs": {
+      "name": "file_blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_uri": {
+          "name": "storage_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_blobs_tenant_id_tenants_id_fk": {
+          "name": "file_blobs_tenant_id_tenants_id_fk",
+          "tableFrom": "file_blobs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_blobs_tenant_id_sha256_unique": {
+          "name": "file_blobs_tenant_id_sha256_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_communities": {
+      "name": "graph_communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_key": {
+          "name": "community_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "graph_communities_tenant_id_tenants_id_fk": {
+          "name": "graph_communities_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_communities",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_communities_space_id_spaces_id_fk": {
+          "name": "graph_communities_space_id_spaces_id_fk",
+          "tableFrom": "graph_communities",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_communities_graphify_run_id_graphify_runs_id_fk": {
+          "name": "graph_communities_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "graph_communities",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "graph_communities_tenant_id_space_id_graphify_run_id_community_key_unique": {
+          "name": "graph_communities_tenant_id_space_id_graphify_run_id_community_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "graphify_run_id",
+            "community_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_edges": {
+      "name": "graph_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_node_id": {
+          "name": "target_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence_label": {
+          "name": "confidence_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_confidence_score": {
+          "name": "raw_confidence_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_confidence_score": {
+          "name": "effective_confidence_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_count": {
+          "name": "evidence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "evidence_refs_json": {
+          "name": "evidence_refs_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_edges_source": {
+          "name": "idx_graph_edges_source",
+          "columns": [
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_edges_target": {
+          "name": "idx_graph_edges_target",
+          "columns": [
+            {
+              "expression": "target_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_edges_confidence": {
+          "name": "idx_graph_edges_confidence",
+          "columns": [
+            {
+              "expression": "confidence_label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_confidence_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_edges_tenant_id_tenants_id_fk": {
+          "name": "graph_edges_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_edges_space_id_spaces_id_fk": {
+          "name": "graph_edges_space_id_spaces_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_edges_graphify_run_id_graphify_runs_id_fk": {
+          "name": "graph_edges_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_edges_source_node_id_graph_nodes_id_fk": {
+          "name": "graph_edges_source_node_id_graph_nodes_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "graph_nodes",
+          "columnsFrom": [
+            "source_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_edges_target_node_id_graph_nodes_id_fk": {
+          "name": "graph_edges_target_node_id_graph_nodes_id_fk",
+          "tableFrom": "graph_edges",
+          "tableTo": "graph_nodes",
+          "columnsFrom": [
+            "target_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_evidence_refs": {
+      "name": "graph_evidence_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edge_id": {
+          "name": "edge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_text": {
+          "name": "quote_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_contribution": {
+          "name": "confidence_contribution",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_evidence_refs_edge": {
+          "name": "idx_graph_evidence_refs_edge",
+          "columns": [
+            {
+              "expression": "edge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_evidence_refs_page": {
+          "name": "idx_graph_evidence_refs_page",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_evidence_refs_source_doc": {
+          "name": "idx_graph_evidence_refs_source_doc",
+          "columns": [
+            {
+              "expression": "source_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_evidence_refs_tenant_id_tenants_id_fk": {
+          "name": "graph_evidence_refs_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_space_id_spaces_id_fk": {
+          "name": "graph_evidence_refs_space_id_spaces_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_edge_id_graph_edges_id_fk": {
+          "name": "graph_evidence_refs_edge_id_graph_edges_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "graph_edges",
+          "columnsFrom": [
+            "edge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_page_id_wiki_pages_id_fk": {
+          "name": "graph_evidence_refs_page_id_wiki_pages_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_page_version_id_wiki_page_versions_id_fk": {
+          "name": "graph_evidence_refs_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_section_id_wiki_sections_id_fk": {
+          "name": "graph_evidence_refs_section_id_wiki_sections_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "wiki_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_evidence_refs_source_document_id_source_documents_id_fk": {
+          "name": "graph_evidence_refs_source_document_id_source_documents_id_fk",
+          "tableFrom": "graph_evidence_refs",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_node_aliases": {
+      "name": "graph_node_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_stable_key": {
+          "name": "node_stable_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'graphify'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_node_aliases_lookup": {
+          "name": "idx_graph_node_aliases_lookup",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_node_aliases_tenant_id_tenants_id_fk": {
+          "name": "graph_node_aliases_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_node_aliases",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_node_aliases_space_id_spaces_id_fk": {
+          "name": "graph_node_aliases_space_id_spaces_id_fk",
+          "tableFrom": "graph_node_aliases",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "graph_node_aliases_tenant_id_space_id_node_stable_key_alias_unique": {
+          "name": "graph_node_aliases_tenant_id_space_id_node_stable_key_alias_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "node_stable_key",
+            "alias"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_node_merges": {
+      "name": "graph_node_merges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stable_key": {
+          "name": "from_stable_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stable_key": {
+          "name": "to_stable_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_node_merges_from": {
+          "name": "idx_graph_node_merges_from",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_stable_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_node_merges_tenant_id_tenants_id_fk": {
+          "name": "graph_node_merges_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_node_merges",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_node_merges_space_id_spaces_id_fk": {
+          "name": "graph_node_merges_space_id_spaces_id_fk",
+          "tableFrom": "graph_node_merges",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_node_merges_created_by_users_id_fk": {
+          "name": "graph_node_merges_created_by_users_id_fk",
+          "tableFrom": "graph_node_merges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_nodes": {
+      "name": "graph_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_key": {
+          "name": "node_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stable_key": {
+          "name": "stable_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_label": {
+          "name": "norm_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_refs_json": {
+          "name": "source_refs_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_graph_nodes_stable_key": {
+          "name": "idx_graph_nodes_stable_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stable_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_graph_nodes_label_trgm": {
+          "name": "idx_graph_nodes_label_trgm",
+          "columns": [
+            {
+              "expression": "\"label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graph_nodes_tenant_id_tenants_id_fk": {
+          "name": "graph_nodes_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_nodes_space_id_spaces_id_fk": {
+          "name": "graph_nodes_space_id_spaces_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_nodes_graphify_run_id_graphify_runs_id_fk": {
+          "name": "graph_nodes_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_nodes_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "graph_nodes_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_nodes_page_version_id_wiki_page_versions_id_fk": {
+          "name": "graph_nodes_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "graph_nodes",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "graph_nodes_tenant_id_space_id_graphify_run_id_node_key_unique": {
+          "name": "graph_nodes_tenant_id_space_id_graphify_run_id_node_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "graphify_run_id",
+            "node_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graph_reports": {
+      "name": "graph_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_markdown": {
+          "name": "report_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "graph_reports_tenant_id_tenants_id_fk": {
+          "name": "graph_reports_tenant_id_tenants_id_fk",
+          "tableFrom": "graph_reports",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_reports_space_id_spaces_id_fk": {
+          "name": "graph_reports_space_id_spaces_id_fk",
+          "tableFrom": "graph_reports",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graph_reports_graphify_run_id_graphify_runs_id_fk": {
+          "name": "graph_reports_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "graph_reports",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.graphify_runs": {
+      "name": "graphify_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input_version": {
+          "name": "input_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_version": {
+          "name": "output_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graphify_ref": {
+          "name": "graphify_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_json_uri": {
+          "name": "graph_json_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_output_uri": {
+          "name": "wiki_output_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_uri": {
+          "name": "report_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graph_html_uri": {
+          "name": "graph_html_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_graphify_runs_job": {
+          "name": "idx_graphify_runs_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "graphify_runs_tenant_id_tenants_id_fk": {
+          "name": "graphify_runs_tenant_id_tenants_id_fk",
+          "tableFrom": "graphify_runs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graphify_runs_space_id_spaces_id_fk": {
+          "name": "graphify_runs_space_id_spaces_id_fk",
+          "tableFrom": "graphify_runs",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graphify_runs_job_id_jobs_id_fk": {
+          "name": "graphify_runs_job_id_jobs_id_fk",
+          "tableFrom": "graphify_runs",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "graphify_runs_created_by_users_id_fk": {
+          "name": "graphify_runs_created_by_users_id_fk",
+          "tableFrom": "graphify_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_members_tenant_id_tenants_id_fk": {
+          "name": "group_members_tenant_id_tenants_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "group_members_group_id_user_id_pk": {
+          "name": "group_members_group_id_user_id_pk",
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_permission_version": {
+          "name": "idx_groups_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_tenant_id_tenants_id_fk": {
+          "name": "groups_tenant_id_tenants_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_tenant_id_name_unique": {
+          "name": "groups_tenant_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.index_snapshots": {
+      "name": "index_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_repo_commit_hash": {
+          "name": "wiki_repo_commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "node_count": {
+          "name": "node_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "edge_count": {
+          "name": "edge_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_index_snapshots_space": {
+          "name": "idx_index_snapshots_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_index_snapshots_active": {
+          "name": "idx_index_snapshots_active",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "index_snapshots_tenant_id_tenants_id_fk": {
+          "name": "index_snapshots_tenant_id_tenants_id_fk",
+          "tableFrom": "index_snapshots",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "index_snapshots_space_id_spaces_id_fk": {
+          "name": "index_snapshots_space_id_spaces_id_fk",
+          "tableFrom": "index_snapshots",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "index_snapshots_graphify_run_id_graphify_runs_id_fk": {
+          "name": "index_snapshots_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "index_snapshots",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_events": {
+      "name": "job_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail_json": {
+          "name": "detail_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_job_events_job": {
+          "name": "idx_job_events_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_events_job_id_jobs_id_fk": {
+          "name": "job_events_job_id_jobs_id_fk",
+          "tableFrom": "job_events",
+          "tableTo": "jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "timeout_seconds": {
+          "name": "timeout_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_poll": {
+          "name": "idx_jobs_poll",
+          "columns": [
+            {
+              "expression": "queue_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_locked": {
+          "name": "idx_jobs_locked",
+          "columns": [
+            {
+              "expression": "locked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jobs\".\"locked_by\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_jobs_space": {
+          "name": "idx_jobs_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jobs_tenant_id_tenants_id_fk": {
+          "name": "jobs_tenant_id_tenants_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "jobs_space_id_spaces_id_fk": {
+          "name": "jobs_space_id_spaces_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "jobs_created_by_users_id_fk": {
+          "name": "jobs_created_by_users_id_fk",
+          "tableFrom": "jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "jobs_tenant_id_idempotency_key_unique": {
+          "name": "jobs_tenant_id_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tool_registry": {
+      "name": "mcp_tool_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sse'"
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "policy_json": {
+          "name": "policy_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_tool_registry_tenant": {
+          "name": "idx_mcp_tool_registry_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tool_registry_tenant_id_tenants_id_fk": {
+          "name": "mcp_tool_registry_tenant_id_tenants_id_fk",
+          "tableFrom": "mcp_tool_registry",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "mcp_tool_registry_created_by_users_id_fk": {
+          "name": "mcp_tool_registry_created_by_users_id_fk",
+          "tableFrom": "mcp_tool_registry",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tool_registry_tenant_id_tool_name_unique": {
+          "name": "mcp_tool_registry_tenant_id_tool_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "tool_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_usage_logs": {
+      "name": "model_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_config_id": {
+          "name": "model_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_usage_logs_user": {
+          "name": "idx_model_usage_logs_user",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_usage_logs_model": {
+          "name": "idx_model_usage_logs_model",
+          "columns": [
+            {
+              "expression": "model_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_usage_logs_tenant_id_tenants_id_fk": {
+          "name": "model_usage_logs_tenant_id_tenants_id_fk",
+          "tableFrom": "model_usage_logs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "model_usage_logs_user_id_users_id_fk": {
+          "name": "model_usage_logs_user_id_users_id_fk",
+          "tableFrom": "model_usage_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "model_usage_logs_model_config_id_model_configs_id_fk": {
+          "name": "model_usage_logs_model_config_id_model_configs_id_fk",
+          "tableFrom": "model_usage_logs",
+          "tableTo": "model_configs",
+          "columnsFrom": [
+            "model_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "model_usage_logs_space_id_spaces_id_fk": {
+          "name": "model_usage_logs_space_id_spaces_id_fk",
+          "tableFrom": "model_usage_logs",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "model_usage_logs_conversation_id_chat_sessions_id_fk": {
+          "name": "model_usage_logs_conversation_id_chat_sessions_id_fk",
+          "tableFrom": "model_usage_logs",
+          "tableTo": "chat_sessions",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_configs": {
+      "name": "model_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_api_key_ref": {
+          "name": "encrypted_api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_rpm": {
+          "name": "rate_limit_rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visible_group_ids": {
+          "name": "visible_group_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_configs_tenant_type": {
+          "name": "idx_model_configs_tenant_type",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_configs_tenant_id_tenants_id_fk": {
+          "name": "model_configs_tenant_id_tenants_id_fk",
+          "tableFrom": "model_configs",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_configs_tenant_id_provider_model_id_unique": {
+          "name": "model_configs_tenant_id_provider_model_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "provider",
+            "model_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_block_metadata": {
+      "name": "page_block_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'graphify'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_editor": {
+          "name": "last_editor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editable": {
+          "name": "editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_page_blocks_page_version": {
+          "name": "idx_page_blocks_page_version",
+          "columns": [
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_page_blocks_owner": {
+          "name": "idx_page_blocks_owner",
+          "columns": [
+            {
+              "expression": "wiki_page_pk",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_block_metadata_tenant_id_tenants_id_fk": {
+          "name": "page_block_metadata_tenant_id_tenants_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "page_block_metadata_space_id_spaces_id_fk": {
+          "name": "page_block_metadata_space_id_spaces_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "page_block_metadata_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "page_block_metadata_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "page_block_metadata_page_version_id_wiki_page_versions_id_fk": {
+          "name": "page_block_metadata_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "page_block_metadata_last_editor_users_id_fk": {
+          "name": "page_block_metadata_last_editor_users_id_fk",
+          "tableFrom": "page_block_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "last_editor"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_block_metadata_page_version_id_block_id_unique": {
+          "name": "page_block_metadata_page_version_id_block_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_version_id",
+            "block_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permission_versions": {
+      "name": "permission_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_permissions_json": {
+          "name": "old_permissions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_permissions_json": {
+          "name": "new_permissions_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_permission_versions_space": {
+          "name": "idx_permission_versions_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_permission_versions_subject": {
+          "name": "idx_permission_versions_subject",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_versions_tenant_id_tenants_id_fk": {
+          "name": "permission_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_versions_space_id_spaces_id_fk": {
+          "name": "permission_versions_space_id_spaces_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_versions_actor_user_id_users_id_fk": {
+          "name": "permission_versions_actor_user_id_users_id_fk",
+          "tableFrom": "permission_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrieval_traces": {
+      "name": "retrieval_traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_ids": {
+          "name": "space_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retrieval_mode": {
+          "name": "retrieval_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidates_json": {
+          "name": "candidates_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "acl_filtered_json": {
+          "name": "acl_filtered_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "final_context_json": {
+          "name": "final_context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "retrieval_traces_tenant_id_tenants_id_fk": {
+          "name": "retrieval_traces_tenant_id_tenants_id_fk",
+          "tableFrom": "retrieval_traces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "retrieval_traces_user_id_users_id_fk": {
+          "name": "retrieval_traces_user_id_users_id_fk",
+          "tableFrom": "retrieval_traces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "retrieval_traces_conversation_id_chat_sessions_id_fk": {
+          "name": "retrieval_traces_conversation_id_chat_sessions_id_fk",
+          "tableFrom": "retrieval_traces",
+          "tableTo": "chat_sessions",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user": {
+          "name": "idx_sessions_user",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_refresh": {
+          "name": "idx_sessions_refresh",
+          "columns": [
+            {
+              "expression": "refresh_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_tenant_id_tenants_id_fk": {
+          "name": "sessions_tenant_id_tenants_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_refresh_token_hash_unique": {
+          "name": "sessions_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_links": {
+      "name": "source_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_id": {
+          "name": "source_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_uri": {
+          "name": "source_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_hash": {
+          "name": "quote_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reference'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_source_links_page_version": {
+          "name": "idx_source_links_page_version",
+          "columns": [
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_source_links_source_doc": {
+          "name": "idx_source_links_source_doc",
+          "columns": [
+            {
+              "expression": "source_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "source_links_tenant_id_tenants_id_fk": {
+          "name": "source_links_tenant_id_tenants_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_space_id_spaces_id_fk": {
+          "name": "source_links_space_id_spaces_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "source_links_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_page_version_id_wiki_page_versions_id_fk": {
+          "name": "source_links_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_section_id_wiki_sections_id_fk": {
+          "name": "source_links_section_id_wiki_sections_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "wiki_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_links_source_document_id_source_documents_id_fk": {
+          "name": "source_links_source_document_id_source_documents_id_fk",
+          "tableFrom": "source_links",
+          "tableTo": "source_documents",
+          "columnsFrom": [
+            "source_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.source_documents": {
+      "name": "source_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_blob_id": {
+          "name": "file_blob_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upload'"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploaded'"
+        },
+        "parsed_uri": {
+          "name": "parsed_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_documents_tenant_id_tenants_id_fk": {
+          "name": "source_documents_tenant_id_tenants_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_space_id_spaces_id_fk": {
+          "name": "source_documents_space_id_spaces_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_file_blob_id_file_blobs_id_fk": {
+          "name": "source_documents_file_blob_id_file_blobs_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "file_blobs",
+          "columnsFrom": [
+            "file_blob_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "source_documents_uploader_id_users_id_fk": {
+          "name": "source_documents_uploader_id_users_id_fk",
+          "tableFrom": "source_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "source_documents_space_id_file_blob_id_unique": {
+          "name": "source_documents_space_id_file_blob_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "space_id",
+            "file_blob_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_permissions": {
+      "name": "space_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_permissions_tenant_id_tenants_id_fk": {
+          "name": "space_permissions_tenant_id_tenants_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "space_permissions_space_id_spaces_id_fk": {
+          "name": "space_permissions_space_id_spaces_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "space_permissions_group_id_groups_id_fk": {
+          "name": "space_permissions_group_id_groups_id_fk",
+          "tableFrom": "space_permissions",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "space_permissions_space_id_group_id_permission_unique": {
+          "name": "space_permissions_space_id_group_id_permission_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "space_id",
+            "group_id",
+            "permission"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "docmost_space_id": {
+          "name": "docmost_space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wiki_repo_path": {
+          "name": "wiki_repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_graphify_run_id": {
+          "name": "active_graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_index_snapshot_id": {
+          "name": "active_index_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_consistency_status": {
+          "name": "index_consistency_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "strict_knowledge_only": {
+          "name": "strict_knowledge_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "graphify_config": {
+          "name": "graphify_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "database_config": {
+          "name": "database_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"enabled\":false}'::jsonb"
+        },
+        "default_publish_policy": {
+          "name": "default_publish_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editor_publish'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_spaces_consistency": {
+          "name": "idx_spaces_consistency",
+          "columns": [
+            {
+              "expression": "index_consistency_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_spaces_permission_version": {
+          "name": "idx_spaces_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_tenant_id_tenants_id_fk": {
+          "name": "spaces_tenant_id_tenants_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "spaces_tenant_id_slug_unique": {
+          "name": "spaces_tenant_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_settings_tenant_id_tenants_id_fk": {
+          "name": "system_settings_tenant_id_tenants_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "system_settings_updated_by_users_id_fk": {
+          "name": "system_settings_updated_by_users_id_fk",
+          "tableFrom": "system_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_settings_tenant_id_category_key_unique": {
+          "name": "system_settings_tenant_id_category_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "category",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "docmost_user_id": {
+          "name": "docmost_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_version": {
+          "name": "permission_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_permission_version": {
+          "name": "idx_users_permission_version",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_tenant_id_email_unique": {
+          "name": "users_tenant_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bridge_event_id": {
+          "name": "bridge_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_deliveries_event_attempt": {
+          "name": "idx_webhook_deliveries_event_attempt",
+          "columns": [
+            {
+              "expression": "bridge_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhook_deliveries_direction_created": {
+          "name": "idx_webhook_deliveries_direction_created",
+          "columns": [
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_bridge_event_id_bridge_events_id_fk": {
+          "name": "webhook_deliveries_bridge_event_id_bridge_events_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "bridge_events",
+          "columnsFrom": [
+            "bridge_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_chunks": {
+      "name": "wiki_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_status": {
+          "name": "index_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "index_snapshot_id": {
+          "name": "index_snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_version": {
+          "name": "index_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injection_risk": {
+          "name": "injection_risk",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_chain_json": {
+          "name": "source_chain_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_chunks_space": {
+          "name": "idx_wiki_chunks_space",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wiki_chunks_index_status": {
+          "name": "idx_wiki_chunks_index_status",
+          "columns": [
+            {
+              "expression": "index_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_chunks_tenant_id_tenants_id_fk": {
+          "name": "wiki_chunks_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_chunks_space_id_spaces_id_fk": {
+          "name": "wiki_chunks_space_id_spaces_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_chunks_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_chunks_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_chunks_page_version_id_wiki_page_versions_id_fk": {
+          "name": "wiki_chunks_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_chunks_section_id_wiki_sections_id_fk": {
+          "name": "wiki_chunks_section_id_wiki_sections_id_fk",
+          "tableFrom": "wiki_chunks",
+          "tableTo": "wiki_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_chunks_snapshot_page_version_chunk_unique": {
+          "name": "wiki_chunks_snapshot_page_version_chunk_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index_snapshot_id",
+            "page_version_id",
+            "chunk_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_page_versions": {
+      "name": "wiki_page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_no": {
+          "name": "version_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontmatter_json": {
+          "name": "frontmatter_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_hash": {
+          "name": "commit_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_versions_status": {
+          "name": "idx_wiki_versions_status",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_page_versions_tenant_id_tenants_id_fk": {
+          "name": "wiki_page_versions_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_space_id_spaces_id_fk": {
+          "name": "wiki_page_versions_space_id_spaces_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_page_versions_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_page_versions_created_by_users_id_fk": {
+          "name": "wiki_page_versions_created_by_users_id_fk",
+          "tableFrom": "wiki_page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_page_versions_wiki_page_pk_version_no_unique": {
+          "name": "wiki_page_versions_wiki_page_pk_version_no_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wiki_page_pk",
+            "version_no"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_pages": {
+      "name": "wiki_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexed_version_id": {
+          "name": "indexed_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "docmost_page_id": {
+          "name": "docmost_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_pages_indexed_version": {
+          "name": "idx_wiki_pages_indexed_version",
+          "columns": [
+            {
+              "expression": "indexed_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wiki_pages_current_indexed": {
+          "name": "idx_wiki_pages_current_indexed",
+          "columns": [
+            {
+              "expression": "current_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "indexed_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_pages_tenant_id_tenants_id_fk": {
+          "name": "wiki_pages_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_pages_space_id_spaces_id_fk": {
+          "name": "wiki_pages_space_id_spaces_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_pages_created_by_users_id_fk": {
+          "name": "wiki_pages_created_by_users_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_wiki_pages_current_version": {
+          "name": "fk_wiki_pages_current_version",
+          "tableFrom": "wiki_pages",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "current_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fk_wiki_pages_indexed_version": {
+          "name": "fk_wiki_pages_indexed_version",
+          "tableFrom": "wiki_pages",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "indexed_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_pages_tenant_id_space_id_page_id_unique": {
+          "name": "wiki_pages_tenant_id_space_id_page_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tenant_id",
+            "space_id",
+            "page_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_sections": {
+      "name": "wiki_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_version_id": {
+          "name": "page_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "section_index": {
+          "name": "section_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_offset": {
+          "name": "end_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acl_json": {
+          "name": "acl_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wiki_sections_page_version": {
+          "name": "idx_wiki_sections_page_version",
+          "columns": [
+            {
+              "expression": "page_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_sections_tenant_id_tenants_id_fk": {
+          "name": "wiki_sections_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_space_id_spaces_id_fk": {
+          "name": "wiki_sections_space_id_spaces_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_sections_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_sections_page_version_id_wiki_page_versions_id_fk": {
+          "name": "wiki_sections_page_version_id_wiki_page_versions_id_fk",
+          "tableFrom": "wiki_sections",
+          "tableTo": "wiki_page_versions",
+          "columnsFrom": [
+            "page_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wiki_sections_page_version_id_section_id_unique": {
+          "name": "wiki_sections_page_version_id_section_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_version_id",
+            "section_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_update_proposals": {
+      "name": "wiki_update_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_pk": {
+          "name": "wiki_page_pk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graphify_run_id": {
+          "name": "graphify_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "diff_json": {
+          "name": "diff_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wiki_update_proposals_tenant_id_tenants_id_fk": {
+          "name": "wiki_update_proposals_tenant_id_tenants_id_fk",
+          "tableFrom": "wiki_update_proposals",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_update_proposals_space_id_spaces_id_fk": {
+          "name": "wiki_update_proposals_space_id_spaces_id_fk",
+          "tableFrom": "wiki_update_proposals",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_update_proposals_wiki_page_pk_wiki_pages_id_fk": {
+          "name": "wiki_update_proposals_wiki_page_pk_wiki_pages_id_fk",
+          "tableFrom": "wiki_update_proposals",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_pk"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wiki_update_proposals_graphify_run_id_graphify_runs_id_fk": {
+          "name": "wiki_update_proposals_graphify_run_id_graphify_runs_id_fk",
+          "tableFrom": "wiki_update_proposals",
+          "tableTo": "graphify_runs",
+          "columnsFrom": [
+            "graphify_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/schemas/migrations/meta/_journal.json
+++ b/schemas/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1778474334921,
       "tag": "0015_white_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1778570051286,
+      "tag": "0016_bored_lethal_legion",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/integration/wiki-sync-integration.test.ts
+++ b/tests/integration/wiki-sync-integration.test.ts
@@ -190,7 +190,7 @@ describe('wiki sync integration flows with mocked infrastructure', () => {
       { userId: 'admin-user', email: 'admin@example.com', role: 'admin' },
       { userId: 'editor-user', email: 'editor@example.com', role: 'writer' },
       { userId: 'reader-user', email: 'reader@example.com', role: 'reader' },
-    ]);
+    ], { version: 1, source: 'cherry_api' });
   });
 
   it('coalesces stale page events so only one version is created', async () => {
@@ -418,13 +418,18 @@ class PermissionFlowDb {
                 spaceId: space.id,
                 tenantId: space.tenant_id,
                 docmostSpaceId: space.docmost_space_id,
+                permissionVersion: space.permission_version,
               }));
             }
 
             const space = this.spaces[0];
             return space === undefined
               ? []
-              : [{ tenantId: space.tenant_id, docmostSpaceId: space.docmost_space_id }];
+              : [{
+                  tenantId: space.tenant_id,
+                  docmostSpaceId: space.docmost_space_id,
+                  permissionVersion: space.permission_version,
+                }];
           }
           if (table === space_permissions) {
             return this.permissionRows;


### PR DESCRIPTION
## Summary

- Docmost Fork: `POST /api/internal/bridge/users` — find-or-create user by email
- Docmost Fork: Permission version ordering via Redis — reject stale pushes
- Cherry API: `bridge-user-sync` queue + UserService enqueue on create
- Cherry API: GroupService hooks for permission-sync on member/perm changes + group create
- Cherry API: UserService hooks for permission-sync on user create with groups, disable, delete
- Cherry API: `docmost_user_id` column + migration for user ID mapping
- Wiki-sync worker: user-sync processor writes back docmost_user_id
- Wiki-sync worker: Permission sync uses docmost_user_id, defers when users pending sync
- Wiki-sync worker: User reconciliation at startup for docmost_user_id backfill
- Wiki-sync worker: Fixed permission contract to match Docmost format
- Tests: 3 Jest (Docmost) + 15 Vitest (API + worker)

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] API tests pass (1196 tests)
- [x] Wiki-sync worker typecheck passes
- [x] Docmost bridge tests pass

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `d40be0420eaed41cbbbe0a2b0eda8e606017cfbe`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/285#issuecomment-4428415362) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/285#issuecomment-4428415598) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/285#issuecomment-4428415788) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/285#issuecomment-4428415965)
- Key findings addressed: docmost_user_id mapping + writeback, permission version ordering, user backfill reconciliation, permission defer for pending users, createGroup/createUser hooks, user disable/delete revocation, non-active user filter, versioned permission jobId

Closes #275