### PR TITLE
feat(web): add permission gates for upload and Graphify flows (#296)

### DIFF
--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GraphifyRun } from '../lib/graphifyApi.js';
 import GraphifyRunDetailPage from '../pages/GraphifyRunDetailPage.js';
 import GraphifyRunsPage from '../pages/GraphifyRunsPage.js';
@@ -15,6 +15,10 @@ type PostMock = (path: string, body?: unknown) => Promise<unknown>;
 const apiMocks = vi.hoisted(() => ({
   getWrapped: vi.fn<GetWrappedMock>(),
   post: vi.fn<PostMock>(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
 }));
 
 vi.mock('../lib/api.js', () => {
@@ -41,12 +45,54 @@ vi.mock('../lib/api.js', () => {
   };
 });
 
+vi.mock('../lib/auth.js', () => ({
+  useAuth: authMocks.useAuth,
+}));
+
+beforeEach(() => {
+  authMocks.useAuth.mockReturnValue(buildAuthValue());
+});
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
 describe('GraphifyRunsPage', () => {
+  it('shows no permission and skips list API requests when graphify view is denied', async () => {
+    authMocks.useAuth.mockReturnValue(
+      buildAuthValue({
+        hasSpacePermission: (_spaceId, _permission) => false,
+      }),
+    );
+
+    renderWithRouter(<GraphifyRunsPage />, '/spaces/space-1/graphify');
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(screen.getByText('viewer@example.com does not have Graphify access for this space.')).toBeInTheDocument();
+    expect(screen.queryByText('Graphify Runs')).not.toBeInTheDocument();
+    expect(apiMocks.getWrapped).not.toHaveBeenCalled();
+  });
+
+  it('shows the runs list without New Run controls when graphify run is denied', async () => {
+    authMocks.useAuth.mockReturnValue(
+      buildAuthValue({
+        hasSpacePermission: (_spaceId, permission) => permission === 'graphify:view',
+      }),
+    );
+    apiMocks.getWrapped.mockResolvedValue({
+      data: [buildRun({ run_id: 'run-succeeded', status: 'succeeded' })],
+      meta: { pagination: { page: 1, per_page: 20, total: 1, has_next: false } },
+    });
+
+    renderWithRouter(<GraphifyRunsPage />, '/spaces/space-1/graphify');
+
+    expect(await screen.findByText('Graphify Runs')).toBeInTheDocument();
+    expect(await screen.findByText('run-succeeded')).toBeInTheDocument();
+    expect(screen.queryByText('New Run')).not.toBeInTheDocument();
+    expect(screen.queryByText('New Graphify Run')).not.toBeInTheDocument();
+  });
+
   it('renders run list with antd Table and status tags', async () => {
     apiMocks.getWrapped.mockResolvedValue({
       data: [
@@ -160,6 +206,19 @@ describe('formatRunLabel', () => {
     expect(label).toEqual({ primary: 'Plan.pdf, Overview', secondary: 'run-1' });
   });
 });
+
+type AuthValue = {
+  user: { email: string };
+  hasSpacePermission: (spaceId: string, permission: string) => boolean;
+};
+
+function buildAuthValue(overrides: Partial<AuthValue> = {}): AuthValue {
+  return {
+    user: { email: 'viewer@example.com' },
+    hasSpacePermission: () => true,
+    ...overrides,
+  };
+}
 
 async function renderDetailStatus(status: GraphifyRun['status']): Promise<void> {
   apiMocks.getWrapped.mockImplementation((path: string) => {

--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -62,7 +62,7 @@ describe('GraphifyRunsPage', () => {
   it('shows no permission and skips list API requests when graphify view is denied', async () => {
     authMocks.useAuth.mockReturnValue(
       buildAuthValue({
-        hasSpacePermission: (_spaceId, _permission) => false,
+        hasSpacePermission: () => false,
       }),
     );
 
@@ -155,7 +155,7 @@ describe('GraphifyRunDetailPage', () => {
   it('shows no permission and skips detail API requests when graphify view is denied', async () => {
     authMocks.useAuth.mockReturnValue(
       buildAuthValue({
-        hasSpacePermission: (_spaceId, _permission) => false,
+        hasSpacePermission: () => false,
       }),
     );
 

--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -152,6 +152,40 @@ describe('GraphifyRunsPage', () => {
 });
 
 describe('GraphifyRunDetailPage', () => {
+  it('shows no permission and skips detail API requests when graphify view is denied', async () => {
+    authMocks.useAuth.mockReturnValue(
+      buildAuthValue({
+        hasSpacePermission: (_spaceId, _permission) => false,
+      }),
+    );
+
+    renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-1/graphify/run-1');
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(screen.getByText('viewer@example.com does not have Graphify access for this space.')).toBeInTheDocument();
+    expect(screen.queryByText('Graphify Run Detail')).not.toBeInTheDocument();
+    expect(apiMocks.getWrapped).not.toHaveBeenCalled();
+  });
+
+  it('hides cancel and retry actions on detail when graphify run is denied', async () => {
+    authMocks.useAuth.mockReturnValue(
+      buildAuthValue({
+        hasSpacePermission: (_spaceId, permission) => permission === 'graphify:view',
+      }),
+    );
+
+    await renderDetailStatus('running');
+    expect(screen.queryByText('Cancel Run')).not.toBeInTheDocument();
+    expect(screen.queryByText('Retry Run')).not.toBeInTheDocument();
+
+    cleanup();
+    apiMocks.getWrapped.mockReset();
+
+    await renderDetailStatus('failed');
+    expect(screen.queryByText('Cancel Run')).not.toBeInTheDocument();
+    expect(screen.queryByText('Retry Run')).not.toBeInTheDocument();
+  });
+
   it('shows cancel button for running status', async () => {
     await renderDetailStatus('running');
     expect(await screen.findByText('Cancel Run')).toBeInTheDocument();

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -5,6 +5,7 @@ import type { ComponentProps } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from '../i18n';
+import * as authModule from '../lib/auth';
 import { AuthProvider, type AuthUser } from '../lib/auth';
 import FileUploadZone from '../pages/uploads/FileUploadZone';
 import UploadCenter from '../pages/uploads/UploadCenter';
@@ -15,6 +16,7 @@ import type { UploadItem, UploadResponse, UploadStatus } from '../pages/uploads/
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -242,6 +244,39 @@ describe('UploadCenter', () => {
     });
   });
 
+  it('lets viewers read the upload list without rendering upload forms', async () => {
+    const fetchMock = stubUploadListApi();
+
+    renderUploadCenter(VIEWER_USER);
+
+    expect(await screen.findByText('roadmap.pdf')).toBeInTheDocument();
+    expect(screen.getByText('Space Documents')).toBeInTheDocument();
+    expect(screen.queryByText('Files')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Add URL/i })).not.toBeInTheDocument();
+    expect(getRequestUrls(fetchMock)).toContain('/api/spaces/space-1/uploads?page=1&per_page=20&sort=-created_at');
+  });
+
+  it('shows no permission and skips upload API requests when upload read is denied', async () => {
+    const fetchMock = stubUploadListApi();
+    vi.spyOn(authModule, 'useAuth').mockReturnValue({
+      user: NO_UPLOAD_PERMISSION_USER,
+      accessToken: 'test-token',
+      login: vi.fn(),
+      logout: vi.fn(),
+      refresh: vi.fn(),
+      isAuthenticated: true,
+      isAdmin: false,
+      hasSpacePermission: (_spaceId, _permission) => false,
+    });
+
+    renderUploadCenter(NO_UPLOAD_PERMISSION_USER);
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(screen.getByText('blocked@example.com does not have upload access for this space.')).toBeInTheDocument();
+    expect(screen.queryByText('Space Documents')).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('ignores stale upload drawer status responses after selection changes', async () => {
     const statusRequests = stubUploadDrawerRaceApi();
 
@@ -339,6 +374,18 @@ const TEST_USER: AuthUser = {
   spaces: [{ id: 'space-1', name: 'Space One', role: 'editor' }],
 };
 
+const VIEWER_USER: AuthUser = {
+  ...TEST_USER,
+  email: 'space-viewer@example.com',
+  spaces: [{ id: 'space-1', name: 'Space One', role: 'viewer' }],
+};
+
+const NO_UPLOAD_PERMISSION_USER: AuthUser = {
+  ...TEST_USER,
+  email: 'blocked@example.com',
+  spaces: [],
+};
+
 function renderUploadList(overrides: Partial<ComponentProps<typeof UploadList>> = {}) {
   const props: ComponentProps<typeof UploadList> = {
     uploads: [],
@@ -360,10 +407,10 @@ function renderUploadList(overrides: Partial<ComponentProps<typeof UploadList>> 
   return render(<UploadList {...props} />);
 }
 
-function renderUploadCenter() {
+function renderUploadCenter(user: AuthUser = TEST_USER) {
   return render(
     <MemoryRouter initialEntries={['/spaces/space-1/uploads']}>
-      <AuthProvider initialSession={{ user: TEST_USER, accessToken: 'test-token', expiresIn: 3600 }}>
+      <AuthProvider initialSession={{ user, accessToken: 'test-token', expiresIn: 3600 }}>
         <Routes>
           <Route path="/spaces/:spaceId/uploads" element={<UploadCenter />} />
           <Route path="/login" element={<h1>Login</h1>} />

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -256,6 +256,26 @@ describe('UploadCenter', () => {
     expect(getRequestUrls(fetchMock)).toContain('/api/spaces/space-1/uploads?page=1&per_page=20&sort=-created_at');
   });
 
+  it('hides reprocess for read-only viewers on failed uploads', async () => {
+    const fetchMock = stubUploadListApi(
+      buildUpload({
+        id: 'source-failed',
+        filename: 'failed.pdf',
+        status: 'parse_failed',
+        mime_type: 'application/pdf',
+      }),
+    );
+
+    renderUploadCenter(VIEWER_USER);
+
+    expect(await screen.findByText('failed.pdf')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+
+    await waitFor(() => expect(screen.getAllByText('failed.pdf').length).toBeGreaterThan(1));
+    expect(screen.queryByRole('button', { name: 'Reprocess' })).not.toBeInTheDocument();
+    expect(getRequestUrls(fetchMock)).not.toContain('/api/uploads/source-failed/reprocess');
+  });
+
   it('shows no permission and skips upload API requests when upload read is denied', async () => {
     const fetchMock = stubUploadListApi();
     vi.spyOn(authModule, 'useAuth').mockReturnValue({
@@ -326,6 +346,7 @@ describe('UploadDetail', () => {
         open
         upload={buildUpload({ status: 'parse_failed' })}
         status={buildStatus({ status: 'parse_failed', progress_percent: 65 })}
+        canReprocess
         onClose={vi.fn()}
         onReprocessed={onReprocessed}
       />,
@@ -344,12 +365,31 @@ describe('UploadDetail', () => {
     expect(fetchMock.mock.calls[0]?.[1]?.method).toBe('POST');
   });
 
+  it('hides reprocess for failed uploads when reprocess is denied', () => {
+    const fetchMock = stubReprocessApi();
+
+    render(
+      <UploadDetail
+        open
+        upload={buildUpload({ status: 'parse_failed' })}
+        status={buildStatus({ status: 'parse_failed', progress_percent: 65 })}
+        canReprocess={false}
+        onClose={vi.fn()}
+        onReprocessed={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Reprocess' })).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('hides reprocess for completed uploads', () => {
     render(
       <UploadDetail
         open
         upload={buildUpload({ status: 'parsed' })}
         status={buildStatus({ status: 'parsed', progress_percent: 100 })}
+        canReprocess
         onClose={vi.fn()}
         onReprocessed={vi.fn()}
       />,
@@ -492,19 +532,17 @@ function stubUrlUploadApi() {
   return fetchMock;
 }
 
-function stubUploadListApi() {
+function stubUploadListApi(upload: UploadItem = buildUpload({
+  id: 'source-roadmap',
+  filename: 'roadmap.pdf',
+  status: 'parsed',
+  mime_type: 'application/pdf',
+})) {
   const fetchMock = vi.fn<typeof fetch>((input, init) => {
     if (getRequestPath(input) === '/api/spaces/space-1/uploads' && init?.method === 'GET') {
       return Promise.resolve(
         jsonResponse({
-          data: [
-            buildUpload({
-              id: 'source-roadmap',
-              filename: 'roadmap.pdf',
-              status: 'parsed',
-              mime_type: 'application/pdf',
-            }),
-          ],
+          data: [upload],
           meta: {
             pagination: {
               page: 1,

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -274,7 +274,7 @@ describe('UploadCenter', () => {
     await waitFor(() => expect(screen.getAllByText('failed.pdf').length).toBeGreaterThan(1));
     expect(screen.queryByRole('button', { name: 'Reprocess' })).not.toBeInTheDocument();
     expect(getRequestUrls(fetchMock)).not.toContain('/api/uploads/source-failed/reprocess');
-  });
+  }, 30_000);
 
   it('shows no permission and skips upload API requests when upload read is denied', async () => {
     const fetchMock = stubUploadListApi();

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -286,7 +286,7 @@ describe('UploadCenter', () => {
       refresh: vi.fn(),
       isAuthenticated: true,
       isAdmin: false,
-      hasSpacePermission: (_spaceId, _permission) => false,
+      hasSpacePermission: () => false,
     });
 
     renderUploadCenter(NO_UPLOAD_PERMISSION_USER);

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -184,9 +184,33 @@ export function isAdminRole(role: string): boolean {
 }
 
 const SPACE_ROLE_PERMISSIONS: Record<SpaceRole, readonly string[]> = {
-  viewer: ['space:view', 'chat:use'],
-  editor: ['space:view', 'space:edit', 'chat:use', 'wiki:publish'],
-  admin: ['space:view', 'space:edit', 'space:admin', 'chat:use', 'wiki:publish', 'wiki:rollback'],
+  viewer: ['space:read', 'space:view', 'upload:read', 'chat:use', 'model:use'],
+  editor: [
+    'space:read',
+    'space:view',
+    'space:edit',
+    'upload:create',
+    'upload:read',
+    'wiki:publish',
+    'graphify:run',
+    'graphify:view',
+    'chat:use',
+    'model:use',
+  ],
+  admin: [
+    'space:read',
+    'space:view',
+    'space:edit',
+    'space:admin',
+    'upload:create',
+    'upload:read',
+    'wiki:publish',
+    'wiki:rollback',
+    'graphify:run',
+    'graphify:view',
+    'chat:use',
+    'model:use',
+  ],
 };
 
 function checkSpacePermission(user: AuthUser | null, spaceId: string, permission: string): boolean {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -521,6 +521,10 @@
       "title": "Documents",
       "description": "Browse source documents in this space, add files or URLs, and track processing status."
     },
+    "forbidden": {
+      "title": "Access Denied",
+      "description": "{{email}} does not have upload access for this space."
+    },
     "loading": "Loading documents...",
     "spaceSelector": "Target space",
     "spaceSelectorLabel": "Upload to space",
@@ -788,6 +792,10 @@
       "loading": "Loading graphify runs...",
       "emptyFilter": "No graphify runs match the current filters.",
       "newRun": "New Run",
+      "forbidden": {
+        "title": "Access Denied",
+        "description": "{{email}} does not have Graphify access for this space."
+      },
       "columns": {
         "run": "Run",
         "status": "Status",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -521,6 +521,10 @@
       "title": "文档",
       "description": "浏览此空间的来源文档，添加文件或 URL，并跟踪处理状态。"
     },
+    "forbidden": {
+      "title": "无权访问",
+      "description": "{{email}} 没有此空间的上传权限。"
+    },
     "loading": "加载文档中...",
     "spaceSelector": "目标空间",
     "spaceSelectorLabel": "上传到空间",
@@ -788,6 +792,10 @@
       "loading": "加载图谱化运行中...",
       "emptyFilter": "没有图谱化运行匹配当前筛选条件。",
       "newRun": "新建运行",
+      "forbidden": {
+        "title": "无权访问",
+        "description": "{{email}} 没有此空间的图谱化权限。"
+      },
       "columns": {
         "run": "运行",
         "status": "状态",

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftOutlined } from '@ant-design/icons';
-import { Alert, Button, Card, Descriptions, Popconfirm, Progress, Spin, Statistic, Typography } from 'antd';
+import { Alert, Button, Card, Descriptions, Popconfirm, Progress, Result, Spin, Statistic, Typography } from 'antd';
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
@@ -24,6 +24,7 @@ import {
   isGraphifyRunActive,
   isQuarantined,
 } from './graphifyUi';
+import { useAuth } from '../lib/auth';
 import NotFound from './NotFound';
 
 const GRAPHIFY_REFRESH_INTERVAL_MS = 5_000;
@@ -32,6 +33,7 @@ export default function GraphifyRunDetailPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { spaceId = '', runId = '' } = useParams();
+  const { hasSpacePermission, user } = useAuth();
   const [run, setRun] = useState<GraphifyRun | null>(null);
   const [report, setReport] = useState<GraphifyReport | null>(null);
   const [summary, setSummary] = useState<GraphifySummary | null>(null);
@@ -39,10 +41,12 @@ export default function GraphifyRunDetailPage() {
   const [isCancelling, setIsCancelling] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const canViewGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:view');
+  const canRunGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:run');
 
   const loadRunDetail = useCallback(
     async (background = false) => {
-      if (runId.length === 0) {
+      if (runId.length === 0 || !canViewGraphify) {
         setRun(null);
         setReport(null);
         setSummary(null);
@@ -80,7 +84,7 @@ export default function GraphifyRunDetailPage() {
         }
       }
     },
-    [runId],
+    [canViewGraphify, runId],
   );
 
   useEffect(() => {
@@ -103,6 +107,16 @@ export default function GraphifyRunDetailPage() {
 
   if (spaceId.length === 0 || runId.length === 0) {
     return <NotFound />;
+  }
+
+  if (!canViewGraphify) {
+    return (
+      <Result
+        status="403"
+        title={t('graphify.space.forbidden.title')}
+        subTitle={t('graphify.space.forbidden.description', { email: user?.email ?? '' })}
+      />
+    );
   }
 
   async function cancelRun(): Promise<void> {
@@ -138,8 +152,8 @@ export default function GraphifyRunDetailPage() {
     }
   }
 
-  const showCancelButton = run !== null && isGraphifyRunActive(run);
-  const showRetryButton = run !== null && run.status === 'failed';
+  const showCancelButton = canRunGraphify && run !== null && isGraphifyRunActive(run);
+  const showRetryButton = canRunGraphify && run !== null && run.status === 'failed';
 
   return (
     <>

--- a/apps/web/src/pages/GraphifyRunsPage.tsx
+++ b/apps/web/src/pages/GraphifyRunsPage.tsx
@@ -1,5 +1,5 @@
 import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
-import { Alert, Button, Popconfirm, Select, Space, Table, Typography } from 'antd';
+import { Alert, Button, Popconfirm, Result, Select, Space, Table, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,6 +24,7 @@ import {
   formatRunDurationWithT,
   isGraphifyRunActive,
 } from './graphifyUi';
+import { useAuth } from '../lib/auth';
 import NotFound from './NotFound';
 
 const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
@@ -40,6 +41,7 @@ export default function GraphifyRunsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { spaceId = '' } = useParams();
+  const { hasSpacePermission, user } = useAuth();
   const [runs, setRuns] = useState<GraphifyRun[]>([]);
   const [status, setStatus] = useState('');
   const [triggerType, setTriggerType] = useState('');
@@ -51,10 +53,12 @@ export default function GraphifyRunsPage() {
   const [retryingRunId, setRetryingRunId] = useState<string | null>(null);
   const [isNewRunOpen, setIsNewRunOpen] = useState(false);
   const [isCreatingRun, setIsCreatingRun] = useState(false);
+  const canViewGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:view');
+  const canRunGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:run');
 
   const loadRuns = useCallback(
     async (background = false) => {
-      if (spaceId.length === 0) {
+      if (spaceId.length === 0 || !canViewGraphify) {
         setRuns([]);
         setPagination(DEFAULT_PAGINATION);
         setIsLoading(false);
@@ -92,7 +96,7 @@ export default function GraphifyRunsPage() {
         }
       }
     },
-    [page, perPage, spaceId, status, triggerType],
+    [canViewGraphify, page, perPage, spaceId, status, triggerType],
   );
 
   useEffect(() => {
@@ -103,7 +107,7 @@ export default function GraphifyRunsPage() {
     setPage(1);
   }, [spaceId]);
 
-  const shouldPoll = runs.some(isGraphifyRunActive) || status === 'pending' || status === 'running';
+  const shouldPoll = canViewGraphify && (runs.some(isGraphifyRunActive) || status === 'pending' || status === 'running');
 
   useEffect(() => {
     if (!shouldPoll) {
@@ -121,6 +125,16 @@ export default function GraphifyRunsPage() {
 
   if (spaceId.length === 0) {
     return <NotFound />;
+  }
+
+  if (!canViewGraphify) {
+    return (
+      <Result
+        status="403"
+        title={t('graphify.space.forbidden.title')}
+        subTitle={t('graphify.space.forbidden.description', { email: user?.email ?? '' })}
+      />
+    );
   }
 
   async function createRun(params: CreateGraphifyRunParams): Promise<void> {
@@ -213,6 +227,7 @@ export default function GraphifyRunsPage() {
       title: t('graphify.space.columns.actions'),
       key: 'actions',
       render: (_: unknown, run: GraphifyRun) => {
+        if (!canRunGraphify) return null;
         if (run.status !== 'failed') return null;
         return (
           <Popconfirm
@@ -244,9 +259,11 @@ export default function GraphifyRunsPage() {
           <Button icon={<ReloadOutlined />} onClick={() => { void loadRuns(); }}>
             {t('common.action.refresh')}
           </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsNewRunOpen(true)}>
-            {t('graphify.space.newRun')}
-          </Button>
+          {canRunGraphify && (
+            <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsNewRunOpen(true)}>
+              {t('graphify.space.newRun')}
+            </Button>
+          )}
         </Space>
       </div>
 
@@ -294,7 +311,7 @@ export default function GraphifyRunsPage() {
         size="middle"
       />
 
-      {isNewRunOpen && (
+      {canRunGraphify && isNewRunOpen && (
         <NewRunDialog
           isSubmitting={isCreatingRun}
           onClose={() => setIsNewRunOpen(false)}

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -336,6 +336,7 @@ export default function UploadCenter() {
             open={selectedUpload !== null}
             upload={selectedUpload}
             status={selectedStatus}
+            canReprocess={canCreateUploads}
             onClose={() => {
               selectionSeqRef.current++;
               selectedUploadIdRef.current = null;

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -1,5 +1,5 @@
 import { ReloadOutlined } from '@ant-design/icons';
-import { Alert, Button, Select, Spin, Typography, message } from 'antd';
+import { Alert, Button, Result, Select, Spin, Typography, message } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router';
@@ -32,7 +32,7 @@ const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
 export default function UploadCenter() {
   const { t } = useTranslation();
   const { spaceId = '' } = useParams();
-  const { accessToken, isAuthenticated, user } = useAuth();
+  const { accessToken, hasSpacePermission, isAuthenticated, user } = useAuth();
   const [uploads, setUploads] = useState<UploadItem[]>([]);
   const [page, setPage] = useState(DEFAULT_PAGINATION.page);
   const [statusFilter, setStatusFilter] = useState('');
@@ -49,10 +49,12 @@ export default function UploadCenter() {
   const requestSeqRef = useRef(0);
   const selectionSeqRef = useRef(0);
   const selectedUploadIdRef = useRef<string | null>(null);
+  const canReadUploads = uploadSpaceId.length > 0 && hasSpacePermission(uploadSpaceId, 'upload:read');
+  const canCreateUploads = uploadSpaceId.length > 0 && hasSpacePermission(uploadSpaceId, 'upload:create');
 
   const loadUploads = useCallback(
     async (background = false) => {
-      if (uploadSpaceId.length === 0) {
+      if (uploadSpaceId.length === 0 || !canReadUploads) {
         setUploads([]);
         setPagination(DEFAULT_PAGINATION);
         setIsLoading(false);
@@ -98,7 +100,7 @@ export default function UploadCenter() {
         }
       }
     },
-    [page, searchTerm, sortOrder, sourceTypeFilter, statusFilter, uploadSpaceId],
+    [canReadUploads, page, searchTerm, sortOrder, sourceTypeFilter, statusFilter, uploadSpaceId],
   );
 
   useEffect(() => {
@@ -153,7 +155,7 @@ export default function UploadCenter() {
   }, []);
 
   useUploadPolling({
-    uploads,
+    uploads: canReadUploads ? uploads : [],
     onStatuses: mergeStatuses,
     onError: (err) => setError(getErrorMessage(err)),
   });
@@ -238,7 +240,7 @@ export default function UploadCenter() {
           <Typography.Title level={4} style={{ margin: 0 }}>{t('upload.browser.title')}</Typography.Title>
           <Typography.Text type="secondary">{t('upload.browser.description')}</Typography.Text>
         </div>
-        <Button icon={<ReloadOutlined />} onClick={() => { void loadUploads(); }}>
+        <Button icon={<ReloadOutlined />} disabled={!canReadUploads} onClick={() => { void loadUploads(); }}>
           {t('common.action.refresh')}
         </Button>
       </div>
@@ -255,96 +257,108 @@ export default function UploadCenter() {
         />
       </div>
 
-      {error !== null && (
-        <Alert message={error} type="error" showIcon closable style={{ marginBottom: 16 }} onClose={() => setError(null)} />
-      )}
-
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16, ...(uploadSpaceId.length === 0 ? { opacity: 0.5, pointerEvents: 'none' } : {}) }}>
-        <FileUploadZone
-          spaceId={uploadSpaceId}
-          accessToken={accessToken}
-          onUploaded={(response, file) =>
-            addOptimisticUpload(response, {
-              filename: file.name,
-              sourceType: 'upload',
-              sizeBytes: file.size,
-            })
-          }
+      {!canReadUploads ? (
+        <Result
+          status="403"
+          title={t('upload.forbidden.title')}
+          subTitle={t('upload.forbidden.description', { email: user?.email ?? '' })}
         />
-        <UrlUploadForm
-          spaceId={uploadSpaceId}
-          onUploaded={(response, url) =>
-            addOptimisticUpload(response, {
-              filename: url,
-              sourceType: 'url',
-              sizeBytes: null,
-            })
-          }
-        />
-      </div>
-
-      {isLoading ? (
-        <Spin tip={t('upload.loading')}><div style={{ minHeight: 200 }} /></Spin>
       ) : (
-        <UploadList
-          uploads={uploads}
-          page={pagination.page}
-          total={pagination.total}
-          statusFilter={statusFilter}
-          sourceTypeFilter={sourceTypeFilter}
-          searchTerm={searchInput}
-          sortOrder={sortOrder}
-          onStatusFilterChange={(nextStatus) => {
-            setStatusFilter(normalizeUploadStatusFilter(nextStatus));
-            setPage(1);
-          }}
-          onSourceTypeFilterChange={(nextSourceType) => {
-            setSourceTypeFilter(normalizeUploadSourceTypeFilter(nextSourceType));
-            setPage(1);
-          }}
-          onSearchTermChange={(nextSearchInput) => {
-            setSearchInput(nextSearchInput);
-          }}
-          onSortOrderChange={(nextSortOrder) => {
-            setSortOrder(normalizeUploadSort(nextSortOrder));
-            setPage(1);
-          }}
-          onPageChange={setPage}
-          onSelectUpload={(upload) => {
-            const selectionSeq = ++selectionSeqRef.current;
-            selectedUploadIdRef.current = upload.id;
-            setSelectedUploadId(upload.id);
-            setSelectedStatus(null);
-            void loadUploadStatus(upload.id, selectionSeq);
-          }}
-        />
-      )}
+        <>
+          {error !== null && (
+            <Alert message={error} type="error" showIcon closable style={{ marginBottom: 16 }} onClose={() => setError(null)} />
+          )}
 
-      <UploadDetail
-        open={selectedUpload !== null}
-        upload={selectedUpload}
-        status={selectedStatus}
-        onClose={() => {
-          selectionSeqRef.current++;
-          selectedUploadIdRef.current = null;
-          setSelectedUploadId(null);
-          setSelectedStatus(null);
-        }}
-        onReprocessed={(response) => {
-          mergeStatuses([
-            {
-              source_document_id: response.source_document_id,
-              status: response.status,
-              job_id: response.job_id,
-              job_status: null,
-              progress_percent: null,
-              error_json: null,
-            },
-          ]);
-          void loadUploads(true);
-          void loadUploadStatus(response.source_document_id);
-        }}
-      />
+          {canCreateUploads && (
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16, ...(uploadSpaceId.length === 0 ? { opacity: 0.5, pointerEvents: 'none' } : {}) }}>
+              <FileUploadZone
+                spaceId={uploadSpaceId}
+                accessToken={accessToken}
+                onUploaded={(response, file) =>
+                  addOptimisticUpload(response, {
+                    filename: file.name,
+                    sourceType: 'upload',
+                    sizeBytes: file.size,
+                  })
+                }
+              />
+              <UrlUploadForm
+                spaceId={uploadSpaceId}
+                onUploaded={(response, url) =>
+                  addOptimisticUpload(response, {
+                    filename: url,
+                    sourceType: 'url',
+                    sizeBytes: null,
+                  })
+                }
+              />
+            </div>
+          )}
+
+          {isLoading ? (
+            <Spin tip={t('upload.loading')}><div style={{ minHeight: 200 }} /></Spin>
+          ) : (
+            <UploadList
+              uploads={uploads}
+              page={pagination.page}
+              total={pagination.total}
+              statusFilter={statusFilter}
+              sourceTypeFilter={sourceTypeFilter}
+              searchTerm={searchInput}
+              sortOrder={sortOrder}
+              onStatusFilterChange={(nextStatus) => {
+                setStatusFilter(normalizeUploadStatusFilter(nextStatus));
+                setPage(1);
+              }}
+              onSourceTypeFilterChange={(nextSourceType) => {
+                setSourceTypeFilter(normalizeUploadSourceTypeFilter(nextSourceType));
+                setPage(1);
+              }}
+              onSearchTermChange={(nextSearchInput) => {
+                setSearchInput(nextSearchInput);
+              }}
+              onSortOrderChange={(nextSortOrder) => {
+                setSortOrder(normalizeUploadSort(nextSortOrder));
+                setPage(1);
+              }}
+              onPageChange={setPage}
+              onSelectUpload={(upload) => {
+                const selectionSeq = ++selectionSeqRef.current;
+                selectedUploadIdRef.current = upload.id;
+                setSelectedUploadId(upload.id);
+                setSelectedStatus(null);
+                void loadUploadStatus(upload.id, selectionSeq);
+              }}
+            />
+          )}
+
+          <UploadDetail
+            open={selectedUpload !== null}
+            upload={selectedUpload}
+            status={selectedStatus}
+            onClose={() => {
+              selectionSeqRef.current++;
+              selectedUploadIdRef.current = null;
+              setSelectedUploadId(null);
+              setSelectedStatus(null);
+            }}
+            onReprocessed={(response) => {
+              mergeStatuses([
+                {
+                  source_document_id: response.source_document_id,
+                  status: response.status,
+                  job_id: response.job_id,
+                  job_status: null,
+                  progress_percent: null,
+                  error_json: null,
+                },
+              ]);
+              void loadUploads(true);
+              void loadUploadStatus(response.source_document_id);
+            }}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/apps/web/src/pages/uploads/UploadDetail.tsx
+++ b/apps/web/src/pages/uploads/UploadDetail.tsx
@@ -18,11 +18,12 @@ type UploadDetailProps = {
   open: boolean;
   upload: UploadItem | null;
   status: UploadStatus | null;
+  canReprocess: boolean;
   onClose: () => void;
   onReprocessed: (response: UploadResponse) => void;
 };
 
-export default function UploadDetail({ open, upload, status, onClose, onReprocessed }: UploadDetailProps) {
+export default function UploadDetail({ open, upload, status, canReprocess, onClose, onReprocessed }: UploadDetailProps) {
   const { t } = useTranslation();
   const [isReprocessing, setIsReprocessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -38,6 +39,8 @@ export default function UploadDetail({ open, upload, status, onClose, onReproces
 
   async function reprocessUpload(): Promise<void> {
     if (upload === null) return;
+    if (!canReprocess) return;
+
     setIsReprocessing(true);
     setError(null);
 
@@ -111,7 +114,7 @@ export default function UploadDetail({ open, upload, status, onClose, onReproces
         {JSON.stringify(upload.metadata_json ?? {}, null, 2)}
       </pre>
 
-      {activeStatus === 'parse_failed' && (
+      {activeStatus === 'parse_failed' && canReprocess && (
         <div style={{ marginTop: 16, textAlign: 'right' }}>
           <Button
             type="primary"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,8 @@ export default defineConfig({
       'tests/**/*.test.ts',
     ],
     exclude: runsExplicitWebTest ? configDefaults.exclude : [...configDefaults.exclude, 'apps/web/**'],
+    environment: runsExplicitWebTest ? 'jsdom' : 'node',
+    setupFiles: runsExplicitWebTest ? ['apps/web/src/__tests__/setup.ts'] : [],
     passWithNoTests: true,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- Frontend now checks `upload:read`/`upload:create` before rendering upload list and forms
- `graphify:view`/`graphify:run` gates applied to runs list and "New Run" action
- UploadDetail Reprocess button gated by `upload:create`
- No-permission states show localized messages (en/zh-CN) and suppress API requests
- Negative-permission tests cover upload create denied, reprocess hidden, and Graphify view/run denied

Closes #296

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `2beb40c92c2a48b4235f54526e06b436f1cdd6dc`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/314#issuecomment-4437042219) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/314#issuecomment-4437042306) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/314#issuecomment-4437042470) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/314#issuecomment-4437042620)
- Key findings addressed: UploadDetail Reprocess gated with upload:create prop; graphify detail permission tests added; lint errors fixed

## Test plan
- [x] Upload list hidden when user lacks `upload:read` permission
- [x] Upload forms hidden when user lacks `upload:create` permission
- [x] Reprocess button hidden for read-only viewers on failed uploads
- [x] Graphify runs list hidden when user lacks `graphify:view` permission
- [x] "New Run" button hidden when user lacks `graphify:run` permission
- [x] Graphify detail access denied without `graphify:view`
- [x] TypeScript passes
- [x] All 1247 tests pass (144 web tests)