### PR TITLE
feat(ci): add live-stack smoke tests for MinIO, Redis, and egress (#300)

### DIFF
--- a/.github/workflows/live-stack-smoke.yml
+++ b/.github/workflows/live-stack-smoke.yml
@@ -1,0 +1,96 @@
+name: Live Stack Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/live-stack-smoke.yml'
+      - 'apps/url-fetcher-worker/**'
+      - 'apps/api/src/storage/**'
+      - 'docker-compose.yml'
+      - 'docker-compose.prod.yml'
+      - 'package.json'
+      - 'packages/job-core/**'
+      - 'pnpm-lock.yaml'
+      - 'tests/smoke/**'
+      - 'vitest.config.ts'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-stack-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: MinIO, Redis, and Egress
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      minio:
+        image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+        command: server /data --console-address ":9001"
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        options: >-
+          --health-cmd "curl -sf http://localhost:9000/minio/health/live || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:8-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      MINIO_ENDPOINT: http://localhost:9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+      REDIS_URL: redis://localhost:6379
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate production Docker Compose
+        env:
+          POSTGRES_PASSWORD: ci-postgres-password
+          JWT_SECRET: ci-jwt-secret-minimum-32-characters
+          ADMIN_PASSWORD: ci-admin-password
+          MINIO_ACCESS_KEY: ci-minio-access-key
+          MINIO_SECRET_KEY: ci-minio-secret-key
+          WORKER_API_KEY: ci-worker-api-key
+        run: docker compose -f docker-compose.prod.yml config --quiet
+
+      - name: Run live-stack smoke tests
+        run: pnpm exec vitest run tests/smoke/ --config vitest.config.ts

--- a/tests/smoke/egress-smoke.test.ts
+++ b/tests/smoke/egress-smoke.test.ts
@@ -1,0 +1,76 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const rootDir = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+
+describe('egress SSRF smoke', () => {
+  it('blocks private and metadata IPs while allowing public IPs', () => {
+    const script = String.raw`
+import importlib.util
+import json
+import pathlib
+import sys
+import types
+
+root = pathlib.Path("apps/url-fetcher-worker/src").resolve()
+src_package = types.ModuleType("src")
+src_package.__path__ = [str(root)]
+sys.modules["src"] = src_package
+ssrf_package = types.ModuleType("src.ssrf")
+ssrf_package.__path__ = [str(root / "ssrf")]
+sys.modules["src.ssrf"] = ssrf_package
+
+errors_spec = importlib.util.spec_from_file_location("src.errors", root / "errors.py")
+errors_module = importlib.util.module_from_spec(errors_spec)
+sys.modules["src.errors"] = errors_module
+errors_spec.loader.exec_module(errors_module)
+
+validator_spec = importlib.util.spec_from_file_location(
+    "src.ssrf.ip_validator",
+    root / "ssrf" / "ip_validator.py",
+)
+validator_module = importlib.util.module_from_spec(validator_spec)
+sys.modules["src.ssrf.ip_validator"] = validator_module
+validator_spec.loader.exec_module(validator_module)
+
+from src.errors import SsrfBlockedError
+
+IpValidator = validator_module.IpValidator
+
+validator = IpValidator()
+blocked = {}
+for ip in ("169.254.169.254", "10.0.0.1", "127.0.0.1"):
+    try:
+        validator.validate_ip(ip, target_url=f"http://{ip}/")
+    except SsrfBlockedError as exc:
+        blocked[ip] = exc.metadata["block_reason"]
+    else:
+        raise AssertionError(f"{ip} was allowed")
+
+allowed = validator.validate_ip("8.8.8.8", target_url="http://8.8.8.8/")
+print(json.dumps({"blocked": blocked, "allowed": allowed.ip}, sort_keys=True))
+`;
+
+    const result = spawnSync('python3', ['-c', script], {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        PYTHONPATH: path.join(rootDir, 'apps/url-fetcher-worker'),
+      },
+      encoding: 'utf8',
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      allowed: '8.8.8.8',
+      blocked: {
+        '10.0.0.1': 'private_ip_rfc1918',
+        '127.0.0.1': 'private_ip_localhost',
+        '169.254.169.254': 'link_local_metadata',
+      },
+    });
+  });
+});

--- a/tests/smoke/minio-smoke.test.ts
+++ b/tests/smoke/minio-smoke.test.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from 'node:crypto';
+import { Readable } from 'node:stream';
+
+import {
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '../../apps/api/node_modules/@aws-sdk/client-s3';
+import { describe, expect, it } from 'vitest';
+
+describe('MinIO live-stack smoke', () => {
+  it('uploads, reads back, and cleans up an object', async () => {
+    const bucket = `cherrywiki-smoke-${randomUUID()}`;
+    const key = 'smoke.txt';
+    const body = `live-stack-smoke-${Date.now()}`;
+    const client = new S3Client({
+      region: 'us-east-1',
+      endpoint: process.env.MINIO_ENDPOINT ?? 'http://localhost:9000',
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: process.env.MINIO_ACCESS_KEY ?? 'minioadmin',
+        secretAccessKey: process.env.MINIO_SECRET_KEY ?? 'minioadmin_dev_secret',
+      },
+    });
+
+    try {
+      await client.send(new CreateBucketCommand({ Bucket: bucket }));
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: body,
+          ContentType: 'text/plain',
+        }),
+      );
+
+      const response = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+
+      await expect(readBody(response.Body)).resolves.toBe(body);
+    } finally {
+      await ignoreMissing(() => client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key })));
+      await ignoreMissing(() => client.send(new DeleteBucketCommand({ Bucket: bucket })));
+      client.destroy();
+    }
+  });
+});
+
+async function readBody(body: unknown): Promise<string> {
+  if (body !== null && typeof body === 'object' && 'transformToString' in body) {
+    const transformToString = body.transformToString;
+    if (typeof transformToString === 'function') {
+      return transformToString.call(body);
+    }
+  }
+
+  if (body instanceof Readable) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of body) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks).toString('utf8');
+  }
+
+  throw new Error('Unsupported S3 response body');
+}
+
+async function ignoreMissing(action: () => Promise<unknown>): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    const name = error instanceof Error ? error.name : '';
+    if (!['NoSuchBucket', 'NoSuchKey', 'NotFound'].includes(name)) {
+      throw error;
+    }
+  }
+}

--- a/tests/smoke/redis-smoke.test.ts
+++ b/tests/smoke/redis-smoke.test.ts
@@ -1,0 +1,28 @@
+import { Queue } from '../../packages/job-core/node_modules/bullmq';
+import { describe, expect, it } from 'vitest';
+
+import { createBullMQConnection } from '@cherrygraph/job-core';
+
+describe('Redis and BullMQ live-stack smoke', () => {
+  it('pings Redis and persists a queued BullMQ job', async () => {
+    const connection = createBullMQConnection(process.env.REDIS_URL ?? 'redis://localhost:6379');
+    const queueName = `cherrywiki-smoke-${process.pid}-${Date.now()}`;
+    const queue = new Queue(queueName, { connection });
+
+    try {
+      await expect(connection.ping()).resolves.toBe('PONG');
+
+      const job = await queue.add('connectivity', { source: 'live-stack-smoke' });
+      const stored = await queue.getJob(job.id ?? '');
+
+      expect(stored).not.toBeNull();
+      expect(stored?.name).toBe('connectivity');
+      expect(stored?.data).toEqual({ source: 'live-stack-smoke' });
+    } finally {
+      await queue.drain(true);
+      await queue.obliterate({ force: true });
+      await queue.close();
+      await connection.quit();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- New `live-stack-smoke.yml` CI workflow with real MinIO and Redis services
- MinIO smoke: upload, read-back, delete cycle
- Redis smoke: PING + BullMQ queue/job creation
- Egress smoke: SSRF private/metadata IP blocking validation
- docker-compose.prod.yml config validation added

Closes #300

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `579be8a22ba5f180891488f10802e8923142ac33`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/316#issuecomment-4437329317) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/316#issuecomment-4437329591) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/316#issuecomment-4437329816) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/316#issuecomment-4437329983)
- Key findings addressed: All reviewers clean; Dockerfile target validation deferred per issue scope (part of 4.7)

## Test plan
- [x] MinIO upload/read smoke with real MinIO service
- [x] Redis PING + BullMQ job smoke with real Redis service
- [x] SSRF egress smoke verifies private/metadata IP blocking
- [x] docker-compose.prod.yml config validates
- [x] TypeScript passes
- [x] All smoke tests pass (3/3)