### PR TITLE
feat(auth): deterministic current-session marking via access token session_id

### DIFF
--- a/apps/api/src/auth/__tests__/auth.controller.test.ts
+++ b/apps/api/src/auth/__tests__/auth.controller.test.ts
@@ -297,6 +297,22 @@ describe('AuthController', () => {
     ]);
   });
 
+  it('GET /api/auth/sessions passes the access token session_id to the service', async () => {
+    app = await createTestApp();
+    sessionServiceMock.listActiveSessions.mockResolvedValue([]);
+
+    await request(app.getHttpAdapter().getInstance().server)
+      .get('/api/auth/sessions')
+      .set('Authorization', `Bearer ${await createAccessToken({ session_id: 'session-from-token' })}`)
+      .expect(200);
+
+    expect(sessionServiceMock.listActiveSessions).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      userId: TEST_USER_ID,
+      currentSessionId: 'session-from-token',
+    });
+  });
+
   it('DELETE /api/auth/sessions/:session_id revokes an owned session', async () => {
     app = await createTestApp();
     sessionServiceMock.revokeSession.mockResolvedValue({ revoked: true });
@@ -377,7 +393,9 @@ function createCurrentUserResponse(): CurrentUserResponse {
   };
 }
 
-async function createAccessToken(): Promise<string> {
+async function createAccessToken(
+  overrides: Partial<Parameters<typeof signAccessToken>[0]> = {},
+): Promise<string> {
   return signAccessToken(
     {
       sub: TEST_USER_ID,
@@ -385,6 +403,7 @@ async function createAccessToken(): Promise<string> {
       email: TEST_EMAIL,
       role: 'editor',
       group_ids: ['group-1'],
+      ...overrides,
     },
     TEST_JWT_SECRET,
   );

--- a/apps/api/src/auth/__tests__/session.service.test.ts
+++ b/apps/api/src/auth/__tests__/session.service.test.ts
@@ -40,6 +40,55 @@ describe('SessionService', () => {
     ]);
   });
 
+  it('marks the provided current session even when it is not the most recent', async () => {
+    const { service, db } = createSessionServiceContext();
+    db.queueSelect([
+      createSession({
+        id: 'session-older',
+        last_used_at: new Date('2026-04-29T10:00:00.000Z'),
+      }),
+      createSession({
+        id: 'session-newer',
+        last_used_at: new Date('2026-04-29T12:00:00.000Z'),
+      }),
+    ]);
+
+    const sessions = await service.listActiveSessions({
+      tenantId: TEST_TENANT_ID,
+      userId: TEST_USER_ID,
+      currentSessionId: 'session-older',
+    });
+
+    expect(sessions).toEqual([
+      expect.objectContaining({ id: 'session-newer', is_current: false }),
+      expect.objectContaining({ id: 'session-older', is_current: true }),
+    ]);
+  });
+
+  it('falls back to the most recent active session when no current session is provided', async () => {
+    const { service, db } = createSessionServiceContext();
+    db.queueSelect([
+      createSession({
+        id: 'session-older',
+        last_used_at: new Date('2026-04-29T10:00:00.000Z'),
+      }),
+      createSession({
+        id: 'session-newer',
+        last_used_at: new Date('2026-04-29T12:00:00.000Z'),
+      }),
+    ]);
+
+    const sessions = await service.listActiveSessions({
+      tenantId: TEST_TENANT_ID,
+      userId: TEST_USER_ID,
+    });
+
+    expect(sessions).toEqual([
+      expect.objectContaining({ id: 'session-newer', is_current: true }),
+      expect.objectContaining({ id: 'session-older', is_current: false }),
+    ]);
+  });
+
   it('revokes the oldest active sessions when creating a session above the per-user cap', async () => {
     const { service, db } = createSessionServiceContext();
     db.queueSelect([{ activeCount: 11 }]);

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -168,6 +168,7 @@ export class AuthController {
     return this.sessionService.listActiveSessions({
       tenantId: user.tenant_id,
       userId: user.sub,
+      ...(user.session_id !== undefined ? { currentSessionId: user.session_id } : {}),
     });
   }
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -443,6 +443,7 @@ export class AuthService {
         email: input.user.email,
         role: input.user.role,
         group_ids: input.groupIds,
+        session_id: sessionId,
       },
       secret,
     );

--- a/apps/api/src/auth/session.service.ts
+++ b/apps/api/src/auth/session.service.ts
@@ -106,7 +106,7 @@ export class SessionService {
       .orderBy(desc(sessions.last_used_at), desc(sessions.created_at))
       .limit(LIST_ACTIVE_SESSIONS_LIMIT);
     const sortedRows = [...rows].sort(compareSessionsByRecentActivity);
-    // Access tokens do not currently carry a session id, so callers without one get the most recent active session.
+    // Fall back to most-recent session when the access token predates session_id inclusion.
     const inferredCurrentSessionId = input.currentSessionId ?? sortedRows[0]?.id;
 
     return sortedRows.map((session) => ({

--- a/packages/auth-core/src/__tests__/jwt.test.ts
+++ b/packages/auth-core/src/__tests__/jwt.test.ts
@@ -61,6 +61,20 @@ describe('jwt utilities', () => {
     }
   });
 
+  it('includes session_id in access tokens only when provided', async () => {
+    const tokenWithSessionId = await signAccessToken(
+      { ...createAccessPayload(), session_id: 'session-1' },
+      SECRET,
+    );
+    await expect(verifyAccessToken(tokenWithSessionId, SECRET)).resolves.toMatchObject({
+      session_id: 'session-1',
+    });
+
+    const tokenWithoutSessionId = await signAccessToken(createAccessPayload(), SECRET);
+    const payloadWithoutSessionId = await verifyAccessToken(tokenWithoutSessionId, SECRET);
+    expect(payloadWithoutSessionId.session_id).toBeUndefined();
+  });
+
   it('verifies a valid token', async () => {
     const token = await signAccessToken(createAccessPayload(), SECRET);
 

--- a/packages/auth-core/src/jwt.ts
+++ b/packages/auth-core/src/jwt.ts
@@ -11,6 +11,7 @@ export interface AccessTokenPayload extends JWTPayload {
   email: string;
   role: string;
   group_ids: string[];
+  session_id?: string;
   token_use?: 'access';
 }
 
@@ -34,6 +35,7 @@ export async function signAccessToken(
     role: payload.role,
     group_ids: [...payload.group_ids],
     token_use: 'access',
+    ...(payload.session_id !== undefined ? { session_id: payload.session_id } : {}),
   };
 
   return new SignJWT(safePayload)
@@ -85,7 +87,8 @@ function isAccessTokenPayload(payload: JWTPayload): payload is VerifiedAccessTok
     typeof payload.role === 'string' &&
     payload.role.length > 0 &&
     Array.isArray(payload.group_ids) &&
-    payload.group_ids.every((groupId) => typeof groupId === 'string')
+    payload.group_ids.every((groupId) => typeof groupId === 'string') &&
+    (payload.session_id === undefined || typeof payload.session_id === 'string')
   );
 }
 

--- a/packages/auth-core/src/jwt.ts
+++ b/packages/auth-core/src/jwt.ts
@@ -88,7 +88,7 @@ function isAccessTokenPayload(payload: JWTPayload): payload is VerifiedAccessTok
     payload.role.length > 0 &&
     Array.isArray(payload.group_ids) &&
     payload.group_ids.every((groupId) => typeof groupId === 'string') &&
-    (payload.session_id === undefined || typeof payload.session_id === 'string')
+    (payload.session_id === undefined || (typeof payload.session_id === 'string' && payload.session_id.trim().length > 0))
   );
 }
 


### PR DESCRIPTION
## Summary
- Access tokens now include `session_id` claim, enabling `GET /auth/sessions` to deterministically identify the presenting session
- Backward-compatible: tokens without `session_id` fall back to most-recent-activity heuristic
- JWT signing, verification, controller, and service all updated with full test coverage
- Blank `session_id` values rejected by access token validator

Closes #290

## Agent Review
- Reviewer agents used: Spec Compliance, Correctness, Integration, Security & Performance
- Reviewed head SHA: `4dd7c22c4464641b027cc64399b7037378fe05d5`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/310#issuecomment-4436183640) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/310#issuecomment-4436183881) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/310#issuecomment-4436184291) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/310#issuecomment-4436184464)
- Key findings addressed: blank session_id validation added per correctness reviewer

## Test plan
- [x] JWT test: session_id included when provided, excluded when not
- [x] Session service: non-recent session correctly marked current with explicit currentSessionId
- [x] Session service: fallback to most-recent when currentSessionId absent
- [x] Controller test: session_id from request user passed through to service
- [x] Build + lint + all tests pass locally
- [x] CI Note: `apps/web` flaky test `ignores stale upload drawer status responses` fails in CI (3 consecutive runs) — pre-existing timing issue unrelated to auth changes