### PR TITLE
feat(web): validate Graphify run route Space against run.space_id (#298)

### DIFF
--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -167,6 +167,29 @@ describe('GraphifyRunDetailPage', () => {
     expect(apiMocks.getWrapped).not.toHaveBeenCalled();
   });
 
+  it('renders run detail when the run space matches the route space', async () => {
+    mockDetailApis(buildRun({ run_id: 'run-1', space_id: 'space-1', status: 'succeeded' }));
+
+    renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-1/graphify/run-1');
+
+    expect(await screen.findByText('Graphify Run Detail')).toBeInTheDocument();
+    expect(screen.getAllByText('run-1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('space-1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Page Not Found')).not.toBeInTheDocument();
+  });
+
+  it('shows not found and blocks detail rendering when the run space does not match the route space', async () => {
+    mockDetailApis(buildRun({ run_id: 'run-1', space_id: 'space-2', status: 'succeeded' }));
+
+    renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-1/graphify/run-1');
+
+    expect(await screen.findByText('Page Not Found')).toBeInTheDocument();
+    expect(screen.queryByText('Graphify Run Detail')).not.toBeInTheDocument();
+    expect(screen.queryByText('space-2')).not.toBeInTheDocument();
+    expect(apiMocks.getWrapped).toHaveBeenCalledTimes(1);
+    expect(apiMocks.getWrapped).toHaveBeenCalledWith('/graphify/runs/run-1');
+  });
+
   it('hides cancel and retry actions on detail when graphify run is denied', async () => {
     authMocks.useAuth.mockReturnValue(
       buildAuthValue({
@@ -255,14 +278,21 @@ function buildAuthValue(overrides: Partial<AuthValue> = {}): AuthValue {
 }
 
 async function renderDetailStatus(status: GraphifyRun['status']): Promise<void> {
+  mockDetailApis(buildRun({
+    run_id: 'run-1',
+    status,
+    error_json: status === 'failed' ? { reason: 'quarantined', quarantine_type: 'shrink_guard' } : null,
+  }));
+
+  renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-1/graphify/run-1');
+  expect(await screen.findByText('Graphify Run Detail')).toBeInTheDocument();
+}
+
+function mockDetailApis(run: GraphifyRun): void {
   apiMocks.getWrapped.mockImplementation((path: string) => {
     if (path === '/graphify/runs/run-1') {
       return Promise.resolve({
-        data: buildRun({
-          run_id: 'run-1',
-          status,
-          error_json: status === 'failed' ? { reason: 'quarantined', quarantine_type: 'shrink_guard' } : null,
-        }),
+        data: run,
       });
     }
 
@@ -290,9 +320,6 @@ async function renderDetailStatus(status: GraphifyRun['status']): Promise<void> 
 
     return Promise.reject(new Error('not found'));
   });
-
-  renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-1/graphify/run-1');
-  expect(await screen.findByText('Graphify Run Detail')).toBeInTheDocument();
 }
 
 function renderWithRouter(element: ReactElement, path: string): void {

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -40,6 +40,7 @@ export default function GraphifyRunDetailPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [isCancelling, setIsCancelling] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
+  const [isRunSpaceMismatch, setIsRunSpaceMismatch] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const canViewGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:view');
   const canRunGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:run');
@@ -50,6 +51,7 @@ export default function GraphifyRunDetailPage() {
         setRun(null);
         setReport(null);
         setSummary(null);
+        setIsRunSpaceMismatch(false);
         setIsLoading(false);
         return;
       }
@@ -58,10 +60,20 @@ export default function GraphifyRunDetailPage() {
         setIsLoading(true);
       }
       setError(null);
+      setIsRunSpaceMismatch(false);
 
       try {
         const runResponse = await getGraphifyRun(runId);
         const currentRun = runResponse.data;
+
+        if (currentRun.space_id !== spaceId) {
+          setRun(null);
+          setReport(null);
+          setSummary(null);
+          setIsRunSpaceMismatch(true);
+          return;
+        }
+
         setRun(currentRun);
 
         if (isGraphifyRunActive(currentRun)) {
@@ -84,7 +96,7 @@ export default function GraphifyRunDetailPage() {
         }
       }
     },
-    [canViewGraphify, runId],
+    [canViewGraphify, runId, spaceId],
   );
 
   useEffect(() => {
@@ -117,6 +129,10 @@ export default function GraphifyRunDetailPage() {
         subTitle={t('graphify.space.forbidden.description', { email: user?.email ?? '' })}
       />
     );
+  }
+
+  if (isRunSpaceMismatch) {
+    return <NotFound />;
   }
 
   async function cancelRun(): Promise<void> {


### PR DESCRIPTION
## Summary
- GraphifyRunDetailPage validates route spaceId against loaded run's space_id
- Mismatched routes render NotFound, preventing runs from showing under wrong Space context
- Test covers both matching and mismatched space scenarios

Closes #298

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `c3e143c68714e03f89f9be971fcbad426e91b3bf`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/315#issuecomment-4437200053) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/315#issuecomment-4437200202) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/315#issuecomment-4437200357) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/315#issuecomment-4437200461)
- Key findings addressed: All reviewers clean; cross-space probe concern noted as backend API design issue outside scope

## Test plan
- [x] Run detail renders correctly when route spaceId matches run.space_id
- [x] Run detail shows NotFound when route spaceId differs from run.space_id
- [x] TypeScript passes
- [x] All 146 web tests pass