### PR TITLE
feat(wiki-core): preserve human-owned blocks across Graphify churn

### DIFF
--- a/apps/wiki-sync-worker/src/__tests__/page-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/page-sync.test.ts
@@ -265,7 +265,7 @@ describe('page-sync processor', () => {
       content_hash: normalizeBlockHash('## Deleted Block\nRemoved'),
     });
     expect(db.insertedVersions[0]?.content_markdown).toContain(
-      '<!-- graphify:human:retained id="deleted-block" reason="unmatched after Graphify regeneration" -->',
+      '<!-- graphify:human:start id="deleted-block" retained="true" -->',
     );
     expect(db.insertedVersions[0]?.content_markdown).toContain('## Deleted Block\nRemoved');
   });

--- a/apps/wiki-sync-worker/src/__tests__/page-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/page-sync.test.ts
@@ -213,6 +213,20 @@ describe('page-sync processor', () => {
       createMetadataRow({ block_id: 'human-block', owner: 'human', content: '## Human Block\nOriginal', last_editor: 'old-user' }),
       createMetadataRow({ block_id: 'deleted-block', owner: 'human', content: '## Deleted Block\nRemoved' }),
     ];
+    db.currentVersion = createVersion({
+      content_markdown: frontmatter(
+        [
+          '## Graphify Block',
+          'Original',
+          '',
+          '## Human Block',
+          'Original',
+          '',
+          '## Deleted Block',
+          'Removed',
+        ].join('\n'),
+      ),
+    });
     const markdown = frontmatter(
       [
         '## Graphify Block',
@@ -228,7 +242,7 @@ describe('page-sync processor', () => {
 
     await runProcessor(db, bridgeClientWithMarkdown(markdown));
 
-    expect(db.insertedBlockMetadata).toHaveLength(3);
+    expect(db.insertedBlockMetadata).toHaveLength(4);
     expect(blockById(db, 'graphify-block')).toMatchObject({
       owner: 'human',
       last_editor: 'user-1',
@@ -245,7 +259,15 @@ describe('page-sync processor', () => {
       last_editor: 'user-1',
       editable: true,
     });
-    expect(db.insertedBlockMetadata.some((row) => row.block_id === 'deleted-block')).toBe(false);
+    expect(blockById(db, 'deleted-block')).toMatchObject({
+      owner: 'human',
+      editable: true,
+      content_hash: normalizeBlockHash('## Deleted Block\nRemoved'),
+    });
+    expect(db.insertedVersions[0]?.content_markdown).toContain(
+      '<!-- graphify:human:retained id="deleted-block" reason="unmatched after Graphify regeneration" -->',
+    );
+    expect(db.insertedVersions[0]?.content_markdown).toContain('## Deleted Block\nRemoved');
   });
 
   it('coalesces stale same-page events so only the latest creates a version', async () => {

--- a/apps/wiki-sync-worker/src/processors/page-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/page-sync.processor.ts
@@ -239,7 +239,7 @@ async function processPageSaved(deps: PageSyncDeps, data: PageSyncJobData): Prom
   }
 
   const matchedBlocks = matchExportedBlocks(repaired.content, sidecar);
-  const mergeResult = mergeBlocks(matchedBlocks, user.userId, currentVersion?.graphify_run_id ?? undefined);
+  const mergeResult = mergeBlocks(matchedBlocks, user.userId, currentVersion?.graphify_run_id ?? undefined, sidecar);
   const contentMarkdown = generateFrontmatter(repaired.frontmatter, mergeResult.mergedMarkdown);
   const versionId = randomUUID();
   const versionNo = (currentVersion?.version_no ?? 0) + 1;
@@ -661,6 +661,7 @@ function enrichSidecarWithNormalizedContent(
 
     return {
       ...metadata,
+      content,
       normalizedContent: normalizeBlockContent(content),
     };
   });

--- a/packages/wiki-core/src/__tests__/block-merge.test.ts
+++ b/packages/wiki-core/src/__tests__/block-merge.test.ts
@@ -84,9 +84,12 @@ describe('block merge', () => {
       });
     });
 
-    it('marks unmatched markdown blocks as new and omits deleted sidecar blocks', () => {
+    it('marks unmatched markdown blocks as new when positional matching is ambiguous', () => {
       const markdown = '## New Section\nDraft';
-      const sidecar = [metadata({ blockId: 'deleted-section', content: '## Deleted Section\nGone' })];
+      const sidecar = [
+        metadata({ blockId: 'deleted-section', content: '## Deleted Section\nGone' }),
+        metadata({ blockId: 'other-deleted-section', content: '## Other Deleted Section\nGone' }),
+      ];
 
       const results = matchBlocksFallback(markdown, sidecar);
 
@@ -98,6 +101,53 @@ describe('block merge', () => {
         },
       ]);
       expect(results.some((result) => result.blockId === 'deleted-section')).toBe(false);
+    });
+
+    it('matches a heading change by exact body content hash before fuzzy matching', () => {
+      const previousContent = '## Overview\n\nThe import keeps curated prose intact.';
+      const regeneratedContent = '## Project Overview\n\nThe import keeps curated prose intact.';
+      const sidecar = [
+        metadata({
+          blockId: 'overview',
+          owner: 'human',
+          content: previousContent,
+        }),
+      ];
+
+      const [result] = matchBlocksFallback(regeneratedContent, sidecar);
+      const mergeResult = mergeBlocks(result ? [result] : [], 'user-1', 'gf-2', sidecar);
+
+      expect(result).toMatchObject({
+        blockId: 'overview',
+        matchType: 'hash',
+        matchedMetadata: sidecar[0],
+      });
+      expect(mergeResult.newMetadata[0]).toMatchObject({
+        blockId: 'overview',
+        owner: 'human',
+        editable: true,
+      });
+      expect(mergeResult.mergedMarkdown).not.toContain('graphify:human:retained');
+    });
+
+    it('matches by page-local position when exactly one sidecar entry and one incoming block remain', () => {
+      const markdown = '## Regenerated\nDifferent generated text.';
+      const sidecar = [
+        metadata({
+          blockId: 'legacy-human-section',
+          owner: 'human',
+          content: '## Legacy Human Section\nOriginal curated text.',
+        }),
+      ];
+
+      const [result] = matchBlocksFallback(markdown, sidecar);
+
+      expect(result).toMatchObject({
+        blockId: 'legacy-human-section',
+        content: markdown,
+        matchType: 'position',
+        matchedMetadata: sidecar[0],
+      });
     });
   });
 
@@ -188,6 +238,64 @@ describe('block merge', () => {
         },
       ]);
     });
+
+    it('retains completely unmatched human-owned sidecar blocks at the end', () => {
+      const overview = metadata({
+        blockId: 'overview',
+        owner: 'graphify',
+        content: '## Overview\nOriginal graphify text',
+        editable: false,
+      });
+      const notes = metadata({
+        blockId: 'my-notes',
+        owner: 'human',
+        content: '## My Notes\nHuman notes that Graphify did not regenerate.',
+      });
+      const matchedBlocks = matchBlocksFallback('## Overview\nRegenerated graphify text', [overview, notes]);
+
+      const result = mergeBlocks(matchedBlocks, 'user-1', 'gf-2', [overview, notes]);
+
+      expect(result.mergedMarkdown).toContain('## Overview\nRegenerated graphify text');
+      expect(result.mergedMarkdown).toContain(
+        '<!-- graphify:human:retained id="my-notes" reason="unmatched after Graphify regeneration" -->',
+      );
+      expect(result.mergedMarkdown).toContain('## My Notes\nHuman notes that Graphify did not regenerate.');
+      expect(result.mergedMarkdown).toContain('<!-- graphify:human:retained:end -->');
+      expect(result.newMetadata.find((block) => block.blockId === 'my-notes')).toMatchObject({
+        blockId: 'my-notes',
+        owner: 'human',
+        contentHash: notes.contentHash,
+        editable: true,
+      });
+    });
+
+    it('retains unmatched human-owned sidecar blocks when positional matching is ambiguous', () => {
+      const first = metadata({
+        blockId: 'first-human',
+        owner: 'human',
+        content: '## First Human\nFirst curated block.',
+      });
+      const second = metadata({
+        blockId: 'second-human',
+        owner: 'human',
+        content: '## Second Human\nSecond curated block.',
+      });
+      const matchedBlocks = matchBlocksFallback('## Regenerated\nUnrelated regenerated content.', [first, second]);
+
+      const result = mergeBlocks(matchedBlocks, 'user-1', 'gf-2', [first, second]);
+
+      expect(matchedBlocks[0]).toMatchObject({ blockId: 'regenerated', matchType: 'new' });
+      expect(result.mergedMarkdown).toContain('## Regenerated\nUnrelated regenerated content.');
+      expect(result.mergedMarkdown).toContain('id="first-human"');
+      expect(result.mergedMarkdown).toContain('## First Human\nFirst curated block.');
+      expect(result.mergedMarkdown).toContain('id="second-human"');
+      expect(result.mergedMarkdown).toContain('## Second Human\nSecond curated block.');
+      expect(result.newMetadata.filter((block) => block.owner === 'human').map((block) => block.blockId)).toEqual([
+        'regenerated',
+        'first-human',
+        'second-human',
+      ]);
+    });
   });
 });
 
@@ -204,6 +312,7 @@ function metadata(overrides: {
     blockId: overrides.blockId,
     owner: overrides.owner ?? 'human',
     contentHash: normalizeBlockHash(overrides.content),
+    content: overrides.content,
     normalizedContent: normalizeBlockContent(overrides.normalizedContent ?? overrides.content),
     ...(overrides.graphifyRunId !== undefined ? { graphifyRunId: overrides.graphifyRunId } : {}),
     ...(overrides.lastEditor !== undefined ? { lastEditor: overrides.lastEditor } : {}),

--- a/packages/wiki-core/src/__tests__/block-merge.test.ts
+++ b/packages/wiki-core/src/__tests__/block-merge.test.ts
@@ -257,10 +257,10 @@ describe('block merge', () => {
 
       expect(result.mergedMarkdown).toContain('## Overview\nRegenerated graphify text');
       expect(result.mergedMarkdown).toContain(
-        '<!-- graphify:human:retained id="my-notes" reason="unmatched after Graphify regeneration" -->',
+        '<!-- graphify:human:start id="my-notes" retained="true" -->',
       );
       expect(result.mergedMarkdown).toContain('## My Notes\nHuman notes that Graphify did not regenerate.');
-      expect(result.mergedMarkdown).toContain('<!-- graphify:human:retained:end -->');
+      expect(result.mergedMarkdown).toContain('<!-- graphify:human:end -->');
       expect(result.newMetadata.find((block) => block.blockId === 'my-notes')).toMatchObject({
         blockId: 'my-notes',
         owner: 'human',

--- a/packages/wiki-core/src/normalization/block-merge.ts
+++ b/packages/wiki-core/src/normalization/block-merge.ts
@@ -6,6 +6,7 @@ export interface BlockMetadataInfo {
   blockId: string;
   owner: 'graphify' | 'human';
   contentHash: string;
+  content?: string;
   normalizedContent?: string;
   graphifyRunId?: string;
   lastEditor?: string;
@@ -16,7 +17,7 @@ export interface BlockMatchResult {
   blockId: string;
   content: string;
   matchedMetadata?: BlockMetadataInfo;
-  matchType: 'marker' | 'heading' | 'hash' | 'new';
+  matchType: 'marker' | 'heading' | 'hash' | 'position' | 'new';
 }
 
 export interface MergeResult {
@@ -53,47 +54,115 @@ export function matchBlocksFallback(
   const sidecarByBlockId = new Map(sidecar.map((metadata) => [metadata.blockId, metadata]));
   const matchedSidecarIds = new Set<string>();
   const blocks = extractH2Blocks(markdown);
+  const results: BlockMatchResult[] = [];
 
-  return blocks.map((block, index) => {
+  for (const [index, block] of blocks.entries()) {
     const heading = readH2Heading(block.content);
     const headingBlockId = heading ? blockIdFromHeading(heading, index) : block.blockId;
-    const headingMatch = sidecarByBlockId.get(headingBlockId) ?? sidecarByBlockId.get(block.blockId);
+    const headingMatch = findFirstUnmatchedByBlockId(
+      [block.blockId, headingBlockId],
+      sidecarByBlockId,
+      matchedSidecarIds,
+    );
 
     if (headingMatch !== undefined && !matchedSidecarIds.has(headingMatch.blockId)) {
       matchedSidecarIds.add(headingMatch.blockId);
-      return {
+      results.push({
         blockId: headingMatch.blockId,
         content: block.content,
         matchedMetadata: headingMatch,
         matchType: 'heading',
-      };
+      });
+      continue;
+    }
+
+    const stableHeadingMatch = findStableHeadingMatch(heading, sidecar, matchedSidecarIds);
+    if (stableHeadingMatch !== undefined) {
+      matchedSidecarIds.add(stableHeadingMatch.blockId);
+      results.push({
+        blockId: stableHeadingMatch.blockId,
+        content: block.content,
+        matchedMetadata: stableHeadingMatch,
+        matchType: 'heading',
+      });
+      continue;
     }
 
     const normalizedContent = normalizeBlockContent(block.content);
+    const hashMatch = findContentHashMatch(normalizedContent, sidecar, matchedSidecarIds);
+    if (hashMatch !== undefined) {
+      matchedSidecarIds.add(hashMatch.blockId);
+      results.push({
+        blockId: hashMatch.blockId,
+        content: block.content,
+        matchedMetadata: hashMatch,
+        matchType: 'hash',
+      });
+      continue;
+    }
+
+    const markerMatch = findMarkerMatch(block.content, markdown, block.start, sidecarByBlockId, matchedSidecarIds);
+    if (markerMatch !== undefined) {
+      matchedSidecarIds.add(markerMatch.blockId);
+      results.push({
+        blockId: markerMatch.blockId,
+        content: block.content,
+        matchedMetadata: markerMatch,
+        matchType: 'marker',
+      });
+      continue;
+    }
+
     const contentMatch = findBestContentMatch(normalizedContent, sidecar, matchedSidecarIds);
     if (contentMatch !== undefined) {
       matchedSidecarIds.add(contentMatch.blockId);
-      return {
+      results.push({
         blockId: contentMatch.blockId,
         content: block.content,
         matchedMetadata: contentMatch,
         matchType: 'hash',
-      };
+      });
+      continue;
     }
 
-    return {
+    results.push({
       blockId: block.blockId,
       content: block.content,
       matchType: 'new',
-    };
-  });
+    });
+  }
+
+  const unmatchedSidecar = sidecar.filter((metadata) => !matchedSidecarIds.has(metadata.blockId));
+  const unmatchedBlockIndexes = results
+    .map((result, index) => ({ result, index }))
+    .filter(({ result }) => result.matchType === 'new');
+  if (sidecar.length === 1 && results.length === 1 && unmatchedSidecar.length === 1 && unmatchedBlockIndexes.length === 1) {
+    const metadata = unmatchedSidecar[0];
+    const unmatchedBlock = unmatchedBlockIndexes[0];
+    if (metadata !== undefined && unmatchedBlock !== undefined) {
+      results[unmatchedBlock.index] = {
+        blockId: metadata.blockId,
+        content: unmatchedBlock.result.content,
+        matchedMetadata: metadata,
+        matchType: 'position',
+      };
+    }
+  }
+
+  return results;
 }
 
 export function mergeBlocks(
   matchedBlocks: BlockMatchResult[],
   userId?: string,
   runId?: string,
+  sidecar: BlockMetadataInfo[] = [],
 ): MergeResult {
+  const matchedSidecarIds = new Set(
+    matchedBlocks
+      .map((block) => block.matchedMetadata?.blockId)
+      .filter((blockId): blockId is string => blockId !== undefined),
+  );
   const newMetadata = matchedBlocks.map((block) => {
     const contentHash = normalizeBlockHash(block.content);
     const existing = block.matchedMetadata;
@@ -135,10 +204,17 @@ export function mergeBlocks(
       editable: true,
     };
   });
+  const retainedHumanBlocks = sidecar.filter(
+    (metadata) => metadata.owner === 'human' && !matchedSidecarIds.has(metadata.blockId),
+  );
+  const retainedMarkdown = retainedHumanBlocks.map(formatRetainedHumanBlock);
 
   return {
-    mergedMarkdown: matchedBlocks.map((block) => block.content.trimEnd()).join('\n\n').trimEnd(),
-    newMetadata,
+    mergedMarkdown: [...matchedBlocks.map((block) => block.content.trimEnd()), ...retainedMarkdown]
+      .filter((content) => content.length > 0)
+      .join('\n\n')
+      .trimEnd(),
+    newMetadata: [...newMetadata, ...retainedHumanBlocks.map((metadata) => ({ ...metadata }))],
     proposals: [],
   };
 }
@@ -146,6 +222,85 @@ export function mergeBlocks(
 function readH2Heading(content: string): string | undefined {
   const match = /^##(?!#)[ \t]+(.+?)\s*#*\s*$/m.exec(content);
   return match?.[1]?.trim().replace(/\s+#*$/, '');
+}
+
+function findFirstUnmatchedByBlockId(
+  blockIds: string[],
+  sidecarByBlockId: Map<string, BlockMetadataInfo>,
+  matchedSidecarIds: Set<string>,
+): BlockMetadataInfo | undefined {
+  for (const blockId of new Set(blockIds)) {
+    const metadata = sidecarByBlockId.get(blockId);
+    if (metadata !== undefined && !matchedSidecarIds.has(metadata.blockId)) {
+      return metadata;
+    }
+  }
+
+  return undefined;
+}
+
+function findStableHeadingMatch(
+  heading: string | undefined,
+  sidecar: BlockMetadataInfo[],
+  matchedSidecarIds: Set<string>,
+): BlockMetadataInfo | undefined {
+  const headingKey = normalizeHeadingKey(heading);
+  if (headingKey === undefined) {
+    return undefined;
+  }
+
+  return findUniqueSidecarMatch(sidecar, matchedSidecarIds, (metadata) => {
+    const sidecarHeadingKey =
+      normalizeHeadingKey(readH2Heading(metadata.content ?? metadata.normalizedContent ?? '')) ??
+      normalizeHeadingKey(metadata.blockId.replace(/-/g, ' '));
+    return sidecarHeadingKey === headingKey;
+  });
+}
+
+function findContentHashMatch(
+  normalizedContent: string,
+  sidecar: BlockMetadataInfo[],
+  matchedSidecarIds: Set<string>,
+): BlockMetadataInfo | undefined {
+  const incomingFullHash = hashNormalizedContent(normalizedContent);
+  const incomingBodyContent = stripLeadingH2(normalizedContent);
+  const incomingBodyHash = hashNormalizedContent(incomingBodyContent);
+
+  return findUniqueSidecarMatch(sidecar, matchedSidecarIds, (metadata) => {
+    if (metadata.contentHash === incomingFullHash || metadata.contentHash === incomingBodyHash) {
+      return true;
+    }
+
+    if (metadata.normalizedContent === undefined && metadata.content === undefined) {
+      return false;
+    }
+
+    const sidecarContent = normalizeBlockContent(metadata.content ?? metadata.normalizedContent ?? '');
+    return (
+      hashNormalizedContent(sidecarContent) === incomingFullHash ||
+      hashNormalizedContent(stripLeadingH2(sidecarContent)) === incomingBodyHash
+    );
+  });
+}
+
+function findMarkerMatch(
+  content: string,
+  markdown: string,
+  blockStart: number,
+  sidecarByBlockId: Map<string, BlockMetadataInfo>,
+  matchedSidecarIds: Set<string>,
+): BlockMetadataInfo | undefined {
+  const markerId = readEmbeddedMarkerId(content) ?? readPrecedingMarkerId(markdown, blockStart);
+  if (markerId === undefined) {
+    return undefined;
+  }
+
+  const metadata = sidecarByBlockId.get(markerId);
+  if (metadata === undefined || matchedSidecarIds.has(metadata.blockId)) {
+    return undefined;
+  }
+
+  return metadata;
 }
 
 function findBestContentMatch(
@@ -173,6 +328,77 @@ function findBestContentMatch(
   }
 
   return bestMatch;
+}
+
+function findUniqueSidecarMatch(
+  sidecar: BlockMetadataInfo[],
+  matchedSidecarIds: Set<string>,
+  predicate: (metadata: BlockMetadataInfo) => boolean,
+): BlockMetadataInfo | undefined {
+  let match: BlockMetadataInfo | undefined;
+
+  for (const metadata of sidecar) {
+    if (matchedSidecarIds.has(metadata.blockId) || !predicate(metadata)) {
+      continue;
+    }
+
+    if (match !== undefined) {
+      return undefined;
+    }
+    match = metadata;
+  }
+
+  return match;
+}
+
+function normalizeHeadingKey(heading: string | undefined): string | undefined {
+  if (heading === undefined) {
+    return undefined;
+  }
+
+  const normalized = heading
+    .toLowerCase()
+    .trim()
+    .replace(/\p{P}+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function hashNormalizedContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function stripLeadingH2(content: string): string {
+  return content.replace(/^##(?!#)[ \t]+.+(?:\n|$)/, '').trimEnd();
+}
+
+function readEmbeddedMarkerId(content: string): string | undefined {
+  const markerMatch =
+    /<!--\s*(?:graphify:(?:managed|human)(?::retained)?|human:curated)(?::start)?\s+id="([^"]+)"/.exec(content);
+  return markerMatch?.[1];
+}
+
+function readPrecedingMarkerId(markdown: string, blockStart: number): string | undefined {
+  const beforeBlock = markdown.slice(0, blockStart);
+  const markerMatch =
+    /<!--\s*(?:graphify:(?:managed|human)|human:curated):start\s+id="([^"]+)"(?:\s+run="[^"]*")?\s*-->\s*$/.exec(
+      beforeBlock,
+    );
+  return markerMatch?.[1];
+}
+
+function formatRetainedHumanBlock(metadata: BlockMetadataInfo): string {
+  const content = (metadata.content ?? metadata.normalizedContent ?? '').trimEnd();
+  return [
+    `<!-- graphify:human:retained id="${escapeMarkerAttribute(metadata.blockId)}" reason="unmatched after Graphify regeneration" -->`,
+    content,
+    '<!-- graphify:human:retained:end -->',
+  ].join('\n');
+}
+
+function escapeMarkerAttribute(value: string): string {
+  return value.replace(/"/g, '&quot;');
 }
 
 function characterJaccardSimilarity(left: string, right: string): number {

--- a/packages/wiki-core/src/normalization/block-merge.ts
+++ b/packages/wiki-core/src/normalization/block-merge.ts
@@ -76,6 +76,18 @@ export function matchBlocksFallback(
       continue;
     }
 
+    const markerMatch = findMarkerMatch(block.content, markdown, block.start, sidecarByBlockId, matchedSidecarIds);
+    if (markerMatch !== undefined) {
+      matchedSidecarIds.add(markerMatch.blockId);
+      results.push({
+        blockId: markerMatch.blockId,
+        content: block.content,
+        matchedMetadata: markerMatch,
+        matchType: 'marker',
+      });
+      continue;
+    }
+
     const stableHeadingMatch = findStableHeadingMatch(heading, sidecar, matchedSidecarIds);
     if (stableHeadingMatch !== undefined) {
       matchedSidecarIds.add(stableHeadingMatch.blockId);
@@ -97,18 +109,6 @@ export function matchBlocksFallback(
         content: block.content,
         matchedMetadata: hashMatch,
         matchType: 'hash',
-      });
-      continue;
-    }
-
-    const markerMatch = findMarkerMatch(block.content, markdown, block.start, sidecarByBlockId, matchedSidecarIds);
-    if (markerMatch !== undefined) {
-      matchedSidecarIds.add(markerMatch.blockId);
-      results.push({
-        blockId: markerMatch.blockId,
-        content: block.content,
-        matchedMetadata: markerMatch,
-        matchType: 'marker',
       });
       continue;
     }
@@ -391,9 +391,9 @@ function readPrecedingMarkerId(markdown: string, blockStart: number): string | u
 function formatRetainedHumanBlock(metadata: BlockMetadataInfo): string {
   const content = (metadata.content ?? metadata.normalizedContent ?? '').trimEnd();
   return [
-    `<!-- graphify:human:retained id="${escapeMarkerAttribute(metadata.blockId)}" reason="unmatched after Graphify regeneration" -->`,
+    `<!-- graphify:human:start id="${escapeMarkerAttribute(metadata.blockId)}" retained="true" -->`,
     content,
-    '<!-- graphify:human:retained:end -->',
+    '<!-- graphify:human:end -->',
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Enhanced block matching with full fallback chain: blockId → marker → stable heading → content hash → fuzzy → safe positional match
- Unmatched human-owned blocks retained using standard `graphify:human:start/end` format (compatible with downstream parsers)
- Preserves human content through Graphify block ID/heading regeneration

Closes #293

## Agent Review
- Reviewer agents used: Spec Compliance, Correctness, Integration, Security & Performance
- Reviewed head SHA: `b04bbe5191e79235fc2e5033403deebbf6e4ecdf`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/312#issuecomment-4436426894) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/312#issuecomment-4436427072) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/312#issuecomment-4436427274) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/312#issuecomment-4436427455)
- Key findings addressed: retained marker format changed to graphify:human:start for parser compatibility, fallback order corrected to marker-first

## Test plan
- [x] Heading change preserves human block via content hash
- [x] Unmatched human block retained with standard markers
- [x] Positional fallback matches when unambiguous
- [x] Ambiguous match retains instead of guessing
- [x] Build + lint + 1244 tests pass