### PR TITLE
feat(auth): enforce API token scope boundary

### DIFF
--- a/docs/schemas/openapi.yaml
+++ b/docs/schemas/openapi.yaml
@@ -997,26 +997,27 @@ components:
     # --- Phase 4: API Tokens ---
     ApiToken:
       type: object
+      required: [id, name, token_prefix, scopes, last_used_at, expires_at, created_at]
       properties:
         id: { type: string }
-        user_id: { type: string }
         name: { type: string }
         token_prefix: { type: string, description: "First 8 chars of the token for identification" }
         scopes: { type: array, items: { type: string } }
-        last_used_at: { type: string, format: date-time }
-        expires_at: { type: string, format: date-time }
-        revoked_at: { type: string, format: date-time }
+        last_used_at: { type: [string, 'null'], format: date-time }
+        expires_at: { type: [string, 'null'], format: date-time }
         created_at: { type: string, format: date-time }
 
     ApiTokenCreated:
       type: object
+      required: [id, name, raw_token, token_prefix, scopes, last_used_at, expires_at, created_at]
       properties:
         id: { type: string }
         name: { type: string }
         raw_token: { type: string, description: "Full token — shown only once at creation" }
         token_prefix: { type: string }
         scopes: { type: array, items: { type: string } }
-        expires_at: { type: string, format: date-time }
+        last_used_at: { type: [string, 'null'], format: date-time }
+        expires_at: { type: [string, 'null'], format: date-time }
         created_at: { type: string, format: date-time }
 
     CreateApiTokenRequest:
@@ -1024,7 +1025,7 @@ components:
       required: [name, scopes]
       properties:
         name: { type: string }
-        scopes: { type: array, items: { type: string }, description: "e.g. mcp:invoke, graph:read, wiki:read" }
+        scopes: { type: array, items: { type: string }, description: "REST permissions require same-named scopes, e.g. admin:user_manage, upload:create, graphify:run. MCP scopes such as mcp:invoke are MCP-only." }
         expires_in_days: { type: integer, minimum: 1, maximum: 365, description: "Token TTL in days; omit for non-expiring" }
 
     # --- Phase 4: MCP ---
@@ -3161,10 +3162,9 @@ paths:
       summary: List API tokens
       tags: [ApiTokens]
       parameters:
-        - { $ref: '#/components/parameters/pageParam' }
-        - { $ref: '#/components/parameters/perPageParam' }
-        - { name: user_id, in: query, schema: { type: string } }
-        - { name: include_revoked, in: query, schema: { type: boolean, default: false } }
+        - name: include_revoked
+          in: query
+          schema: { type: string, enum: ['true', 'false'], default: 'false' }
       responses:
         '200':
           description: API tokens (masked)

--- a/packages/auth-core/src/__tests__/constants.test.ts
+++ b/packages/auth-core/src/__tests__/constants.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { PERMISSION_POINTS, ROLE_PERMISSIONS, ROLES } from '../constants.js';
+import { PERMISSION_POINTS, REST_API_TOKEN_SCOPE_BY_PERMISSION, ROLE_PERMISSIONS, ROLES } from '../constants.js';
 
 describe('auth constants', () => {
   it('defines all 16 permission points', () => {
@@ -18,5 +18,14 @@ describe('auth constants', () => {
   it('grants upload permissions to admin and upload read to viewer', () => {
     expect(ROLE_PERMISSIONS[ROLES.ADMIN]).toEqual(expect.arrayContaining(['upload:create', 'upload:read']));
     expect(ROLE_PERMISSIONS[ROLES.VIEWER]).toContain('upload:read');
+  });
+
+  it('maps REST permission points to same-named API token scopes', () => {
+    expect(REST_API_TOKEN_SCOPE_BY_PERMISSION).toMatchObject({
+      'admin:user_manage': 'admin:user_manage',
+      'upload:create': 'upload:create',
+      'graphify:run': 'graphify:run',
+    });
+    expect(Object.hasOwn(REST_API_TOKEN_SCOPE_BY_PERMISSION, 'mcp:invoke')).toBe(false);
   });
 });

--- a/packages/auth-core/src/__tests__/guards.test.ts
+++ b/packages/auth-core/src/__tests__/guards.test.ts
@@ -207,6 +207,23 @@ describe('RbacGuard', () => {
     expect(getHttpExceptionMessage(error)).toBe('API token cannot access routes without explicit permission scope');
   });
 
+  it('allows an API token on a public route without explicit permissions', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPublicMetadata();
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createApiTokenRequestUser({ scopes: ['mcp:invoke'] }),
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
   it('allows a JWT session user on a route without explicit permissions', async () => {
     const guard = new RbacGuard(new Reflector());
 
@@ -489,6 +506,12 @@ function createContext(input: {
 function withPermissions(permissions: string[]): () => undefined {
   const handler = () => undefined;
   Reflect.defineMetadata(PERMISSIONS_METADATA_KEY, permissions, handler);
+  return handler;
+}
+
+function withPublicMetadata(): () => undefined {
+  const handler = () => undefined;
+  Reflect.defineMetadata(PUBLIC_METADATA_KEY, true, handler);
   return handler;
 }
 

--- a/packages/auth-core/src/__tests__/guards.test.ts
+++ b/packages/auth-core/src/__tests__/guards.test.ts
@@ -188,6 +188,147 @@ describe('RbacGuard', () => {
     ).resolves.toBe(true);
   });
 
+  it('allows an API token when both token scope and role permission match', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['admin:user_manage']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createApiTokenRequestUser({ role: ROLES.ADMIN, scopes: ['admin:user_manage'] }),
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it('throws 403 when an API token role matches but the token scope is missing', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['admin:user_manage']);
+
+    const error = await getRejectedHttpException(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createApiTokenRequestUser({ role: ROLES.ADMIN, scopes: ['admin:audit_view'] }),
+          },
+        }),
+      ),
+    );
+
+    expect(error.getStatus()).toBe(403);
+    expect(getHttpExceptionCode(error)).toBe(ErrorCode.PERMISSION_DENIED);
+    expect(getHttpExceptionDetails(error)).toEqual({ denied_scope: 'admin:user_manage' });
+  });
+
+  it('throws 403 when an owner API token lacks the admin REST scope', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['admin:user_manage']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createApiTokenRequestUser({ role: ROLES.OWNER, scopes: ['upload:create'] }),
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('does not let an MCP-only scope satisfy a REST admin permission', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['admin:user_manage']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createApiTokenRequestUser({ role: ROLES.OWNER, scopes: ['mcp:invoke'] }),
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('checks upload and graphify REST scopes independently for API tokens', async () => {
+    const guard = new RbacGuard(new Reflector(), {
+      getPermissionsForUser() {
+        return Promise.resolve(['upload:create', 'graphify:run']);
+      },
+    });
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler: withPermissions(['upload:create']),
+          request: {
+            params: { spaceId: 'space-1' },
+            user: createApiTokenRequestUser({ role: ROLES.EDITOR, scopes: ['upload:create'] }),
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler: withPermissions(['graphify:run']),
+          request: {
+            params: { spaceId: 'space-1' },
+            user: createApiTokenRequestUser({ role: ROLES.EDITOR, scopes: ['upload:create'] }),
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('keeps JWT session RBAC behavior free of token scope checks', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['admin:user_manage']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createRequestUser({ role: ROLES.OWNER }),
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it('allows an API token with all required REST scopes', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['admin', 'admin:user_manage']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createApiTokenRequestUser({
+              role: ROLES.ADMIN,
+              scopes: ['admin', 'admin:user_manage'],
+            }),
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
   it('uses body space_id for space-scoped chat permissions', async () => {
     let resolverInput: SpacePermissionResolverInput | undefined;
     const guard = new RbacGuard(new Reflector(), {
@@ -334,6 +475,38 @@ function createRequestUser(overrides: Partial<AuthenticatedRequestUser> = {}): A
   };
 }
 
+function createApiTokenRequestUser(
+  overrides: Partial<AuthenticatedRequestUser & { scopes: string[]; token_id: string }> = {},
+): AuthenticatedRequestUser & { scopes: string[]; token_id: string } {
+  return {
+    ...createRequestUser({ role: ROLES.ADMIN }),
+    scopes: ['admin:user_manage'],
+    token_id: 'api-token-1',
+    ...overrides,
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+async function getRejectedHttpException(promise: Promise<unknown>): Promise<HttpException> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).toBeInstanceOf(HttpException);
+    return err as HttpException;
+  }
+
+  throw new Error('Expected promise to reject with HttpException');
+}
+
+function getHttpExceptionCode(error: HttpException): unknown {
+  const response = error.getResponse();
+  return isRecord(response) ? response.code : undefined;
+}
+
+function getHttpExceptionDetails(error: HttpException): unknown {
+  const response = error.getResponse();
+  return isRecord(response) ? response.details : undefined;
 }

--- a/packages/auth-core/src/__tests__/guards.test.ts
+++ b/packages/auth-core/src/__tests__/guards.test.ts
@@ -188,6 +188,40 @@ describe('RbacGuard', () => {
     ).resolves.toBe(true);
   });
 
+  it('throws 403 for an API token on a route without explicit permissions', async () => {
+    const guard = new RbacGuard(new Reflector());
+
+    const error = await getRejectedHttpException(
+      guard.canActivate(
+        createContext({
+          request: {
+            params: {},
+            user: createApiTokenRequestUser({ scopes: ['mcp:invoke'] }),
+          },
+        }),
+      ),
+    );
+
+    expect(error.getStatus()).toBe(403);
+    expect(getHttpExceptionCode(error)).toBe(ErrorCode.PERMISSION_DENIED);
+    expect(getHttpExceptionMessage(error)).toBe('API token cannot access routes without explicit permission scope');
+  });
+
+  it('allows a JWT session user on a route without explicit permissions', async () => {
+    const guard = new RbacGuard(new Reflector());
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          request: {
+            params: {},
+            user: createRequestUser(),
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
   it('allows an API token when both token scope and role permission match', async () => {
     const guard = new RbacGuard(new Reflector());
     const handler = withPermissions(['admin:user_manage']);
@@ -223,7 +257,8 @@ describe('RbacGuard', () => {
 
     expect(error.getStatus()).toBe(403);
     expect(getHttpExceptionCode(error)).toBe(ErrorCode.PERMISSION_DENIED);
-    expect(getHttpExceptionDetails(error)).toEqual({ denied_scope: 'admin:user_manage' });
+    expect(getHttpExceptionDetails(error)).toBeUndefined();
+    expect(getHttpExceptionResponse(error)).not.toHaveProperty('denied_scope');
   });
 
   it('throws 403 when an owner API token lacks the admin REST scope', async () => {
@@ -502,11 +537,21 @@ async function getRejectedHttpException(promise: Promise<unknown>): Promise<Http
 }
 
 function getHttpExceptionCode(error: HttpException): unknown {
-  const response = error.getResponse();
+  const response = getHttpExceptionResponse(error);
   return isRecord(response) ? response.code : undefined;
 }
 
+function getHttpExceptionMessage(error: HttpException): unknown {
+  const response = getHttpExceptionResponse(error);
+  return isRecord(response) ? response.message : undefined;
+}
+
 function getHttpExceptionDetails(error: HttpException): unknown {
-  const response = error.getResponse();
+  const response = getHttpExceptionResponse(error);
   return isRecord(response) ? response.details : undefined;
+}
+
+function getHttpExceptionResponse(error: HttpException): unknown {
+  const response = error.getResponse();
+  return response;
 }

--- a/packages/auth-core/src/constants.ts
+++ b/packages/auth-core/src/constants.ts
@@ -19,6 +19,38 @@ export const PERMISSION_POINTS = [
 
 export type PermissionPoint = (typeof PERMISSION_POINTS)[number];
 
+/**
+ * REST API token scope mapping.
+ *
+ * Ordinary REST route permission points use the same string as the required API
+ * token scope. For example, an upload route decorated with `upload:create`
+ * requires an API token containing `upload:create`; an admin user-management
+ * route requires `admin:user_manage`; a graphify run route requires
+ * `graphify:run`.
+ *
+ * MCP scopes such as `mcp:invoke` are intentionally absent from this table.
+ * They are enforced by the MCP policy layer only and do not authorize REST
+ * routes.
+ */
+export const REST_API_TOKEN_SCOPE_BY_PERMISSION = {
+  'space:read': 'space:read',
+  'space:view': 'space:view',
+  'space:edit': 'space:edit',
+  'space:admin': 'space:admin',
+  'upload:create': 'upload:create',
+  'upload:read': 'upload:read',
+  'wiki:publish': 'wiki:publish',
+  'wiki:rollback': 'wiki:rollback',
+  'graphify:run': 'graphify:run',
+  'graphify:view': 'graphify:view',
+  'chat:use': 'chat:use',
+  'model:use': 'model:use',
+  admin: 'admin',
+  'admin:user_manage': 'admin:user_manage',
+  'admin:model_manage': 'admin:model_manage',
+  'admin:audit_view': 'admin:audit_view',
+} as const satisfies Record<PermissionPoint, PermissionPoint>;
+
 export const ROLES = {
   OWNER: 'owner',
   ADMIN: 'admin',
@@ -116,4 +148,8 @@ export function isPermissionPoint(permission: string): permission is PermissionP
 
 export function isSpaceScopedPermission(permission: string): permission is (typeof SPACE_SCOPED_PERMISSIONS)[number] {
   return (SPACE_SCOPED_PERMISSIONS as readonly string[]).includes(permission);
+}
+
+export function getRestApiTokenScopeForPermission(permission: string): PermissionPoint | undefined {
+  return isPermissionPoint(permission) ? REST_API_TOKEN_SCOPE_BY_PERMISSION[permission] : undefined;
 }

--- a/packages/auth-core/src/rbac.guard.ts
+++ b/packages/auth-core/src/rbac.guard.ts
@@ -20,6 +20,7 @@ import {
   type Role,
 } from './constants.js';
 import { PERMISSIONS_METADATA_KEY } from './permissions.decorator.js';
+import { PUBLIC_METADATA_KEY } from './public.decorator.js';
 
 export const SPACE_PERMISSION_RESOLVER = Symbol('SPACE_PERMISSION_RESOLVER');
 
@@ -76,6 +77,13 @@ export class RbacGuard implements CanActivate {
     const request = context.switchToHttp().getRequest<RequestWithAuth>();
 
     if (requiredPermissions === undefined || requiredPermissions.length === 0) {
+      const isPublic =
+        this.reflector.getAllAndOverride<boolean>(PUBLIC_METADATA_KEY, [context.getHandler(), context.getClass()]) ===
+        true;
+      if (isPublic) {
+        return true;
+      }
+
       const user = request.user === undefined ? undefined : getValidatedRequestUser(request.user);
       if (user !== undefined && isApiTokenRequestUser(user)) {
         throw new ForbiddenException({

--- a/packages/auth-core/src/rbac.guard.ts
+++ b/packages/auth-core/src/rbac.guard.ts
@@ -73,11 +73,20 @@ export class RbacGuard implements CanActivate {
       context.getHandler(),
       context.getClass(),
     ]);
+    const request = context.switchToHttp().getRequest<RequestWithAuth>();
+
     if (requiredPermissions === undefined || requiredPermissions.length === 0) {
+      const user = request.user === undefined ? undefined : getValidatedRequestUser(request.user);
+      if (user !== undefined && isApiTokenRequestUser(user)) {
+        throw new ForbiddenException({
+          code: ErrorCode.PERMISSION_DENIED,
+          message: 'API token cannot access routes without explicit permission scope',
+        });
+      }
+
       return true;
     }
 
-    const request = context.switchToHttp().getRequest<RequestWithAuth>();
     const user = getValidatedRequestUser(request.user);
 
     const tokenScopeDenial = getApiTokenScopeDenial(user, requiredPermissions);
@@ -90,7 +99,7 @@ export class RbacGuard implements CanActivate {
           required_permission: tokenScopeDenial.requiredPermission,
         }),
       );
-      throwPermissionDenied({ denied_scope: tokenScopeDenial.deniedScope });
+      throwPermissionDenied();
     }
 
     const role = normalizeRole(user.role);

--- a/packages/auth-core/src/rbac.guard.ts
+++ b/packages/auth-core/src/rbac.guard.ts
@@ -2,6 +2,7 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  Logger,
   Optional,
   UnauthorizedException,
   type CanActivate,
@@ -13,6 +14,7 @@ import { ErrorCode } from '@cherrygraph/shared';
 import {
   ROLE_PERMISSIONS,
   ROLES,
+  getRestApiTokenScopeForPermission,
   isSpaceScopedPermission,
   normalizeRole,
   type Role,
@@ -40,6 +42,8 @@ type RequestUser = {
   group_ids: string[];
   permissions?: string[];
   space_permissions?: Record<string, string[]>;
+  scopes?: string[];
+  token_id?: string;
 };
 
 type RequestWithAuth = {
@@ -57,6 +61,8 @@ type RequestWithAuth = {
 
 @Injectable()
 export class RbacGuard implements CanActivate {
+  private readonly logger = new Logger(RbacGuard.name);
+
   constructor(
     private readonly reflector: Reflector,
     @Optional() @Inject(SPACE_PERMISSION_RESOLVER) private readonly resolver?: SpacePermissionResolver,
@@ -73,6 +79,19 @@ export class RbacGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest<RequestWithAuth>();
     const user = getValidatedRequestUser(request.user);
+
+    const tokenScopeDenial = getApiTokenScopeDenial(user, requiredPermissions);
+    if (tokenScopeDenial !== undefined) {
+      this.logger.debug(
+        JSON.stringify({
+          reason: 'api_token_scope_denied',
+          token_id: tokenScopeDenial.tokenId,
+          denied_scope: tokenScopeDenial.deniedScope,
+          required_permission: tokenScopeDenial.requiredPermission,
+        }),
+      );
+      throwPermissionDenied({ denied_scope: tokenScopeDenial.deniedScope });
+    }
 
     const role = normalizeRole(user.role);
     if (role === ROLES.OWNER) {
@@ -161,6 +180,35 @@ function canDeferSpaceReadToResourceAcl(
   rolePermissions: ReadonlySet<string>,
 ): boolean {
   return requiredPermissions.every((permission) => permission === 'space:read' && rolePermissions.has(permission));
+}
+
+type ApiTokenScopeDenial = {
+  tokenId: string;
+  deniedScope: string;
+  requiredPermission: string;
+};
+
+function getApiTokenScopeDenial(
+  user: RequestUser,
+  requiredPermissions: readonly string[],
+): ApiTokenScopeDenial | undefined {
+  if (!isApiTokenRequestUser(user)) {
+    return undefined;
+  }
+
+  const tokenScopes = new Set(user.scopes);
+  for (const permission of requiredPermissions) {
+    const requiredScope = getRestApiTokenScopeForPermission(permission);
+    if (requiredScope === undefined || !tokenScopes.has(requiredScope)) {
+      return {
+        tokenId: user.token_id,
+        deniedScope: requiredScope ?? permission,
+        requiredPermission: permission,
+      };
+    }
+  }
+
+  return undefined;
 }
 
 async function getRequestPermissions(
@@ -263,7 +311,20 @@ function getValidatedRequestUser(user: unknown): RequestUser {
     requestUser.space_permissions = user.space_permissions;
   }
 
+  if (user.scopes !== undefined || user.token_id !== undefined) {
+    if (!isStringArray(user.scopes) || !isNonEmptyString(user.token_id)) {
+      throwUnauthenticated();
+    }
+
+    requestUser.scopes = user.scopes;
+    requestUser.token_id = user.token_id;
+  }
+
   return requestUser;
+}
+
+function isApiTokenRequestUser(user: RequestUser): user is RequestUser & { scopes: string[]; token_id: string } {
+  return user.scopes !== undefined && user.token_id !== undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -289,9 +350,10 @@ function throwUnauthenticated(): never {
   });
 }
 
-function throwPermissionDenied(): never {
+function throwPermissionDenied(details?: Record<string, unknown>): never {
   throw new ForbiddenException({
     code: ErrorCode.PERMISSION_DENIED,
     message: 'Permission denied',
+    ...(details !== undefined ? { details } : {}),
   });
 }

--- a/tests/integration/api-token-lifecycle.test.ts
+++ b/tests/integration/api-token-lifecycle.test.ts
@@ -1,4 +1,7 @@
 import { ErrorCode, apiTokens } from '@cherrygraph/shared';
+import { type ExecutionContext } from '@nestjs/common';
+import { RbacGuard } from '@cherrygraph/auth-core';
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -11,7 +14,10 @@ import {
   getHttpExceptionCode,
   getRejectedHttpException,
 } from '../../apps/api/src/users/__tests__/user-group-service-test-utils.js';
+import { ApiTokenGuard } from '../../apps/api/src/api-tokens/api-token.guard.js';
 import { ApiTokenService, hashRawToken } from '../../apps/api/src/api-tokens/api-token.service.js';
+
+const permissionsByHandler = new WeakMap<object, string[]>();
 
 describe('API token lifecycle integration', () => {
   it('P4-E8 creates, uses, expires, revokes, and rejects an API token', async () => {
@@ -71,6 +77,63 @@ describe('API token lifecycle integration', () => {
     expect(revoked.getStatus()).toBe(401);
     expect(getHttpExceptionCode(revoked)).toBe(ErrorCode.TOKEN_REVOKED);
   });
+
+  it('enforces REST route scopes after cwt API token authentication', async () => {
+    const rawToken = `cwt_${'b'.repeat(64)}`;
+    const db = new ScriptedDb();
+    const audit = createAuditMock();
+    const service = new ApiTokenService(db.asDrizzle(), audit.service);
+    const reflector = createReflector();
+    const apiTokenGuard = new ApiTokenGuard(service, reflector);
+    const rbacGuard = new RbacGuard(reflector);
+    const handler = withPermissions(['admin:user_manage']);
+
+    const deniedRequest = createBearerRequest(rawToken);
+    db.queueSelect([
+      createApiTokenRow({
+        token_hash: hashRawToken(rawToken),
+        scopes: ['mcp:invoke'],
+      }),
+    ]);
+    db.queueSelect([createUserRow({ id: TEST_USER_ID, role: 'owner' })]);
+
+    await expect(apiTokenGuard.canActivate(createContext(handler, deniedRequest))).resolves.toBe(true);
+    const denied = await getRejectedHttpException(rbacGuard.canActivate(createContext(handler, deniedRequest)));
+    expect(denied.getStatus()).toBe(403);
+    expect(getHttpExceptionCode(denied)).toBe(ErrorCode.PERMISSION_DENIED);
+
+    const allowedRequest = createBearerRequest(rawToken);
+    db.queueSelect([
+      createApiTokenRow({
+        token_hash: hashRawToken(rawToken),
+        scopes: ['admin:user_manage'],
+      }),
+    ]);
+    db.queueSelect([createUserRow({ id: TEST_USER_ID, role: 'owner' })]);
+
+    await expect(apiTokenGuard.canActivate(createContext(handler, allowedRequest))).resolves.toBe(true);
+    await expect(rbacGuard.canActivate(createContext(handler, allowedRequest))).resolves.toBe(true);
+  });
+
+  it('keeps the OpenAPI token list endpoint aligned with the controller contract', () => {
+    const openapi = readFileSync(new URL('../../docs/schemas/openapi.yaml', import.meta.url), 'utf8');
+    const listEndpoint = sliceBetween(openapi, '  /admin/api-tokens:', '  /admin/api-tokens/{token_id}:');
+    const apiTokenSchema = sliceBetween(openapi, '    ApiToken:', '    ApiTokenCreated:');
+    const createTokenSchema = sliceBetween(openapi, '    CreateApiTokenRequest:', '    # --- Phase 4: MCP ---');
+
+    expect(listEndpoint).toContain("enum: ['true', 'false']");
+    expect(listEndpoint).not.toContain("name: user_id");
+    expect(listEndpoint).not.toContain('#/components/parameters/pageParam');
+    expect(listEndpoint).not.toContain('#/components/parameters/perPageParam');
+    expect(apiTokenSchema).toContain('last_used_at');
+    expect(apiTokenSchema).not.toContain('user_id');
+    expect(apiTokenSchema).not.toContain('revoked_at');
+    expect(createTokenSchema).toContain('admin:user_manage');
+    expect(createTokenSchema).toContain('upload:create');
+    expect(createTokenSchema).toContain('graphify:run');
+    expect(createTokenSchema).toContain('mcp:invoke');
+    expect(createTokenSchema).toContain('MCP-only');
+  });
 });
 
 function createApiTokenRow(overrides: Partial<typeof apiTokens.$inferSelect> = {}): typeof apiTokens.$inferSelect {
@@ -88,4 +151,62 @@ function createApiTokenRow(overrides: Partial<typeof apiTokens.$inferSelect> = {
     created_at: new Date('2026-05-01T00:00:00.000Z'),
     ...overrides,
   };
+}
+
+function withPermissions(permissions: string[]): () => undefined {
+  const handler = () => undefined;
+  permissionsByHandler.set(handler, permissions);
+  return handler;
+}
+
+function createBearerRequest(rawToken: string): {
+  headers: Record<string, string>;
+  user?: unknown;
+} {
+  return {
+    headers: {
+      authorization: `Bearer ${rawToken}`,
+    },
+  };
+}
+
+function createContext(handler: () => undefined, request: unknown): ExecutionContext {
+  return {
+    getHandler: () => handler,
+    getClass: () => class TestController {},
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function createReflector(): ConstructorParameters<typeof RbacGuard>[0] {
+  return {
+    getAllAndOverride<T>(_metadataKey: string | symbol, targets: Array<object | undefined>): T | undefined {
+      void _metadataKey;
+
+      for (const target of targets) {
+        if (target === undefined) {
+          continue;
+        }
+
+        const value = permissionsByHandler.get(target) as T | undefined;
+        if (value !== undefined) {
+          return value;
+        }
+      }
+
+      return undefined;
+    },
+  } as ConstructorParameters<typeof RbacGuard>[0];
+}
+
+function sliceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(`OpenAPI marker not found: ${start}`);
+  }
+
+  return source.slice(startIndex, endIndex);
 }


### PR DESCRIPTION
## Summary
- Add `REST_API_TOKEN_SCOPE_BY_PERMISSION` mapping in auth-core constants — REST permission points map 1:1 to token scopes, MCP scopes excluded
- Enforce scope intersection in `RbacGuard` before owner/admin role bypass — `cwt_` tokens are constrained by declared scopes regardless of role
- API token users fail-closed on undecorated (no @Permissions) non-@Public routes
- Removed denied_scope from 403 response body (kept in debug logs only)
- Align OpenAPI `GET /admin/api-tokens` schema with controller implementation
- Add unit tests (8 scenarios) and integration tests for scope enforcement

Closes #287

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `e772a01c6f70896cde8cacaa49e0594ff3a958ad`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/302#issuecomment-4431586585) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/302#issuecomment-4431587105) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/302#issuecomment-4431587369) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/302#issuecomment-4431587617)
- Key findings addressed: R1 — undecorated route bypass fixed with fail-closed; R2 — @Public MCP route exempted from fail-closed; R1 — denied_scope removed from response body

## Test plan
- [x] Owner token without admin scope → 403 on admin route
- [x] Admin token with matching scope → authorized
- [x] MCP-only scope (`mcp:invoke`) cannot authorize REST routes
- [x] Upload scope does not authorize Graphify routes
- [x] JWT session users unaffected (no scope check)
- [x] API token on undecorated non-public route → 403 fail-closed
- [x] API token on @Public route → allowed (MCP invoke preserved)
- [x] OpenAPI spec-parity test validates schema alignment
- [x] All 1209 existing tests pass