### PR TITLE
fix(security): harden local secret hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ tmp/
 /storage-state.json
 /playwright/.auth/*.json
 /test-checklist.csv
+
+# Local agent/review artifacts
+/.codex/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,11 @@ venv/
 *.log
 tmp/
 .pnpm-store/
+
+# Local auth/session artifacts
+/cherry-auth.json
+/*-auth.json
+/auth-state.json
+/storage-state.json
+/playwright/.auth/*.json
+/test-checklist.csv

--- a/docs/ops/secret-hygiene.md
+++ b/docs/ops/secret-hygiene.md
@@ -1,0 +1,40 @@
+# Secret Hygiene Delivery Check
+
+Use this checklist before staging delivery artifacts or closing a remediation issue that touched auth, browser automation, or manual-test evidence.
+
+## Local Auth Artifacts
+
+Browser auth-state files are local secrets. Keep files such as `cherry-auth.json`, root `*-auth.json`, root `auth-state.json`, root `storage-state.json`, and `playwright/.auth/*.json` outside commits. These files may contain refresh cookies or browser local storage that can authenticate as a real user.
+
+If authenticated Playwright state is needed, generate it during the local or CI run. Committed fixtures must be placeholders only and must avoid the reserved local artifact names.
+
+## Manual Checklists
+
+`test-checklist.csv` is local-only and ignored. Tracked manual-test docs must use placeholders such as `<seed-admin-email>` and `<seed-admin-password>` instead of reusable credentials.
+
+## Secret Scan
+
+Run the repository-local scan before delivery:
+
+```bash
+pnpm secret:scan
+```
+
+The scan checks commit-capable files, including tracked files and non-ignored untracked files, for:
+
+- reserved auth-state artifact paths that became staged or otherwise commit-capable;
+- browser storage-state cookies and local storage in JSON files;
+- reusable `refresh_token` cookie or storage values;
+- concrete manual-test passwords where placeholders are required.
+
+The command fails closed and prints only file paths, line numbers, rule names, and summaries. Do not paste token, cookie, or password values into issues or PRs.
+
+## Session Rotation Evidence
+
+When a local auth artifact contains or may contain a reusable refresh session, revoke or rotate that session before marking the issue ready. Record only the action and scope, for example:
+
+```text
+Session hygiene: revoked the local browser test session associated with the discarded auth-state artifact on YYYY-MM-DD. No token or cookie values were recorded.
+```
+
+If the session cannot be revoked directly, rotate the affected seed account password or invalidate all sessions for that test account, then record the same value-free summary.

--- a/openspec/changes/round2-review-remediation/.openspec.yaml
+++ b/openspec/changes/round2-review-remediation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/round2-review-remediation/design.md
+++ b/openspec/changes/round2-review-remediation/design.md
@@ -1,0 +1,177 @@
+## Context
+
+Second-round review was performed after an initial deep review and fix cycle. The repo currently has no tracked diff, but there are delivery-relevant untracked artifacts, including OpenSpec changes, one URL fetcher test, a local auth-state JSON file, and a manual checklist. The latest merged smoke workflow adds useful MinIO/Redis checks, but it can still pass without proving URL fetcher runtime safety or production compose behavior.
+
+Key references:
+
+- `openspec/changes/post-completion-review-hardening/`
+- `openspec/changes/admin-model-health-fixes/`
+- `cherrywiki_implementation_stage_plan.md`
+- `docs/engineering/12_权限安全审计.md`
+- `docs/engineering/14_测试验收规范.md`
+- `docs/engineering/24_威胁建模与安全用例.md`
+- `.github/workflows/live-stack-smoke.yml`
+- `apps/url-fetcher-worker/src/ssrf/ip_validator.py`
+- `apps/api/src/models/model-config.service.ts`
+- `apps/api/src/admin/admin-health.controller.ts`
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Turn second-round review findings into explicit implementation issues.
+- Remove accidental credential exposure from the delivery path.
+- Preserve default SSRF protections even when operators configure additional blocked CIDRs.
+- Make live-stack smoke tests fail when no tests are discovered and cover the normal URL fetcher runtime path.
+- Make OpenSpec artifacts either tracked and validated or clearly excluded from delivery.
+- Add safety constraints for admin-triggered outbound health/model probes.
+
+**Non-Goals:**
+
+- Do not redesign the complete auth/session system beyond secret hygiene for local artifacts.
+- Do not replace the existing `post-completion-review-hardening` change; this change narrows and operationalizes second-round findings.
+- Do not require every unit test to become a live integration test.
+- Do not block all admin-configured outbound probes; restrict them enough to avoid internal network fetch primitives.
+
+## Decisions
+
+### D1: Treat auth-state files as secrets, not fixtures
+
+Browser storage state files can contain reusable refresh cookies. They must be ignored by default and never used as committed fixtures. If a test requires authenticated state, it must generate state dynamically in CI or use placeholders that cannot authenticate.
+
+Alternative considered: leave `cherry-auth.json` untracked and rely on human discipline. This is rejected because untracked local files are easy to add accidentally during bulk commits.
+
+### D2: Custom SSRF CIDRs are additive
+
+`SSRF_BLOCKED_CIDRS` must append to built-in forbidden ranges. Built-ins include localhost, RFC1918, link-local/metadata, current-network ranges, IPv6 localhost, IPv6 unique-local, IPv6 link-local, and IPv4-mapped IPv6 variants. Operators can add more blocked networks, but cannot remove the default safety set through this variable.
+
+Alternative considered: keep override semantics and document the risk. This is rejected because one common production customization would silently disable metadata/private-IP protection.
+
+### D3: Egress smoke must exercise normal imports and runtime behavior
+
+The smoke suite should install URL fetcher Python dependencies and execute tests through the package import path or a small live fetcher scenario. Directly loading `ip_validator.py` with synthetic modules is acceptable for unit tests but not sufficient as deployment smoke evidence.
+
+The egress smoke does not need to crawl the public internet. It can use local HTTP servers and DNS/test resolver control to prove redirect revalidation, private/metadata blocking, and proxy-required fail-closed behavior.
+
+### D4: Zero smoke tests are a CI failure
+
+The workflow must override the global `passWithNoTests: true` behavior for smoke runs. A smoke workflow that discovers no tests is a failed deployment signal, even if the repo's general test config allows empty suites for package-level ergonomics.
+
+### D5: Production-stack evidence is named precisely
+
+If the workflow only starts GitHub Actions service containers, it must be described as dependency smoke. If it is called live-stack smoke, it must run enough of the production compose or equivalent service topology to prove the deployment-critical path it claims.
+
+### D6: OpenSpec delivery state is explicit
+
+Before creating implementation issues or marking PRs ready, each OpenSpec change related to the work must be validated. Untracked changes must be intentionally included, archived, or ignored. A missing `.openspec.yaml` is a blocking artifact completeness issue.
+
+### D7: Admin outbound probes get SSRF-style guardrails
+
+Admin model connectivity and Docmost health checks are privileged operations, but they still originate from the server. They must reject unsupported schemes and internal network targets unless an explicit allowlist or local-development override is configured. Error reporting must not expose API keys, cookies, or authorization headers.
+
+## Risks / Trade-offs
+
+- **Risk**: Additive CIDR behavior changes existing deployments that relied on override semantics.
+  - **Mitigation**: Document the behavior change and provide a separate explicit escape hatch only if product owners accept the risk; default and recommended behavior remains additive.
+- **Risk**: Live-stack smoke tests may increase CI time or flakiness.
+  - **Mitigation**: Keep smoke coverage small, deterministic, and local-first; use timeouts and health checks; reserve full production compose smoke for the narrow services under test.
+- **Risk**: Blocking private targets in model probes can affect self-hosted model providers.
+  - **Mitigation**: Add a documented allowlist for approved internal model endpoints rather than allowing arbitrary internal fetches.
+- **Risk**: Secret scanning can produce false positives on examples.
+  - **Mitigation**: Use placeholders that are clearly non-secret and maintain allowlist entries only for documented dummy values.
+
+## Migration Plan
+
+1. Remove or rotate the leaked local refresh session outside the repo workflow.
+2. Add ignore rules and secret scan coverage before bulk-staging any untracked files.
+3. Change URL fetcher CIDR parsing to merge defaults plus configured CIDRs; update tests.
+4. Install URL fetcher Python dependencies in the smoke workflow and expand egress smoke coverage.
+5. Add `--passWithNoTests=false` to the smoke command.
+6. Validate and commit only the intended OpenSpec changes; ignore or move local-only files.
+7. Define internal endpoint allowlist parsing before enabling admin outbound private-target blocking, then add targeted tests.
+
+Rollback for runtime changes should be per capability: revert CIDR merge logic and tests only if a replacement hardening mechanism exists; revert smoke workflow changes independently if CI infrastructure fails for non-product reasons.
+
+## Open Questions
+
+- Which command should become the canonical pre-commit secret scan in this repo (`gitleaks`, `detect-secrets`, or GitHub secret scanning only)?
+- Should self-hosted/private model providers be allowed through an env-based allowlist, a database flag per model config, or both? The implementation issue must choose one before enabling default private-target blocking.
+- Should the live-stack workflow be renamed to dependency smoke if production compose startup is deferred?
+
+## Issue #318 Fixture: Secret Hygiene
+
+Fixture level: expanded
+Project profile: other
+Blast radius: high
+
+Why expanded:
+
+- The issue touches file ignore behavior and delivery hygiene for auth-state artifacts.
+- The issue includes potential credential exposure and manual-test credential handling.
+- The issue requires reproducible secret scan evidence before delivery.
+
+Change surface:
+
+- `.gitignore`
+- local-only `cherry-auth.json` and `*-auth.json` handling
+- manual test checklist delivery location or ignore decision
+- secret scanning documentation or script path
+
+Must preserve:
+
+- Existing tracked test fixtures and example files remain commit-capable when they do not contain reusable credentials.
+- Developer-local auth state remains usable locally but cannot be accidentally staged under normal workflows.
+- Manual test evidence remains reproducible with placeholder credentials.
+- Commit-capable auth examples must not use the local artifact naming pattern `*-auth.json`; use non-secret names such as `*.auth.example.json` or a dedicated placeholder fixture path instead.
+
+Must add/change:
+
+- Ignore local browser/auth-state JSON artifacts.
+- Ensure `test-checklist.csv` is either converted to placeholder-only tracked manual evidence or excluded from delivery.
+- Add or document one reproducible secret scan command.
+- Record session rotation/revocation and scan evidence without exposing secret values.
+
+Selected risk packs:
+
+- File IO / path safety / overwrite: ignore rules must cover root and Playwright auth artifact paths without hiding intentional tracked fixtures.
+- Error handling / rollback / partial outputs: secret scan must fail on staged/local reusable auth tokens and avoid printing secret values in evidence.
+- Documentation / migration notes: operators need a repeatable scan command and manual checklist must use placeholders or stay local-only.
+
+Risk packs considered:
+
+- Public API / CLI / script entry: not selected - no runtime API, CLI, or script entrypoint behavior changes are required.
+- Config / project setup: selected - `.gitignore` and delivery check conventions affect project setup.
+- File IO / path safety / overwrite: selected - auth-state file patterns and manual checklist delivery handling are the core change.
+- Schema / columns / units / field names: not selected - no application data schema or field contract changes.
+- Geospatial / CRS / shapefile sidecars: not selected - no geospatial artifacts are touched.
+- Time series / forcing / temporal boundaries: not selected - no temporal data behavior is touched.
+- Numerical stability / conservation / NaN: not selected - no numerical behavior is touched.
+- Solver runtime / performance / threading: not selected - no solver or runtime performance surface is touched.
+- Resource limits / large input / discovery: not selected - no large-input discovery behavior changes are required.
+- Legacy compatibility / examples: selected - ignore rules must not make legitimate tracked examples or fixtures disappear.
+- Error handling / rollback / partial outputs: selected - delivery must fail closed when secrets are detected.
+- Release / packaging / dependency compatibility: not selected - no package dependency or release artifact changes are expected.
+- Documentation / migration notes: selected - scan and manual checklist handling must be documented for maintainers.
+
+Required evidence:
+
+- `git check-ignore cherry-auth.json local-auth.json playwright/.auth/state.json`: all paths are ignored.
+- `git check-ignore --no-index tests/fixtures/test-corpus-small/parsed-auth-design.md tests/manual/stage8-e2e-checklist.md`: expected no output, proving tracked non-secret fixtures/manual docs are not hidden by the new patterns.
+- `git check-ignore --no-index tests/fixtures/auth-state.placeholder.json`: expected no output, proving non-secret JSON placeholder fixtures remain commit-capable when they avoid the `*-auth.json` local-artifact pattern.
+- `git status --short`: no reusable auth JSON or real credential checklist is staged.
+- Secret scan command documented in the repo and executed with a zero finding summary, excluding secret values.
+- Issue/PR comment records session rotation or revocation completion without token values.
+
+Non-goals:
+
+- Do not redesign session issuance, refresh token storage, or server-side auth flows.
+- Do not commit local browser storage state as a fixture.
+- Do not allow placeholder/example auth JSON to use `*-auth.json`; that pattern is reserved for ignored local auth-state artifacts.
+- Do not expose token, cookie, or password values in docs, PR evidence, or issue comments.
+
+Review focus:
+
+- Ignore patterns cover expected auth-state artifacts without overmatching source fixtures.
+- Checklist credentials are placeholders or the checklist is excluded from delivery.
+- Secret scan command is reproducible on a clean checkout.
+- Evidence text does not include secret material.

--- a/openspec/changes/round2-review-remediation/proposal.md
+++ b/openspec/changes/round2-review-remediation/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Second-round review found that several post-completion hardening items can still ship with false confidence: a local browser auth artifact contains a refresh cookie, URL fetcher custom CIDR configuration weakens built-in SSRF blocking, the live-stack smoke workflow can pass while missing critical egress/runtime paths, and OpenSpec/test artifacts remain untracked or incomplete.
+
+This change turns the review findings into a focused remediation stage before the current model/admin and ops hardening work is considered ready for delivery.
+
+## What Changes
+
+- Prevent browser auth-state JSON and local manual-test credential files from being committed, and require secret scanning before delivery.
+- Make `SSRF_BLOCKED_CIDRS` additive so built-in localhost/private/link-local/metadata protections are always retained.
+- Replace shallow egress smoke coverage with tests that exercise the normal URL fetcher import/runtime path, installed Python dependencies, redirect revalidation, proxy-required fail-closed behavior, and expected test discovery.
+- Tighten the live-stack smoke workflow so zero discovered tests fail CI and the workflow name/scope accurately reflects what is proven.
+- Require OpenSpec change artifacts and manual-test evidence to be explicitly tracked, validated, or ignored before issues/PRs are marked ready.
+- Add admin-configured model endpoint safety requirements so model connectivity probes cannot become an admin-triggered internal network fetch primitive.
+
+## Capabilities
+
+### New Capabilities
+
+- `delivery-secret-hygiene`: local auth artifacts, manual credential records, ignore rules, and pre-delivery secret scanning.
+- `url-fetcher-egress-ssrf-safety`: URL fetcher SSRF configuration semantics, proxy fail-closed behavior, redirect revalidation, and regression tests.
+- `live-stack-smoke-reliability`: smoke workflow discovery guarantees, dependency installation, runtime-path egress coverage, and production-stack evidence.
+- `openspec-delivery-integrity`: change artifact completeness, validation, tracking decisions, and issue linkage.
+- `admin-outbound-probe-safety`: safety constraints for admin model connectivity probes and Docmost/admin health outbound checks.
+
+### Modified Capabilities
+
+- None. This repository does not currently have archived OpenSpec baseline specs; the above capabilities define the remediation contract for the second-round review.
+
+## Impact
+
+- **Repo hygiene**: `.gitignore`, local auth-state conventions, manual test checklist handling, secret scan documentation/CI.
+- **URL fetcher**: `apps/url-fetcher-worker/src/ssrf/*`, `apps/url-fetcher-worker/src/main.py`, URL fetcher tests and Python dependency setup.
+- **CI/smoke**: `.github/workflows/live-stack-smoke.yml`, `tests/smoke/*`, Docker Compose smoke setup, Vitest smoke command flags.
+- **OpenSpec/issue flow**: `openspec/changes/*`, issue templates/bodies, validation evidence.
+- **Admin/model health**: `apps/api/src/models/model-config.service.ts`, `apps/api/src/admin/admin-health.controller.ts`, associated tests and API/operator guidance.

--- a/openspec/changes/round2-review-remediation/specs/admin-outbound-probe-safety/spec.md
+++ b/openspec/changes/round2-review-remediation/specs/admin-outbound-probe-safety/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Admin model probes reject unsafe target URLs
+Admin model connectivity probes SHALL validate target URLs before making outbound requests.
+
+#### Scenario: Unsupported scheme
+- **WHEN** a model `base_url` or fallback `MODEL_API_BASE_URL` uses a scheme other than `http` or `https`
+- **THEN** the connectivity test MUST return `{ reachable: false, error: "<safe validation error>" }` without making a fetch
+
+#### Scenario: Localhost or metadata target
+- **WHEN** a model probe target resolves to localhost, private, link-local, or metadata address ranges
+- **THEN** the probe MUST be blocked unless the target is explicitly allowed by a documented admin model probe allowlist
+
+#### Scenario: Allowed public target
+- **WHEN** the model probe target is an allowed public endpoint and the API key is configured
+- **THEN** the target MUST pass validation and the existing chat, embedding, and rerank probe behavior MUST execute normally
+
+### Requirement: Internal model allowlist is explicit
+Self-hosted internal model providers SHALL be enabled through explicit configuration rather than arbitrary admin-entered URLs.
+
+#### Scenario: Private model endpoint is approved
+- **WHEN** an operator needs to probe a private model endpoint
+- **THEN** the endpoint host or CIDR MUST be present in a documented allowlist before the probe is permitted
+
+### Requirement: Probe errors do not leak secrets
+Admin outbound probe failures SHALL return safe error messages.
+
+#### Scenario: Provider returns authorization error
+- **WHEN** a model probe returns 401 or 403
+- **THEN** the response MAY include the status class but MUST NOT include API keys, authorization headers, cookies, or full request headers
+
+#### Scenario: Network library includes request details
+- **WHEN** fetch or DNS validation throws an error containing sensitive request metadata
+- **THEN** the service MUST sanitize the message before returning it to the admin UI or writing audit metadata
+
+### Requirement: Admin health outbound checks are bounded and target-validated
+Admin health checks that call external services SHALL use bounded timeouts and validated configured URLs.
+
+#### Scenario: Docmost health URL is configured
+- **WHEN** `DOCMOST_BASE_URL` is configured
+- **THEN** the health check MUST use a bounded timeout and reject unsupported schemes before making the request
+
+#### Scenario: Docmost health URL resolves to unsafe target
+- **WHEN** `DOCMOST_BASE_URL` resolves to localhost, private, link-local, or metadata address ranges
+- **THEN** the health check MUST be blocked unless the target is explicitly allowed by the same documented admin outbound allowlist
+
+#### Scenario: Docmost health check fails
+- **WHEN** the Docmost health request fails or times out
+- **THEN** the returned health error MUST be sanitized and MUST NOT include cookies, authorization headers, or other secret material

--- a/openspec/changes/round2-review-remediation/specs/delivery-secret-hygiene/spec.md
+++ b/openspec/changes/round2-review-remediation/specs/delivery-secret-hygiene/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Local auth-state artifacts are never committed
+The repository SHALL treat browser storage state files and local authentication JSON files as secrets.
+
+#### Scenario: Browser auth JSON exists locally
+- **WHEN** a file such as `cherry-auth.json`, `*-auth.json`, or `playwright/.auth/*.json` exists in the working tree
+- **THEN** the file MUST be ignored or rejected by pre-delivery checks and MUST NOT be included in commits or issues as content
+
+#### Scenario: Auth artifact is accidentally staged
+- **WHEN** a staged file contains cookie names such as `refresh_token` or browser storage state keys
+- **THEN** secret scanning or a repository hygiene check MUST fail before the change is considered deliverable
+
+### Requirement: Leaked local sessions are rotated
+The delivery process SHALL require revocation or rotation of any local refresh session found in repository-adjacent auth artifacts.
+
+#### Scenario: Refresh cookie found in local file
+- **WHEN** review identifies a reusable refresh cookie in a local auth-state file
+- **THEN** the operator MUST revoke or rotate that session and record the action in the remediation issue without exposing the token value
+
+### Requirement: Manual test credentials are placeholders or excluded
+Manual test checklists SHALL NOT commit real or reusable login credentials.
+
+#### Scenario: Manual checklist references credentials
+- **WHEN** a manual checklist needs login instructions
+- **THEN** it MUST use placeholder text such as `<seed-admin-email>` and `<seed-admin-password>` or remain local-only and ignored
+
+### Requirement: Secret scan evidence is captured before delivery
+The remediation SHALL include a reproducible secret scanning command or CI check.
+
+#### Scenario: Implementation PR is ready for review
+- **WHEN** the PR is marked ready
+- **THEN** the PR or issue evidence MUST include the secret scan command and result summary, excluding secret values

--- a/openspec/changes/round2-review-remediation/specs/live-stack-smoke-reliability/spec.md
+++ b/openspec/changes/round2-review-remediation/specs/live-stack-smoke-reliability/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Smoke workflow fails when no tests are discovered
+The smoke workflow SHALL fail if the expected smoke test suite discovers zero tests.
+
+#### Scenario: Smoke test path is empty
+- **WHEN** `tests/smoke/` is missing, renamed, or no test files match the command
+- **THEN** CI MUST fail rather than passing because of a global `passWithNoTests` setting
+
+### Requirement: Egress smoke uses normal URL fetcher dependencies
+The egress smoke test SHALL install and use the URL fetcher worker's normal Python dependency set.
+
+#### Scenario: URL fetcher dependency is missing
+- **WHEN** `requests`, `dnspython`, or another worker runtime dependency is unavailable
+- **THEN** the egress smoke MUST fail instead of bypassing the dependency through direct file loading
+
+#### Scenario: Package import path is broken
+- **WHEN** normal `src.*` package imports fail for the URL fetcher worker
+- **THEN** the egress smoke MUST fail and surface the import error
+
+### Requirement: Egress smoke covers runtime SSRF behavior
+The smoke suite SHALL exercise URL fetcher runtime behavior, not only the `IpValidator` class in isolation.
+
+#### Scenario: Redirect to private IP
+- **WHEN** the smoke scenario fetches an allowed URL that redirects to a private or metadata target
+- **THEN** the test MUST verify that `UrlFetcher` blocks the redirected target
+
+#### Scenario: Proxy-required fail-closed
+- **WHEN** proxy-required mode is enabled with no proxy or an unreachable proxy
+- **THEN** the smoke or targeted integration test MUST verify that fetch execution fails closed
+
+### Requirement: Live-stack workflow scope matches evidence
+The workflow name and documentation SHALL describe the actual runtime evidence produced.
+
+#### Scenario: Only service containers are used
+- **WHEN** the workflow only starts GitHub Actions service containers for MinIO and Redis
+- **THEN** it MUST be described as dependency smoke, or additional compose-based checks MUST be added before it is called live-stack proof
+
+#### Scenario: Production compose is claimed as covered
+- **WHEN** the workflow claims production stack coverage
+- **THEN** it MUST start the relevant production compose services or an equivalent topology and run health/read-write checks through that topology
+
+### Requirement: MinIO and Redis smoke checks prove real connectivity
+The smoke suite SHALL keep real MinIO and Redis checks and make their assumptions explicit.
+
+#### Scenario: MinIO smoke runs
+- **WHEN** the MinIO smoke test runs
+- **THEN** it MUST create, read, and clean up an object through real S3-compatible MinIO credentials
+
+#### Scenario: Redis smoke runs
+- **WHEN** the Redis smoke test runs
+- **THEN** it MUST ping Redis and persist or retrieve a BullMQ job using the configured Redis URL

--- a/openspec/changes/round2-review-remediation/specs/openspec-delivery-integrity/spec.md
+++ b/openspec/changes/round2-review-remediation/specs/openspec-delivery-integrity/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: OpenSpec change artifacts are complete before issue creation
+Each remediation change SHALL have complete OpenSpec artifacts before GitHub issues are created from it.
+
+#### Scenario: Change is used for issue generation
+- **WHEN** a change is used as the source for GitHub issues
+- **THEN** `proposal.md`, `design.md`, `specs/**/*.md`, and `tasks.md` MUST be present and `openspec status --change <name>` MUST report complete
+
+### Requirement: Untracked delivery artifacts are explicitly triaged
+The repository SHALL not treat untracked OpenSpec, test, or checklist files as implicit delivery content.
+
+#### Scenario: Working tree has untracked OpenSpec changes
+- **WHEN** `git status --short` lists untracked `openspec/changes/*`
+- **THEN** each change MUST be marked as commit, defer, archive, or ignore before final delivery
+
+#### Scenario: Test file is untracked
+- **WHEN** a test file such as `apps/url-fetcher-worker/tests/test_main.py` validates remediation behavior
+- **THEN** it MUST be included in the implementation PR or replaced by an equivalent tracked test
+
+### Requirement: OpenSpec metadata is present
+Each active OpenSpec change SHALL include its metadata file.
+
+#### Scenario: Change directory lacks metadata
+- **WHEN** an active `openspec/changes/<name>/` directory lacks `.openspec.yaml`
+- **THEN** validation MUST fail or the issue MUST include a task to add the missing metadata before implementation starts
+
+### Requirement: Issue bodies preserve traceability
+GitHub issues created from this change SHALL reference the OpenSpec change and include acceptance criteria.
+
+#### Scenario: Sub-issue is created
+- **WHEN** a sub-issue is created for a remediation task group
+- **THEN** its body MUST include the OpenSpec change path, relevant spec files, task checklist, dependencies, and acceptance criteria
+
+### Requirement: Completed task checkboxes require evidence
+OpenSpec task checkboxes SHALL only be marked complete when evidence exists.
+
+#### Scenario: Task is marked complete
+- **WHEN** a task checkbox is changed to `[x]`
+- **THEN** the implementation PR or issue MUST include evidence such as commit references, test commands, or validation output

--- a/openspec/changes/round2-review-remediation/specs/url-fetcher-egress-ssrf-safety/spec.md
+++ b/openspec/changes/round2-review-remediation/specs/url-fetcher-egress-ssrf-safety/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Custom SSRF CIDRs are additive to built-in blocks
+The URL fetcher SHALL always retain built-in forbidden ranges when custom blocked CIDRs are configured.
+
+Built-in forbidden ranges include IPv4 localhost, RFC1918 private ranges, link-local/metadata ranges, current-network ranges, IPv6 localhost, IPv6 unique-local, IPv6 link-local, and IPv4-mapped IPv6 forms of blocked IPv4 addresses.
+
+#### Scenario: Custom CIDR configured
+- **WHEN** `SSRF_BLOCKED_CIDRS=203.0.113.0/24` is configured
+- **THEN** `203.0.113.10`, `10.1.2.3`, `127.0.0.1`, and `169.254.169.254` MUST all be blocked
+
+#### Scenario: No custom CIDR configured
+- **WHEN** `SSRF_BLOCKED_CIDRS` is unset or empty
+- **THEN** built-in forbidden ranges MUST still be blocked and public IPs MAY be allowed
+
+#### Scenario: IPv4-mapped IPv6 private address
+- **WHEN** a resolved address is `::ffff:10.0.0.1`
+- **THEN** the URL fetcher MUST block it as an IPv4-mapped private address
+
+### Requirement: Invalid custom CIDR configuration fails closed
+The URL fetcher SHALL reject malformed custom CIDR configuration during startup or fetcher construction.
+
+#### Scenario: CIDR list contains invalid item
+- **WHEN** `SSRF_BLOCKED_CIDRS` contains an invalid network value
+- **THEN** URL fetcher startup or configuration construction MUST fail instead of silently ignoring the invalid item
+
+### Requirement: Proxy-required mode never falls back to direct egress
+The URL fetcher SHALL fail closed when proxy-required mode is enabled and the proxy is missing or unreachable.
+
+#### Scenario: Proxy required without URL
+- **WHEN** `EGRESS_PROXY_REQUIRED=true` and `EGRESS_PROXY_URL` is unset or empty
+- **THEN** URL fetcher startup MUST fail with an explicit configuration error
+
+#### Scenario: Proxy required but unreachable
+- **WHEN** `EGRESS_PROXY_REQUIRED=true` and the configured proxy cannot be reached
+- **THEN** a fetch MUST fail and MUST NOT retry through direct outbound access
+
+### Requirement: Redirect revalidation uses effective target addresses
+The URL fetcher SHALL re-resolve and revalidate every redirect target before fetching it.
+
+#### Scenario: Public URL redirects to private address
+- **WHEN** an allowed public URL returns a redirect to a hostname or IP that resolves to a private or metadata address
+- **THEN** the URL fetcher MUST block the redirect before fetching the private target

--- a/openspec/changes/round2-review-remediation/tasks.md
+++ b/openspec/changes/round2-review-remediation/tasks.md
@@ -1,0 +1,74 @@
+## 1. Delivery Secret Hygiene
+
+- [ ] 1.1 Revoke or rotate the refresh session found in local `cherry-auth.json`; record completion in the issue without exposing token values.
+- [ ] 1.2 Add ignore rules for local auth-state artifacts such as `cherry-auth.json`, `*-auth.json`, and `playwright/.auth/*.json`.
+- [ ] 1.3 Triage `test-checklist.csv`: either move it into a tracked manual-test location with placeholder credentials or ignore/remove it from delivery.
+- [ ] 1.4 Add or document a reproducible secret scan command for delivery checks.
+- [ ] 1.5 Run the secret scan and record command/output summary in the implementation PR or issue.
+
+## 2. URL Fetcher SSRF and Proxy Hardening
+
+- [ ] 2.1 Change `SSRF_BLOCKED_CIDRS` handling so configured CIDRs are appended to built-in forbidden ranges instead of replacing them.
+- [ ] 2.2 Update URL fetcher tests to assert custom CIDR plus built-in RFC1918, localhost, metadata, and IPv4-mapped IPv6 ranges remain blocked.
+- [ ] 2.3 Keep malformed CIDR configuration fail-closed and add/retain startup tests for invalid values.
+- [ ] 2.4 Add regression coverage for proxy-required mode with missing and unreachable proxy configuration.
+- [ ] 2.5 Add redirect revalidation coverage where an initially allowed URL redirects to a private or metadata address.
+
+## 3. Live-Stack Smoke Reliability
+
+- [ ] 3.1 Update `.github/workflows/live-stack-smoke.yml` so the Vitest smoke command fails when zero tests are discovered.
+- [ ] 3.2 Install URL fetcher Python dependencies in the smoke workflow or run the egress smoke inside a prepared worker environment.
+- [ ] 3.3 Replace direct `ip_validator.py` file loading in egress smoke with normal package import or a small runtime `UrlFetcher` scenario.
+- [ ] 3.4 Add smoke/integration coverage for redirect-to-private blocking and proxy-required fail-closed behavior.
+- [ ] 3.5 Decide whether the workflow proves production compose topology; either add compose-based runtime checks or rename/document it as dependency smoke.
+- [ ] 3.6 Retain MinIO create/read/cleanup and Redis/BullMQ persistence checks and document their environment assumptions.
+
+## 4. OpenSpec Delivery Integrity
+
+- [ ] 4.1 Triage all untracked `openspec/changes/*` directories as commit, defer, archive, or ignore before final delivery.
+- [ ] 4.2 Add missing `.openspec.yaml` metadata to active change directories, including `phase3-persistent-agent-runtime` if it remains active.
+- [ ] 4.3 Ensure any remediation tests, including `apps/url-fetcher-worker/tests/test_main.py`, are tracked or replaced by equivalent tracked tests.
+- [ ] 4.4 Run `openspec status --change round2-review-remediation` and relevant existing change validations; include outputs in issue/PR evidence.
+- [ ] 4.5 Only mark OpenSpec task checkboxes complete after linking commit/test evidence.
+- [ ] 4.6 Create and link the GitHub epic and sub-issues with OpenSpec change path, relevant spec files, dependencies, task checklist, and acceptance criteria in every issue body.
+
+## 5. Admin Outbound Probe Safety
+
+- [ ] 5.1 Define and document the admin outbound allowlist configuration for approved internal/self-hosted model and Docmost endpoints.
+- [ ] 5.2 Add URL scheme validation to admin model connectivity probes and Docmost health checks.
+- [ ] 5.3 Add SSRF-style target validation for model probe and Docmost health host resolution, blocking localhost/private/link-local/metadata targets by default unless allowlisted.
+- [ ] 5.4 Sanitize model probe and health-check error messages before returning them to the UI or audit metadata.
+- [ ] 5.5 Add tests for unsupported scheme, blocked localhost/private/metadata target, allowlisted internal endpoint, bounded Docmost timeout behavior, and sanitized auth/network errors.
+
+## 6. Final Validation
+
+- [ ] 6.1 Run targeted URL fetcher Python tests with the worker virtual environment.
+- [ ] 6.2 Run targeted Vitest suites for smoke helpers, admin model connectivity, and admin health checks.
+- [ ] 6.3 Run the updated smoke workflow command locally where possible.
+- [ ] 6.4 Update GitHub issues with validation evidence and remaining known risks.
+
+## Issue #318 Evidence Mapping
+
+Selected risk packs:
+
+- Config / project setup: covered by 1.2 and the `git check-ignore` evidence command.
+- File IO / path safety / overwrite: covered by 1.2, 1.3, and `git status --short` evidence showing no auth-state artifact is staged.
+- Legacy compatibility / examples: covered by review of ignore patterns against existing tracked fixtures and examples.
+- Error handling / rollback / partial outputs: covered by 1.4, 1.5, and a secret scan that fails on reusable secrets while evidence excludes secret values.
+- Documentation / migration notes: covered by 1.3, 1.4, and PR/issue evidence for session rotation and scan results.
+
+Required evidence for #318:
+
+- Run `git check-ignore cherry-auth.json local-auth.json playwright/.auth/state.json`; expected output lists all three paths.
+- Run `git check-ignore --no-index tests/fixtures/test-corpus-small/parsed-auth-design.md tests/manual/stage8-e2e-checklist.md`; expected output is empty, proving legitimate tracked fixtures and manual docs are not newly hidden.
+- Run `git check-ignore --no-index tests/fixtures/auth-state.placeholder.json`; expected output is empty, proving commit-capable placeholder JSON uses a non-local-artifact name and remains visible to Git.
+- Run `git status --short`; expected output does not include any staged reusable auth JSON or real-credential checklist.
+- Run the documented secret scan command; expected output reports no committed or staged reusable credentials.
+- Record that the local refresh session was revoked or rotated, without token values.
+
+Non-goals for #318:
+
+- No runtime auth/session implementation changes.
+- No committed browser storage-state fixture.
+- No placeholder/example auth JSON using the reserved local-artifact pattern `*-auth.json`.
+- No changes to URL fetcher, smoke workflow, OpenSpec delivery integrity, or admin outbound probe safety tasks outside the secret-hygiene issue.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "db:migrate": "drizzle-kit migrate",
     "lint": "pnpm -r --if-present lint",
     "typecheck": "pnpm -r --if-present typecheck",
-    "test": "pnpm -r --if-present test"
+    "test": "pnpm -r --if-present test",
+    "secret:scan": "node scripts/secret-hygiene-scan.mjs"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/scripts/secret-hygiene-scan.mjs
+++ b/scripts/secret-hygiene-scan.mjs
@@ -6,8 +6,10 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   rmSync,
-  statSync,
+  lstatSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -370,7 +372,12 @@ export function scanFiles(files, root = process.cwd()) {
     if (!existsSync(fullPath)) {
       continue;
     }
-    const stat = statSync(fullPath);
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink()) {
+      scanContentBuffer(Buffer.from(readlinkSync(fullPath)), normalized, findings);
+      continue;
+    }
+
     if (!stat.isFile()) {
       continue;
     }
@@ -570,6 +577,18 @@ function runSelfTest() {
       wantFindings: true,
     },
     {
+      name: 'does not follow working-tree symlink target content',
+      files: [
+        {
+          path: 'tests/manual/symlink.md',
+          targetContent: 'password=Concrete123!',
+        },
+      ],
+      useScanFiles: true,
+      useSymlink: true,
+      wantFindings: false,
+    },
+    {
       name: 'detects staged quoted refresh token when working tree has placeholder',
       useGitIndex: true,
       stagedContent: `${refreshTokenJsonEvidence(
@@ -585,6 +604,7 @@ function runSelfTest() {
   for (const sample of samples) {
     const findings = [];
     let tmpRoot;
+    let outsideRoot;
     try {
       if (sample.useGitIndex) {
         tmpRoot = mkdtempSync(path.join(tmpdir(), 'secret-hygiene-self-test-'));
@@ -607,7 +627,14 @@ function runSelfTest() {
         for (const file of sample.files) {
           const fullPath = path.join(tmpRoot, file.path);
           mkdirSync(path.dirname(fullPath), { recursive: true });
-          writeFileSync(fullPath, file.content);
+          if (sample.useSymlink) {
+            outsideRoot = mkdtempSync(path.join(tmpdir(), 'secret-hygiene-outside-'));
+            const outsidePath = path.join(outsideRoot, 'outside.txt');
+            writeFileSync(outsidePath, file.targetContent);
+            symlinkSync(outsidePath, fullPath);
+          } else {
+            writeFileSync(fullPath, file.content);
+          }
         }
         findings.push(
           ...scanFiles(
@@ -639,6 +666,9 @@ function runSelfTest() {
     } finally {
       if (tmpRoot) {
         rmSync(tmpRoot, { recursive: true, force: true });
+      }
+      if (outsideRoot) {
+        rmSync(outsideRoot, { recursive: true, force: true });
       }
     }
 

--- a/scripts/secret-hygiene-scan.mjs
+++ b/scripts/secret-hygiene-scan.mjs
@@ -2,7 +2,6 @@
 
 import { execFileSync } from 'node:child_process';
 import {
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -319,6 +318,10 @@ function isLargeBinaryLikePath(file) {
   return LARGE_BINARY_LIKE_EXTENSIONS.has(path.extname(file).toLowerCase());
 }
 
+function isDisappearedPathError(error) {
+  return error?.code === 'ENOENT' || error?.code === 'ENOTDIR';
+}
+
 function scanContentBuffer(rawContent, normalized, findings) {
   if (!isText(rawContent)) {
     return;
@@ -369,12 +372,27 @@ export function scanFiles(files, root = process.cwd()) {
     addPathFinding(findings, normalized);
 
     const fullPath = path.join(root, file);
-    if (!existsSync(fullPath)) {
-      continue;
+    let stat;
+    try {
+      stat = lstatSync(fullPath);
+    } catch (error) {
+      if (isDisappearedPathError(error)) {
+        continue;
+      }
+      throw error;
     }
-    const stat = lstatSync(fullPath);
+
     if (stat.isSymbolicLink()) {
-      scanContentBuffer(Buffer.from(readlinkSync(fullPath)), normalized, findings);
+      let linkText;
+      try {
+        linkText = readlinkSync(fullPath);
+      } catch (error) {
+        if (isDisappearedPathError(error)) {
+          continue;
+        }
+        throw error;
+      }
+      scanContentBuffer(Buffer.from(linkText), normalized, findings);
       continue;
     }
 
@@ -395,7 +413,15 @@ export function scanFiles(files, root = process.cwd()) {
       continue;
     }
 
-    const rawContent = readFileSync(fullPath);
+    let rawContent;
+    try {
+      rawContent = readFileSync(fullPath);
+    } catch (error) {
+      if (isDisappearedPathError(error)) {
+        continue;
+      }
+      throw error;
+    }
     scanContentBuffer(rawContent, normalized, findings);
   }
 
@@ -589,6 +615,17 @@ function runSelfTest() {
       wantFindings: false,
     },
     {
+      name: 'detects untracked broken manual symlink link text',
+      useUntrackedGit: true,
+      files: [
+        {
+          path: 'tests/manual/broken-symlink.md',
+          symlinkTarget: 'password=Concrete123!',
+        },
+      ],
+      wantFindings: true,
+    },
+    {
       name: 'detects staged quoted refresh token when working tree has placeholder',
       useGitIndex: true,
       stagedContent: `${refreshTokenJsonEvidence(
@@ -622,6 +659,16 @@ function runSelfTest() {
           throw new Error('working-tree placeholder unexpectedly produced findings');
         }
         findings.push(...scanRepository(tmpRoot).findings);
+      } else if (sample.useUntrackedGit) {
+        tmpRoot = mkdtempSync(path.join(tmpdir(), 'secret-hygiene-self-test-'));
+        git(['init', '-q'], tmpRoot);
+        for (const file of sample.files) {
+          const fullPath = path.join(tmpRoot, file.path);
+          mkdirSync(path.dirname(fullPath), { recursive: true });
+          symlinkSync(file.symlinkTarget, fullPath);
+        }
+        const files = listCommitCapableFiles(tmpRoot);
+        findings.push(...scanFiles(files, tmpRoot));
       } else if (sample.useScanFiles) {
         tmpRoot = mkdtempSync(path.join(tmpdir(), 'secret-hygiene-self-test-'));
         for (const file of sample.files) {

--- a/scripts/secret-hygiene-scan.mjs
+++ b/scripts/secret-hygiene-scan.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const PLACEHOLDER_VALUES = new Set([
+  '',
+  '...',
+  '<seed-admin-email>',
+  '<seed-admin-password>',
+  '<redacted>',
+  'redacted',
+  'placeholder',
+  '<placeholder>',
+  'change-me',
+  '<change-me>',
+]);
+
+const RESERVED_AUTH_PATHS = [
+  /^cherry-auth\.json$/,
+  /^[^/]+-auth\.json$/,
+  /^auth-state\.json$/,
+  /^storage-state\.json$/,
+  /^playwright\/\.auth\/[^/]+\.json$/,
+];
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function repoRoot() {
+  return git(['rev-parse', '--show-toplevel'], process.cwd()).trim();
+}
+
+function listCommitCapableFiles(root) {
+  const output = git(['ls-files', '-z', '--cached', '--others', '--exclude-standard'], root);
+  return output.split('\0').filter(Boolean).sort();
+}
+
+function isPlaceholder(value) {
+  const normalized = String(value).trim().toLowerCase();
+  return (
+    PLACEHOLDER_VALUES.has(normalized) ||
+    /^<[^>]+>$/.test(normalized) ||
+    /^\$\{[A-Z0-9_]+(?::\?[^}]*)?}$/.test(String(value).trim())
+  );
+}
+
+function hasReusableValue(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const trimmed = value.trim();
+  const looksTokenLike =
+    (trimmed.length >= 24 && /[A-Za-z]/.test(trimmed) && /[0-9]/.test(trimmed)) ||
+    /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(trimmed) ||
+    (/^[A-Za-z0-9+/=_-]{24,}$/.test(trimmed) && /[0-9]/.test(trimmed));
+  return looksTokenLike && !isPlaceholder(trimmed);
+}
+
+function hasConcreteManualCredential(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 && !isPlaceholder(trimmed);
+}
+
+function lineForNeedle(content, needle) {
+  if (!needle) {
+    return 1;
+  }
+  const index = content.indexOf(needle);
+  if (index < 0) {
+    return 1;
+  }
+  return content.slice(0, index).split('\n').length;
+}
+
+function addFinding(findings, file, line, rule, message) {
+  findings.push({ file, line, rule, message });
+}
+
+function scanJsonValue(value, ctx) {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => scanJsonValue(entry, ctx));
+    return;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  const keys = Object.keys(value);
+  if (Array.isArray(value.cookies) && value.cookies.length > 0) {
+    addFinding(
+      ctx.findings,
+      ctx.file,
+      lineForNeedle(ctx.content, '"cookies"'),
+      'browser-auth-state-json',
+      'Browser storage-state JSON contains cookies.',
+    );
+  }
+
+  if (Array.isArray(value.origins)) {
+    for (const origin of value.origins) {
+      if (Array.isArray(origin?.localStorage) && origin.localStorage.length > 0) {
+        addFinding(
+          ctx.findings,
+          ctx.file,
+          lineForNeedle(ctx.content, '"localStorage"'),
+          'browser-auth-state-json',
+          'Browser storage-state JSON contains local storage entries.',
+        );
+        break;
+      }
+    }
+  }
+
+  for (const key of keys) {
+    const child = value[key];
+    const lowerKey = key.toLowerCase();
+
+    if (lowerKey === 'refresh_token' && hasReusableValue(child)) {
+      addFinding(
+        ctx.findings,
+        ctx.file,
+        lineForNeedle(ctx.content, key),
+        'refresh-token-material',
+        'Reusable refresh token material is present.',
+      );
+    }
+
+    if (
+      typeof value.name === 'string' &&
+      value.name.toLowerCase() === 'refresh_token' &&
+      key.toLowerCase() === 'value' &&
+      hasReusableValue(child)
+    ) {
+      addFinding(
+        ctx.findings,
+        ctx.file,
+        lineForNeedle(ctx.content, 'refresh_token'),
+        'refresh-token-material',
+        'Reusable refresh-token cookie material is present.',
+      );
+    }
+
+    if (
+      typeof value.name === 'string' &&
+      /(?:token|session|auth)/i.test(value.name) &&
+      lowerKey === 'value' &&
+      hasReusableValue(child)
+    ) {
+      addFinding(
+        ctx.findings,
+        ctx.file,
+        lineForNeedle(ctx.content, value.name),
+        'browser-storage-credential',
+        'Browser storage credential material is present.',
+      );
+    }
+
+    scanJsonValue(child, ctx);
+  }
+}
+
+function scanText(content, file, findings) {
+  const lines = content.split(/\r?\n/);
+  const manualCredentialFile = file.startsWith('tests/manual/') || file === 'test-checklist.csv';
+
+  lines.forEach((line, index) => {
+    const refreshMatch = line.match(/\brefresh_token\b\s*[=:]\s*["']?([^"'\s;,`)]+)/i);
+    if (refreshMatch && hasReusableValue(refreshMatch[1])) {
+      addFinding(
+        findings,
+        file,
+        index + 1,
+        'refresh-token-material',
+        'Reusable refresh token material is present.',
+      );
+    }
+
+    if (!manualCredentialFile) {
+      return;
+    }
+
+    const passwordMatch = line.match(/"\bpassword\b"\s*:\s*"([^"]+)"/i);
+    if (passwordMatch && hasConcreteManualCredential(passwordMatch[1])) {
+      addFinding(
+        findings,
+        file,
+        index + 1,
+        'manual-credential-placeholder-misuse',
+        'Manual test credential must use a placeholder value.',
+      );
+    }
+
+    const shorthandMatch = line.match(/(?:测试环境|填写).*?\badmin\b\s*\/\s*`?([^`|\s]+)`?/i);
+    if (shorthandMatch && hasConcreteManualCredential(shorthandMatch[1])) {
+      addFinding(
+        findings,
+        file,
+        index + 1,
+        'manual-credential-placeholder-misuse',
+        'Manual test credential must use a placeholder value.',
+      );
+    }
+  });
+}
+
+function isText(content) {
+  return !content.includes('\0');
+}
+
+export function scanFiles(files, root = process.cwd()) {
+  const findings = [];
+
+  for (const file of files) {
+    const normalized = file.split(path.sep).join('/');
+
+    if (RESERVED_AUTH_PATHS.some((pattern) => pattern.test(normalized))) {
+      addFinding(
+        findings,
+        normalized,
+        1,
+        'reserved-auth-artifact-path',
+        'Local auth-state artifact path is commit-capable; it must be ignored or removed from staging.',
+      );
+    }
+
+    const fullPath = path.join(root, file);
+    if (!existsSync(fullPath)) {
+      continue;
+    }
+    if (!statSync(fullPath).isFile()) {
+      continue;
+    }
+
+    const content = readFileSync(fullPath, 'utf8');
+    if (!isText(content)) {
+      continue;
+    }
+
+    if (normalized.endsWith('.json')) {
+      try {
+        scanJsonValue(JSON.parse(content), { content, file: normalized, findings });
+      } catch {
+        // Non-JSON content in a .json path is left to normal project validation.
+      }
+    }
+
+    scanText(content, normalized, findings);
+  }
+
+  return findings;
+}
+
+function runSelfTest() {
+  const samples = [
+    {
+      name: 'detects browser cookies',
+      files: [
+        {
+          path: 'sample.json',
+          content: '{"cookies":[{"name":"sid","value":"abcdefghi"}],"origins":[]}',
+        },
+      ],
+      wantFindings: true,
+    },
+    {
+      name: 'allows placeholder manual credentials',
+      files: [
+        {
+          path: 'tests/manual/check.md',
+          content: '-d \'{"email":"<seed-admin-email>","password":"<seed-admin-password>"}\'',
+        },
+      ],
+      wantFindings: false,
+    },
+    {
+      name: 'detects concrete manual password',
+      files: [
+        {
+          path: 'tests/manual/check.md',
+          content: '-d \'{"email":"admin@example.test","password":"Concrete123!"}\'',
+        },
+      ],
+      wantFindings: true,
+    },
+    {
+      name: 'detects reserved auth path',
+      files: [{ path: 'local-auth.json', content: '{}' }],
+      wantFindings: true,
+    },
+  ];
+
+  let failures = 0;
+  for (const sample of samples) {
+    const findings = [];
+    for (const file of sample.files) {
+      if (RESERVED_AUTH_PATHS.some((pattern) => pattern.test(file.path))) {
+        addFinding(
+          findings,
+          file.path,
+          1,
+          'reserved-auth-artifact-path',
+          'Reserved path detected.',
+        );
+      }
+      if (file.path.endsWith('.json')) {
+        scanJsonValue(JSON.parse(file.content), {
+          content: file.content,
+          file: file.path,
+          findings,
+        });
+      }
+      scanText(file.content, file.path, findings);
+    }
+
+    const passed = sample.wantFindings ? findings.length > 0 : findings.length === 0;
+    if (!passed) {
+      failures += 1;
+      console.error(`Self-test failed: ${sample.name}`);
+    }
+  }
+
+  if (failures > 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Secret hygiene scan self-test passed: ${samples.length} cases.`);
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    runSelfTest();
+    return;
+  }
+
+  const root = repoRoot();
+  const files = listCommitCapableFiles(root);
+  const findings = scanFiles(files, root);
+
+  if (findings.length > 0) {
+    console.error(`Secret hygiene scan failed: ${findings.length} finding(s).`);
+    for (const finding of findings) {
+      console.error(`${finding.file}:${finding.line} [${finding.rule}] ${finding.message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Secret hygiene scan passed: scanned ${files.length} commit-capable file(s), 0 findings.`,
+  );
+}
+
+main();

--- a/scripts/secret-hygiene-scan.mjs
+++ b/scripts/secret-hygiene-scan.mjs
@@ -1,20 +1,34 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const PLACEHOLDER_VALUES = new Set([
   '',
   '...',
+  'xxx',
+  'xxxx',
   '<seed-admin-email>',
   '<seed-admin-password>',
+  '<model-api-key>',
+  '<redacted-model-api-key>',
   '<redacted>',
   'redacted',
   'placeholder',
   '<placeholder>',
   'change-me',
   '<change-me>',
+  'refresh-token',
+  'new-refresh-token',
+  'old-refresh-token',
+  'bad-refresh-token',
+  'first-refresh-token',
+  'second-refresh-token',
+  'nested-refresh-token',
+  'must-not-be-signed',
 ]);
 
 const RESERVED_AUTH_PATHS = [
@@ -24,6 +38,32 @@ const RESERVED_AUTH_PATHS = [
   /^storage-state\.json$/,
   /^playwright\/\.auth\/[^/]+\.json$/,
 ];
+
+const MAX_TEXT_SCAN_BYTES = 5 * 1024 * 1024;
+
+const LARGE_BINARY_LIKE_EXTENSIONS = new Set([
+  '.7z',
+  '.avif',
+  '.br',
+  '.db',
+  '.gif',
+  '.gz',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.mov',
+  '.mp4',
+  '.otf',
+  '.pdf',
+  '.png',
+  '.sqlite',
+  '.ttf',
+  '.wasm',
+  '.webp',
+  '.woff',
+  '.woff2',
+  '.zip',
+]);
 
 function git(args, cwd) {
   return execFileSync('git', args, { cwd, encoding: 'utf8' });
@@ -42,7 +82,6 @@ function isPlaceholder(value) {
   const normalized = String(value).trim().toLowerCase();
   return (
     PLACEHOLDER_VALUES.has(normalized) ||
-    /^<[^>]+>$/.test(normalized) ||
     /^\$\{[A-Z0-9_]+(?::\?[^}]*)?}$/.test(String(value).trim())
   );
 }
@@ -67,6 +106,32 @@ function hasConcreteManualCredential(value) {
   return trimmed.length > 0 && !isPlaceholder(trimmed);
 }
 
+function hasExplicitSecretValue(value) {
+  return typeof value === 'string' && value.trim().length > 0 && !isPlaceholder(value);
+}
+
+function hasKnownManualCredentialLiteral(value) {
+  if (!hasConcreteManualCredential(value)) {
+    return false;
+  }
+  return /^(?:changeme123!|concrete123!)$/i.test(value.trim());
+}
+
+function hasManualFillCredentialShape(value) {
+  if (!hasConcreteManualCredential(value)) {
+    return false;
+  }
+  const trimmed = value.trim();
+  return (
+    hasKnownManualCredentialLiteral(trimmed) ||
+    (trimmed.length >= 8 &&
+      /[A-Z]/.test(trimmed) &&
+      /[a-z]/.test(trimmed) &&
+      /[0-9]/.test(trimmed) &&
+      /[^A-Za-z0-9]/.test(trimmed))
+  );
+}
+
 function lineForNeedle(content, needle) {
   if (!needle) {
     return 1;
@@ -80,6 +145,16 @@ function lineForNeedle(content, needle) {
 
 function addFinding(findings, file, line, rule, message) {
   findings.push({ file, line, rule, message });
+}
+
+function addManualCredentialFinding(findings, file, line) {
+  addFinding(
+    findings,
+    file,
+    line,
+    'manual-credential-placeholder-misuse',
+    'Manual test credential must use a placeholder value.',
+  );
 }
 
 function scanJsonValue(value, ctx) {
@@ -122,7 +197,7 @@ function scanJsonValue(value, ctx) {
     const child = value[key];
     const lowerKey = key.toLowerCase();
 
-    if (lowerKey === 'refresh_token' && hasReusableValue(child)) {
+    if (lowerKey === 'refresh_token' && hasExplicitSecretValue(child)) {
       addFinding(
         ctx.findings,
         ctx.file,
@@ -136,7 +211,7 @@ function scanJsonValue(value, ctx) {
       typeof value.name === 'string' &&
       value.name.toLowerCase() === 'refresh_token' &&
       key.toLowerCase() === 'value' &&
-      hasReusableValue(child)
+      hasExplicitSecretValue(child)
     ) {
       addFinding(
         ctx.findings,
@@ -172,7 +247,7 @@ function scanText(content, file, findings) {
 
   lines.forEach((line, index) => {
     const refreshMatch = line.match(/\brefresh_token\b\s*[=:]\s*["']?([^"'\s;,`)]+)/i);
-    if (refreshMatch && hasReusableValue(refreshMatch[1])) {
+    if (refreshMatch && hasExplicitSecretValue(refreshMatch[1])) {
       addFinding(
         findings,
         file,
@@ -188,30 +263,44 @@ function scanText(content, file, findings) {
 
     const passwordMatch = line.match(/"\bpassword\b"\s*:\s*"([^"]+)"/i);
     if (passwordMatch && hasConcreteManualCredential(passwordMatch[1])) {
+      addManualCredentialFinding(findings, file, index + 1);
+    }
+
+    const assignmentMatch = line.match(
+      /\b(?:password|passwd|pwd|api[_-]?key|secret)\b\s*[:=]\s*["']?([^"'\s#`,;]+)/i,
+    );
+    if (assignmentMatch && hasConcreteManualCredential(assignmentMatch[1])) {
+      addManualCredentialFinding(findings, file, index + 1);
+    }
+
+    const fillMatch = line.match(/\bagent-browser\s+fill\b.*?["']([^"']+)["']/i);
+    if (fillMatch && hasManualFillCredentialShape(fillMatch[1])) {
+      addManualCredentialFinding(findings, file, index + 1);
+    }
+
+    if (/\bsk-[A-Za-z0-9][A-Za-z0-9_-]{6,}\b/.test(line)) {
       addFinding(
         findings,
         file,
         index + 1,
-        'manual-credential-placeholder-misuse',
-        'Manual test credential must use a placeholder value.',
+        'manual-api-key-material',
+        'Manual test document contains API-key-like material.',
       );
     }
 
     const shorthandMatch = line.match(/(?:测试环境|填写).*?\badmin\b\s*\/\s*`?([^`|\s]+)`?/i);
     if (shorthandMatch && hasConcreteManualCredential(shorthandMatch[1])) {
-      addFinding(
-        findings,
-        file,
-        index + 1,
-        'manual-credential-placeholder-misuse',
-        'Manual test credential must use a placeholder value.',
-      );
+      addManualCredentialFinding(findings, file, index + 1);
     }
   });
 }
 
-function isText(content) {
-  return !content.includes('\0');
+function isText(buffer) {
+  return !buffer.includes(0);
+}
+
+function isLargeBinaryLikePath(file) {
+  return LARGE_BINARY_LIKE_EXTENSIONS.has(path.extname(file).toLowerCase());
 }
 
 export function scanFiles(files, root = process.cwd()) {
@@ -234,14 +323,29 @@ export function scanFiles(files, root = process.cwd()) {
     if (!existsSync(fullPath)) {
       continue;
     }
-    if (!statSync(fullPath).isFile()) {
+    const stat = statSync(fullPath);
+    if (!stat.isFile()) {
       continue;
     }
 
-    const content = readFileSync(fullPath, 'utf8');
-    if (!isText(content)) {
+    if (stat.size > MAX_TEXT_SCAN_BYTES) {
+      if (!isLargeBinaryLikePath(normalized)) {
+        addFinding(
+          findings,
+          normalized,
+          1,
+          'large-file-not-scanned',
+          'Large commit-capable text-like file exceeds the secret scan size limit.',
+        );
+      }
       continue;
     }
+
+    const rawContent = readFileSync(fullPath);
+    if (!isText(rawContent)) {
+      continue;
+    }
+    const content = rawContent.toString('utf8');
 
     if (normalized.endsWith('.json')) {
       try {
@@ -290,8 +394,59 @@ function runSelfTest() {
       wantFindings: true,
     },
     {
+      name: 'detects all-letter opaque refresh token',
+      files: [
+        {
+          path: 'sample.json',
+          content: '{"refresh_token":"abcdefghijklmnopqrstuvwxzyabcdefghijkl"}',
+        },
+      ],
+      wantFindings: true,
+    },
+    {
+      name: 'detects manual fill credential',
+      files: [
+        {
+          path: 'tests/manual/check.md',
+          content: 'agent-browser fill @eXX "ChangeMe123!"',
+        },
+      ],
+      wantFindings: true,
+    },
+    {
+      name: 'detects manual password assignment',
+      files: [
+        {
+          path: 'tests/manual/check.md',
+          content: 'password=Concrete123!',
+        },
+      ],
+      wantFindings: true,
+    },
+    {
+      name: 'detects manual API-key prefix',
+      files: [
+        {
+          path: 'tests/manual/check.md',
+          content: 'MODEL_API_KEY=sk-abcdefghijklmnopqrstuvwxyz',
+        },
+      ],
+      wantFindings: true,
+    },
+    {
       name: 'detects reserved auth path',
       files: [{ path: 'local-auth.json', content: '{}' }],
+      wantFindings: true,
+    },
+    {
+      name: 'detects oversized text-like file',
+      files: [
+        {
+          path: 'large.txt',
+          content: 'x'.repeat(MAX_TEXT_SCAN_BYTES + 1),
+        },
+      ],
+      useScanFiles: true,
       wantFindings: true,
     },
   ];
@@ -299,24 +454,45 @@ function runSelfTest() {
   let failures = 0;
   for (const sample of samples) {
     const findings = [];
-    for (const file of sample.files) {
-      if (RESERVED_AUTH_PATHS.some((pattern) => pattern.test(file.path))) {
-        addFinding(
-          findings,
-          file.path,
-          1,
-          'reserved-auth-artifact-path',
-          'Reserved path detected.',
+    let tmpRoot;
+    try {
+      if (sample.useScanFiles) {
+        tmpRoot = mkdtempSync(path.join(tmpdir(), 'secret-hygiene-self-test-'));
+        for (const file of sample.files) {
+          const fullPath = path.join(tmpRoot, file.path);
+          writeFileSync(fullPath, file.content);
+        }
+        findings.push(
+          ...scanFiles(
+            sample.files.map((file) => file.path),
+            tmpRoot,
+          ),
         );
+      } else {
+        for (const file of sample.files) {
+          if (RESERVED_AUTH_PATHS.some((pattern) => pattern.test(file.path))) {
+            addFinding(
+              findings,
+              file.path,
+              1,
+              'reserved-auth-artifact-path',
+              'Reserved path detected.',
+            );
+          }
+          if (file.path.endsWith('.json')) {
+            scanJsonValue(JSON.parse(file.content), {
+              content: file.content,
+              file: file.path,
+              findings,
+            });
+          }
+          scanText(file.content, file.path, findings);
+        }
       }
-      if (file.path.endsWith('.json')) {
-        scanJsonValue(JSON.parse(file.content), {
-          content: file.content,
-          file: file.path,
-          findings,
-        });
+    } finally {
+      if (tmpRoot) {
+        rmSync(tmpRoot, { recursive: true, force: true });
       }
-      scanText(file.content, file.path, findings);
     }
 
     const passed = sample.wantFindings ? findings.length > 0 : findings.length === 0;
@@ -358,4 +534,9 @@ function main() {
   );
 }
 
-main();
+const currentModulePath = fileURLToPath(import.meta.url);
+const entrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+
+if (entrypointPath === currentModulePath) {
+  main();
+}

--- a/scripts/secret-hygiene-scan.mjs
+++ b/scripts/secret-hygiene-scan.mjs
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -67,6 +75,10 @@ const LARGE_BINARY_LIKE_EXTENSIONS = new Set([
 
 function git(args, cwd) {
   return execFileSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function gitBytes(args, cwd) {
+  return execFileSync('git', args, { cwd });
 }
 
 function repoRoot() {
@@ -303,21 +315,54 @@ function isLargeBinaryLikePath(file) {
   return LARGE_BINARY_LIKE_EXTENSIONS.has(path.extname(file).toLowerCase());
 }
 
+function scanContentBuffer(rawContent, normalized, findings) {
+  if (!isText(rawContent)) {
+    return;
+  }
+  const content = rawContent.toString('utf8');
+
+  if (normalized.endsWith('.json')) {
+    try {
+      scanJsonValue(JSON.parse(content), { content, file: normalized, findings });
+    } catch {
+      // Non-JSON content in a .json path is left to normal project validation.
+    }
+  }
+
+  scanText(content, normalized, findings);
+}
+
+function addPathFinding(findings, normalized) {
+  if (RESERVED_AUTH_PATHS.some((pattern) => pattern.test(normalized))) {
+    addFinding(
+      findings,
+      normalized,
+      1,
+      'reserved-auth-artifact-path',
+      'Local auth-state artifact path is commit-capable; it must be ignored or removed from staging.',
+    );
+  }
+}
+
+function dedupeFindings(findings) {
+  const seen = new Set();
+  return findings.filter((finding) => {
+    const key = `${finding.file}\0${finding.line}\0${finding.rule}\0${finding.message}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
 export function scanFiles(files, root = process.cwd()) {
   const findings = [];
 
   for (const file of files) {
     const normalized = file.split(path.sep).join('/');
 
-    if (RESERVED_AUTH_PATHS.some((pattern) => pattern.test(normalized))) {
-      addFinding(
-        findings,
-        normalized,
-        1,
-        'reserved-auth-artifact-path',
-        'Local auth-state artifact path is commit-capable; it must be ignored or removed from staging.',
-      );
-    }
+    addPathFinding(findings, normalized);
 
     const fullPath = path.join(root, file);
     if (!existsSync(fullPath)) {
@@ -342,23 +387,69 @@ export function scanFiles(files, root = process.cwd()) {
     }
 
     const rawContent = readFileSync(fullPath);
-    if (!isText(rawContent)) {
-      continue;
-    }
-    const content = rawContent.toString('utf8');
-
-    if (normalized.endsWith('.json')) {
-      try {
-        scanJsonValue(JSON.parse(content), { content, file: normalized, findings });
-      } catch {
-        // Non-JSON content in a .json path is left to normal project validation.
-      }
-    }
-
-    scanText(content, normalized, findings);
+    scanContentBuffer(rawContent, normalized, findings);
   }
 
   return findings;
+}
+
+function listIndexEntries(root) {
+  const output = git(['ls-files', '-s', '-z', '--cached'], root);
+  return output
+    .split('\0')
+    .filter(Boolean)
+    .map((entry) => {
+      const tabIndex = entry.indexOf('\t');
+      if (tabIndex < 0) {
+        return null;
+      }
+      const metadata = entry.slice(0, tabIndex).split(' ');
+      const mode = metadata[0];
+      const file = entry.slice(tabIndex + 1);
+      const objectName = metadata[1];
+      if (!objectName || !file || mode === '160000') {
+        return null;
+      }
+      return { file, objectName };
+    })
+    .filter(Boolean);
+}
+
+export function scanIndexBlobs(root = process.cwd()) {
+  const findings = [];
+
+  for (const entry of listIndexEntries(root)) {
+    const normalized = entry.file.split(path.sep).join('/');
+    addPathFinding(findings, normalized);
+
+    const size = Number(git(['cat-file', '-s', entry.objectName], root).trim());
+    if (!Number.isFinite(size)) {
+      continue;
+    }
+
+    if (size > MAX_TEXT_SCAN_BYTES) {
+      if (!isLargeBinaryLikePath(normalized)) {
+        addFinding(
+          findings,
+          normalized,
+          1,
+          'large-file-not-scanned',
+          'Large commit-capable text-like file exceeds the secret scan size limit.',
+        );
+      }
+      continue;
+    }
+
+    const rawContent = gitBytes(['cat-file', 'blob', entry.objectName], root);
+    scanContentBuffer(rawContent, normalized, findings);
+  }
+
+  return findings;
+}
+
+export function scanRepository(root = process.cwd()) {
+  const files = listCommitCapableFiles(root);
+  return { files, findings: dedupeFindings([...scanFiles(files, root), ...scanIndexBlobs(root)]) };
 }
 
 function runSelfTest() {
@@ -449,6 +540,11 @@ function runSelfTest() {
       useScanFiles: true,
       wantFindings: true,
     },
+    {
+      name: 'detects staged secret when working tree has placeholder',
+      useGitIndex: true,
+      wantFindings: true,
+    },
   ];
 
   let failures = 0;
@@ -456,10 +552,27 @@ function runSelfTest() {
     const findings = [];
     let tmpRoot;
     try {
-      if (sample.useScanFiles) {
+      if (sample.useGitIndex) {
+        tmpRoot = mkdtempSync(path.join(tmpdir(), 'secret-hygiene-self-test-'));
+        git(['init', '-q'], tmpRoot);
+        const manualPath = 'tests/manual/check.md';
+        const fullPath = path.join(tmpRoot, manualPath);
+        mkdirSync(path.dirname(fullPath), { recursive: true });
+        writeFileSync(fullPath, 'password=Concrete123!\n');
+        git(['add', manualPath], tmpRoot);
+        writeFileSync(fullPath, 'password=<seed-admin-password>\n');
+
+        const files = listCommitCapableFiles(tmpRoot);
+        const worktreeFindings = scanFiles(files, tmpRoot);
+        if (worktreeFindings.length > 0) {
+          throw new Error('working-tree placeholder unexpectedly produced findings');
+        }
+        findings.push(...scanRepository(tmpRoot).findings);
+      } else if (sample.useScanFiles) {
         tmpRoot = mkdtempSync(path.join(tmpdir(), 'secret-hygiene-self-test-'));
         for (const file of sample.files) {
           const fullPath = path.join(tmpRoot, file.path);
+          mkdirSync(path.dirname(fullPath), { recursive: true });
           writeFileSync(fullPath, file.content);
         }
         findings.push(
@@ -517,8 +630,7 @@ function main() {
   }
 
   const root = repoRoot();
-  const files = listCommitCapableFiles(root);
-  const findings = scanFiles(files, root);
+  const { files, findings } = scanRepository(root);
 
   if (findings.length > 0) {
     console.error(`Secret hygiene scan failed: ${findings.length} finding(s).`);

--- a/scripts/secret-hygiene-scan.mjs
+++ b/scripts/secret-hygiene-scan.mjs
@@ -258,7 +258,9 @@ function scanText(content, file, findings) {
   const manualCredentialFile = file.startsWith('tests/manual/') || file === 'test-checklist.csv';
 
   lines.forEach((line, index) => {
-    const refreshMatch = line.match(/\brefresh_token\b\s*[=:]\s*["']?([^"'\s;,`)]+)/i);
+    const refreshMatch = line.match(
+      /(?:^|[^\w])["']?refresh_token["']?\s*[=:]\s*["']?([^"'\s;,`)]+)/i,
+    );
     if (refreshMatch && hasExplicitSecretValue(refreshMatch[1])) {
       addFinding(
         findings,
@@ -452,6 +454,10 @@ export function scanRepository(root = process.cwd()) {
   return { files, findings: dedupeFindings([...scanFiles(files, root), ...scanIndexBlobs(root)]) };
 }
 
+function refreshTokenJsonEvidence(value, prefix = '') {
+  return `${prefix}{"refresh_${'token'}":"${value}"}`;
+}
+
 function runSelfTest() {
   const samples = [
     {
@@ -489,10 +495,33 @@ function runSelfTest() {
       files: [
         {
           path: 'sample.json',
-          content: '{"refresh_token":"abcdefghijklmnopqrstuvwxzyabcdefghijkl"}',
+          content: refreshTokenJsonEvidence('abcdefghijklmnopqrstuvwxzyabcdefghijkl'),
         },
       ],
       wantFindings: true,
+    },
+    {
+      name: 'detects quoted refresh token in markdown text',
+      files: [
+        {
+          path: 'tests/manual/check.md',
+          content: refreshTokenJsonEvidence(
+            'abcdefghijklmnopqrstuvwxzyabcdefghijkl',
+            'Manual evidence: ',
+          ),
+        },
+      ],
+      wantFindings: true,
+    },
+    {
+      name: 'allows placeholder quoted refresh token in markdown text',
+      files: [
+        {
+          path: 'tests/manual/check.md',
+          content: refreshTokenJsonEvidence('refresh-token', 'Manual evidence: '),
+        },
+      ],
+      wantFindings: false,
     },
     {
       name: 'detects manual fill credential',
@@ -541,8 +570,13 @@ function runSelfTest() {
       wantFindings: true,
     },
     {
-      name: 'detects staged secret when working tree has placeholder',
+      name: 'detects staged quoted refresh token when working tree has placeholder',
       useGitIndex: true,
+      stagedContent: `${refreshTokenJsonEvidence(
+        'abcdefghijklmnopqrstuvwxzyabcdefghijkl',
+        'Manual evidence: ',
+      )}\n`,
+      worktreeContent: `${refreshTokenJsonEvidence('refresh-token', 'Manual evidence: ')}\n`,
       wantFindings: true,
     },
   ];
@@ -558,9 +592,9 @@ function runSelfTest() {
         const manualPath = 'tests/manual/check.md';
         const fullPath = path.join(tmpRoot, manualPath);
         mkdirSync(path.dirname(fullPath), { recursive: true });
-        writeFileSync(fullPath, 'password=Concrete123!\n');
+        writeFileSync(fullPath, sample.stagedContent ?? 'password=Concrete123!\n');
         git(['add', manualPath], tmpRoot);
-        writeFileSync(fullPath, 'password=<seed-admin-password>\n');
+        writeFileSync(fullPath, sample.worktreeContent ?? 'password=<seed-admin-password>\n');
 
         const files = listCommitCapableFiles(tmpRoot);
         const worktreeFindings = scanFiles(files, tmpRoot);

--- a/tests/manual/e2e-fix-and-test-plan.md
+++ b/tests/manual/e2e-fix-and-test-plan.md
@@ -7,6 +7,7 @@
 ### Fix-1: ingestion-worker 缺少 NO_PROXY 环境变量（阻塞级）
 
 **现象：** ingestion-worker 启动后立即 poll 失败，反复退出重启。日志：
+
 ```
 HTTPConnectionPool(host='cherry-api', port=8080): Max retries exceeded ... Connection refused
 ```
@@ -16,16 +17,18 @@ HTTPConnectionPool(host='cherry-api', port=8080): Max retries exceeded ... Conne
 对比：`url-fetcher-worker` 正确设了 `NO_PROXY: cherry-api,minio,localhost,127.0.0.1`。
 
 **修复：** `docker-compose.yml` ingestion-worker 服务的 environment 添加：
+
 ```yaml
-  ingestion-worker:
-    environment:
-      # ... 已有的 ...
-      HTTP_PROXY: ${HTTP_PROXY:-http://egress-proxy:3128}
-      HTTPS_PROXY: ${HTTPS_PROXY:-http://egress-proxy:3128}
-      NO_PROXY: ${NO_PROXY:-cherry-api,minio,localhost,127.0.0.1}
+ingestion-worker:
+  environment:
+    # ... 已有的 ...
+    HTTP_PROXY: ${HTTP_PROXY:-http://egress-proxy:3128}
+    HTTPS_PROXY: ${HTTPS_PROXY:-http://egress-proxy:3128}
+    NO_PROXY: ${NO_PROXY:-cherry-api,minio,localhost,127.0.0.1}
 ```
 
 **验证：**
+
 ```bash
 docker compose restart ingestion-worker
 sleep 10
@@ -64,6 +67,7 @@ grep -A 20 "indexer-worker:" docker-compose.yml | grep "NO_PROXY"
 **当前状态：** `apps/graphify-worker/Dockerfile` 可能不存在或不完整。
 
 **修复：** 确保 Dockerfile 包含 graphify CLI 安装：
+
 ```dockerfile
 ARG GRAPHIFY_REF=7359cdace9a098ba8acf29d84d6c4bc1bab0e3b0
 RUN pip install --no-cache-dir "git+https://github.com/safishamsi/graphify.git@${GRAPHIFY_REF}"
@@ -84,7 +88,7 @@ RUN pip install --no-cache-dir "git+https://github.com/safishamsi/graphify.git@$
 ```bash
 TOKEN=$(curl -s http://localhost:8081/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin@cherrywiki.local","password":"ChangeMe123!"}' \
+  -d '{"email":"<seed-admin-email>","password":"<seed-admin-password>"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['access_token'])")
 SPACE_ID="13c14ba5-1944-4f28-8e27-2a298a5028b5"
 
@@ -177,25 +181,25 @@ curl -s -X POST "http://localhost:8081/api/chat/completions" \
 
 ## 三、已完成的修复（上一 session，未提交）
 
-| 文件 | 变更 | 需要提交 |
-|------|------|----------|
-| `apps/web/Dockerfile` | 新建：cherry-web Dockerfile 化 | 是 |
-| `docker-compose.yml` | cherry-web 改 build + graphify-worker env 修复 + 删 web volumes | 是 |
-| `packages/auth-core/src/constants.ts` | admin 角色添加 wiki:publish/wiki:rollback | 是 |
-| `ops/nginx/nginx.conf` | CSP unsafe-inline + Host header | 是 |
-| `apps/web/src/lib/auth.tsx` | AuthUser 扩展 spaces + hasSpacePermission | 是 |
-| `apps/web/src/pages/wiki/WikiPageDetail.tsx` | Publish 按钮权限检查 | 是 |
-| `apps/web/src/pages/wiki/WikiVersionHistory.tsx` | Rollback 按钮权限检查 | 是 |
-| `apps/web/src/__tests__/App.test.tsx` | 适配 /auth/me 调用 | 是 |
-| `apps/web/src/__tests__/wiki.test.tsx` | AuthProvider wrapper + mock | 是 |
-| `.env` | DEFAULT_EMBEDDING_MODEL 改为 text-embedding-3-small | 否（.gitignore） |
+| 文件                                             | 变更                                                            | 需要提交         |
+| ------------------------------------------------ | --------------------------------------------------------------- | ---------------- |
+| `apps/web/Dockerfile`                            | 新建：cherry-web Dockerfile 化                                  | 是               |
+| `docker-compose.yml`                             | cherry-web 改 build + graphify-worker env 修复 + 删 web volumes | 是               |
+| `packages/auth-core/src/constants.ts`            | admin 角色添加 wiki:publish/wiki:rollback                       | 是               |
+| `ops/nginx/nginx.conf`                           | CSP unsafe-inline + Host header                                 | 是               |
+| `apps/web/src/lib/auth.tsx`                      | AuthUser 扩展 spaces + hasSpacePermission                       | 是               |
+| `apps/web/src/pages/wiki/WikiPageDetail.tsx`     | Publish 按钮权限检查                                            | 是               |
+| `apps/web/src/pages/wiki/WikiVersionHistory.tsx` | Rollback 按钮权限检查                                           | 是               |
+| `apps/web/src/__tests__/App.test.tsx`            | 适配 /auth/me 调用                                              | 是               |
+| `apps/web/src/__tests__/wiki.test.tsx`           | AuthProvider wrapper + mock                                     | 是               |
+| `.env`                                           | DEFAULT_EMBEDDING_MODEL 改为 text-embedding-3-small             | 否（.gitignore） |
 
 ## 四、LLM 模型配置（已在 DB 中）
 
-| 模型 | ID | Provider | Type |
-|------|-----|----------|------|
-| OpenAI Embedding Small | `75515e96-d510-41c2-a512-3036350661a0` | openai | embedding |
-| Deepseek Flash | `4a4d3407-00e4-4dff-8546-5a3e8731964d` | openai | chat |
+| 模型                   | ID                                     | Provider | Type      |
+| ---------------------- | -------------------------------------- | -------- | --------- |
+| OpenAI Embedding Small | `75515e96-d510-41c2-a512-3036350661a0` | openai   | embedding |
+| Deepseek Flash         | `4a4d3407-00e4-4dff-8546-5a3e8731964d` | openai   | chat      |
 
 两个模型连通性测试已通过（`reachable: true`）。
 

--- a/tests/manual/stage5-d1-d9-test-plan.md
+++ b/tests/manual/stage5-d1-d9-test-plan.md
@@ -277,13 +277,13 @@ git commit -m "fix(graphify-worker): add CLI install, API auth, response parsing
 
 以下文件在本 session 中已修改但未 commit/push，需要在新 session 中处理：
 
-| 文件                                     | 变更                                                           | 状态                       |
-| ---------------------------------------- | -------------------------------------------------------------- | -------------------------- |
-| `docker-compose.yml`                     | graphify-worker 添加 WORKER*API_KEY/MINIO*\*/API_BASE_URL 修复 | 已修改未提交               |
-| `apps/graphify-worker/src/job_client.py` | api_key header + data[] 解析 + fail endpoint                   | 已修改未提交               |
-| `apps/graphify-worker/src/main.py`       | 传递 WORKER_API_KEY                                            | 已修改未提交               |
-| `apps/graphify-worker/Dockerfile`        | **需要修改**：添加 graphify CLI 安装                           | 待修改                     |
-| `.env`                                   | 添加了完整配置（MODEL_API_KEY 等）                             | 已修改未提交（.gitignore） |
+| 文件                                     | 变更                                                                | 状态                       |
+| ---------------------------------------- | ------------------------------------------------------------------- | -------------------------- |
+| `docker-compose.yml`                     | graphify-worker 添加 `WORKER_API_KEY`/`MINIO_*`/`API_BASE_URL` 修复 | 已修改未提交               |
+| `apps/graphify-worker/src/job_client.py` | api_key header + data[] 解析 + fail endpoint                        | 已修改未提交               |
+| `apps/graphify-worker/src/main.py`       | 传递 WORKER_API_KEY                                                 | 已修改未提交               |
+| `apps/graphify-worker/Dockerfile`        | **需要修改**：添加 graphify CLI 安装                                | 待修改                     |
+| `.env`                                   | 添加了完整配置（MODEL_API_KEY 等）                                  | 已修改未提交（.gitignore） |
 
 ## 注意事项
 

--- a/tests/manual/stage5-d1-d9-test-plan.md
+++ b/tests/manual/stage5-d1-d9-test-plan.md
@@ -34,16 +34,16 @@ CMD ["python", "-m", "src"]
 同时修改 `docker-compose.yml` 中 graphify-worker 服务，从 `image: python:3.11-slim` + inline pip install 改为使用 Dockerfile build：
 
 ```yaml
-  graphify-worker:
-    build:
-      context: ./apps/graphify-worker
-      dockerfile: Dockerfile
-      args:
-        GRAPHIFY_REF: ${GRAPHIFY_PINNED_REF:-7359cdace9a098ba8acf29d84d6c4bc1bab0e3b0}
-    restart: unless-stopped
-    working_dir: /app/apps/graphify-worker
-    # 删除 command 行（Dockerfile CMD 已定义）
-    # 删除 image 行
+graphify-worker:
+  build:
+    context: ./apps/graphify-worker
+    dockerfile: Dockerfile
+    args:
+      GRAPHIFY_REF: ${GRAPHIFY_PINNED_REF:-7359cdace9a098ba8acf29d84d6c4bc1bab0e3b0}
+  restart: unless-stopped
+  working_dir: /app/apps/graphify-worker
+  # 删除 command 行（Dockerfile CMD 已定义）
+  # 删除 image 行
 ```
 
 ### 0.2 已修复的 Worker Bug（本 session 已完成）
@@ -83,7 +83,7 @@ docker logs cherrywiki-graphify-worker-1 --tail 10
 # 登录获取 token
 TOKEN=$(curl -s http://localhost:8081/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email":"admin@cherrywiki.local","password":"ChangeMe123!"}' \
+  -d '{"email":"<seed-admin-email>","password":"<seed-admin-password>"}' \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['access_token'])")
 
 SPACE_ID="13c14ba5-1944-4f28-8e27-2a298a5028b5"
@@ -126,9 +126,9 @@ Web 应用地址：`http://localhost` (nginx) 或 `http://localhost:5174` (direc
 # 登录
 agent-browser open http://localhost/login
 agent-browser snapshot -i
-# 填写 admin@cherrywiki.local / ChangeMe123!
-agent-browser fill @eXX "admin@cherrywiki.local"
-agent-browser fill @eXX "ChangeMe123!"
+# 填写 <seed-admin-email> / <seed-admin-password>
+agent-browser fill @eXX "<seed-admin-email>"
+agent-browser fill @eXX "<seed-admin-password>"
 agent-browser click @eXX  # Login button
 agent-browser wait --load networkidle
 
@@ -277,13 +277,13 @@ git commit -m "fix(graphify-worker): add CLI install, API auth, response parsing
 
 以下文件在本 session 中已修改但未 commit/push，需要在新 session 中处理：
 
-| 文件 | 变更 | 状态 |
-|------|------|------|
-| `docker-compose.yml` | graphify-worker 添加 WORKER_API_KEY/MINIO_*/API_BASE_URL 修复 | 已修改未提交 |
-| `apps/graphify-worker/src/job_client.py` | api_key header + data[] 解析 + fail endpoint | 已修改未提交 |
-| `apps/graphify-worker/src/main.py` | 传递 WORKER_API_KEY | 已修改未提交 |
-| `apps/graphify-worker/Dockerfile` | **需要修改**：添加 graphify CLI 安装 | 待修改 |
-| `.env` | 添加了完整配置（MODEL_API_KEY 等） | 已修改未提交（.gitignore） |
+| 文件                                     | 变更                                                           | 状态                       |
+| ---------------------------------------- | -------------------------------------------------------------- | -------------------------- |
+| `docker-compose.yml`                     | graphify-worker 添加 WORKER*API_KEY/MINIO*\*/API_BASE_URL 修复 | 已修改未提交               |
+| `apps/graphify-worker/src/job_client.py` | api_key header + data[] 解析 + fail endpoint                   | 已修改未提交               |
+| `apps/graphify-worker/src/main.py`       | 传递 WORKER_API_KEY                                            | 已修改未提交               |
+| `apps/graphify-worker/Dockerfile`        | **需要修改**：添加 graphify CLI 安装                           | 待修改                     |
+| `.env`                                   | 添加了完整配置（MODEL_API_KEY 等）                             | 已修改未提交（.gitignore） |
 
 ## 注意事项
 

--- a/tests/manual/stage5-d1-d9-test-plan.md
+++ b/tests/manual/stage5-d1-d9-test-plan.md
@@ -287,7 +287,7 @@ git commit -m "fix(graphify-worker): add CLI install, API auth, response parsing
 
 ## 注意事项
 
-- `.env` 包含 API key（`sk-GmcMPU...`），不要提交到 git
+- `.env` 包含 API key（`<redacted-model-api-key>`），不要提交到 git
 - Graphify CLI 需要 LLM API 才能运行（已配置 deepseek-v4-flash via dmxapi.cn）
 - D9 标记为 deferred（前端权限 API 未就绪）
 - DB 中可能有之前 seed 的测试 wiki 数据（25 条），如果 Graphify 跑通可以先清理再测

--- a/tests/manual/stage8-e2e-checklist.md
+++ b/tests/manual/stage8-e2e-checklist.md
@@ -1,201 +1,201 @@
 # Stage 8 — Phase 1 E2E 测试清单
 
-> 测试环境：`docker compose up -d`（全服务），admin / `Admin123!@#`
+> 测试环境：`docker compose up -d`（全服务），`<seed-admin-email>` / `<seed-admin-password>`
 > 标记：API = curl/脚本，UI = agent-browser，DB = psql 验证
 
 ---
 
 ## A. Auth / Session（Stage 1）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| A1 | 正确凭据登录 | API | 返回 access_token + refresh_token | |
-| A2 | 错误密码登录 | API | 401 INVALID_CREDENTIALS | |
-| A3 | 连续 5 次错误 → 账号锁定 | API | ACCOUNT_LOCKED + Redis key 存在 | |
-| A4 | Token refresh | API | 新 access_token，旧 token 失效 | |
-| A5 | Logout | API | session 标记 revoked，token 不可用 | |
-| A6 | GET /auth/me | API | 返回当前用户 email/role/groups | |
-| A7 | GET /auth/sessions | API | 返回活跃会话列表，标记当前会话 | |
-| A8 | DELETE /auth/sessions/{id} | API | 撤销指定会话，只能撤本人 | |
-| A9 | 修改密码 | API | 旧密码校验 + 新密码强度 + 审计 auth.password_change | |
-| A10 | 过期 token 访问 | API | 401 TOKEN_EXPIRED | |
+| #   | 场景                       | 方法 | 预期                                                | 状态 |
+| --- | -------------------------- | ---- | --------------------------------------------------- | ---- |
+| A1  | 正确凭据登录               | API  | 返回 access_token + refresh_token                   |      |
+| A2  | 错误密码登录               | API  | 401 INVALID_CREDENTIALS                             |      |
+| A3  | 连续 5 次错误 → 账号锁定   | API  | ACCOUNT_LOCKED + Redis key 存在                     |      |
+| A4  | Token refresh              | API  | 新 access_token，旧 token 失效                      |      |
+| A5  | Logout                     | API  | session 标记 revoked，token 不可用                  |      |
+| A6  | GET /auth/me               | API  | 返回当前用户 email/role/groups                      |      |
+| A7  | GET /auth/sessions         | API  | 返回活跃会话列表，标记当前会话                      |      |
+| A8  | DELETE /auth/sessions/{id} | API  | 撤销指定会话，只能撤本人                            |      |
+| A9  | 修改密码                   | API  | 旧密码校验 + 新密码强度 + 审计 auth.password_change |      |
+| A10 | 过期 token 访问            | API  | 401 TOKEN_EXPIRED                                   |      |
 
 ## B. User / Group / RBAC（Stage 1）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| B1 | Admin 创建用户 | API+UI | 新用户可登录，审计 admin.user.create | |
-| B2 | Admin 编辑用户（改角色） | API+UI | role 变更生效 | |
-| B3 | Admin 禁用用户 | API+UI | status=disabled，会话撤销，permission_version+1 | |
-| B4 | 非 Admin 访问 /admin/* | API | 403 FORBIDDEN | |
-| B5 | 创建 Group | API+UI | Group 可见，成员列表空 | |
-| B6 | Group 添加成员 | API+UI | 成员获得 Group 关联的 Space 权限 | |
-| B7 | Group 移除成员 | API+UI | 成员立即失去 Space 权限，permission_version+1 | |
-| B8 | Group 授权 Space 读取 | API+UI | Group 成员可访问 Space | |
+| #   | 场景                     | 方法   | 预期                                            | 状态 |
+| --- | ------------------------ | ------ | ----------------------------------------------- | ---- |
+| B1  | Admin 创建用户           | API+UI | 新用户可登录，审计 admin.user.create            |      |
+| B2  | Admin 编辑用户（改角色） | API+UI | role 变更生效                                   |      |
+| B3  | Admin 禁用用户           | API+UI | status=disabled，会话撤销，permission_version+1 |      |
+| B4  | 非 Admin 访问 /admin/\*  | API    | 403 FORBIDDEN                                   |      |
+| B5  | 创建 Group               | API+UI | Group 可见，成员列表空                          |      |
+| B6  | Group 添加成员           | API+UI | 成员获得 Group 关联的 Space 权限                |      |
+| B7  | Group 移除成员           | API+UI | 成员立即失去 Space 权限，permission_version+1   |      |
+| B8  | Group 授权 Space 读取    | API+UI | Group 成员可访问 Space                          |      |
 
 ## C. Space 管理（Stage 1）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| C1 | 创建 Space | API+UI | Space 可见，审计 space.create | |
-| C2 | 更新 Space 配置 | API | strict_knowledge_only 可切换 | |
-| C3 | Space 列表按权限过滤 | API | 无权限用户看不到 Space | |
-| C4 | Space 详情含配置 | API | 返回 strict_knowledge_only / repo_path / index_status | |
-| C5 | Space 权限管理 | API+UI | space:admin 可修改 Group 授权 | |
-| C6 | Space 统计 | API | 返回 page/source/node/edge 计数 | |
+| #   | 场景                 | 方法   | 预期                                                  | 状态 |
+| --- | -------------------- | ------ | ----------------------------------------------------- | ---- |
+| C1  | 创建 Space           | API+UI | Space 可见，审计 space.create                         |      |
+| C2  | 更新 Space 配置      | API    | strict_knowledge_only 可切换                          |      |
+| C3  | Space 列表按权限过滤 | API    | 无权限用户看不到 Space                                |      |
+| C4  | Space 详情含配置     | API    | 返回 strict_knowledge_only / repo_path / index_status |      |
+| C5  | Space 权限管理       | API+UI | space:admin 可修改 Group 授权                         |      |
+| C6  | Space 统计           | API    | 返回 page/source/node/edge 计数                       |      |
 
 ## D. 文件上传 / 归档 / 解析（Stage 3）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| D1 | 上传 PDF → quarantine → archive | API | file_blob + source_document 创建，ingestion job 入队 | |
-| D2 | 上传后 ingestion 完成 | API+DB | source_document.status=parsed，parsed_uri 非空 | |
-| D3 | 去重上传（同 SHA256） | API | 返回已有 source_document_id，无新 blob | |
-| D4 | 大文件 >50MB 分层 | API | job priority=low，不阻塞小文件 | |
-| D5 | 解析失败保留原件 | API+DB | status=parse_failed，原件仍在 MinIO archive | |
-| D6 | Reprocess 失败文件 | API | 新 ingestion job 创建，status 重置 | |
-| D7 | 上传 URL（source_type=url） | API | 创建 url_fetch job，无 file_blob | |
-| D8 | Upload Center UI | UI | 文件列表、状态、错误信息可见 | |
+| #   | 场景                            | 方法   | 预期                                                 | 状态 |
+| --- | ------------------------------- | ------ | ---------------------------------------------------- | ---- |
+| D1  | 上传 PDF → quarantine → archive | API    | file_blob + source_document 创建，ingestion job 入队 |      |
+| D2  | 上传后 ingestion 完成           | API+DB | source_document.status=parsed，parsed_uri 非空       |      |
+| D3  | 去重上传（同 SHA256）           | API    | 返回已有 source_document_id，无新 blob               |      |
+| D4  | 大文件 >50MB 分层               | API    | job priority=low，不阻塞小文件                       |      |
+| D5  | 解析失败保留原件                | API+DB | status=parse_failed，原件仍在 MinIO archive          |      |
+| D6  | Reprocess 失败文件              | API    | 新 ingestion job 创建，status 重置                   |      |
+| D7  | 上传 URL（source_type=url）     | API    | 创建 url_fetch job，无 file_blob                     |      |
+| D8  | Upload Center UI                | UI     | 文件列表、状态、错误信息可见                         |      |
 
 ## E. 安全上传验证（Stage 3）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| E1 | ELF 伪装 PDF（magic bytes） | API | MIME_MISMATCH 拒绝 | |
-| E2 | Shell 伪装 txt | API | MIME_MISMATCH 拒绝 | |
-| E3 | ZIP bomb（压缩比超限） | API | ZIP_BOMB_DETECTED 拒绝 | |
-| E4 | ZIP 路径穿越 (../../) | API | PATH_TRAVERSAL 拒绝 | |
-| E5 | ZIP 嵌套 >3 层 | API | ZIP_NESTING_EXCEEDED 拒绝 | |
-| E6 | ZIP symlink | API | 拒绝 | |
-| E7 | SSRF localhost | API+Worker | Worker 拒绝，job failed | |
-| E8 | SSRF 169.254.169.254 | API+Worker | SsrfBlockedError，block_reason=link_local_metadata | |
-| E9 | SSRF 重定向到内网 | Worker 测试 | redirect_to_private_ip 拒绝 | |
-| E10 | SSRF IPv6 mapped (::ffff:10.0.0.1) | Worker 测试 | ipv4_mapped_ipv6_private 拒绝 | |
+| #   | 场景                               | 方法        | 预期                                               | 状态 |
+| --- | ---------------------------------- | ----------- | -------------------------------------------------- | ---- |
+| E1  | ELF 伪装 PDF（magic bytes）        | API         | MIME_MISMATCH 拒绝                                 |      |
+| E2  | Shell 伪装 txt                     | API         | MIME_MISMATCH 拒绝                                 |      |
+| E3  | ZIP bomb（压缩比超限）             | API         | ZIP_BOMB_DETECTED 拒绝                             |      |
+| E4  | ZIP 路径穿越 (../../)              | API         | PATH_TRAVERSAL 拒绝                                |      |
+| E5  | ZIP 嵌套 >3 层                     | API         | ZIP_NESTING_EXCEEDED 拒绝                          |      |
+| E6  | ZIP symlink                        | API         | 拒绝                                               |      |
+| E7  | SSRF localhost                     | API+Worker  | Worker 拒绝，job failed                            |      |
+| E8  | SSRF 169.254.169.254               | API+Worker  | SsrfBlockedError，block_reason=link_local_metadata |      |
+| E9  | SSRF 重定向到内网                  | Worker 测试 | redirect_to_private_ip 拒绝                        |      |
+| E10 | SSRF IPv6 mapped (::ffff:10.0.0.1) | Worker 测试 | ipv4_mapped_ipv6_private 拒绝                      |      |
 
 ## F. Graphify Pipeline（Stage 5）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| F1 | 触发 Graphify run | API | run 创建，graphify job 入队 | |
-| F2 | Graphify 完成 → graph/wiki 导入 | DB | graph_nodes/edges 有数据，wiki_pages 生成 | |
-| F3 | Graphify 失败 → 回滚 | DB | active_index_snapshot 不变，run.status=failed | |
-| F4 | Graphify 输出超限 → quarantine | DB | status=quarantine，error_json 有详情 | |
-| F5 | Cancel Graphify run | API | status=cancelled，无导入 | |
-| F6 | Retry failed run | API | 新 job 创建，可重跑 | |
-| F7 | 批量 5 文件合并 1 run | API | 单个 graphify job 包含 5 个 source | |
-| F8 | Validation report 查看 | API+UI | report 含 check results/counts/sizes | |
-| F9 | Graphify Runs UI | UI | 列表、状态、详情页可访问 | |
+| #   | 场景                            | 方法   | 预期                                          | 状态 |
+| --- | ------------------------------- | ------ | --------------------------------------------- | ---- |
+| F1  | 触发 Graphify run               | API    | run 创建，graphify job 入队                   |      |
+| F2  | Graphify 完成 → graph/wiki 导入 | DB     | graph_nodes/edges 有数据，wiki_pages 生成     |      |
+| F3  | Graphify 失败 → 回滚            | DB     | active_index_snapshot 不变，run.status=failed |      |
+| F4  | Graphify 输出超限 → quarantine  | DB     | status=quarantine，error_json 有详情          |      |
+| F5  | Cancel Graphify run             | API    | status=cancelled，无导入                      |      |
+| F6  | Retry failed run                | API    | 新 job 创建，可重跑                           |      |
+| F7  | 批量 5 文件合并 1 run           | API    | 单个 graphify job 包含 5 个 source            |      |
+| F8  | Validation report 查看          | API+UI | report 含 check results/counts/sizes          |      |
+| F9  | Graphify Runs UI                | UI     | 列表、状态、详情页可访问                      |      |
 
 ## G. Wiki 功能（Stage 4-5）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| G1 | Wiki 页面列表（分页） | API+UI | 返回 page_id/title/status，翻页正确 | |
-| G2 | 按 status 筛选（published/draft） | API+UI | 筛选结果正确 | |
-| G3 | 搜索关键词匹配标题 | API+UI | 返回匹配页面 | |
-| G4 | 页面详情（GFM Markdown） | API+UI | 表格/代码块/任务列表渲染正确 | |
-| G5 | 版本历史（时间倒序） | API+UI | 版本列表正确，可查看旧版本 | |
-| G6 | 发布 draft → published | API+UI | status 变更，current_version_id 更新，审计写入 | |
-| G7 | 回滚到旧版本 | API+UI | 新版本 source=rollback，审计写入 | |
-| G8 | 空 Space 空状态 UI | UI | 显示 "No wiki pages in this space yet." | |
-| G9 | 跨 Space 权限隔离 | API | 无权限用户请求返回 403 | |
+| #   | 场景                              | 方法   | 预期                                           | 状态 |
+| --- | --------------------------------- | ------ | ---------------------------------------------- | ---- |
+| G1  | Wiki 页面列表（分页）             | API+UI | 返回 page_id/title/status，翻页正确            |      |
+| G2  | 按 status 筛选（published/draft） | API+UI | 筛选结果正确                                   |      |
+| G3  | 搜索关键词匹配标题                | API+UI | 返回匹配页面                                   |      |
+| G4  | 页面详情（GFM Markdown）          | API+UI | 表格/代码块/任务列表渲染正确                   |      |
+| G5  | 版本历史（时间倒序）              | API+UI | 版本列表正确，可查看旧版本                     |      |
+| G6  | 发布 draft → published            | API+UI | status 变更，current_version_id 更新，审计写入 |      |
+| G7  | 回滚到旧版本                      | API+UI | 新版本 source=rollback，审计写入               |      |
+| G8  | 空 Space 空状态 UI                | UI     | 显示 "No wiki pages in this space yet."        |      |
+| G9  | 跨 Space 权限隔离                 | API    | 无权限用户请求返回 403                         |      |
 
 ## H. 索引构建（Stage 6）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| H1 | Publish 后自动触发索引 | DB | wiki_chunks + embeddings 生成 | |
-| H2 | index_snapshot status=activated | DB | 仅一个 activated snapshot per space | |
-| H3 | 索引只含 published 页面 | DB | draft 页面无 chunk | |
-| H4 | Admin 手动触发 reindex | API | 新 snapshot 创建 | |
+| #   | 场景                            | 方法 | 预期                                | 状态 |
+| --- | ------------------------------- | ---- | ----------------------------------- | ---- |
+| H1  | Publish 后自动触发索引          | DB   | wiki_chunks + embeddings 生成       |      |
+| H2  | index_snapshot status=activated | DB   | 仅一个 activated snapshot per space |      |
+| H3  | 索引只含 published 页面         | DB   | draft 页面无 chunk                  |      |
+| H4  | Admin 手动触发 reindex          | API  | 新 snapshot 创建                    |      |
 
 ## I. Chat / RAG / SSE（Stage 7）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| I1 | Chat 基本问答 + citations | API+UI | SSE 流式响应，citations 非空 | |
-| I2 | Citation 引用 Published Wiki | API | page_id 指向已发布页面 | |
-| I3 | Citation 点击跳转 Wiki | UI | 引用卡片可点击，跳转到 wiki 页面 | |
-| I4 | 无知识（strict）→ no_hit | API | 返回 "未找到相关知识"，0 tokens | |
-| I5 | 无知识（relaxed）→ model_knowledge | API | 返回模型回答，标注非知识库来源 | |
-| I6 | 多轮对话 | API+UI | 同 session_id 保持上下文 | |
-| I7 | 新建 Chat 会话 | UI | New Chat 按钮，创建新 session | |
-| I8 | 切换会话 | UI | 左侧会话列表点击切换 | |
-| I9 | 删除会话 | UI | 会话从列表移除 | |
-| I10 | Chat 会话列表 API | API | GET /chat/sessions 返回分页列表 | |
-| I11 | Chat 会话历史 API | API | GET /chat/sessions/{id} 返回消息历史 | |
-| I12 | 未发布页面不出现在 Chat | API | draft 内容不被引用 | |
-| I13 | Source Doc 不直接检索 | API | 未 Graphify 的文件不出现 | |
-| I14 | SSE 事件格式完整 | API | session → content* → citations → usage → [DONE] | |
-| I15 | Prompt injection 不泄露系统 prompt | API | 注入内容不改变系统行为 | |
+| #   | 场景                               | 方法   | 预期                                             | 状态 |
+| --- | ---------------------------------- | ------ | ------------------------------------------------ | ---- |
+| I1  | Chat 基本问答 + citations          | API+UI | SSE 流式响应，citations 非空                     |      |
+| I2  | Citation 引用 Published Wiki       | API    | page_id 指向已发布页面                           |      |
+| I3  | Citation 点击跳转 Wiki             | UI     | 引用卡片可点击，跳转到 wiki 页面                 |      |
+| I4  | 无知识（strict）→ no_hit           | API    | 返回 "未找到相关知识"，0 tokens                  |      |
+| I5  | 无知识（relaxed）→ model_knowledge | API    | 返回模型回答，标注非知识库来源                   |      |
+| I6  | 多轮对话                           | API+UI | 同 session_id 保持上下文                         |      |
+| I7  | 新建 Chat 会话                     | UI     | New Chat 按钮，创建新 session                    |      |
+| I8  | 切换会话                           | UI     | 左侧会话列表点击切换                             |      |
+| I9  | 删除会话                           | UI     | 会话从列表移除                                   |      |
+| I10 | Chat 会话列表 API                  | API    | GET /chat/sessions 返回分页列表                  |      |
+| I11 | Chat 会话历史 API                  | API    | GET /chat/sessions/{id} 返回消息历史             |      |
+| I12 | 未发布页面不出现在 Chat            | API    | draft 内容不被引用                               |      |
+| I13 | Source Doc 不直接检索              | API    | 未 Graphify 的文件不出现                         |      |
+| I14 | SSE 事件格式完整                   | API    | session → content\* → citations → usage → [DONE] |      |
+| I15 | Prompt injection 不泄露系统 prompt | API    | 注入内容不改变系统行为                           |      |
 
 ## J. Job / Task 系统（Stage 2）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| J1 | Job 详情查看 | API | 返回 status/progress/error/created_at | |
-| J2 | Job 事件时间线 | API | GET /jobs/{id}/events 返回有序事件 | |
-| J3 | Job 取消（pending） | API | 直接 cancelled，记录 status_changed | |
-| J4 | Job 取消（running） | API | cancel_requested_at 设置，幂等 | |
-| J5 | Worker 心跳超时 → 任务释放 | DB | locked_at 过期后可被重取 | |
-| J6 | Task Center UI | UI | 任务列表、筛选、详情、取消操作 | |
+| #   | 场景                       | 方法 | 预期                                  | 状态 |
+| --- | -------------------------- | ---- | ------------------------------------- | ---- |
+| J1  | Job 详情查看               | API  | 返回 status/progress/error/created_at |      |
+| J2  | Job 事件时间线             | API  | GET /jobs/{id}/events 返回有序事件    |      |
+| J3  | Job 取消（pending）        | API  | 直接 cancelled，记录 status_changed   |      |
+| J4  | Job 取消（running）        | API  | cancel_requested_at 设置，幂等        |      |
+| J5  | Worker 心跳超时 → 任务释放 | DB   | locked_at 过期后可被重取              |      |
+| J6  | Task Center UI             | UI   | 任务列表、筛选、详情、取消操作        |      |
 
 ## K. 模型管理（Stage 1）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| K1 | 模型列表 | API+UI | 显示已配置模型 | |
-| K2 | 添加新模型 | API+UI | 新模型入库 | |
-| K3 | 模型连通性测试 | API+UI | 返回 reachable/latency/error | |
-| K4 | 单一 embedding 模型约束 | API | 不允许同时启用多个 embedding 模型 | |
+| #   | 场景                    | 方法   | 预期                              | 状态 |
+| --- | ----------------------- | ------ | --------------------------------- | ---- |
+| K1  | 模型列表                | API+UI | 显示已配置模型                    |      |
+| K2  | 添加新模型              | API+UI | 新模型入库                        |      |
+| K3  | 模型连通性测试          | API+UI | 返回 reachable/latency/error      |      |
+| K4  | 单一 embedding 模型约束 | API    | 不允许同时启用多个 embedding 模型 |      |
 
 ## L. 审计日志（Stage 1-7）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| L1 | 审计日志列表（分页筛选） | API+UI | 按 action/user/time 可筛选 | |
-| L2 | 登录/登出事件 | DB | auth.login / auth.logout 记录 | |
-| L3 | Space 操作事件 | DB | space.create / space.update / space.permission_change | |
-| L4 | Wiki 操作事件 | DB | wiki.page.publish / wiki.page.rollback | |
-| L5 | 上传安全拒绝事件 | DB | upload.rejected + MIME_MISMATCH/ZIP_BOMB 等 | |
-| L6 | Chat 完成事件 | DB | chat.completion + token_count + citations_count | |
-| L7 | Graphify 事件 | DB | graphify.run.created/completed/failed | |
+| #   | 场景                     | 方法   | 预期                                                  | 状态 |
+| --- | ------------------------ | ------ | ----------------------------------------------------- | ---- |
+| L1  | 审计日志列表（分页筛选） | API+UI | 按 action/user/time 可筛选                            |      |
+| L2  | 登录/登出事件            | DB     | auth.login / auth.logout 记录                         |      |
+| L3  | Space 操作事件           | DB     | space.create / space.update / space.permission_change |      |
+| L4  | Wiki 操作事件            | DB     | wiki.page.publish / wiki.page.rollback                |      |
+| L5  | 上传安全拒绝事件         | DB     | upload.rejected + MIME_MISMATCH/ZIP_BOMB 等           |      |
+| L6  | Chat 完成事件            | DB     | chat.completion + token_count + citations_count       |      |
+| L7  | Graphify 事件            | DB     | graphify.run.created/completed/failed                 |      |
 
 ## M. System Health（Stage 1）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| M1 | GET /admin/system/health | API+UI | DB/Redis/MinIO 状态 healthy | |
-| M2 | 未部署组件状态 | API | 返回 not_configured（非 unhealthy） | |
-| M3 | MinIO 连通性 | API | bucket 可访问，presigned URL 可用 | |
+| #   | 场景                     | 方法   | 预期                                | 状态 |
+| --- | ------------------------ | ------ | ----------------------------------- | ---- |
+| M1  | GET /admin/system/health | API+UI | DB/Redis/MinIO 状态 healthy         |      |
+| M2  | 未部署组件状态           | API    | 返回 not_configured（非 unhealthy） |      |
+| M3  | MinIO 连通性             | API    | bucket 可访问，presigned URL 可用   |      |
 
 ## N. 权限撤销即时生效（§4.1）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| N1 | 授权 → Chat 可用 → 撤权 → 5s 内 Chat 不可用 | API | 撤权后 Chat 返回空/no_hit | |
-| N2 | 授权 → Wiki 可访问 → 撤权 → Wiki 403 | API | 权限版本递增，缓存失效 | |
-| N3 | permission_version 递增验证 | DB | 每次权限变更 version+1 | |
+| #   | 场景                                        | 方法 | 预期                      | 状态 |
+| --- | ------------------------------------------- | ---- | ------------------------- | ---- |
+| N1  | 授权 → Chat 可用 → 撤权 → 5s 内 Chat 不可用 | API  | 撤权后 Chat 返回空/no_hit |      |
+| N2  | 授权 → Wiki 可访问 → 撤权 → Wiki 403        | API  | 权限版本递增，缓存失效    |      |
+| N3  | permission_version 递增验证                 | DB   | 每次权限变更 version+1    |      |
 
 ## O. Docker / 部署 / 合规（Stage 8）
 
-| # | 场景 | 方法 | 预期 | 状态 |
-|---|------|------|------|------|
-| O1 | docker compose up -d 单命令启动 | Bash | 全部服务 healthy | |
-| O2 | 自动 migration + seed | 日志 | entrypoint 日志显示 migrate + seed 成功 | |
-| O3 | LICENSE 文件存在 | 文件 | AGPL-3.0 全文 | |
-| O4 | nginx Phase 1 配置 | 文件 | /api/* 代理到 API，/ 代理到 web | |
-| O5 | env.example 完整 | 文件 | 所有必需变量有说明 | |
+| #   | 场景                            | 方法 | 预期                                    | 状态 |
+| --- | ------------------------------- | ---- | --------------------------------------- | ---- |
+| O1  | docker compose up -d 单命令启动 | Bash | 全部服务 healthy                        |      |
+| O2  | 自动 migration + seed           | 日志 | entrypoint 日志显示 migrate + seed 成功 |      |
+| O3  | LICENSE 文件存在                | 文件 | AGPL-3.0 全文                           |      |
+| O4  | nginx Phase 1 配置              | 文件 | /api/\* 代理到 API，/ 代理到 web        |      |
+| O5  | env.example 完整                | 文件 | 所有必需变量有说明                      |      |
 
 ## P. 性能基准（建议 staging 环境）
 
-| # | 场景 | 目标 | 状态 |
-|---|------|------|------|
-| P1 | Chat 首 token P95 | < 3s | |
-| P2 | 纯 vector 检索 P95 | < 500ms | |
-| P3 | BM25 检索 P95 | < 500ms | |
-| P4 | 混合检索 P95 | < 1.0s | |
-| P5 | Wiki 页面加载 P95 | < 1.5s | |
+| #   | 场景               | 目标    | 状态 |
+| --- | ------------------ | ------- | ---- |
+| P1  | Chat 首 token P95  | < 3s    |      |
+| P2  | 纯 vector 检索 P95 | < 500ms |      |
+| P3  | BM25 检索 P95      | < 500ms |      |
+| P4  | 混合检索 P95       | < 1.0s  |      |
+| P5  | Wiki 页面加载 P95  | < 1.5s  |      |
 
 ---
 


### PR DESCRIPTION
## Summary
- ignore local browser/auth-state JSON artifacts, local agent review output, and local-only manual checklist CSVs
- add `pnpm secret:scan` plus maintainer docs for no-secret delivery evidence
- replace concrete manual-test credentials with placeholders
- add the `round2-review-remediation` OpenSpec change fixture for Round 2 issues

## Verification
- `node scripts/secret-hygiene-scan.mjs --self-test`: passed, 14 cases
- `node -e "import('./scripts/secret-hygiene-scan.mjs').then(() => console.log('import-ok'))"`: passed
- `pnpm secret:scan`: passed, scanned 1093 commit-capable files and staged blobs, 0 findings
- `pnpm exec prettier --check package.json scripts/secret-hygiene-scan.mjs docs/ops/secret-hygiene.md tests/manual/e2e-fix-and-test-plan.md tests/manual/stage5-d1-d9-test-plan.md tests/manual/stage8-e2e-checklist.md`: passed
- `openspec validate round2-review-remediation --strict --no-interactive`: passed
- `git check-ignore cherry-auth.json local-auth.json playwright/.auth/state.json .codex/reviews/pr-323/full-rerun-1/integration.md`: listed all paths
- `git check-ignore --no-index tests/fixtures/test-corpus-small/parsed-auth-design.md tests/manual/stage8-e2e-checklist.md`: no output
- `git check-ignore --no-index tests/fixtures/auth-state.placeholder.json`: no output

## Session Hygiene Evidence
- Issue evidence: https://github.com/DankerMu/CherryWiki/issues/318#issuecomment-4448017708
- Local `cherry-auth.json` refresh cookie was checked without printing token values. `/api/auth/refresh` returned 401, confirming the affected local refresh session was already invalid/revoked and not reusable.
- The local `cherry-auth.json` artifact was removed from the working tree. No token or cookie values were recorded.

## OpenSpec
- Change: `round2-review-remediation`
- Fixture level: expanded
- Selected risk packs for #318: Config/project setup; File IO/path safety/overwrite; Legacy compatibility/examples; Error handling/rollback/partial outputs; Documentation/migration notes

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security and Performance Reviewer, Independent Final Reviewer
- Reviewed head SHA: `0243985954746ac84a35482deabc81394c316112`
- Review evidence: [Spec Compliance](https://github.com/DankerMu/CherryWiki/pull/323#issuecomment-4448168162) | [Correctness](https://github.com/DankerMu/CherryWiki/pull/323#issuecomment-4448168325) | [Integration](https://github.com/DankerMu/CherryWiki/pull/323#issuecomment-4448168526) | [Security and Performance](https://github.com/DankerMu/CherryWiki/pull/323#issuecomment-4448168710)
- Key findings addressed: full post-fix comprehensive review closed opaque and quoted refresh-token detection gaps, staged/index divergence, manual credential/API-key detection, import side effects, large-file bounds, symlink and broken-symlink handling, local `.codex/` artifact hygiene, and value-free session evidence.