### PR TITLE
chore(ops): production hardening — non-root, creds, pinned images, CI

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -7,11 +7,11 @@
 # All GENERATE_ME_* values MUST be replaced before deployment
 
 # --- Required (no defaults, will error if missing) ---
-POSTGRES_PASSWORD=change-me-strong-password
+POSTGRES_PASSWORD=GENERATE_ME_openssl_rand_base64_32
 JWT_SECRET=GENERATE_ME_openssl_rand_base64_48
 ADMIN_PASSWORD=GENERATE_ME_openssl_rand_base64_32
-MINIO_ACCESS_KEY=change-me-access-key
-MINIO_SECRET_KEY=change-me-secret-key-at-least-16-chars
+MINIO_ACCESS_KEY=GENERATE_ME_openssl_rand_hex_16
+MINIO_SECRET_KEY=GENERATE_ME_openssl_rand_base64_32
 
 # --- Admin ---
 ADMIN_EMAIL=admin@cherrywiki.local

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -3,10 +3,13 @@
 # Copy to .env.prod and fill in all required values
 # ============================================================
 
+# Generate secrets: openssl rand -base64 32
+# All GENERATE_ME_* values MUST be replaced before deployment
+
 # --- Required (no defaults, will error if missing) ---
 POSTGRES_PASSWORD=change-me-strong-password
-JWT_SECRET=change-me-minimum-32-characters-long-random-string
-ADMIN_PASSWORD=ChangeMe123!
+JWT_SECRET=GENERATE_ME_openssl_rand_base64_48
+ADMIN_PASSWORD=GENERATE_ME_openssl_rand_base64_32
 MINIO_ACCESS_KEY=change-me-access-key
 MINIO_SECRET_KEY=change-me-secret-key-at-least-16-chars
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,16 @@ jobs:
       - name: Validate Docker Compose
         run: docker compose config --quiet
 
+      - name: Validate Production Compose
+        env:
+          POSTGRES_PASSWORD: ci-postgres-password
+          JWT_SECRET: ci-jwt-secret-minimum-32-characters
+          ADMIN_PASSWORD: ci-admin-password
+          MINIO_ACCESS_KEY: ci-minio-access-key
+          MINIO_SECRET_KEY: ci-minio-secret-key
+          WORKER_API_KEY: ci-worker-api-key
+        run: docker compose -f docker-compose.prod.yml config --quiet
+
       - name: Verify Dockerfiles build (syntax only)
         run: |
           status=0
@@ -160,6 +170,15 @@ jobs:
               echo "Checking $f..."
               docker buildx build --check -f "$f" "$(dirname "$f")" || status=1
             fi
+          done
+          exit $status
+
+      - name: Verify root Dockerfile production targets (syntax only)
+        run: |
+          status=0
+          for target in api web ingestion-worker url-fetcher-worker indexer-worker; do
+            echo "Checking Dockerfile target $target..."
+            docker buildx build --check -f Dockerfile --target "$target" . || status=1
           done
           exit $status
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,15 +48,19 @@ RUN cp -r /app/schemas /deploy/api/schemas && \
 FROM base AS api
 COPY --from=deploy /deploy/api /app
 ENV PATH="/app/node_modules/.bin:$PATH"
+RUN addgroup --system --gid 1001 appgroup \
+    && adduser --system --uid 1001 --ingroup appgroup appuser
+USER appuser
 EXPOSE 8080
 CMD ["sh", "-c", "drizzle-kit migrate && node --import tsx schemas/seed.ts && exec node dist/main.js"]
 
 # ============================================================
 # Target: web (nginx serving static build)
 # ============================================================
-FROM nginx:alpine AS web
+FROM nginx:1.28.3-alpine AS web
 COPY ops/nginx/nginx-prod-web.conf /etc/nginx/nginx.conf
 COPY --from=build /app/apps/web/dist /usr/share/nginx/html
+USER nginx
 EXPOSE 80
 
 # ============================================================
@@ -96,5 +100,8 @@ CMD ["python", "-m", "src"]
 # ============================================================
 FROM base AS indexer-worker
 COPY --from=deploy /deploy/indexer-worker /app
+RUN addgroup --system --gid 1001 appgroup \
+    && adduser --system --uid 1001 --ingroup appgroup appuser
+USER appuser
 EXPOSE 9093
 CMD ["node", "dist/main.js"]

--- a/apps/graphify-worker/Dockerfile
+++ b/apps/graphify-worker/Dockerfile
@@ -31,4 +31,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY src/ src/
 
 EXPOSE 9094
+USER graphify
 CMD ["python", "-m", "src"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,7 +30,8 @@ services:
       start_period: 5s
 
   minio:
-    image: minio/minio:latest
+    # Drift owner: platform; review cadence: monthly.
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
@@ -51,12 +52,20 @@ services:
       - url_fetch_private
 
   cherry-api:
+    # Pin to release tag during deployment; :latest is build-time default.
     image: cherrywiki/api:latest
     build:
       context: .
       dockerfile: Dockerfile
       target: api
     restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=512m,mode=1777
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
       NODE_ENV: production
 
@@ -97,12 +106,23 @@ services:
       - url_fetch_private
 
   cherry-web:
+    # Pin to release tag during deployment; :latest is build-time default.
     image: cherrywiki/web:latest
     build:
       context: .
       dockerfile: Dockerfile
       target: web
     restart: unless-stopped
+    user: "101:101"
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx:size=64m,uid=101,gid=101,mode=0755
+      - /var/run:size=16m,mode=0755
+      - /tmp:size=64m,mode=1777
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:80/ >/dev/null"]
       interval: 10s
@@ -111,6 +131,7 @@ services:
       start_period: 10s
 
   ingestion-worker:
+    # Pin to release tag during deployment; :latest is build-time default.
     image: cherrywiki/ingestion-worker:latest
     build:
       context: ./apps/ingestion-worker
@@ -147,6 +168,7 @@ services:
         condition: service_healthy
 
   url-fetcher-worker:
+    # Pin to release tag during deployment; :latest is build-time default.
     image: cherrywiki/url-fetcher-worker:latest
     build:
       context: .
@@ -197,7 +219,8 @@ services:
       - url_fetch_private
 
   egress-proxy:
-    image: ubuntu/squid:latest
+    # Drift owner: platform; review cadence: monthly.
+    image: ubuntu/squid:6.10-24.10_beta
     restart: unless-stopped
     volumes:
       - ./ops/squid/squid.conf:/etc/squid/squid.conf:ro
@@ -208,6 +231,7 @@ services:
       - url_fetch_private
 
   indexer-worker:
+    # Pin to release tag during deployment; :latest is build-time default.
     image: cherrywiki/indexer-worker:latest
     build:
       context: .
@@ -243,6 +267,7 @@ services:
         condition: service_healthy
 
   graphify-worker:
+    # Pin to release tag during deployment; :latest is build-time default.
     image: cherrywiki/graphify-worker:latest
     build:
       context: ./apps/graphify-worker
@@ -254,6 +279,7 @@ services:
     tmpfs:
       - /tmp:size=1g
       - /work/graphify:size=2g
+      - /home/graphify:size=256m,uid=10001,gid=10001,mode=0700
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -283,8 +309,19 @@ services:
         condition: service_healthy
 
   nginx:
-    image: nginx:alpine
+    # Drift owner: platform; review cadence: monthly.
+    image: nginx:1.28.3-alpine
     restart: unless-stopped
+    user: "101:101"
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx:size=64m,uid=101,gid=101,mode=0755
+      - /var/run:size=16m,mode=0755
+      - /tmp:size=64m,mode=1777
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     ports:
       - "${LISTEN_PORT:-80}:80"
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -117,14 +117,14 @@ services:
     read_only: true
     tmpfs:
       - /var/cache/nginx:size=64m,uid=101,gid=101,mode=0755
-      - /var/run:size=16m,mode=0755
+      - /var/run:size=16m,uid=101,gid=101,mode=0755
       - /tmp:size=64m,mode=1777
     security_opt:
       - no-new-privileges:true
     cap_drop:
       - ALL
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:80/ >/dev/null"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ >/dev/null"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -316,7 +316,7 @@ services:
     read_only: true
     tmpfs:
       - /var/cache/nginx:size=64m,uid=101,gid=101,mode=0755
-      - /var/run:size=16m,mode=0755
+      - /var/run:size=16m,uid=101,gid=101,mode=0755
       - /tmp:size=64m,mode=1777
     security_opt:
       - no-new-privileges:true

--- a/docs/ops/env.example
+++ b/docs/ops/env.example
@@ -11,7 +11,7 @@ REFRESH_TOKEN_EXPIRES_IN=7d
 
 # --- Stage 1 Admin Seed / Tenant ---
 ADMIN_EMAIL=admin@cherrywiki.local
-ADMIN_PASSWORD=ChangeMe123!
+ADMIN_PASSWORD=GENERATE_ME_openssl_rand_base64_32
 # Optional; keep the seeded tenant id for deterministic local development.
 DEFAULT_TENANT_ID=default
 
@@ -74,6 +74,7 @@ EGRESS_PROXY_REQUIRED=false
 # --- Docmost (Phase 2 — not used in Phase 1) ---
 DOCMOST_BASE_URL=http://localhost:3000
 DOCMOST_APP_SECRET=replace-with-long-random-secret
+DOCMOST_ADMIN_PASSWORD=GENERATE_ME_openssl_rand_base64_24
 DOCMOST_IMAGE=docmost/docmost:0.80.1
 DOCMOST_DATABASE_URL=postgresql://cherrygraph:replace-with-strong-password@postgres:5432/docmost
 DOCMOST_REDIS_URL=redis://redis:6379

--- a/docs/ops/env.example
+++ b/docs/ops/env.example
@@ -1,11 +1,11 @@
 # =============================================================================
 # CherryGraph Studio — Phase 1 Environment Variables
-# Copy to .env and replace all 'replace-with-*' values before first start.
+# Copy to .env and replace all GENERATE_ME_* values before first start.
 # =============================================================================
 
 # --- App ---
 APP_URL=http://localhost
-JWT_SECRET=change-me-in-production-32-characters-minimum
+JWT_SECRET=GENERATE_ME_openssl_rand_base64_48
 JWT_EXPIRES_IN=1h
 REFRESH_TOKEN_EXPIRES_IN=7d
 
@@ -16,8 +16,8 @@ ADMIN_PASSWORD=GENERATE_ME_openssl_rand_base64_32
 DEFAULT_TENANT_ID=default
 
 # --- PostgreSQL ---
-POSTGRES_PASSWORD=replace-with-strong-password
-DATABASE_URL=postgresql://cherrygraph:replace-with-strong-password@postgres:5432/cherrygraph
+POSTGRES_PASSWORD=GENERATE_ME_openssl_rand_base64_32
+DATABASE_URL=postgresql://cherrygraph:GENERATE_ME_openssl_rand_base64_32@postgres:5432/cherrygraph
 
 # --- Redis ---
 # Host-side URL for local pnpm dev:
@@ -27,13 +27,13 @@ COMPOSE_REDIS_URL=redis://redis:6379
 
 # --- MinIO / S3 ---
 MINIO_ENDPOINT=http://minio:9000
-MINIO_ACCESS_KEY=minioadmin
-MINIO_SECRET_KEY=replace-with-strong-password
+MINIO_ACCESS_KEY=GENERATE_ME_openssl_rand_hex_16
+MINIO_SECRET_KEY=GENERATE_ME_openssl_rand_base64_32
 STORAGE_BUCKET_PREFIX=cherrywiki
 
 # --- Model API ---
 MODEL_API_BASE_URL=https://api.openai.com/v1
-MODEL_API_KEY=replace-with-model-api-key
+MODEL_API_KEY=GENERATE_ME_provider_api_key
 DEFAULT_CHAT_MODEL=gpt-4.1
 DEFAULT_EMBEDDING_MODEL=text-embedding-3-large
 
@@ -47,7 +47,7 @@ GRAPHIFY_MAX_NODES=50000
 GRAPHIFY_MAX_EDGES=200000
 
 # --- Worker (shared across all Python workers) ---
-WORKER_API_KEY=replace-with-strong-random-key
+WORKER_API_KEY=GENERATE_ME_openssl_rand_base64_32
 WORKER_HEALTH_PORT=9090
 API_BASE_URL=http://cherry-api:8080
 # Optional: override per-worker; falls back to API_BASE_URL
@@ -73,13 +73,13 @@ EGRESS_PROXY_REQUIRED=false
 
 # --- Docmost (Phase 2 — not used in Phase 1) ---
 DOCMOST_BASE_URL=http://localhost:3000
-DOCMOST_APP_SECRET=replace-with-long-random-secret
+DOCMOST_APP_SECRET=GENERATE_ME_openssl_rand_base64_32
 DOCMOST_ADMIN_PASSWORD=GENERATE_ME_openssl_rand_base64_24
 DOCMOST_IMAGE=docmost/docmost:0.80.1
-DOCMOST_DATABASE_URL=postgresql://cherrygraph:replace-with-strong-password@postgres:5432/docmost
+DOCMOST_DATABASE_URL=postgresql://cherrygraph:GENERATE_ME_openssl_rand_base64_32@postgres:5432/docmost
 DOCMOST_REDIS_URL=redis://redis:6379
 CHERRY_API_INTERNAL_URL=http://cherry-api:8080
-DOCMOST_BRIDGE_SECRET=replace-with-bridge-shared-secret
+DOCMOST_BRIDGE_SECRET=GENERATE_ME_openssl_rand_base64_32
 # Optional rotation key. During rotation, Cherry API accepts signatures from
 # DOCMOST_BRIDGE_SECRET or DOCMOST_BRIDGE_SECRET_NEXT.
 DOCMOST_BRIDGE_SECRET_NEXT=
@@ -87,7 +87,7 @@ DOCMOST_BRIDGE_SECRET_NEXT=
 # --- wiki-sync-worker ---
 REDIS_URL=redis://localhost:6379
 DOCMOST_BASE_URL=http://localhost:3000
-DOCMOST_BRIDGE_SECRET=your-bridge-secret
+DOCMOST_BRIDGE_SECRET=GENERATE_ME_openssl_rand_base64_32
 WORKER_HEALTH_PORT=9090
 
 # --- Claude Code Agent (Phase 3+ — not used in Phase 1) ---
@@ -104,7 +104,7 @@ AGENT_ANTHROPIC_API_KEY=sk-xxxx
 # AGENT_ANTHROPIC_MODEL=deepseek-v4-flash
 
 # Agent sandbox and internal API access.
-CHERRY_AGENT_TOKEN=replace-with-agent-internal-token
+CHERRY_AGENT_TOKEN=GENERATE_ME_openssl_rand_base64_32
 CHERRY_AGENT_TMP_ROOT=/tmp/cherry-agent
 CHERRY_GRAPHIFY_BASE_PATH=/graphs
 CHERRY_AGENT_MAX_CONCURRENT=20
@@ -116,7 +116,7 @@ CHERRY_AGENT_MAX_CONCURRENT=20
 # Only set these when a Space database_config enables database access.
 # The application persists encrypted per-Space DSNs; these values are for
 # container-level smoke tests and sandbox defaults.
-CHERRY_DB_DSN=postgresql://readonly:replace-with-password@postgres:5432/cherrygraph
+CHERRY_DB_DSN=postgresql://readonly:GENERATE_ME_openssl_rand_base64_32@postgres:5432/cherrygraph
 CHERRY_DB_ALLOWED_TABLES=orders,customers
 CHERRY_DB_MASKED_COLUMNS=customers.email,users.email
 CHERRY_DB_STATEMENT_TIMEOUT_MS=5000


### PR DESCRIPTION
## Summary
- API/indexer/graphify containers run non-root with cap_drop/no-new-privileges/read_only
- nginx tmpfs with uid=101 for pid file access
- All weak example passwords replaced with GENERATE_ME placeholders
- External images pinned: minio, squid, nginx
- CI validates docker-compose.prod.yml and Dockerfile targets
- Healthcheck uses wget (available in nginx:alpine)

Closes #301

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `befa2309897abdaa7b8aafdad914623f77bcea03`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/308#issuecomment-4433624779) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/308#issuecomment-4433625012) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/308#issuecomment-4433625274) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/308#issuecomment-4433625496)
- Key findings addressed: R1 — nginx tmpfs uid, wget healthcheck, all remaining weak creds replaced

## Test plan
- [x] docker compose -f docker-compose.prod.yml config --quiet passes
- [x] No weak passwords in env examples
- [x] All Dockerfiles have USER directive for production targets
- [x] CI validates prod compose and Dockerfile targets
- [x] Build and lint pass