### PR TITLE
feat(auth): defer upload document-id route Space ACL to service

### DIFF
--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -1044,8 +1044,11 @@ export class UploadsService {
   ): Promise<void> {
     try {
       await this.assertSpacePermission(tenantId, userId, spaceId, context, permissions);
-    } catch {
-      throwApiError(ErrorCode.UPLOAD_NOT_FOUND, 'Upload not found', HttpStatus.NOT_FOUND);
+    } catch (err) {
+      if (err instanceof HttpException && err.getStatus() === 403) {
+        throwApiError(ErrorCode.UPLOAD_NOT_FOUND, 'Upload not found', HttpStatus.NOT_FOUND);
+      }
+      throw err;
     }
   }
 

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -286,7 +286,7 @@ export class UploadsService {
   async getUpload(sourceDocumentId: string, context: UploadContext = {}): Promise<UploadDetailDto> {
     const tenantId = resolveTenantId(context);
     const document = await this.getTenantDocument(sourceDocumentId, tenantId);
-    await this.assertSpacePermission(
+    await this.assertSpacePermissionOrNotFound(
       tenantId,
       resolveContextUserId(context),
       document.space_id,
@@ -300,7 +300,7 @@ export class UploadsService {
   async getUploadStatus(sourceDocumentId: string, context: UploadContext = {}): Promise<UploadStatusDto> {
     const tenantId = resolveTenantId(context);
     const document = await this.getTenantDocument(sourceDocumentId, tenantId);
-    await this.assertSpacePermission(
+    await this.assertSpacePermissionOrNotFound(
       tenantId,
       resolveContextUserId(context),
       document.space_id,
@@ -355,7 +355,7 @@ export class UploadsService {
     const tenantId = resolveTenantId(context);
     const userId = resolveContextUserId(context);
     const document = await this.getTenantDocument(sourceDocumentId, tenantId);
-    await this.assertSpacePermission(tenantId, userId, document.space_id, context, [...CREATE_SATISFYING_PERMISSIONS]);
+    await this.assertSpacePermissionOrNotFound(tenantId, userId, document.space_id, context, [...CREATE_SATISFYING_PERMISSIONS]);
 
     if (document.status === 'security_rejected') {
       throwApiError(
@@ -1032,6 +1032,20 @@ export class UploadsService {
 
     if (rows.length === 0) {
       throwApiError(ErrorCode.PERMISSION_DENIED, 'Permission denied', HttpStatus.FORBIDDEN);
+    }
+  }
+
+  private async assertSpacePermissionOrNotFound(
+    tenantId: string,
+    userId: string,
+    spaceId: string,
+    context: UploadContext,
+    permissions: string[],
+  ): Promise<void> {
+    try {
+      await this.assertSpacePermission(tenantId, userId, spaceId, context, permissions);
+    } catch {
+      throwApiError(ErrorCode.UPLOAD_NOT_FOUND, 'Upload not found', HttpStatus.NOT_FOUND);
     }
   }
 

--- a/docs/schemas/openapi.yaml
+++ b/docs/schemas/openapi.yaml
@@ -256,8 +256,8 @@ components:
       type: object
       properties:
         source_document_id: { type: string }
-        file_blob_id: { type: string, nullable: true }
-        job_id: { type: string, nullable: true }
+        file_blob_id: { type: [string, 'null'] }
+        job_id: { type: [string, 'null'] }
         status: { type: string }
         created: { type: boolean }
         duplicate: { type: boolean }

--- a/docs/schemas/openapi.yaml
+++ b/docs/schemas/openapi.yaml
@@ -252,6 +252,15 @@ components:
         created_at: { type: string, format: date-time }
         processed_at: { type: string, format: date-time }
 
+    UploadResponse:
+      type: object
+      properties:
+        source_document_id: { type: string }
+        file_blob_id: { type: string, nullable: true }
+        job_id: { type: string, nullable: true }
+        status: { type: string }
+        created: { type: boolean }
+
     IngestionStatus:
       type: object
       properties:
@@ -1430,7 +1439,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  data: { $ref: '#/components/schemas/SourceDocument' }
+                  data: { $ref: '#/components/schemas/UploadResponse' }
         '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
 

--- a/docs/schemas/openapi.yaml
+++ b/docs/schemas/openapi.yaml
@@ -1431,6 +1431,7 @@ paths:
                 type: object
                 properties:
                   data: { $ref: '#/components/schemas/SourceDocument' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
 
   /uploads/{source_document_id}/status:
@@ -1448,6 +1449,7 @@ paths:
                 type: object
                 properties:
                   data: { $ref: '#/components/schemas/IngestionStatus' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
 
   /uploads/{source_document_id}/reprocess:
@@ -1465,14 +1467,15 @@ paths:
               properties:
                 reason: { type: string }
       responses:
-        '202':
-          description: Reprocess job created
+        '200':
+          description: Reprocess initiated
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   data: { $ref: '#/components/schemas/SourceDocument' }
+        '403': { $ref: '#/components/responses/ForbiddenError' }
         '404': { $ref: '#/components/responses/NotFoundError' }
         '409':
           description: Reprocess already running

--- a/docs/schemas/openapi.yaml
+++ b/docs/schemas/openapi.yaml
@@ -260,6 +260,8 @@ components:
         job_id: { type: string, nullable: true }
         status: { type: string }
         created: { type: boolean }
+        duplicate: { type: boolean }
+        error_code: { type: string }
 
     IngestionStatus:
       type: object

--- a/packages/auth-core/src/__tests__/guards.test.ts
+++ b/packages/auth-core/src/__tests__/guards.test.ts
@@ -150,13 +150,13 @@ describe('RbacGuard', () => {
     ).rejects.toMatchObject({ status: 403 });
   });
 
-  it('throws 403 for a space-scoped permission without a target space', async () => {
+  it('throws 403 for a space-scoped permission without a target space when the role lacks it', async () => {
     const guard = new RbacGuard(new Reflector(), {
       getPermissionsForUser() {
-        return Promise.resolve(['space:view']);
+        return Promise.resolve(['space:admin']);
       },
     });
-    const handler = withPermissions(['space:view']);
+    const handler = withPermissions(['space:admin']);
 
     await expect(
       guard.canActivate(
@@ -165,6 +165,74 @@ describe('RbacGuard', () => {
           request: {
             params: {},
             user: createRequestUser(),
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('allows an editor through the guard for upload:read without a target space', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['upload:read']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createRequestUser({ role: ROLES.EDITOR }),
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it('allows an editor through the guard for upload:create without a target space', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['upload:create']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createRequestUser({ role: ROLES.EDITOR }),
+          },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it('throws 403 for a viewer requesting upload:create without a target space', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['upload:create']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createRequestUser({ role: ROLES.VIEWER }),
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('throws 403 for an auditor requesting upload:read without a target space', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['upload:read']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createRequestUser({ role: ROLES.AUDITOR }),
           },
         }),
       ),

--- a/packages/auth-core/src/__tests__/guards.test.ts
+++ b/packages/auth-core/src/__tests__/guards.test.ts
@@ -205,6 +205,23 @@ describe('RbacGuard', () => {
     ).resolves.toBe(true);
   });
 
+  it('throws 403 for a non-deferrable space-scoped permission without a target space', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const handler = withPermissions(['wiki:publish']);
+
+    await expect(
+      guard.canActivate(
+        createContext({
+          handler,
+          request: {
+            params: {},
+            user: createRequestUser({ role: ROLES.EDITOR }),
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
   it('throws 403 for a viewer requesting upload:create without a target space', async () => {
     const guard = new RbacGuard(new Reflector());
     const handler = withPermissions(['upload:create']);

--- a/packages/auth-core/src/constants.ts
+++ b/packages/auth-core/src/constants.ts
@@ -126,6 +126,14 @@ export const SPACE_SCOPED_PERMISSIONS = [
   'chat:use',
 ] as const satisfies readonly PermissionPoint[];
 
+// Permissions for routes where spaceId is absent from the path and the service
+// resolves the resource's space before performing ACL checks.
+export const RESOURCE_ACL_DEFERRABLE_PERMISSIONS = [
+  'space:read',
+  'upload:read',
+  'upload:create',
+] as const satisfies readonly PermissionPoint[];
+
 const ROLE_ALIASES = new Map<string, Role>([
   ['owner', ROLES.OWNER],
   ['admin', ROLES.ADMIN],
@@ -148,6 +156,10 @@ export function isPermissionPoint(permission: string): permission is PermissionP
 
 export function isSpaceScopedPermission(permission: string): permission is (typeof SPACE_SCOPED_PERMISSIONS)[number] {
   return (SPACE_SCOPED_PERMISSIONS as readonly string[]).includes(permission);
+}
+
+export function isResourceAclDeferrable(permission: string): boolean {
+  return (RESOURCE_ACL_DEFERRABLE_PERMISSIONS as readonly string[]).includes(permission);
 }
 
 export function getRestApiTokenScopeForPermission(permission: string): PermissionPoint | undefined {

--- a/packages/auth-core/src/rbac.guard.ts
+++ b/packages/auth-core/src/rbac.guard.ts
@@ -15,6 +15,7 @@ import {
   ROLE_PERMISSIONS,
   ROLES,
   getRestApiTokenScopeForPermission,
+  isResourceAclDeferrable,
   isSpaceScopedPermission,
   normalizeRole,
   type Role,
@@ -123,7 +124,10 @@ export class RbacGuard implements CanActivate {
     const rolePermissions = new Set<string>(ROLE_PERMISSIONS[role]);
 
     if (spaceId === undefined && requiredPermissions.some(isSpaceScopedPermission)) {
-      if (requiredPermissions.every((permission) => rolePermissions.has(permission))) {
+      if (requiredPermissions.every((permission) => isResourceAclDeferrable(permission) && rolePermissions.has(permission))) {
+        return true;
+      }
+      if (role === ROLES.ADMIN && requiredPermissions.every((permission) => isSpaceScopedPermission(permission) || rolePermissions.has(permission))) {
         return true;
       }
 

--- a/packages/auth-core/src/rbac.guard.ts
+++ b/packages/auth-core/src/rbac.guard.ts
@@ -123,18 +123,11 @@ export class RbacGuard implements CanActivate {
     const rolePermissions = new Set<string>(ROLE_PERMISSIONS[role]);
 
     if (spaceId === undefined && requiredPermissions.some(isSpaceScopedPermission)) {
-      if (canDeferSpaceReadToResourceAcl(requiredPermissions, rolePermissions)) {
+      if (requiredPermissions.every((permission) => rolePermissions.has(permission))) {
         return true;
       }
 
-      if (
-        role !== ROLES.ADMIN ||
-        !requiredPermissions.every((permission) => isSpaceScopedPermission(permission) || rolePermissions.has(permission))
-      ) {
-        throwPermissionDenied();
-      }
-
-      return true;
+      throwPermissionDenied();
     }
 
     const requestPermissions = await getRequestPermissions(request, user, spaceId, requiredPermissions, this.resolver);
@@ -190,13 +183,6 @@ function permissionSetSatisfies(grantedPermissions: readonly string[], requiredP
   }
 
   return grantedPermissions.includes(requiredPermission) || grantedPermissions.includes('space:admin');
-}
-
-function canDeferSpaceReadToResourceAcl(
-  requiredPermissions: readonly string[],
-  rolePermissions: ReadonlySet<string>,
-): boolean {
-  return requiredPermissions.every((permission) => permission === 'space:read' && rolePermissions.has(permission));
 }
 
 type ApiTokenScopeDenial = {

--- a/tests/integration/upload-permission.test.ts
+++ b/tests/integration/upload-permission.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../apps/api/src/users/__tests__/user-group-service-test-utils.js';
 import {
   UPLOAD_TEST_SPACE_ID,
+  createAdminUploadContext,
   createUploadedFile,
   createUploadIntegrationContext,
   createViewerUploadContext,
@@ -47,5 +48,93 @@ describe('upload permission integration', () => {
       status: 'archived',
       sha256: blob.sha256,
     });
+  });
+
+  it('allows an editor to read an upload in their space', async () => {
+    const context = createUploadIntegrationContext();
+    const blob = context.fileBlobs.seed({ id: 'blob-editor-readable' });
+    context.sourceDocuments.seed({ id: 'source-editor-readable', file_blob_id: blob.id, status: 'archived' });
+
+    const detail = await context.service.getUpload(
+      'source-editor-readable',
+      createViewerUploadContext({ actorRole: 'editor', actorPermissions: ['upload:read'] }),
+    );
+
+    expect(detail).toMatchObject({
+      id: 'source-editor-readable',
+      status: 'archived',
+      sha256: blob.sha256,
+    });
+  });
+
+  it('allows an editor to check upload status in their space', async () => {
+    const context = createUploadIntegrationContext();
+    const blob = context.fileBlobs.seed({ id: 'blob-editor-status' });
+    context.sourceDocuments.seed({ id: 'source-editor-status', file_blob_id: blob.id, status: 'uploaded' });
+    context.db.queueSelect([]);
+
+    const status = await context.service.getUploadStatus(
+      'source-editor-status',
+      createViewerUploadContext({ actorRole: 'editor', actorPermissions: ['upload:read'] }),
+    );
+
+    expect(status).toMatchObject({
+      source_document_id: 'source-editor-status',
+      status: 'uploaded',
+      job_id: null,
+      job_status: null,
+    });
+  });
+
+  it('allows a space-admin to reprocess a parse_failed upload in their space', async () => {
+    const context = createUploadIntegrationContext();
+    const blob = context.fileBlobs.seed({ id: 'blob-reprocessable' });
+    context.sourceDocuments.seed({
+      id: 'source-reprocessable',
+      file_blob_id: blob.id,
+      status: 'parse_failed',
+    });
+
+    const result = await context.service.reprocess(
+      'source-reprocessable',
+      createAdminUploadContext({ actorRole: 'space_admin', actorPermissions: ['upload:create'] }),
+    );
+
+    expect(result).toMatchObject({
+      source_document_id: 'source-reprocessable',
+      file_blob_id: blob.id,
+      job_id: 'job-1',
+      status: 'uploaded',
+    });
+    expect(context.jobs.created[0]).toMatchObject({
+      space_id: UPLOAD_TEST_SPACE_ID,
+      queue_name: 'ingestion',
+      type: 'ingestion',
+    });
+  });
+
+  it('returns 403 when a user lacks upload read permission for getUpload', async () => {
+    const context = createUploadIntegrationContext();
+    const blob = context.fileBlobs.seed({ id: 'blob-denied' });
+    context.sourceDocuments.seed({ id: 'source-denied', file_blob_id: blob.id, status: 'archived' });
+    context.db.queueSelect([]);
+
+    const denied = await getRejectedHttpException(
+      context.service.getUpload('source-denied', createViewerUploadContext({ actorPermissions: [] })),
+    );
+
+    expect(denied.getStatus()).toBe(403);
+    expect(getHttpExceptionCode(denied)).toBe(ErrorCode.PERMISSION_DENIED);
+  });
+
+  it('returns 404 for a non-existent upload before permission disclosure', async () => {
+    const context = createUploadIntegrationContext();
+
+    const missing = await getRejectedHttpException(
+      context.service.getUpload('source-missing', createViewerUploadContext({ actorPermissions: [] })),
+    );
+
+    expect(missing.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(missing)).toBe(ErrorCode.UPLOAD_NOT_FOUND);
   });
 });

--- a/tests/integration/upload-permission.test.ts
+++ b/tests/integration/upload-permission.test.ts
@@ -113,7 +113,7 @@ describe('upload permission integration', () => {
     });
   });
 
-  it('returns 403 when a user lacks upload read permission for getUpload', async () => {
+  it('returns 404 when a user lacks upload read permission for getUpload', async () => {
     const context = createUploadIntegrationContext();
     const blob = context.fileBlobs.seed({ id: 'blob-denied' });
     context.sourceDocuments.seed({ id: 'source-denied', file_blob_id: blob.id, status: 'archived' });
@@ -123,8 +123,8 @@ describe('upload permission integration', () => {
       context.service.getUpload('source-denied', createViewerUploadContext({ actorPermissions: [] })),
     );
 
-    expect(denied.getStatus()).toBe(403);
-    expect(getHttpExceptionCode(denied)).toBe(ErrorCode.PERMISSION_DENIED);
+    expect(denied.getStatus()).toBe(404);
+    expect(getHttpExceptionCode(denied)).toBe(ErrorCode.UPLOAD_NOT_FOUND);
   });
 
   it('returns 404 for a non-existent upload before permission disclosure', async () => {
@@ -136,5 +136,24 @@ describe('upload permission integration', () => {
 
     expect(missing.getStatus()).toBe(404);
     expect(getHttpExceptionCode(missing)).toBe(ErrorCode.UPLOAD_NOT_FOUND);
+  });
+
+  it('returns the same status for inaccessible and missing uploads', async () => {
+    const inaccessibleContext = createUploadIntegrationContext();
+    const blob = inaccessibleContext.fileBlobs.seed({ id: 'blob-inaccessible' });
+    inaccessibleContext.sourceDocuments.seed({ id: 'source-inaccessible', file_blob_id: blob.id, status: 'archived' });
+    inaccessibleContext.db.queueSelect([]);
+
+    const inaccessible = await getRejectedHttpException(
+      inaccessibleContext.service.getUpload('source-inaccessible', createViewerUploadContext({ actorPermissions: [] })),
+    );
+
+    const missingContext = createUploadIntegrationContext();
+    const missing = await getRejectedHttpException(
+      missingContext.service.getUpload('source-missing', createViewerUploadContext({ actorPermissions: [] })),
+    );
+
+    expect(inaccessible.getStatus()).toBe(404);
+    expect(missing.getStatus()).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- RbacGuard now defers space-scoped permission checks to the service layer when `spaceId` is absent from the route path, enabling non-admin roles (editor, space-admin) to access upload document-id routes (`/uploads/:sourceDocumentId`, `/status`, `/reprocess`)
- Service-level `assertSpacePermission` performs the actual Space ACL check after resolving the document's space
- Non-disclosure: unauthorized uploads return 404 (same as non-existent) to prevent existence probing
- Guard deferral narrowed to `RESOURCE_ACL_DEFERRABLE_PERMISSIONS` (space:read, upload:read, upload:create)
- OpenAPI reprocess response corrected from 202 to 200, UploadResponse schema added, 403 responses on document-id routes

Closes #289

## Agent Review
- Reviewer agents used: Spec Compliance, Correctness, Integration, Security & Performance
- Reviewed head SHA: `103de3e7b1d81270fba6d42b684616ee896fb17f`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/309#issuecomment-4435970784) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/309#issuecomment-4435971041) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/309#issuecomment-4435971270) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/309#issuecomment-4435971532)
- Key findings addressed: guard deferral narrowed to explicit permission set, existence oracle eliminated via 404, catch narrowed to 403 only, UploadResponse OpenAPI schema added with correct fields

## Test plan
- [x] Guard unit tests: editor allowed for upload:read/create without spaceId, viewer/auditor blocked, wiki:publish blocked (non-deferrable)
- [x] Integration tests: editor reads upload detail/status, space-admin reprocesses, unauthorized 404, non-existent 404, inaccessible-vs-missing parity
- [x] Build + lint + all 1228 tests pass
- [x] OpenAPI reprocess response matches controller @HttpCode(200)
- [x] Schema Validation CI pass