### PR TITLE
feat(auth): migrate browser refresh/logout to cookie-only flow

### DIFF
--- a/apps/api/src/auth/__tests__/auth.controller.test.ts
+++ b/apps/api/src/auth/__tests__/auth.controller.test.ts
@@ -185,6 +185,18 @@ describe('AuthController', () => {
     expect(getErrorPayload(response.text).code).toBe(ErrorCode.INVALID_REFRESH_TOKEN);
   });
 
+  it('POST /api/auth/refresh rejects duplicate refresh cookies', async () => {
+    app = await createTestApp();
+
+    const response = await request(app.getHttpAdapter().getInstance().server)
+      .post('/api/auth/refresh')
+      .set('Cookie', 'refresh_token=first-refresh-token; refresh_token=second-refresh-token')
+      .expect(401);
+
+    expect(getErrorPayload(response.text).code).toBe(ErrorCode.INVALID_REFRESH_TOKEN);
+    expect(authServiceMock.refresh).not.toHaveBeenCalled();
+  });
+
   it('POST /api/auth/logout requires auth and returns success', async () => {
     app = await createTestApp();
     authServiceMock.logout.mockResolvedValue({ success: true });

--- a/apps/api/src/auth/__tests__/auth.controller.test.ts
+++ b/apps/api/src/auth/__tests__/auth.controller.test.ts
@@ -16,9 +16,9 @@ import {
   type ChangePasswordInput,
   type CurrentUserResponse,
   type LoginInput,
-  type LoginResponse,
+  type LoginResult,
   type LogoutInput,
-  type TokenPairResponse,
+  type TokenPairResult,
 } from '../auth.service.js';
 import {
   SessionService,
@@ -30,11 +30,11 @@ import { TEST_EMAIL, TEST_JWT_SECRET, TEST_TENANT_ID, TEST_USER_ID } from './aut
 
 type AuthServiceMock = {
   login: ReturnType<
-    typeof vi.fn<(input: LoginInput, metadata?: AuthRequestMetadata) => Promise<LoginResponse>>
+    typeof vi.fn<(input: LoginInput, metadata?: AuthRequestMetadata) => Promise<LoginResult>>
   >;
   refresh: ReturnType<
     typeof vi.fn<
-      (refreshToken: string, metadata?: AuthRequestMetadata) => Promise<TokenPairResponse>
+      (refreshToken: string, metadata?: AuthRequestMetadata) => Promise<TokenPairResult>
     >
   >;
   logout: ReturnType<
@@ -103,7 +103,7 @@ describe('AuthController', () => {
     expect(metadata).toEqual({ limit: 30, windowSec: 60, mode: 'ip' });
   });
 
-  it('POST /api/auth/login returns the token pair and user payload with status 200', async () => {
+  it('POST /api/auth/login sets the refresh cookie and omits it from the body', async () => {
     app = await createTestApp();
     authServiceMock.login.mockResolvedValue(createLoginResponse());
 
@@ -115,7 +115,6 @@ describe('AuthController', () => {
     const body = parseJsonObject(response.text);
     expect(body.data).toMatchObject({
       access_token: 'access-token',
-      refresh_token: 'refresh-token',
       expires_in: 3600,
       user: {
         id: TEST_USER_ID,
@@ -125,6 +124,7 @@ describe('AuthController', () => {
         groups: ['group-1'],
       },
     });
+    expect(body.data).not.toHaveProperty('refresh_token');
     expect(response.headers['set-cookie']?.[0]).toContain('refresh_token=refresh-token');
     expect(authServiceMock.login).toHaveBeenCalledWith(
       expect.objectContaining({ email: TEST_EMAIL, password: 'Correct1!' }),
@@ -132,28 +132,40 @@ describe('AuthController', () => {
     );
   });
 
-  it('POST /api/auth/refresh returns a rotated token pair', async () => {
+  it('POST /api/auth/refresh accepts a cookie and rotates it without returning it in the body', async () => {
     app = await createTestApp();
     authServiceMock.refresh.mockResolvedValue({
       access_token: 'new-access-token',
-      refresh_token: 'new-refresh-token',
+      refreshToken: 'new-refresh-token',
       expires_in: 3600,
     });
 
     const response = await request(app.getHttpAdapter().getInstance().server)
       .post('/api/auth/refresh')
-      .send({ refresh_token: 'old-refresh-token' })
+      .set('Cookie', ['refresh_token=old-refresh-token'])
       .expect(200);
 
     expect(parseJsonObject(response.text).data).toMatchObject({
       access_token: 'new-access-token',
-      refresh_token: 'new-refresh-token',
       expires_in: 3600,
     });
+    expect(parseJsonObject(response.text).data).not.toHaveProperty('refresh_token');
     expect(response.headers['set-cookie']?.[0]).toContain('refresh_token=new-refresh-token');
+    expect(authServiceMock.refresh).toHaveBeenCalledWith('old-refresh-token', expect.any(Object));
   });
 
-  it('POST /api/auth/refresh maps invalid refresh tokens to 401', async () => {
+  it('POST /api/auth/refresh requires a refresh cookie', async () => {
+    app = await createTestApp();
+
+    const response = await request(app.getHttpAdapter().getInstance().server)
+      .post('/api/auth/refresh')
+      .expect(401);
+
+    expect(getErrorPayload(response.text).code).toBe(ErrorCode.INVALID_REFRESH_TOKEN);
+    expect(authServiceMock.refresh).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/auth/refresh maps invalid refresh cookies to 401', async () => {
     app = await createTestApp();
     authServiceMock.refresh.mockRejectedValue(
       new HttpException(
@@ -167,7 +179,7 @@ describe('AuthController', () => {
 
     const response = await request(app.getHttpAdapter().getInstance().server)
       .post('/api/auth/refresh')
-      .send({ refresh_token: 'bad-refresh-token' })
+      .set('Cookie', ['refresh_token=bad-refresh-token'])
       .expect(401);
 
     expect(getErrorPayload(response.text).code).toBe(ErrorCode.INVALID_REFRESH_TOKEN);
@@ -185,28 +197,35 @@ describe('AuthController', () => {
     const response = await request(app.getHttpAdapter().getInstance().server)
       .post('/api/auth/logout')
       .set('Authorization', `Bearer ${await createAccessToken()}`)
-      .send({ refresh_token: 'refresh-token' })
+      .set('Cookie', ['refresh_token=refresh-token'])
       .expect(200);
 
     expect(parseJsonObject(response.text).data).toEqual({ success: true });
+    expect(response.headers['set-cookie']?.[0]).toContain('refresh_token=');
+    expect(response.headers['set-cookie']?.[0]).toContain('Max-Age=0');
     expect(authServiceMock.logout).toHaveBeenCalledWith(
       expect.objectContaining({ sub: TEST_USER_ID, tenant_id: TEST_TENANT_ID }),
-      expect.objectContaining({ refresh_token: 'refresh-token' }),
+      expect.objectContaining({ refreshToken: 'refresh-token' }),
       expect.any(Object),
     );
   });
 
-  it('POST /api/auth/logout requires a refresh token', async () => {
+  it('POST /api/auth/logout works without a refresh cookie', async () => {
     app = await createTestApp();
+    authServiceMock.logout.mockResolvedValue({ success: true });
 
     const response = await request(app.getHttpAdapter().getInstance().server)
       .post('/api/auth/logout')
       .set('Authorization', `Bearer ${await createAccessToken()}`)
-      .send({})
-      .expect(422);
+      .expect(200);
 
-    expect(getErrorPayload(response.text).code).toBe(ErrorCode.VALIDATION_ERROR);
-    expect(authServiceMock.logout).not.toHaveBeenCalled();
+    expect(parseJsonObject(response.text).data).toEqual({ success: true });
+    expect(response.headers['set-cookie']?.[0]).toContain('Max-Age=0');
+    expect(authServiceMock.logout).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: TEST_USER_ID, tenant_id: TEST_TENANT_ID }),
+      expect.objectContaining({ refreshToken: undefined }),
+      expect.any(Object),
+    );
   });
 
   it('GET /api/auth/me requires auth and returns the current user shape', async () => {
@@ -320,10 +339,10 @@ function createSessionServiceMock(): SessionServiceMock {
   };
 }
 
-function createLoginResponse(): LoginResponse {
+function createLoginResponse(): LoginResult {
   return {
     access_token: 'access-token',
-    refresh_token: 'refresh-token',
+    refreshToken: 'refresh-token',
     expires_in: 3600,
     user: {
       id: TEST_USER_ID,

--- a/apps/api/src/auth/__tests__/auth.service.test.ts
+++ b/apps/api/src/auth/__tests__/auth.service.test.ts
@@ -68,7 +68,7 @@ describe('AuthService', () => {
       groups: ['group-1'],
     });
     expect(typeof result.access_token).toBe('string');
-    expect(typeof result.refresh_token).toBe('string');
+    expect(typeof result.refreshToken).toBe('string');
 
     const accessPayload = await verifyToken(result.access_token, TEST_JWT_SECRET);
     expect(accessPayload).toMatchObject({
@@ -81,7 +81,7 @@ describe('AuthService', () => {
     });
 
     const insertedSession = requireRecord(db.inserts[0]);
-    expect(insertedSession.refresh_token_hash).toBe(hashRefreshToken(result.refresh_token));
+    expect(insertedSession.refresh_token_hash).toBe(hashRefreshToken(result.refreshToken));
     expect(insertedSession.user_id).toBe(TEST_USER_ID);
 
     const userUpdate = requireRecord(db.updates[0]);
@@ -222,8 +222,8 @@ describe('AuthService', () => {
     const result = await service.refresh(oldRefreshToken, { request_id: 'req-refresh' });
 
     expect(result.expires_in).toBe(3600);
-    expect(result.refresh_token).not.toBe(oldRefreshToken);
-    const newRefreshPayload = await verifyToken(result.refresh_token, TEST_JWT_SECRET);
+    expect(result.refreshToken).not.toBe(oldRefreshToken);
+    const newRefreshPayload = await verifyToken(result.refreshToken, TEST_JWT_SECRET);
     const insertedSession = requireRecord(db.inserts[0]);
     expect(newRefreshPayload.session_id).toBe(insertedSession.id);
 
@@ -295,7 +295,7 @@ describe('AuthService', () => {
 
     const result = await service.logout(
       createAuthenticatedUser(),
-      { refresh_token: refreshToken },
+      { refreshToken },
       { request_id: 'req-logout' },
     );
 
@@ -311,13 +311,10 @@ describe('AuthService', () => {
     );
   });
 
-  it('rejects logout without a refresh token', async () => {
+  it('allows logout without a refresh token', async () => {
     const { service } = createServiceContext();
 
-    const err = await getRejectedHttpException(service.logout(createAuthenticatedUser()));
-
-    expect(err.getStatus()).toBe(401);
-    expect(getHttpExceptionCode(err)).toBe(ErrorCode.INVALID_REFRESH_TOKEN);
+    await expect(service.logout(createAuthenticatedUser())).resolves.toEqual({ success: true });
   });
 
   it('changes password with the correct current password and records auth.password_change', async () => {

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -18,7 +18,12 @@ import type { IncomingHttpHeaders } from 'node:http';
 
 import { RateLimit } from '../common/guards/rate-limit.guard.js';
 import { getRequestIdFromRequest } from '../common/middleware/request-context.middleware.js';
-import { AuthService, type AuthRequestMetadata } from './auth.service.js';
+import {
+  AuthService,
+  type AuthRequestMetadata,
+  type LoginResponse,
+  type TokenPairResponse,
+} from './auth.service.js';
 import { SessionService, type SessionSummary } from './session.service.js';
 
 class LoginDto {
@@ -30,20 +35,6 @@ class LoginDto {
   @IsNotEmpty()
   @MaxLength(128)
   password!: string;
-}
-
-class RefreshDto {
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(4096)
-  refresh_token!: string;
-}
-
-class LogoutDto {
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(4096)
-  refresh_token!: string;
 }
 
 class ChangePasswordDto {
@@ -61,6 +52,7 @@ class ChangePasswordDto {
 type RequestWithAuth = {
   user?: AuthenticatedRequestUser;
   headers?: IncomingHttpHeaders;
+  cookies?: Record<string, string | undefined>;
   ip?: string;
   request_id?: string;
   raw?: {
@@ -102,10 +94,10 @@ export class AuthController {
     @Body() body: LoginDto,
     @Req() request: RequestWithAuth,
     @Res({ passthrough: true }) response: CookieResponse,
-  ): Promise<Awaited<ReturnType<AuthService['login']>>> {
+  ): Promise<LoginResponse> {
     const result = await this.authService.login(body, getRequestMetadata(request));
-    setRefreshCookie(response, result.refresh_token);
-    return result;
+    setRefreshCookie(response, result.refreshToken);
+    return toLoginResponse(result);
   }
 
   @Public()
@@ -113,29 +105,40 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @Post('refresh')
   async refresh(
-    @Body() body: RefreshDto,
     @Req() request: RequestWithAuth,
     @Res({ passthrough: true }) response: CookieResponse,
-  ): Promise<Awaited<ReturnType<AuthService['refresh']>>> {
-    const result = await this.authService.refresh(body.refresh_token, getRequestMetadata(request));
-    setRefreshCookie(response, result.refresh_token);
-    return result;
+  ): Promise<TokenPairResponse> {
+    const refreshToken = getRefreshTokenCookie(request);
+    if (refreshToken === undefined) {
+      throw new HttpException(
+        {
+          code: ErrorCode.INVALID_REFRESH_TOKEN,
+          message: 'Refresh token cookie is required',
+        },
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    const result = await this.authService.refresh(refreshToken, getRequestMetadata(request));
+    setRefreshCookie(response, result.refreshToken);
+    return toTokenPairResponse(result);
   }
 
   @HttpCode(HttpStatus.OK)
   @Post('logout')
   async logout(
-    @Body() body: LogoutDto,
     @Req() request: RequestWithAuth,
     @Res({ passthrough: true }) response: CookieResponse,
   ): Promise<{ success: true }> {
-    const result = await this.authService.logout(
-      getAuthenticatedUser(request),
-      body,
-      getRequestMetadata(request),
-    );
-    clearRefreshCookie(response);
-    return result;
+    try {
+      return await this.authService.logout(
+        getAuthenticatedUser(request),
+        { refreshToken: getRefreshTokenCookie(request) },
+        getRequestMetadata(request),
+      );
+    } finally {
+      clearRefreshCookie(response);
+    }
   }
 
   @Get('me')
@@ -182,6 +185,21 @@ export class AuthController {
   }
 }
 
+function toLoginResponse(result: Awaited<ReturnType<AuthService['login']>>): LoginResponse {
+  return {
+    access_token: result.access_token,
+    expires_in: result.expires_in,
+    user: result.user,
+  };
+}
+
+function toTokenPairResponse(result: Awaited<ReturnType<AuthService['refresh']>>): TokenPairResponse {
+  return {
+    access_token: result.access_token,
+    expires_in: result.expires_in,
+  };
+}
+
 function getAuthenticatedUser(request: RequestWithAuth): AuthenticatedRequestUser {
   if (request.user === undefined) {
     throw new HttpException(
@@ -222,6 +240,49 @@ function clearRefreshCookie(response: CookieResponse): void {
     'Set-Cookie',
     `${REFRESH_COOKIE_NAME}=; Max-Age=0; Path=/api/auth; HttpOnly; Secure; SameSite=Lax`,
   );
+}
+
+function getRefreshTokenCookie(request: RequestWithAuth): string | undefined {
+  const cookieValue = request.cookies?.[REFRESH_COOKIE_NAME] ?? parseCookieHeader(request)[REFRESH_COOKIE_NAME];
+  if (cookieValue === undefined || cookieValue.trim().length === 0) {
+    return undefined;
+  }
+
+  return cookieValue;
+}
+
+function parseCookieHeader(request: RequestWithAuth): Record<string, string> {
+  const header = (request.headers ?? request.raw?.headers)?.cookie;
+  const rawCookie = Array.isArray(header) ? header.join(';') : header;
+  if (typeof rawCookie !== 'string' || rawCookie.trim().length === 0) {
+    return {};
+  }
+
+  const cookies: Record<string, string> = {};
+  for (const part of rawCookie.split(';')) {
+    const separatorIndex = part.indexOf('=');
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const name = part.slice(0, separatorIndex).trim();
+    const rawValue = part.slice(separatorIndex + 1).trim();
+    if (name.length === 0 || name in cookies) {
+      continue;
+    }
+
+    cookies[name] = safeDecodeURIComponent(rawValue);
+  }
+
+  return cookies;
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function setResponseHeader(response: CookieResponse, name: string, value: string): void {

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -10,6 +10,7 @@ import {
   Post,
   Req,
   Res,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { Public, type AuthenticatedRequestUser } from '@cherrygraph/auth-core';
 import { ErrorCode } from '@cherrygraph/shared';
@@ -243,12 +244,41 @@ function clearRefreshCookie(response: CookieResponse): void {
 }
 
 function getRefreshTokenCookie(request: RequestWithAuth): string | undefined {
+  if (countCookieHeaderEntries(request, REFRESH_COOKIE_NAME) > 1) {
+    throw new UnauthorizedException({
+      code: ErrorCode.INVALID_REFRESH_TOKEN,
+      message: 'Multiple refresh token cookies are not allowed',
+    });
+  }
+
   const cookieValue = request.cookies?.[REFRESH_COOKIE_NAME] ?? parseCookieHeader(request)[REFRESH_COOKIE_NAME];
   if (cookieValue === undefined || cookieValue.trim().length === 0) {
     return undefined;
   }
 
   return cookieValue;
+}
+
+function countCookieHeaderEntries(request: RequestWithAuth, cookieName: string): number {
+  const header = (request.headers ?? request.raw?.headers)?.cookie;
+  const rawCookie = Array.isArray(header) ? header.join(';') : header;
+  if (typeof rawCookie !== 'string' || rawCookie.trim().length === 0) {
+    return 0;
+  }
+
+  let count = 0;
+  for (const part of rawCookie.split(';')) {
+    const separatorIndex = part.indexOf('=');
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    if (part.slice(0, separatorIndex).trim() === cookieName) {
+      count += 1;
+    }
+  }
+
+  return count;
 }
 
 function parseCookieHeader(request: RequestWithAuth): Record<string, string> {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -44,7 +44,6 @@ export type LoginInput = {
 
 export type LoginResponse = {
   access_token: string;
-  refresh_token: string;
   expires_in: number;
   user: {
     id: string;
@@ -57,12 +56,19 @@ export type LoginResponse = {
 
 export type TokenPairResponse = {
   access_token: string;
-  refresh_token: string;
   expires_in: number;
 };
 
 export type LogoutInput = {
-  refresh_token: string;
+  refreshToken?: string | undefined;
+};
+
+export type LoginResult = LoginResponse & {
+  refreshToken: string;
+};
+
+export type TokenPairResult = TokenPairResponse & {
+  refreshToken: string;
 };
 
 export type ChangePasswordInput = {
@@ -138,7 +144,7 @@ export class AuthService {
     @Optional() @Inject(AUTH_CORE_OPTIONS) private readonly options?: AuthCoreOptions,
   ) {}
 
-  async login(input: LoginInput, metadata: AuthRequestMetadata = {}): Promise<LoginResponse> {
+  async login(input: LoginInput, metadata: AuthRequestMetadata = {}): Promise<LoginResult> {
     const email = normalizeEmail(input.email);
     const tenantId = await this.resolveTenantId();
 
@@ -195,7 +201,7 @@ export class AuthService {
 
     return {
       access_token: tokens.accessToken,
-      refresh_token: tokens.refreshToken,
+      refreshToken: tokens.refreshToken,
       expires_in: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
       user: {
         id: user.id,
@@ -210,7 +216,7 @@ export class AuthService {
   async refresh(
     refreshToken: string,
     metadata: AuthRequestMetadata = {},
-  ): Promise<TokenPairResponse> {
+  ): Promise<TokenPairResult> {
     const claims = await this.verifyRefreshToken(refreshToken);
     const tokenHash = hashRefreshToken(refreshToken);
     const session = await this.sessionService.findSessionById(claims.session_id);
@@ -285,21 +291,21 @@ export class AuthService {
 
     return {
       access_token: rotation.tokens.accessToken,
-      refresh_token: rotation.tokens.refreshToken,
+      refreshToken: rotation.tokens.refreshToken,
       expires_in: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
     };
   }
 
   async logout(
     user: AuthenticatedRequestUser,
-    input: Partial<LogoutInput> = {},
+    input: LogoutInput = {},
     metadata: AuthRequestMetadata = {},
   ): Promise<{ success: true }> {
     const now = new Date();
-    const refreshToken = input.refresh_token;
+    const refreshToken = input.refreshToken;
 
     if (refreshToken === undefined || refreshToken.trim().length === 0) {
-      throwAuthError(ErrorCode.INVALID_REFRESH_TOKEN, 'Invalid refresh token');
+      return { success: true };
     }
 
     const claims = await this.verifyRefreshToken(refreshToken);

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -24,7 +24,6 @@ export type AuthUser = {
 
 type LoginResponse = {
   access_token: string;
-  refresh_token?: string;
   expires_in: number;
   user: AuthUser;
 };
@@ -40,7 +39,6 @@ type CurrentUserResponse = {
 
 type TokenPairResponse = {
   access_token: string;
-  refresh_token?: string;
   expires_in: number;
 };
 

--- a/docs/design/11_API规范.md
+++ b/docs/design/11_API规范.md
@@ -112,7 +112,6 @@
 {
   "data": {
     "access_token": "eyJ...",
-    "refresh_token": "rt_...",
     "expires_in": 3600,
     "user": {
       "id": "usr_001",
@@ -124,6 +123,8 @@
   }
 }
 ```
+
+响应同时设置 `Set-Cookie: refresh_token=...; HttpOnly; Secure; SameSite=Lax; Path=/api/auth; Max-Age=604800`。浏览器端 refresh token 仅通过 HttpOnly Cookie 保存，不在 JSON body 中返回。
 
 错误码：
 
@@ -140,7 +141,7 @@
 | 权限点 | 已认证即可 |
 | 审计动作 | `auth.logout` |
 
-输入：无（Bearer token 即可）
+输入：无（Bearer token + 自动携带的 `refresh_token` Cookie）。如果 Cookie 存在，服务端撤销对应 refresh session；无 Cookie 时仍清理 Cookie 并返回成功。
 
 输出：`{ "data": { "success": true } }`
 
@@ -174,16 +175,10 @@
 
 | 项目 | 说明 |
 |---|---|
-| 权限点 | 无（用 refresh_token） |
+| 权限点 | 无（用 `refresh_token` HttpOnly Cookie） |
 | 审计动作 | `auth.token_refresh` |
 
-输入：
-
-```json
-{
-  "refresh_token": "rt_..."
-}
-```
+输入：无 JSON body。浏览器通过 `credentials: include` 自动携带 `refresh_token` Cookie。
 
 输出：
 
@@ -191,11 +186,12 @@
 {
   "data": {
     "access_token": "eyJ...",
-    "refresh_token": "rt_new...",
     "expires_in": 3600
   }
 }
 ```
+
+响应同时轮换 `Set-Cookie: refresh_token=...; HttpOnly; Secure; SameSite=Lax; Path=/api/auth; Max-Age=604800`。
 
 错误码：
 
@@ -203,6 +199,12 @@
 |---|---|
 | `INVALID_REFRESH_TOKEN` | refresh token 无效或已过期 |
 | `TOKEN_REVOKED` | 已被撤销 |
+
+### Auth refresh/logout 迁移说明
+
+- 浏览器客户端不得读取、缓存或提交 JSON body 中的 `refresh_token`；登录和刷新响应 body 只包含 `access_token`、`expires_in` 以及登录时的 `user`。
+- 前端请求 `/api/auth/login`、`/api/auth/refresh`、`/api/auth/logout` 必须使用 `credentials: include`，由浏览器自动管理 `refresh_token` Cookie。
+- 旧客户端如果仍依赖 body `refresh_token` 刷新或登出，需要迁移到 Cookie Jar；当前浏览器 Auth API 不保留 JSON body refresh-token 模式。若未来恢复机器客户端 body token 模式，必须使用独立端点或在 OpenAPI 中作为非浏览器模式单独声明。
 
 ---
 
@@ -2419,7 +2421,7 @@ GET /api/internal/bridge/spaces/{docmost_space_id}/sync-status
 | `/api/auth/login` | POST | 无（公开） |
 | `/api/auth/logout` | POST | 已认证 |
 | `/api/auth/me` | GET | 已认证 |
-| `/api/auth/refresh` | POST | 无（用 refresh_token） |
+| `/api/auth/refresh` | POST | 无（用 `refresh_token` HttpOnly Cookie） |
 | `/api/auth/password/change` | POST | 已认证 |
 | `/api/auth/sessions` | GET | 已认证 |
 | `/api/auth/sessions/{id}` | DELETE | 已认证（仅自己） |

--- a/docs/schemas/openapi.yaml
+++ b/docs/schemas/openapi.yaml
@@ -112,15 +112,8 @@ components:
       type: object
       properties:
         access_token: { type: string }
-        refresh_token: { type: string }
         expires_in: { type: integer }
         user: { $ref: '#/components/schemas/User' }
-
-    RefreshRequest:
-      type: object
-      required: [refresh_token]
-      properties:
-        refresh_token: { type: string }
 
     # --- User ---
     User:
@@ -1100,6 +1093,7 @@ paths:
   /auth/login:
     post:
       summary: Login
+      description: Browser login returns an access token in the JSON body and sets the refresh token as an HttpOnly `refresh_token` cookie.
       tags: [Auth]
       security: []
       requestBody:
@@ -1109,7 +1103,11 @@ paths:
             schema: { $ref: '#/components/schemas/LoginRequest' }
       responses:
         '200':
-          description: Login successful
+          description: Login successful. The refresh token is set in the `Set-Cookie` header and is not included in the JSON body.
+          headers:
+            Set-Cookie:
+              description: HttpOnly `refresh_token` cookie scoped to `/api/auth`.
+              schema: { type: string }
           content:
             application/json:
               schema:
@@ -1123,10 +1121,15 @@ paths:
   /auth/logout:
     post:
       summary: Logout
+      description: Browser logout revokes the refresh session identified by the `refresh_token` cookie when present and clears that cookie. The request body is empty.
       tags: [Auth]
       responses:
         '200':
-          description: Logged out
+          description: Logged out. The refresh cookie is cleared even when no refresh cookie was present.
+          headers:
+            Set-Cookie:
+              description: Expired HttpOnly `refresh_token` cookie.
+              schema: { type: string }
           content:
             application/json:
               schema:
@@ -1156,16 +1159,16 @@ paths:
   /auth/refresh:
     post:
       summary: Refresh token
+      description: Browser refresh reads the HttpOnly `refresh_token` cookie, rotates it, and returns only a new access token in the JSON body. No JSON request body is required or used.
       tags: [Auth]
       security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: { $ref: '#/components/schemas/RefreshRequest' }
       responses:
         '200':
-          description: Token refreshed
+          description: Token refreshed. The rotated refresh token is set in the `Set-Cookie` header and is not included in the JSON body.
+          headers:
+            Set-Cookie:
+              description: Rotated HttpOnly `refresh_token` cookie scoped to `/api/auth`.
+              schema: { type: string }
           content:
             application/json:
               schema:

--- a/docs/schemas/openapi.yaml
+++ b/docs/schemas/openapi.yaml
@@ -108,12 +108,30 @@ components:
         email: { type: string, format: email }
         password: { type: string, minLength: 8 }
 
-    TokenResponse:
+    BrowserLoginResponse:
       type: object
+      required: [access_token, expires_in, user]
       properties:
         access_token: { type: string }
         expires_in: { type: integer }
-        user: { $ref: '#/components/schemas/User' }
+        user:
+          type: object
+          required: [id, email, name, role, groups]
+          properties:
+            id: { type: string }
+            email: { type: string, format: email }
+            name: { type: string }
+            role: { type: string, enum: [owner, admin, space_admin, editor, viewer, auditor] }
+            groups:
+              type: array
+              items: { type: string }
+
+    BrowserRefreshResponse:
+      type: object
+      required: [access_token, expires_in]
+      properties:
+        access_token: { type: string }
+        expires_in: { type: integer }
 
     # --- User ---
     User:
@@ -1113,7 +1131,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  data: { $ref: '#/components/schemas/TokenResponse' }
+                  data: { $ref: '#/components/schemas/BrowserLoginResponse' }
                   meta: { $ref: '#/components/schemas/Meta' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
         '429': { $ref: '#/components/responses/RateLimitError' }
@@ -1174,7 +1192,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  data: { $ref: '#/components/schemas/TokenResponse' }
+                  data: { $ref: '#/components/schemas/BrowserRefreshResponse' }
         '401': { $ref: '#/components/responses/UnauthorizedError' }
 
   /auth/password/change:

--- a/tests/integration/browser-auth-openapi-parity.test.ts
+++ b/tests/integration/browser-auth-openapi-parity.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('browser auth OpenAPI parity', () => {
+  it('keeps login, refresh, and logout aligned with the cookie-based controller contract', () => {
+    const openapi = readFileSync(new URL('../../docs/schemas/openapi.yaml', import.meta.url), 'utf8');
+    const loginEndpoint = sliceBetween(openapi, '  /auth/login:', '  /auth/logout:');
+    const logoutEndpoint = sliceBetween(openapi, '  /auth/logout:', '  /auth/me:');
+    const refreshEndpoint = sliceBetween(openapi, '  /auth/refresh:', '  /auth/password/change:');
+    const loginSchema = sliceBetween(
+      openapi,
+      '    BrowserLoginResponse:',
+      '    BrowserRefreshResponse:',
+    );
+    const refreshSchema = sliceBetween(openapi, '    BrowserRefreshResponse:', '    # --- User ---');
+
+    expect(loginEndpoint).toContain('#/components/schemas/BrowserLoginResponse');
+    expect(loginEndpoint).toContain('Set-Cookie:');
+    expect(loginSchema).not.toContain('refresh_token');
+    expect(loginSchema).toContain('required: [access_token, expires_in, user]');
+    expect(loginSchema).toContain('items: { type: string }');
+
+    expect(refreshEndpoint).toContain('#/components/schemas/BrowserRefreshResponse');
+    expect(refreshEndpoint).toContain('Set-Cookie:');
+    expect(refreshEndpoint).not.toContain('requestBody:');
+    expect(refreshSchema).not.toContain('refresh_token');
+    expect(refreshSchema).not.toContain('user:');
+
+    expect(logoutEndpoint).not.toContain('requestBody:');
+  });
+});
+
+function sliceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(`OpenAPI marker not found: ${start}`);
+  }
+
+  return source.slice(startIndex, endIndex);
+}


### PR DESCRIPTION
## Summary
- Remove `refresh_token` from login/refresh JSON response bodies — cookie-only via HttpOnly/Secure/SameSite=Lax
- Refresh reads token from cookie; returns 401 on missing/duplicate cookie
- Logout succeeds without cookie (graceful degradation), clears cookie in all cases
- Split OpenAPI schemas: `BrowserLoginResponse` / `BrowserRefreshResponse`
- Frontend auth types/client updated, OpenAPI parity test added
- `docs/design/11_API规范.md` aligned with cookie flow + migration notes

Closes #288

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `6c1ac7f0411967f36326d0a56cb5cfc324ee4b3b`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/303#issuecomment-4432082487) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/303#issuecomment-4432082867) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/303#issuecomment-4432083151) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/303#issuecomment-4432083526)
- Key findings addressed: R1 — split OpenAPI schemas for login/refresh, reject duplicate cookies, add parity test

## Test plan
- [x] Login sets HttpOnly cookie, body has no refresh_token
- [x] Refresh reads cookie, rotates cookie, body has no refresh_token
- [x] Refresh without cookie → 401
- [x] Refresh with invalid cookie → 401
- [x] Duplicate refresh_token cookies → 401
- [x] Logout with cookie → revokes session, clears cookie
- [x] Logout without cookie → succeeds, clears cookie
- [x] OpenAPI parity test validates schema alignment
- [x] All 1212 tests pass