### PR TITLE
feat(wiki-sync): retry or expose deferred permission-sync states (#295)

### DIFF
--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -278,7 +278,7 @@ describe('UploadCenter', () => {
     await waitFor(() => expect(screen.getAllByText('doc-b.md').length).toBeGreaterThan(1));
     expect(screen.queryByText('A stale failure should not render')).not.toBeInTheDocument();
     expect(screen.queryByText('stale_doc_a')).not.toBeInTheDocument();
-  });
+  }, 30_000);
 });
 
 describe('UploadDetail', () => {

--- a/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/permission-sync.test.ts
@@ -1,4 +1,4 @@
-import type { Job } from 'bullmq';
+import { UnrecoverableError, type Job } from 'bullmq';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -45,7 +45,7 @@ describe('permission-sync processor', () => {
     ], { version: 1, source: 'cherry_api' });
   });
 
-  it('defers permission pushes while active users are pending Docmost sync', async () => {
+  it('deferred permission sync throws retriable error and writes audit event', async () => {
     const db = new PermissionSyncTestDb();
     db.permissionRows = [
       { userId: 'docmost-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
@@ -53,9 +53,30 @@ describe('permission-sync processor', () => {
     ];
     const bridgeClient = createBridgeClient();
 
-    await runProcessor(db, bridgeClient);
+    let error: unknown;
+    try {
+      await runProcessor(db, bridgeClient);
+    } catch (caught) {
+      error = caught;
+    }
 
-    expect(bridgeClient.pushPermissions).not.toHaveBeenCalled();
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(UnrecoverableError);
+    expect(error).toHaveProperty(
+      'message',
+      'Permission sync deferred for space space-1: 1 users pending Docmost sync',
+    );
+    expect(pushPermissionsMock(bridgeClient)).not.toHaveBeenCalled();
+    expect(db.auditRows).toHaveLength(1);
+    expect(db.auditRows[0]).toMatchObject({
+      action: 'permission_sync_deferred',
+      space_id: 'space-1',
+    });
+    expect(db.auditRows[0]?.metadata_json).toMatchObject({
+      pendingDocmostUserCount: 1,
+      spaceId: 'space-1',
+      tenantId: 'tenant-1',
+    });
   });
 
   it('skips spaces that have not been synced to Docmost', async () => {
@@ -111,7 +132,7 @@ describe('permission-sync processor', () => {
       getPermissions: vi.fn(() => Promise.resolve([])),
     };
 
-    await expect(reconcilePermissions(db.asDb(), bridgeClient)).resolves.toEqual({ fixed: 1, errors: 0 });
+    await expect(reconcilePermissions(db.asDb(), bridgeClient)).resolves.toEqual({ fixed: 1, errors: 0, deferred: 0 });
 
     expect(bridgeClient.pushPermissions).toHaveBeenCalledWith('docmost-space-1', [
       { userId: 'docmost-admin', email: 'admin@example.com', role: 'admin' },
@@ -130,10 +151,52 @@ describe('permission-sync processor', () => {
       ),
     };
 
-    await expect(reconcilePermissions(db.asDb(), bridgeClient)).resolves.toEqual({ fixed: 0, errors: 0 });
+    await expect(reconcilePermissions(db.asDb(), bridgeClient)).resolves.toEqual({ fixed: 0, errors: 0, deferred: 0 });
 
     expect(bridgeClient.pushPermissions).not.toHaveBeenCalled();
     expect(db.auditRows).toHaveLength(0);
+  });
+
+  it('reconciliation logs deferred audit event for spaces with pending users', async () => {
+    const db = new PermissionSyncTestDb();
+    db.permissionRows = [
+      { userId: 'docmost-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
+      { userId: null, email: 'unsynced@example.com', cherryRole: 'space:view' },
+    ];
+    const bridgeClient = {
+      pushPermissions: vi.fn<PermissionSyncBridgeClient['pushPermissions']>(() => Promise.resolve()),
+      getPermissions: vi.fn(() => Promise.resolve([])),
+    };
+
+    await expect(reconcilePermissions(db.asDb(), bridgeClient)).resolves.toEqual({ fixed: 0, errors: 0, deferred: 1 });
+
+    expect(pushPermissionsMock(bridgeClient)).not.toHaveBeenCalled();
+    expect(db.auditRows).toHaveLength(1);
+    expect(db.auditRows[0]).toMatchObject({
+      action: 'permission_sync_deferred',
+      space_id: 'space-1',
+    });
+    expect(db.auditRows[0]?.metadata_json).toMatchObject({
+      pendingDocmostUserCount: 1,
+      spaceId: 'space-1',
+      tenantId: 'tenant-1',
+    });
+  });
+
+  it('permission sync succeeds after all users are synced', async () => {
+    const db = new PermissionSyncTestDb();
+    db.permissionRows = [
+      { userId: 'docmost-admin', email: 'admin@example.com', cherryRole: 'space:admin' },
+      { userId: 'docmost-reader', email: 'reader@example.com', cherryRole: 'space:view' },
+    ];
+    const bridgeClient = createBridgeClient();
+
+    await runProcessor(db, bridgeClient);
+
+    expect(pushPermissionsMock(bridgeClient)).toHaveBeenCalledWith('docmost-space-1', [
+      { userId: 'docmost-admin', email: 'admin@example.com', role: 'admin' },
+      { userId: 'docmost-reader', email: 'reader@example.com', role: 'reader' },
+    ], { version: 1, source: 'cherry_api' });
   });
 });
 
@@ -251,6 +314,14 @@ function createBridgeClient(error?: Error): PermissionSyncBridgeClient {
       error === undefined ? Promise.resolve() : Promise.reject(error),
     ),
   };
+}
+
+function pushPermissionsMock(
+  bridgeClient: PermissionSyncBridgeClient,
+): ReturnType<typeof vi.fn<PermissionSyncBridgeClient['pushPermissions']>> {
+  return Reflect.get(bridgeClient, 'pushPermissions') as ReturnType<
+    typeof vi.fn<PermissionSyncBridgeClient['pushPermissions']>
+  >;
 }
 
 function createSpace(overrides: Partial<SpaceRow> = {}): SpaceRow {

--- a/apps/wiki-sync-worker/src/__tests__/user-sync.test.ts
+++ b/apps/wiki-sync-worker/src/__tests__/user-sync.test.ts
@@ -34,10 +34,59 @@ describe('user-sync processor', () => {
     });
     expect(db.update).toHaveBeenCalled();
   });
+
+  it('user-sync completion enqueues permission-sync for affected spaces', async () => {
+    const bridgeClient = {
+      syncUser: vi.fn<UserSyncBridgeClient['syncUser']>(() =>
+        Promise.resolve({ docmost_user_id: 'docmost-user-1' }),
+      ),
+    };
+    const db = createDb([
+      { spaceId: 'space-1', tenantId: 'tenant-1' },
+      { spaceId: 'space-2', tenantId: 'tenant-1' },
+    ]);
+    const permissionSyncQueue = {
+      add: vi.fn(() => Promise.resolve()),
+    };
+    const processor = createUserSyncProcessor({
+      db: db as never,
+      bridgeClient,
+      permissionSyncQueue,
+    });
+
+    await processor({
+      data: {
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        email: 'user@example.com',
+        name: 'Test User',
+      },
+    } as Job<UserSyncJobData>);
+
+    expect(permissionSyncQueue.add).toHaveBeenCalledTimes(2);
+    expect(permissionSyncQueue.add).toHaveBeenCalledWith('permission.sync', {
+      spaceId: 'space-1',
+      tenantId: 'tenant-1',
+    });
+    expect(permissionSyncQueue.add).toHaveBeenCalledWith('permission.sync', {
+      spaceId: 'space-2',
+      tenantId: 'tenant-1',
+    });
+  });
 });
 
-function createDb(): { update: ReturnType<typeof vi.fn> } {
+function createDb(
+  affectedSpaces: Array<{ spaceId: string; tenantId: string }> = [],
+): { select: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> } {
+  const selectBuilder = {
+    innerJoin: vi.fn(() => selectBuilder),
+    where: vi.fn(() => Promise.resolve(affectedSpaces)),
+  };
+
   return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => selectBuilder),
+    })),
     update: vi.fn(() => ({
       set: vi.fn(() => ({
         where: vi.fn(() => ({

--- a/apps/wiki-sync-worker/src/main.ts
+++ b/apps/wiki-sync-worker/src/main.ts
@@ -106,7 +106,7 @@ export async function bootstrap(): Promise<void> {
   const queues = createQueues(connection);
 
   await reconcileOnStartup(db as unknown as ReconciliationDb, queues);
-  await reconcileSpaces(db as SpaceProvisionDeps['db'], queues.spaceProvision);
+  await reconcileSpaces(db, queues.spaceProvision);
 
   const bridgeBaseUrl = process.env.DOCMOST_BRIDGE_BASE_URL ?? process.env.DOCMOST_BASE_URL ?? 'http://localhost:3000';
   const bridgeSecret = process.env.DOCMOST_BRIDGE_SECRET ?? process.env.DOCMOST_BRIDGE_TOKEN ?? '';
@@ -137,27 +137,25 @@ export async function bootstrap(): Promise<void> {
     userSync: {
       db,
       bridgeClient,
+      permissionSyncQueue: queues.permissionSync,
     },
   });
 
   try {
-    const userReconcileCount = await reconcileUsers(db as UserSyncDeps['db'], queues.userSync);
+    const userReconcileCount = await reconcileUsers(db, queues.userSync);
     if (userReconcileCount > 0) {
       console.log(`${WORKER_NAME}: enqueued user reconciliation jobs`, {
         count: userReconcileCount,
       });
     }
     await waitForUserSyncQueueToDrain(queues.userSync);
-    await runStartupPermissionReconciliation(db as PermissionSyncDeps['db'], bridgeClient);
+    await runStartupPermissionReconciliation(db, bridgeClient);
   } finally {
     await queues.permissionSync.resume();
   }
 
   const permissionReconcileTimer = startPermissionReconcileTimer(db, bridgeClient);
-  const spaceReconcileTimer = startSpaceReconcileTimer(
-    db as SpaceProvisionDeps['db'],
-    queues.spaceProvision,
-  );
+  const spaceReconcileTimer = startSpaceReconcileTimer(db, queues.spaceProvision);
 
   const healthServer = await startHealthServer(
     {

--- a/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/permission-sync.processor.ts
@@ -71,8 +71,9 @@ export function createPermissionSyncProcessor(
   return async (job) => {
     const data = readJobData(job.data);
 
+    let result: PushSpacePermissionsResult;
     try {
-      await pushSpacePermissions(deps.db, deps.bridgeClient, data);
+      result = await pushSpacePermissions(deps.db, deps.bridgeClient, data);
     } catch (error) {
       if (isHttpStatus(error, 404)) {
         await logPermissionSyncFailure(deps.db, data, error, true);
@@ -86,6 +87,28 @@ export function createPermissionSyncProcessor(
       }
 
       throw error;
+    }
+
+    if (result.deferred === true) {
+      const pendingDocmostUserCount = result.pendingDocmostUserCount ?? 0;
+      const tenantId = result.tenantId ?? data.tenantId;
+      if (tenantId !== undefined) {
+        await logPermissionAuditEvent(deps.db, {
+          tenantId,
+          spaceId: data.spaceId,
+          action: 'permission_sync_deferred',
+          metadata: {
+            pendingDocmostUserCount,
+            spaceId: data.spaceId,
+            tenantId,
+            docmostSpaceId: result.docmostSpaceId,
+          },
+        });
+      }
+
+      throw new Error(
+        `Permission sync deferred for space ${data.spaceId}: ${pendingDocmostUserCount} users pending Docmost sync`,
+      );
     }
   };
 }
@@ -186,7 +209,11 @@ export async function logPermissionAuditEvent(
   input: {
     tenantId: string;
     spaceId: string;
-    action: 'bridge.permission_sync_failed' | 'permission_consistency_fixed' | 'permission_consistency_failed';
+    action:
+      | 'bridge.permission_sync_failed'
+      | 'permission_consistency_fixed'
+      | 'permission_consistency_failed'
+      | 'permission_sync_deferred';
     metadata: Record<string, unknown>;
   },
 ): Promise<void> {

--- a/apps/wiki-sync-worker/src/processors/user-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/user-sync.processor.ts
@@ -1,17 +1,18 @@
 import type { Job } from 'bullmq';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNotNull, isNull } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
-import { users } from '@cherrygraph/shared';
+import { group_members, space_permissions, spaces, users } from '@cherrygraph/shared';
 
 export const BRIDGE_USER_SYNC_QUEUE = 'bridge-user-sync';
 
 export type DrizzleDatabase = NodePgDatabase;
-type DatabaseClient = Pick<DrizzleDatabase, 'update'>;
+type DatabaseClient = Pick<DrizzleDatabase, 'select' | 'update'>;
 
 export interface UserSyncDeps {
-  db: DrizzleDatabase;
+  db: DatabaseClient;
   bridgeClient: UserSyncBridgeClient;
+  permissionSyncQueue?: PermissionSyncQueue;
 }
 
 export interface UserSyncBridgeClient {
@@ -29,6 +30,19 @@ export type UserSyncJobData = {
   tenantId: string;
 };
 
+export type PermissionSyncQueue = {
+  add(
+    name: string,
+    data: { spaceId: string; tenantId: string },
+    opts?: { jobId?: string },
+  ): Promise<unknown>;
+};
+
+type AffectedSpaceRow = {
+  spaceId: string;
+  tenantId: string;
+};
+
 export function createUserSyncProcessor(
   deps: UserSyncDeps,
 ): (job: Job<UserSyncJobData>) => Promise<void> {
@@ -41,6 +55,7 @@ export function createUserSyncProcessor(
     });
 
     await writeBackDocmostUserId(deps.db, data, result.docmost_user_id);
+    await enqueueAffectedPermissionSyncJobs(deps.db, deps.permissionSyncQueue, data);
 
     console.info('user-sync: user synced to Docmost', {
       userId: data.userId,
@@ -74,6 +89,64 @@ async function writeBackDocmostUserId(
       docmostUserId,
     });
   }
+}
+
+async function enqueueAffectedPermissionSyncJobs(
+  db: DatabaseClient,
+  queue: PermissionSyncQueue | undefined,
+  data: UserSyncJobData,
+): Promise<void> {
+  if (queue === undefined) {
+    return;
+  }
+
+  const rows = await loadAffectedSyncedSpaces(db, data);
+  const uniqueSpaces = new Map<string, AffectedSpaceRow>();
+  for (const row of rows) {
+    uniqueSpaces.set(`${row.tenantId}:${row.spaceId}`, row);
+  }
+
+  await Promise.all(
+    [...uniqueSpaces.values()].map((space) =>
+      queue.add('permission.sync', {
+        spaceId: space.spaceId,
+        tenantId: space.tenantId,
+      }),
+    ),
+  );
+}
+
+async function loadAffectedSyncedSpaces(
+  db: DatabaseClient,
+  data: UserSyncJobData,
+): Promise<AffectedSpaceRow[]> {
+  return db
+    .select({
+      spaceId: spaces.id,
+      tenantId: spaces.tenant_id,
+    })
+    .from(space_permissions)
+    .innerJoin(
+      group_members,
+      and(
+        eq(space_permissions.tenant_id, group_members.tenant_id),
+        eq(space_permissions.group_id, group_members.group_id),
+      ),
+    )
+    .innerJoin(
+      spaces,
+      and(
+        eq(space_permissions.tenant_id, spaces.tenant_id),
+        eq(space_permissions.space_id, spaces.id),
+      ),
+    )
+    .where(
+      and(
+        eq(group_members.user_id, data.userId),
+        eq(group_members.tenant_id, data.tenantId),
+        isNotNull(spaces.docmost_space_id),
+      ),
+    );
 }
 
 function readJobData(data: unknown): UserSyncJobData {

--- a/apps/wiki-sync-worker/src/processors/user-sync.processor.ts
+++ b/apps/wiki-sync-worker/src/processors/user-sync.processor.ts
@@ -106,7 +106,7 @@ async function enqueueAffectedPermissionSyncJobs(
     uniqueSpaces.set(`${row.tenantId}:${row.spaceId}`, row);
   }
 
-  await Promise.all(
+  const results = await Promise.allSettled(
     [...uniqueSpaces.values()].map((space) =>
       queue.add('permission.sync', {
         spaceId: space.spaceId,
@@ -114,6 +114,12 @@ async function enqueueAffectedPermissionSyncJobs(
       }),
     ),
   );
+
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('user-sync: failed to enqueue permission-sync job', result.reason);
+    }
+  }
 }
 
 async function loadAffectedSyncedSpaces(

--- a/apps/wiki-sync-worker/src/reconciliation/permission-reconcile.ts
+++ b/apps/wiki-sync-worker/src/reconciliation/permission-reconcile.ts
@@ -26,25 +26,28 @@ type ReconcileSpaceRow = {
 export async function reconcilePermissions(
   db: DrizzleDatabase,
   bridgeClient: PermissionReconcileBridgeClient,
-): Promise<{ fixed: number; errors: number }> {
+): Promise<PermissionReconcileResult> {
   return runPermissionReconcile(db, bridgeClient, false);
 }
 
 export async function triggerFullReconcile(
   db: DrizzleDatabase,
   bridgeClient: PermissionReconcileBridgeClient,
-): Promise<{ fixed: number; errors: number }> {
+): Promise<PermissionReconcileResult> {
   return runPermissionReconcile(db, bridgeClient, true);
 }
+
+type PermissionReconcileResult = { fixed: number; errors: number; deferred: number };
 
 async function runPermissionReconcile(
   db: DatabaseClient,
   bridgeClient: PermissionReconcileBridgeClient,
   full: boolean,
-): Promise<{ fixed: number; errors: number }> {
+): Promise<PermissionReconcileResult> {
   const spacesToReconcile = await loadSyncedSpaces(db);
   let fixed = 0;
   let errors = 0;
+  let deferred = 0;
 
   for (const space of spacesToReconcile) {
     if (space.docmostSpaceId === null) {
@@ -60,6 +63,19 @@ async function runPermissionReconcile(
         console.info(`Permission sync deferred: ${expectedState.pendingDocmostUserCount} users pending Docmost sync`, {
           spaceId: space.spaceId,
           tenantId: space.tenantId,
+        });
+        deferred += 1;
+        await logPermissionAuditEvent(db, {
+          tenantId: space.tenantId,
+          spaceId: space.spaceId,
+          action: 'permission_sync_deferred',
+          metadata: {
+            pendingDocmostUserCount: expectedState.pendingDocmostUserCount,
+            spaceId: space.spaceId,
+            tenantId: space.tenantId,
+            docmostSpaceId: space.docmostSpaceId,
+            full,
+          },
         });
         continue;
       }
@@ -101,7 +117,7 @@ async function runPermissionReconcile(
     }
   }
 
-  return { fixed, errors };
+  return { fixed, errors, deferred };
 }
 
 async function loadSyncedSpaces(db: DatabaseClient): Promise<ReconcileSpaceRow[]> {

--- a/openspec/changes/post-completion-review-hardening/tasks.md
+++ b/openspec/changes/post-completion-review-hardening/tasks.md
@@ -1,0 +1,62 @@
+## 1. Auth and API Permission Hardening
+
+- [ ] 1.1 Add API-token context to the request model so global authorization can distinguish bearer JWT sessions from `cwt_` API tokens.
+- [ ] 1.2 Enforce token scopes in or before `RbacGuard`; add regression tests proving owner/admin role cannot exceed token scopes.
+- [ ] 1.2a Define and document the API token scope mapping table: ordinary REST route permission points are token scopes by default, MCP scopes remain MCP-only, and admin/upload/graphify examples are covered.
+- [x] 1.3 Update browser login/refresh/logout flow so refresh tokens are cookie-only and not present in JSON response bodies or required logout request bodies.
+- [x] 1.4 Update frontend auth client and auth controller/service tests for cookie-only refresh/logout.
+- [ ] 1.5 Fix `/api/uploads/{source_document_id}`, `/status`, and `/reprocess` authorization so service-level Space ACL lookup occurs before final permission decision.
+- [ ] 1.6 Add API tests for editor/space-admin upload detail, status, and reprocess access plus unauthorized non-disclosure behavior.
+- [ ] 1.7 Make `/api/auth/sessions` current-session marking deterministic from token/session context.
+- [ ] 1.8 Align OpenAPI and `docs/design/11_API规范.md` for API token list, browser login/refresh/logout cookie flow, any separately documented machine refresh mode, and upload reprocess contracts; add spec-parity tests or schema validation.
+
+## 2. Async Index, Docmost Sync, and Wiki Preservation
+
+- [x] 2.1 Add transactional lock or database constraint so only one `building` index snapshot can exist per `(tenant_id, space_id)`.
+- [x] 2.2 Update indexer failure handling so failed snapshots move to a non-building state and later reindex can proceed.
+- [x] 2.3 Add migration/preflight cleanup for existing duplicate `building` snapshots, rollback notes for the new constraint/lock, and same-Space concurrent reindex plus post-failure retry tests.
+- [ ] 2.4 Define the Docmost page-sync state machine and canonical persistence contract, including repo path/branch/commit metadata, wiki page version linkage, and reindex job id or invalidation marker.
+- [ ] 2.5 Replace Docmost page-sync placeholder repo commit behavior so `page.saved` and `page.deleted` enqueue or trigger reindex/invalidation before marking sync complete.
+- [ ] 2.6 Add reconciliation tests and test data for page sync commit failure, reindex enqueue failure, retry/defer behavior, and deletion invalidation.
+- [ ] 2.7 Use fallback block matching in Graphify wiki import so human-owned blocks survive block-id/heading churn.
+- [ ] 2.8 Add tests where Graphify changes heading/slug and existing human-owned blocks are preserved or converted into proposals using the fallback order `blockId -> stable heading -> content hash -> marker -> safe page-local order`.
+- [ ] 2.9 Fix bridge reconciliation pagination to avoid skipping pending events under concurrent status changes.
+- [ ] 2.10 Ensure deferred permission-sync states are retried, reconciled, or visibly pending.
+  - [ ] 2.10a In `createPermissionSyncProcessor`, throw a retriable error when `pushSpacePermissions` returns deferred so BullMQ retries with backoff; log a `permission_sync_deferred` audit event.
+  - [ ] 2.10b After user-sync processor writes back `docmost_user_id`, query all spaces the user belongs to and enqueue permission-sync jobs for each (reactive retry chain).
+  - [ ] 2.10c In `reconcilePermissions`, log `permission_sync_deferred` audit events for spaces with pending users instead of silently continuing.
+  - [ ] 2.10d Test: deferred permission sync throws retriable error (not UnrecoverableError) and writes audit event; input: space with 1 synced user + 1 unsynced user; expected: `pushPermissions` not called, error thrown, audit row with action `permission_sync_deferred`.
+  - [ ] 2.10e Test: user-sync completion enqueues permission-sync for affected spaces; input: user with memberships in 2 spaces; expected: 2 permission-sync jobs enqueued after docmost_user_id writeback.
+  - [ ] 2.10f Test: reconciliation logs deferred audit event for spaces with pending users; input: reconcile with 1 space having pending users; expected: audit row with action `permission_sync_deferred`, `errors` counter not incremented.
+  - [ ] 2.10g Test: permission sync succeeds after user becomes synced; input: space where all users now have docmost_user_id; expected: `pushPermissions` called with correct member list.
+
+## 3. Frontend Contract and UX Regression Fixes
+
+- [ ] 3.1 Extend frontend permission helpers to include `upload:create`, `upload:read`, `graphify:view`, and `graphify:run` semantics after backend permission points and API response shapes are stable.
+- [ ] 3.2 Gate upload routes/forms/actions using upload permissions and add no-permission tests.
+- [ ] 3.3 Gate Graphify list/detail actions using graphify permissions and add no-permission tests.
+- [ ] 3.4 Fix graph explorer empty-state logic so `node_count > 0` shows graph UI even when no run is currently active.
+- [ ] 3.5 Add graph explorer regression test for `node_count > 0` regardless of active Graphify run presence; update OpenAPI if the UI depends on a run-presence field.
+- [ ] 3.6 Protect upload detail status loading with a request sequence or abort mechanism so stale responses are ignored.
+- [ ] 3.7 Add upload drawer race test for out-of-order status responses.
+- [ ] 3.8 Validate Graphify run detail route Space against `run.space_id`; add mismatch test.
+
+## 4. Ops, Container, and CI Evidence Hardening
+
+- [ ] 4.1 Align `docs/ops/docker-compose.skeleton.yml`, `docs/ops/env.example`, and runtime env names for URL fetcher egress configuration.
+- [ ] 4.2 Implement or remove documented `SSRF_BLOCKED_CIDRS` support; add tests for configurable blocked ranges if retained.
+- [ ] 4.3 Add egress/proxy smoke verification proving proxy-required mode fails closed when proxy is missing/unreachable and URL fetcher cannot bypass the intended outbound route.
+- [ ] 4.4 Add live-stack CI smoke tests for real MinIO upload/read and Redis/job or worker heartbeat connectivity; publish the workflow name and CI run evidence.
+- [ ] 4.5 Harden production Dockerfiles/compose so API and workers run non-root with compatible `read_only`, `cap_drop`, and `no-new-privileges` settings.
+- [ ] 4.6 Replace copy-pasteable weak production credentials with fail-fast placeholders and document secret generation.
+- [ ] 4.7 Extend CI validation to `docker compose -f docker-compose.prod.yml config --quiet` and root multi-target Dockerfile production targets.
+- [ ] 4.8 Pin `latest` image references in production compose by version or digest, or add explicit drift-risk exceptions with owner and review cadence.
+
+## 5. Final Validation and Rollout
+
+- [ ] 5.1 Run `pnpm -r --if-present typecheck`.
+- [ ] 5.2 Run `pnpm -r --if-present lint`.
+- [ ] 5.3 Run targeted JS/TS tests for auth, API tokens, uploads, indexer, wiki-sync, wiki-core, frontend upload/graph/Graphify, and CI smoke helpers; record package commands such as `pnpm --filter <api-package> test`, `pnpm --filter <web-package> test`, and any package-specific smoke commands in the implementation issue or PR.
+- [ ] 5.4 Run Python worker tests through each worker virtual environment, including `apps/ingestion-worker/.venv/bin/python -m pytest apps/ingestion-worker/tests`, `apps/graphify-worker/.venv/bin/python -m pytest apps/graphify-worker/tests`, and `apps/url-fetcher-worker/.venv/bin/python -m pytest apps/url-fetcher-worker/tests`.
+- [ ] 5.5 Run `openspec status --change post-completion-review-hardening` and resolve any incomplete artifacts.
+- [ ] 5.6 Document migration and compatibility notes inside the relevant implementation PRs for API token scopes, cookie-only refresh/logout, index snapshot cleanup, and deployment hardening, then summarize them in the final rollout notes.


### PR DESCRIPTION
## Summary
- Permission sync processor now throws a retriable error (not UnrecoverableError) when users are pending Docmost sync, enabling BullMQ automatic retry with exponential backoff
- User-sync processor reactively enqueues permission-sync jobs for all affected spaces after writing back `docmost_user_id`, using Promise.allSettled for partial-failure resilience
- Permission reconciliation logs `permission_sync_deferred` audit events instead of silently skipping spaces with pending users
- All deferred states are now observable via audit logs

Closes #295

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `663d39305599ef89a1f79e17b2a7365f152bdd20`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/313#issuecomment-4436791631) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/313#issuecomment-4436791777) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/313#issuecomment-4436791985) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/313#issuecomment-4436792702)
- Key findings addressed: Promise.all replaced with Promise.allSettled in user-sync permission enqueue to prevent cascading failures; unindexed lookup and per-retry audit rows accepted as wontfix per design scope

## Test plan
- [x] Deferred permission sync throws retriable error and writes audit event (2.10d)
- [x] User-sync completion enqueues permission-sync for affected spaces (2.10e)
- [x] Reconciliation logs deferred audit event for spaces with pending users (2.10f)
- [x] Permission sync succeeds after all users are synced (2.10g)
- [x] TypeScript passes (`npx tsc --noEmit`)
- [x] All 1247 tests pass, 199 test files pass