### PR TITLE
fix(bridge): pagination-safe reconciliation using keyset cursor

### DIFF
--- a/apps/wiki-sync-worker/src/__tests__/reconciliation.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/reconciliation.test.ts
@@ -60,42 +60,84 @@ describe('wiki-sync-worker startup reconciliation', () => {
     expect(queues.attachmentSync.add).not.toHaveBeenCalled();
     expect(queues.docmostPush.add).not.toHaveBeenCalled();
   });
+
+  it('does not skip later received events when earlier statuses change between batches', async () => {
+    const rows = Array.from({ length: 5 }, (_, index) =>
+      createBridgeEvent({
+        id: `event-${index + 1}`,
+        event_id: `docmost-${index + 1}`,
+        event_type: 'page.saved',
+        status: 'received',
+        received_at: new Date(`2026-05-05T12:00:0${index}.000Z`),
+      }),
+    );
+    const db = new TestReconciliationDb(rows, (events, testDb) => {
+      if (testDb.selectBatches.length === 1) {
+        expect(events.map((event) => event.id)).toEqual(['event-1', 'event-2']);
+        testDb.markStatus('event-1', 'processed');
+      }
+    });
+    const queues = createQueues();
+
+    const enqueued = await reconcileOnStartup(db.asDb(), queues, { batchSize: 2 });
+
+    expect(enqueued).toBe(5);
+    expect(db.selectBatches).toEqual([
+      ['event-1', 'event-2'],
+      ['event-3', 'event-4'],
+      ['event-5'],
+    ]);
+    expect(queues.pageSync.add.mock.calls.map((call) => call[1].bridgeEventId)).toEqual([
+      'event-1',
+      'event-2',
+      'event-3',
+      'event-4',
+      'event-5',
+    ]);
+    expect(rows.find((row) => row.id === 'event-1')?.status).toBe('processed');
+  });
 });
 
 type BridgeEventRow = typeof bridgeEvents.$inferSelect;
 
 class TestReconciliationDb {
   readonly updated: Array<Partial<typeof bridgeEvents.$inferInsert>> = [];
+  readonly selectBatches: string[][] = [];
 
-  constructor(private readonly rows: BridgeEventRow[]) {}
+  constructor(
+    private readonly rows: BridgeEventRow[],
+    private readonly onAfterSelect?: (events: BridgeEventRow[], db: TestReconciliationDb) => void,
+  ) {}
+
+  markStatus(id: string, status: BridgeEventRow['status']): void {
+    const row = this.rows.find((candidate) => candidate.id === id);
+    if (row !== undefined) {
+      row.status = status;
+    }
+  }
 
   select(): {
     from: () => {
-      where: () => {
+      where: (condition: unknown) => {
         orderBy: () => {
-          limit: (limit: number) => {
-            offset: (offset: number) => Promise<BridgeEventRow[]>;
-          };
+          limit: (limit: number) => Promise<BridgeEventRow[]>;
         };
       };
     };
   } {
     return {
       from: () => ({
-        where: () => ({
+        where: (condition) => ({
           orderBy: () => ({
-            limit: (limit) => ({
-              offset: (offset) =>
-                Promise.resolve(
-                  this.rows
-                    .filter(
-                      (row) =>
-                        row.status === 'received' ||
-                        row.received_at < new Date('2026-05-05T11:55:00.000Z'),
-                    )
-                    .slice(offset, offset + limit),
-                ),
-            }),
+            limit: (limit) => {
+              const events = this.rows
+                .filter((row) => matchesSelectCondition(row, condition))
+                .sort(compareBridgeEventRows)
+                .slice(0, limit);
+              this.selectBatches.push(events.map((event) => event.id));
+              this.onAfterSelect?.(events, this);
+              return Promise.resolve(events);
+            },
           }),
         }),
       }),
@@ -104,13 +146,21 @@ class TestReconciliationDb {
 
   update(): {
     set: (values: Partial<typeof bridgeEvents.$inferInsert>) => {
-      where: () => Promise<void>;
+      where: (condition: unknown) => Promise<void>;
     };
   } {
     return {
       set: (values) => ({
-        where: () => {
+        where: (condition) => {
           this.updated.push(values);
+          const params = extractSqlParams(condition);
+          const status = params.find((param): param is string => typeof param === 'string');
+          const threshold = params.find((param): param is Date => param instanceof Date);
+          for (const row of this.rows) {
+            if (row.status === status && (threshold === undefined || row.received_at < threshold)) {
+              Object.assign(row, values);
+            }
+          }
           return Promise.resolve();
         },
       }),
@@ -119,6 +169,54 @@ class TestReconciliationDb {
 
   asDb(): ReconciliationDb {
     return this as unknown as ReconciliationDb;
+  }
+}
+
+function matchesSelectCondition(row: BridgeEventRow, condition: unknown): boolean {
+  const params = extractSqlParams(condition);
+  const status = params.find((param): param is string => typeof param === 'string');
+  if (row.status !== status) {
+    return false;
+  }
+
+  const cursorReceivedAt = params.find((param): param is Date => param instanceof Date);
+  const cursorId = params.find((param): param is string => typeof param === 'string' && param !== status);
+  if (cursorReceivedAt === undefined || cursorId === undefined) {
+    return true;
+  }
+
+  return (
+    row.received_at.getTime() > cursorReceivedAt.getTime() ||
+    (row.received_at.getTime() === cursorReceivedAt.getTime() && row.id > cursorId)
+  );
+}
+
+function compareBridgeEventRows(a: BridgeEventRow, b: BridgeEventRow): number {
+  return a.received_at.getTime() - b.received_at.getTime() || a.id.localeCompare(b.id);
+}
+
+function extractSqlParams(condition: unknown): unknown[] {
+  const params: unknown[] = [];
+  collectSqlParams(condition, params);
+  return params;
+}
+
+function collectSqlParams(value: unknown, params: unknown[]): void {
+  if (value === null || typeof value !== 'object') {
+    return;
+  }
+
+  if (value.constructor.name === 'Param' && 'value' in value) {
+    params.push(value.value);
+  }
+
+  const queryChunks = 'queryChunks' in value ? value.queryChunks : undefined;
+  if (!Array.isArray(queryChunks)) {
+    return;
+  }
+
+  for (const chunk of queryChunks) {
+    collectSqlParams(chunk, params);
   }
 }
 

--- a/apps/wiki-sync-worker/src/reconciliation.ts
+++ b/apps/wiki-sync-worker/src/reconciliation.ts
@@ -1,5 +1,5 @@
 import { bridgeEvents, type BridgeEventType } from '@cherrygraph/shared';
-import { and, asc, eq, lt } from 'drizzle-orm';
+import { and, asc, eq, gt, lt, or } from 'drizzle-orm';
 
 export type BridgeSyncJobData = {
   bridgeEventId: string;
@@ -26,15 +26,17 @@ export type ReconciliationQueues = {
 
 type BridgeEventRow = typeof bridgeEvents.$inferSelect;
 type BridgeEventInsert = typeof bridgeEvents.$inferInsert;
+type ReconciliationCursor = {
+  receivedAt: Date;
+  id: string;
+};
 
 export type ReconciliationDb = {
   select: () => {
     from: (table: typeof bridgeEvents) => {
       where: (condition: unknown) => {
         orderBy: (...columns: unknown[]) => {
-          limit: (limit: number) => {
-            offset: (offset: number) => Promise<BridgeEventRow[]>;
-          };
+          limit: (limit: number) => PromiseLike<BridgeEventRow[]>;
         };
       };
     };
@@ -52,6 +54,7 @@ const RECONCILIATION_BATCH_SIZE = 50;
 export async function reconcileOnStartup(
   db: ReconciliationDb,
   queues: ReconciliationQueues,
+  options: { batchSize?: number } = {},
 ): Promise<number> {
   const staleThreshold = new Date(Date.now() - STUCK_PROCESSING_MS);
   await db
@@ -62,26 +65,44 @@ export async function reconcileOnStartup(
     );
 
   let enqueued = 0;
-  let offset = 0;
+  let cursor: ReconciliationCursor | undefined;
+  const batchSize = options.batchSize ?? RECONCILIATION_BATCH_SIZE;
 
   while (true) {
     const events = await db
       .select()
       .from(bridgeEvents)
-      .where(eq(bridgeEvents.status, 'received'))
+      .where(receivedEventsCondition(cursor))
       .orderBy(asc(bridgeEvents.received_at), asc(bridgeEvents.id))
-      .limit(RECONCILIATION_BATCH_SIZE)
-      .offset(offset);
+      .limit(batchSize);
 
     const results = await Promise.allSettled(events.map((event) => enqueueBridgeEvent(event, queues)));
     enqueued += results.filter((r) => r.status === 'fulfilled').length;
 
-    if (events.length < RECONCILIATION_BATCH_SIZE) {
+    if (events.length < batchSize) {
       return enqueued;
     }
 
-    offset += RECONCILIATION_BATCH_SIZE;
+    const last = events.at(-1);
+    if (last === undefined) {
+      return enqueued;
+    }
+    cursor = { receivedAt: last.received_at, id: last.id };
   }
+}
+
+function receivedEventsCondition(cursor: ReconciliationCursor | undefined): unknown {
+  if (cursor === undefined) {
+    return eq(bridgeEvents.status, 'received');
+  }
+
+  return and(
+    eq(bridgeEvents.status, 'received'),
+    or(
+      gt(bridgeEvents.received_at, cursor.receivedAt),
+      and(eq(bridgeEvents.received_at, cursor.receivedAt), gt(bridgeEvents.id, cursor.id)),
+    ),
+  );
 }
 
 async function enqueueBridgeEvent(


### PR DESCRIPTION
## Summary
- Replace offset pagination with cursor-based (received_at, id) keyset pagination in bridge reconciliation
- Concurrent status changes no longer cause events to be skipped
- Regression test simulates concurrent processing during pagination

Closes #294

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `95626640b1763c8e1a27d28472f0dc3b351975da`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/305#issuecomment-4432676187) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/305#issuecomment-4432676406) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/305#issuecomment-4432676601) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/305#issuecomment-4432676825)
- Key findings addressed: Clean round 1 — no critical/major findings

## Test plan
- [x] Events processed concurrently during pagination are not skipped
- [x] Stale processing events reset before reconciliation
- [x] All event types enqueued correctly
- [x] All 1217 tests pass