### PR TITLE
fix(web): graph explorer empty-state and upload drawer race condition

### DIFF
--- a/apps/web/src/__tests__/graph-explorer.test.tsx
+++ b/apps/web/src/__tests__/graph-explorer.test.tsx
@@ -248,6 +248,23 @@ describe('SpaceGraphExplorerPage', () => {
     expect(screen.getByText('Run Graphify').closest('a')).toHaveAttribute('href', '/spaces/space-1/graphify');
   });
 
+  it('shows graph UI when graph nodes exist without an active graphify run', async () => {
+    apiMocks.get.mockImplementation((path) => {
+      if (path === '/spaces/space-1') {
+        return Promise.resolve(createSpaceDetail({ active_graphify_run_id: null }));
+      }
+      if (path === '/spaces/space-1/stats') {
+        return Promise.resolve(createSpaceStats({ node_count: 5 }));
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId('graph-canvas')).toBeInTheDocument();
+    expect(screen.queryByText('No active graph yet')).not.toBeInTheDocument();
+  });
+
   it('shows an error state when the API fails', async () => {
     searchGraphNodesMock.mockRejectedValue(new Error('Graph API failed'));
 

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -241,6 +241,44 @@ describe('UploadCenter', () => {
       expect(getRequestUrls(fetchMock)).toContain('/api/spaces/space-1/uploads?page=1&per_page=20&source_type=url&search=roadmap&sort=-updated_at');
     });
   });
+
+  it('ignores stale upload drawer status responses after selection changes', async () => {
+    const statusRequests = stubUploadDrawerRaceApi();
+
+    renderUploadCenter();
+
+    expect(await screen.findByText('doc-a.md')).toBeInTheDocument();
+    const detailsButtons = screen.getAllByRole('button', { name: 'Details' });
+
+    fireEvent.click(detailsButtons[0]!);
+    await waitFor(() => expect(screen.getAllByText('doc-a.md').length).toBeGreaterThan(1));
+
+    fireEvent.click(detailsButtons[1]!);
+    await waitFor(() => expect(screen.getAllByText('doc-b.md').length).toBeGreaterThan(1));
+
+    statusRequests.get('doc-b')?.resolve(jsonResponse({ data: buildStatus({ source_document_id: 'doc-b', status: 'parsed', progress_percent: 100 }) }));
+    await waitFor(() => expect(screen.getAllByText('Parsed').length).toBeGreaterThan(0));
+
+    statusRequests
+      .get('doc-a')
+      ?.resolve(
+        jsonResponse({
+          data: buildStatus({
+            source_document_id: 'doc-a',
+            status: 'parse_failed',
+            progress_percent: 65,
+            error_json: {
+              error_type: 'stale_doc_a',
+              error_message: 'A stale failure should not render',
+            },
+          }),
+        }),
+      );
+
+    await waitFor(() => expect(screen.getAllByText('doc-b.md').length).toBeGreaterThan(1));
+    expect(screen.queryByText('A stale failure should not render')).not.toBeInTheDocument();
+    expect(screen.queryByText('stale_doc_a')).not.toBeInTheDocument();
+  });
 });
 
 describe('UploadDetail', () => {
@@ -436,6 +474,63 @@ function stubUploadListApi() {
   });
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;
+}
+
+function stubUploadDrawerRaceApi() {
+  const statusRequests = new Map<string, Deferred<Response>>();
+  statusRequests.set('doc-a', createDeferred<Response>());
+  statusRequests.set('doc-b', createDeferred<Response>());
+
+  const fetchMock = vi.fn<typeof fetch>((input, init) => {
+    const path = getRequestPath(input);
+    if (path === '/api/spaces/space-1/uploads' && init?.method === 'GET') {
+      return Promise.resolve(
+        jsonResponse({
+          data: [
+            buildUpload({ id: 'doc-a', filename: 'doc-a.md', status: 'uploaded' }),
+            buildUpload({ id: 'doc-b', filename: 'doc-b.md', status: 'uploaded' }),
+          ],
+          meta: {
+            pagination: {
+              page: 1,
+              per_page: 20,
+              total: 2,
+              has_next: false,
+            },
+          },
+        }),
+      );
+    }
+
+    if (path === '/api/uploads/doc-a/status' && init?.method === 'GET') {
+      return statusRequests.get('doc-a')!.promise;
+    }
+
+    if (path === '/api/uploads/doc-b/status' && init?.method === 'GET') {
+      return statusRequests.get('doc-b')!.promise;
+    }
+
+    return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return statusRequests;
+}
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+
+  return { promise, resolve, reject };
 }
 
 function stubReprocessApi() {

--- a/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
+++ b/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
@@ -102,14 +102,14 @@ export default function SpaceGraphExplorerPage() {
 
     void (async () => {
       try {
-        const [space, stats] = await Promise.all([
+        const [, stats] = await Promise.all([
           api.get<AdminSpaceDetail>(`/spaces/${encodeURIComponent(spaceId)}`),
           api.get<SpaceStatsResponse>(`/spaces/${encodeURIComponent(spaceId)}/stats`),
         ]);
         if (spaceSeq !== spaceSeqRef.current) {
           return;
         }
-        setHasEmptyGraph(stats.node_count === 0 || space.active_graphify_run_id === null);
+        setHasEmptyGraph(stats.node_count === 0);
       } catch (err) {
         if (spaceSeq !== spaceSeqRef.current) {
           return;

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -47,6 +47,8 @@ export default function UploadCenter() {
   const [selectedUploadId, setSelectedUploadId] = useState<string | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<UploadStatus | null>(null);
   const requestSeqRef = useRef(0);
+  const selectionSeqRef = useRef(0);
+  const selectedUploadIdRef = useRef<string | null>(null);
 
   const loadUploads = useCallback(
     async (background = false) => {
@@ -117,6 +119,8 @@ export default function UploadCenter() {
   }, [searchInput]);
 
   useEffect(() => {
+    selectionSeqRef.current++;
+    selectedUploadIdRef.current = null;
     setSelectedUploadId(null);
     setSelectedStatus(null);
     setPage(1);
@@ -139,11 +143,12 @@ export default function UploadCenter() {
       }),
     );
     setSelectedStatus((current) => {
-      if (current === null) {
+      const selectedId = selectedUploadIdRef.current;
+      if (selectedId === null) {
         return current;
       }
 
-      return statuses.find((status) => status.source_document_id === current.source_document_id) ?? current;
+      return statuses.find((status) => status.source_document_id === selectedId) ?? current;
     });
   }, []);
 
@@ -158,11 +163,17 @@ export default function UploadCenter() {
     [selectedUploadId, uploads],
   );
 
-  const loadUploadStatus = useCallback(async (uploadId: string) => {
+  const loadUploadStatus = useCallback(async (uploadId: string, selectionSeq = selectionSeqRef.current) => {
     try {
       const status = await api.get<UploadStatus>(`/uploads/${encodeURIComponent(uploadId)}/status`);
+      if (selectionSeq !== selectionSeqRef.current || selectedUploadIdRef.current !== uploadId) {
+        return;
+      }
       setSelectedStatus(status);
     } catch (err) {
+      if (selectionSeq !== selectionSeqRef.current || selectedUploadIdRef.current !== uploadId) {
+        return;
+      }
       setError(getErrorMessage(err));
     }
   }, []);
@@ -300,9 +311,11 @@ export default function UploadCenter() {
           }}
           onPageChange={setPage}
           onSelectUpload={(upload) => {
+            const selectionSeq = ++selectionSeqRef.current;
+            selectedUploadIdRef.current = upload.id;
             setSelectedUploadId(upload.id);
             setSelectedStatus(null);
-            void loadUploadStatus(upload.id);
+            void loadUploadStatus(upload.id, selectionSeq);
           }}
         />
       )}
@@ -312,6 +325,8 @@ export default function UploadCenter() {
         upload={selectedUpload}
         status={selectedStatus}
         onClose={() => {
+          selectionSeqRef.current++;
+          selectedUploadIdRef.current = null;
           setSelectedUploadId(null);
           setSelectedStatus(null);
         }}


### PR DESCRIPTION
## Summary
- Graph explorer shows UI when node_count > 0 regardless of active Graphify run
- Upload drawer ignores stale status responses via selection sequence counter
- Regression tests for both cases

Closes #297

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `a2d4c522929eb250f0c8dcbe2c91fc23771e6744`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/306#issuecomment-4432873042) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/306#issuecomment-4432873271) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/306#issuecomment-4432873515) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/306#issuecomment-4432873904)
- Key findings addressed: Clean round 1 — no critical/major findings

## Test plan
- [x] node_count > 0 with no active run → graph UI shown
- [x] Out-of-order upload status responses ignored
- [x] 136 web tests pass