### PR TITLE
fix(url-fetcher): harden SSRF CIDR and proxy behavior

### DIFF
--- a/apps/url-fetcher-worker/src/ssrf/ip_validator.py
+++ b/apps/url-fetcher-worker/src/ssrf/ip_validator.py
@@ -36,13 +36,13 @@ class IpValidationResult:
 
 class IpValidator:
     def __init__(self, forbidden_cidrs: Sequence[str] | None = None) -> None:
+        forbidden_v4: list[ForbiddenRange] = list(DEFAULT_FORBIDDEN_V4)
+        forbidden_v6: list[ForbiddenRange] = list(DEFAULT_FORBIDDEN_V6)
         if forbidden_cidrs is None:
-            self._forbidden_v4 = DEFAULT_FORBIDDEN_V4
-            self._forbidden_v6 = DEFAULT_FORBIDDEN_V6
+            self._forbidden_v4 = tuple(forbidden_v4)
+            self._forbidden_v6 = tuple(forbidden_v6)
             return
 
-        forbidden_v4: list[ForbiddenRange] = []
-        forbidden_v6: list[ForbiddenRange] = []
         for cidr in forbidden_cidrs:
             network = ipaddress.ip_network(cidr.strip(), strict=False)
             entry = (network, _default_reason_for_network(network))

--- a/apps/url-fetcher-worker/tests/test_fetcher.py
+++ b/apps/url-fetcher-worker/tests/test_fetcher.py
@@ -57,6 +57,29 @@ def test_redirect_to_private_ip_is_blocked_after_revalidation() -> None:
         == "http://private.example/admin"
     )
     assert resolver.calls == ["public.example", "private.example"]
+    assert len(session.requests) == 1
+
+
+def test_redirect_to_metadata_ip_is_blocked_before_redirect_fetch() -> None:
+    session = FakeSession(
+        [FakeResponse(302, b"", {"location": "http://metadata.example/latest"})]
+    )
+    resolver = FakeResolver(
+        {
+            "public.example": ["93.184.216.34"],
+            "metadata.example": ["169.254.169.254"],
+        }
+    )
+    fetcher = UrlFetcher(resolver=resolver, session=session)
+
+    with pytest.raises(SsrfBlockedError) as exc:
+        fetcher.fetch("http://public.example/start")
+
+    assert exc.value.metadata["block_reason"] == "redirect_to_private_ip"
+    assert exc.value.metadata["original_block_reason"] == "link_local_metadata"
+    assert exc.value.metadata["resolved_ip"] == "169.254.169.254"
+    assert len(session.requests) == 1
+    assert resolver.calls == ["public.example", "metadata.example"]
 
 
 def test_response_too_large_is_aborted() -> None:
@@ -155,6 +178,20 @@ def test_proxy_required_unreachable_proxy_fails_closed() -> None:
         "http": "http://127.0.0.1:1",
         "https": "http://127.0.0.1:1",
     }
+
+
+def test_proxy_required_constructor_without_proxy_url_fails_before_fetching() -> None:
+    session = FakeSession([FakeResponse(200, b"hello", {"content-type": "text/plain"})])
+
+    with pytest.raises(ValueError) as exc:
+        UrlFetcher(
+            resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+            session=session,
+            proxy_required=True,
+        )
+
+    assert str(exc.value) == "proxy_required requires proxy_url"
+    assert session.requests == []
 
 
 def test_invalid_proxy_required_env_value_fails_startup(

--- a/apps/url-fetcher-worker/tests/test_main.py
+++ b/apps/url-fetcher-worker/tests/test_main.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from src.errors import SsrfBlockedError
+from src.main import _build_fetcher_from_env
+
+
+def test_proxy_required_without_proxy_url_fails_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EGRESS_PROXY_REQUIRED", "true")
+    monkeypatch.delenv("EGRESS_PROXY_URL", raising=False)
+
+    with pytest.raises(RuntimeError) as exc:
+        _build_fetcher_from_env()
+
+    assert str(exc.value) == "EGRESS_PROXY_REQUIRED=true requires EGRESS_PROXY_URL"
+
+
+def test_fetcher_env_applies_proxy_and_custom_ssrf_cidrs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("EGRESS_PROXY_REQUIRED", "true")
+    monkeypatch.setenv("EGRESS_PROXY_URL", "http://proxy.example:3128")
+    monkeypatch.setenv("SSRF_BLOCKED_CIDRS", "203.0.113.0/24")
+
+    fetcher = _build_fetcher_from_env()
+
+    assert fetcher.proxy_required is True
+    assert fetcher.proxies == {
+        "http": "http://proxy.example:3128",
+        "https": "http://proxy.example:3128",
+    }
+    with pytest.raises(SsrfBlockedError):
+        fetcher.resolver.ip_validator.validate_ip("203.0.113.10")
+    with pytest.raises(SsrfBlockedError):
+        fetcher.resolver.ip_validator.validate_ip("10.1.2.3")
+
+
+def test_invalid_ssrf_blocked_cidrs_fails_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SSRF_BLOCKED_CIDRS", "not-a-cidr")
+
+    with pytest.raises(ValueError):
+        _build_fetcher_from_env()

--- a/apps/url-fetcher-worker/tests/test_ssrf.py
+++ b/apps/url-fetcher-worker/tests/test_ssrf.py
@@ -35,21 +35,36 @@ def test_public_ip_is_allowed() -> None:
     assert result.ip == "93.184.216.34"
 
 
-def test_custom_blocked_cidrs_override_defaults() -> None:
+@pytest.mark.parametrize(
+    ("ip", "reason"),
+    [
+        ("203.0.113.10", "configured_blocked_cidr"),
+        ("10.1.2.3", "private_ip_rfc1918"),
+        ("127.0.0.1", "private_ip_localhost"),
+        ("169.254.169.254", "link_local_metadata"),
+        ("::ffff:10.0.0.1", "ipv4_mapped_ipv6_private"),
+    ],
+)
+def test_custom_blocked_cidrs_append_to_defaults(ip: str, reason: str) -> None:
     validator = IpValidator(forbidden_cidrs=("203.0.113.0/24",))
 
     with pytest.raises(SsrfBlockedError) as exc:
-        validator.validate_ip("203.0.113.10", target_url="http://target.test")
+        validator.validate_ip(ip, target_url="http://target.test")
 
-    assert exc.value.metadata["block_reason"] == "configured_blocked_cidr"
-    assert validator.validate_ip("10.1.2.3").ip == "10.1.2.3"
+    assert exc.value.metadata["block_reason"] == reason
 
 
-def test_default_ranges_still_apply_without_custom_cidrs() -> None:
+@pytest.mark.parametrize("forbidden_cidrs", [None, ()])
+def test_default_ranges_apply_without_custom_cidrs(
+    forbidden_cidrs: tuple[str, ...] | None,
+) -> None:
+    validator = IpValidator(forbidden_cidrs=forbidden_cidrs)
+
     with pytest.raises(SsrfBlockedError) as exc:
-        IpValidator().validate_ip("10.1.2.3", target_url="http://target.test")
+        validator.validate_ip("10.1.2.3", target_url="http://target.test")
 
     assert exc.value.metadata["block_reason"] == "private_ip_rfc1918"
+    assert validator.validate_ip("93.184.216.34").ip == "93.184.216.34"
 
 
 def test_parse_blocked_cidrs_rejects_empty_parsed_value() -> None:
@@ -57,3 +72,8 @@ def test_parse_blocked_cidrs_rejects_empty_parsed_value() -> None:
         parse_blocked_cidrs(",")
 
     assert "produced zero valid CIDRs" in str(exc.value)
+
+
+def test_parse_blocked_cidrs_rejects_invalid_cidr() -> None:
+    with pytest.raises(ValueError):
+        parse_blocked_cidrs("203.0.113.0/24,not-a-cidr")

--- a/openspec/changes/round2-review-remediation/design.md
+++ b/openspec/changes/round2-review-remediation/design.md
@@ -175,3 +175,87 @@ Review focus:
 - Checklist credentials are placeholders or the checklist is excluded from delivery.
 - Secret scan command is reproducible on a clean checkout.
 - Evidence text does not include secret material.
+
+## Issue #319 Fixture: URL Fetcher SSRF and Proxy Hardening
+
+Fixture level: expanded
+Project profile: other
+Blast radius: high
+
+Why expanded:
+
+- The issue changes network egress security defaults and proxy-required behavior.
+- The issue touches runtime URL fetching, redirect handling, and startup configuration validation.
+- The issue must preserve built-in SSRF protections while adding operator-configured blocked CIDRs.
+
+Change surface:
+
+- `apps/url-fetcher-worker/src/ssrf/ip_validator.py`
+- URL fetcher configuration and startup paths that parse `SSRF_BLOCKED_CIDRS`, `EGRESS_PROXY_REQUIRED`, and `EGRESS_PROXY_URL`
+- URL fetcher redirect handling/runtime fetch path
+- `apps/url-fetcher-worker/tests/**`
+
+Must preserve:
+
+- Built-in localhost, RFC1918, link-local, metadata, current-network, IPv6 localhost, IPv6 ULA, IPv6 link-local, and IPv4-mapped IPv6 blocking remains enabled when no custom CIDRs are configured.
+- Public, non-blocked destinations remain fetchable when proxy-required mode is disabled and normal SSRF validation passes.
+- Malformed CIDR configuration continues to fail closed rather than silently weakening validation.
+- Existing successful proxy behavior remains compatible when `EGRESS_PROXY_REQUIRED=true` and a reachable proxy is configured.
+
+Must add/change:
+
+- `SSRF_BLOCKED_CIDRS` appends to the built-in forbidden ranges instead of replacing them.
+- Proxy-required mode fails during startup/configuration when no proxy URL is configured.
+- Proxy-required runtime failures do not retry through direct egress when the proxy is unreachable.
+- Redirect targets are re-resolved and revalidated before any redirected request is fetched.
+
+Selected risk packs:
+
+- Public API / CLI / script entry: environment-variable behavior is part of the worker operator contract.
+- Config / project setup: SSRF and proxy settings must be parsed consistently and fail closed on invalid values.
+- File IO / path safety / overwrite: not selected for implementation behavior, but path safety is not involved because the change is network egress only.
+- Resource limits / large input / discovery: redirect handling must remain bounded by existing redirect/fetch limits and must not introduce unbounded resolution loops.
+- Legacy compatibility / examples: default allow/block behavior for existing deployments without custom CIDRs must be preserved.
+- Error handling / rollback / partial outputs: proxy and CIDR failures must stop before unsafe direct egress or partial private-target fetches occur.
+- Documentation / migration notes: changed additive semantics and proxy-required failure modes need operator-facing notes or test evidence.
+
+Risk packs considered:
+
+- Public API / CLI / script entry: selected - env vars configure worker startup and runtime egress behavior.
+- Config / project setup: selected - CIDR and proxy env parsing are the core change.
+- File IO / path safety / overwrite: not selected - no filesystem read/write, publish, overwrite, symlink, or path behavior is changed.
+- Schema / columns / units / field names: not selected - no data schema or field contract changes.
+- Geospatial / CRS / shapefile sidecars: not selected - no geospatial artifacts are touched.
+- Time series / forcing / temporal boundaries: not selected - no temporal data behavior is touched.
+- Numerical stability / conservation / NaN: not selected - no numerical behavior is touched.
+- Solver runtime / performance / threading: not selected - no solver, threading, or numerical runtime surface is touched.
+- Resource limits / large input / discovery: selected - redirect chains and DNS/address validation must remain bounded and deterministic.
+- Legacy compatibility / examples: selected - no-custom-CIDR deployments and normal public URL fetches must keep working.
+- Error handling / rollback / partial outputs: selected - invalid config, unreachable proxy, and private redirects must fail closed with no direct fallback.
+- Release / packaging / dependency compatibility: not selected - no new runtime dependency is required for this issue.
+- Documentation / migration notes: selected - additive CIDR semantics are a behavior change from replacement semantics.
+
+Required evidence:
+
+- `PYTHONPATH=apps/url-fetcher-worker apps/url-fetcher-worker/.venv/bin/pytest apps/url-fetcher-worker/tests -q`: URL fetcher tests pass with the worker virtualenv.
+- Test `SSRF_BLOCKED_CIDRS=203.0.113.0/24`: `203.0.113.10`, `10.1.2.3`, `127.0.0.1`, `169.254.169.254`, and `::ffff:10.0.0.1` are blocked.
+- Test unset/empty `SSRF_BLOCKED_CIDRS`: built-in blocked ranges still fail and a representative public IP remains allowed.
+- Test malformed `SSRF_BLOCKED_CIDRS`: worker configuration construction or startup raises an explicit configuration error.
+- Test `EGRESS_PROXY_REQUIRED=true` with missing proxy URL: startup/configuration fails before fetching.
+- Test `EGRESS_PROXY_REQUIRED=true` with an unreachable proxy URL: fetch fails through the proxy path and never falls back to a direct request.
+- Test public URL redirecting to a private or metadata target: redirect target is blocked before private-target fetch.
+
+Non-goals:
+
+- Do not implement live-stack smoke workflow changes in #319; those belong to #320.
+- Do not add admin model/Docmost outbound probe allowlists in #319; those belong to #322.
+- Do not weaken or remove built-in blocked ranges to preserve custom CIDR compatibility.
+- Do not add a broad direct-egress fallback for proxy-required deployments.
+
+Review focus:
+
+- Built-in and custom CIDR lists are additive in all construction paths.
+- IPv4-mapped IPv6 private/metadata addresses are normalized and blocked.
+- Redirect validation uses the effective redirected target, not only the original URL.
+- Proxy-required mode cannot silently perform direct outbound requests.
+- Tests exercise the normal package/runtime paths rather than only private helper functions.

--- a/openspec/changes/round2-review-remediation/tasks.md
+++ b/openspec/changes/round2-review-remediation/tasks.md
@@ -8,11 +8,11 @@
 
 ## 2. URL Fetcher SSRF and Proxy Hardening
 
-- [ ] 2.1 Change `SSRF_BLOCKED_CIDRS` handling so configured CIDRs are appended to built-in forbidden ranges instead of replacing them.
-- [ ] 2.2 Update URL fetcher tests to assert custom CIDR plus built-in RFC1918, localhost, metadata, and IPv4-mapped IPv6 ranges remain blocked.
-- [ ] 2.3 Keep malformed CIDR configuration fail-closed and add/retain startup tests for invalid values.
-- [ ] 2.4 Add regression coverage for proxy-required mode with missing and unreachable proxy configuration.
-- [ ] 2.5 Add redirect revalidation coverage where an initially allowed URL redirects to a private or metadata address.
+- [x] 2.1 Change `SSRF_BLOCKED_CIDRS` handling so configured CIDRs are appended to built-in forbidden ranges instead of replacing them.
+- [x] 2.2 Update URL fetcher tests to assert custom CIDR plus built-in RFC1918, localhost, metadata, and IPv4-mapped IPv6 ranges remain blocked.
+- [x] 2.3 Keep malformed CIDR configuration fail-closed and add/retain startup tests for invalid values.
+- [x] 2.4 Add regression coverage for proxy-required mode with missing and unreachable proxy configuration.
+- [x] 2.5 Add redirect revalidation coverage where an initially allowed URL redirects to a private or metadata address.
 
 ## 3. Live-Stack Smoke Reliability
 
@@ -72,3 +72,31 @@ Non-goals for #318:
 - No committed browser storage-state fixture.
 - No placeholder/example auth JSON using the reserved local-artifact pattern `*-auth.json`.
 - No changes to URL fetcher, smoke workflow, OpenSpec delivery integrity, or admin outbound probe safety tasks outside the secret-hygiene issue.
+
+## Issue #319 Evidence Mapping
+
+Selected risk packs:
+
+- Public API / CLI / script entry: covered by 2.1, 2.3, 2.4, and tests that exercise env-var-driven construction/startup behavior.
+- Config / project setup: covered by 2.1 and 2.3, including additive CIDR parsing and malformed CIDR fail-closed behavior.
+- Resource limits / large input / discovery: covered by 2.5 and redirect tests that prove revalidation stays within the existing bounded fetch/redirect behavior.
+- Legacy compatibility / examples: covered by 2.2 tests for unset/empty custom CIDRs and representative public destination allow behavior.
+- Error handling / rollback / partial outputs: covered by 2.3, 2.4, and 2.5 tests for invalid config, missing/unreachable proxy, and private redirects.
+- Documentation / migration notes: covered by implementation notes or docs/test names explaining additive CIDR semantics and proxy-required fail-closed behavior.
+
+Required evidence for #319:
+
+- Run `PYTHONPATH=apps/url-fetcher-worker apps/url-fetcher-worker/.venv/bin/pytest apps/url-fetcher-worker/tests -q`; expected result is pass.
+- Add/retain a test with `SSRF_BLOCKED_CIDRS=203.0.113.0/24`; expected result is that `203.0.113.10`, `10.1.2.3`, `127.0.0.1`, `169.254.169.254`, and `::ffff:10.0.0.1` are blocked.
+- Add/retain a test with `SSRF_BLOCKED_CIDRS` unset or empty; expected result is that built-in blocked ranges remain blocked and a representative public IP remains allowed.
+- Add/retain a malformed CIDR test; expected result is an explicit configuration/startup failure and no unsafe default allow behavior.
+- Add/retain a proxy-required missing URL test; expected result is startup/configuration failure before any fetch.
+- Add/retain a proxy-required unreachable proxy test; expected result is request failure with no direct egress fallback.
+- Add/retain a redirect test where an initially allowed URL redirects to a private or metadata address; expected result is block before fetching the private target.
+
+Non-goals for #319:
+
+- No live-stack smoke workflow changes; those remain in #320.
+- No admin model or Docmost outbound probe safety changes; those remain in #322.
+- No new secret-hygiene behavior beyond consuming the already merged #318 repo hygiene baseline.
+- No replacement of the URL fetcher architecture or broad HTTP client migration.


### PR DESCRIPTION
## Summary
- Keep built-in URL fetcher SSRF blocked ranges when SSRF_BLOCKED_CIDRS is configured
- Add URL fetcher coverage for additive custom CIDRs, IPv4-mapped IPv6, invalid CIDRs, proxy-required fail-closed behavior, and redirect revalidation
- Add #319 OpenSpec fixture/evidence mapping under round2-review-remediation

## OpenSpec
- Change: openspec/changes/round2-review-remediation/
- Spec: specs/url-fetcher-egress-ssrf-safety/spec.md
- Fixture level: expanded
- Selected risk packs: Public API / CLI / script entry; Config / project setup; Resource limits / large input / discovery; Legacy compatibility / examples; Error handling / rollback / partial outputs; Documentation / migration notes

## Verification
- Fixture review: pass
- openspec validate round2-review-remediation --strict --no-interactive
- PYTHONPATH=apps/url-fetcher-worker apps/url-fetcher-worker/.venv/bin/pytest apps/url-fetcher-worker/tests -q (36 passed)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security and Performance Reviewer, Independent Final Reviewer
- Reviewed head SHA: `03b6f54f30613da16f2ac0f4f4ea8c1d28656611`
- Review evidence: [Spec Compliance](https://github.com/DankerMu/CherryWiki/pull/324#issuecomment-4448339394) | [Correctness](https://github.com/DankerMu/CherryWiki/pull/324#issuecomment-4448341198) | [Integration](https://github.com/DankerMu/CherryWiki/pull/324#issuecomment-4448342647) | [Security and Performance](https://github.com/DankerMu/CherryWiki/pull/324#issuecomment-4448344480) | [Final Review](https://github.com/DankerMu/CherryWiki/pull/324#issuecomment-4448345684)
- Key findings addressed: No actionable findings. Cross-review and independent final review were clean; no fix rounds were needed.

Closes #319