### PR TITLE
ci(smoke): make egress smoke fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,18 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Install URL fetcher Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r apps/url-fetcher-worker/requirements.txt
 
       - name: Build
         run: pnpm build
@@ -73,6 +83,8 @@ jobs:
         run: pnpm exec vitest run packages/rag-core/src/__tests__/graph-retrieval.test.ts packages/rag-core/src/__tests__/retrieval-engine.test.ts --config vitest.config.ts
 
       - name: Test with coverage
+        env:
+          URL_FETCHER_PYTHON: python
         run: pnpm test -- --coverage
 
       - name: Integration tests
@@ -253,4 +265,4 @@ jobs:
       - name: E2E integration tests
         run: pnpm exec vitest run tests/integration/ --config vitest.config.ts
         env:
-          E2E: "true"
+          E2E: 'true'

--- a/.github/workflows/live-stack-smoke.yml
+++ b/.github/workflows/live-stack-smoke.yml
@@ -13,6 +13,7 @@ on:
       - 'docker-compose.prod.yml'
       - 'package.json'
       - 'packages/job-core/**'
+      - 'packages/shared/**'
       - 'pnpm-lock.yaml'
       - 'tests/smoke/**'
       - 'vitest.config.ts'

--- a/.github/workflows/live-stack-smoke.yml
+++ b/.github/workflows/live-stack-smoke.yml
@@ -1,4 +1,4 @@
-name: Live Stack Smoke
+name: Dependency Container Smoke
 
 on:
   push:
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   smoke:
-    name: MinIO, Redis, and Egress
+    name: MinIO, Redis, and URL Fetcher Egress
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -82,6 +82,11 @@ jobs:
       - name: Install Node dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install URL fetcher Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r apps/url-fetcher-worker/requirements.txt
+
       - name: Validate production Docker Compose
         env:
           POSTGRES_PASSWORD: ci-postgres-password
@@ -92,5 +97,7 @@ jobs:
           WORKER_API_KEY: ci-worker-api-key
         run: docker compose -f docker-compose.prod.yml config --quiet
 
-      - name: Run live-stack smoke tests
-        run: pnpm exec vitest run tests/smoke/ --config vitest.config.ts
+      - name: Run dependency-container smoke tests
+        env:
+          URL_FETCHER_PYTHON: python
+        run: pnpm exec vitest run tests/smoke/ --config vitest.config.ts --passWithNoTests=false

--- a/openspec/changes/round2-review-remediation/design.md
+++ b/openspec/changes/round2-review-remediation/design.md
@@ -259,3 +259,89 @@ Review focus:
 - Redirect validation uses the effective redirected target, not only the original URL.
 - Proxy-required mode cannot silently perform direct outbound requests.
 - Tests exercise the normal package/runtime paths rather than only private helper functions.
+
+## Issue #320 Fixture: Live-Stack Smoke Reliability
+
+Fixture level: expanded
+Project profile: other
+Blast radius: high
+
+Why expanded:
+
+- The issue changes CI deployment evidence and smoke workflow fail/pass behavior.
+- The issue touches smoke test discovery, worker Python dependency setup, and URL fetcher runtime-path coverage.
+- The issue must preserve existing MinIO/Redis/BullMQ smoke evidence while adding egress runtime coverage.
+
+Change surface:
+
+- `.github/workflows/live-stack-smoke.yml`
+- `tests/smoke/egress-smoke.test.ts`
+- `tests/smoke/minio-smoke.test.ts`
+- `tests/smoke/redis-smoke.test.ts`
+- URL fetcher worker test/runtime command wiring used by smoke evidence
+
+Must preserve:
+
+- MinIO smoke continues to create, read, and clean up an object through real S3-compatible credentials.
+- Redis smoke continues to ping Redis and persist/retrieve a BullMQ job through the configured Redis URL.
+- Smoke workflow still runs on PRs that change URL fetcher, smoke tests, shared packages, or the smoke workflow.
+- URL fetcher egress smoke remains deterministic and local-first; it must not depend on public internet availability.
+
+Must add/change:
+
+- The Vitest smoke command fails when zero smoke tests are discovered.
+- Egress smoke uses normal URL fetcher package imports and installed worker dependencies instead of direct `ip_validator.py` file loading.
+- Egress smoke or equivalent targeted smoke evidence covers redirect-to-private blocking and proxy-required fail-closed behavior.
+- Workflow naming, comments, or evidence must accurately state whether it proves dependency containers or production compose topology.
+- Environment assumptions for MinIO, Redis/BullMQ, and URL fetcher dependency setup must be visible in workflow/test evidence.
+
+Selected risk packs:
+
+- Public API / CLI / script entry: CI workflow commands and smoke test entrypoints are release gates.
+- Config / project setup: worker Python dependencies and `PYTHONPATH`/package import setup are core behavior.
+- Resource limits / large input / discovery: test discovery must fail closed and smoke execution must remain bounded/local.
+- Legacy compatibility / examples: existing MinIO and Redis/BullMQ smoke coverage must keep working.
+- Error handling / rollback / partial outputs: missing tests, missing dependencies, broken imports, unsafe redirects, and proxy-required failures must fail CI rather than pass silently.
+- Release / packaging / dependency compatibility: smoke must detect missing URL fetcher runtime dependencies used in deployment.
+- Documentation / migration notes: workflow scope and dependency-container assumptions must be explicit.
+
+Risk packs considered:
+
+- Public API / CLI / script entry: selected - workflow/test commands are CI release-gate entrypoints.
+- Config / project setup: selected - dependency install, `PYTHONPATH`, env vars, MinIO, and Redis setup are the core change.
+- File IO / path safety / overwrite: not selected - no file publish/delete/overwrite behavior is changed beyond test source edits.
+- Schema / columns / units / field names: not selected - no data schema or field contract changes.
+- Geospatial / CRS / shapefile sidecars: not selected - no geospatial artifacts are touched.
+- Time series / forcing / temporal boundaries: not selected - no temporal data behavior is touched.
+- Numerical stability / conservation / NaN: not selected - no numerical behavior is touched.
+- Solver runtime / performance / threading: not selected - no solver or threaded runtime surface is touched.
+- Resource limits / large input / discovery: selected - zero-test discovery and bounded local smoke behavior are central.
+- Legacy compatibility / examples: selected - existing MinIO/Redis smoke tests must remain intact.
+- Error handling / rollback / partial outputs: selected - CI must fail closed on missing smoke tests, missing worker deps/imports, unsafe redirects, and proxy-required misconfiguration.
+- Release / packaging / dependency compatibility: selected - smoke must use the worker dependency set rather than bypassing it.
+- Documentation / migration notes: selected - workflow scope must be accurately named/described.
+
+Required evidence:
+
+- `pnpm exec vitest run tests/smoke/ --config vitest.config.ts --passWithNoTests=false`: smoke tests pass and would fail on zero discovered tests.
+- A CI/workflow command installs or otherwise uses `apps/url-fetcher-worker/requirements.txt` before egress smoke runs.
+- Egress smoke imports URL fetcher through the normal package path such as `src.fetcher`/`src.main`; direct `ip_validator.py` file loading is removed.
+- Egress smoke or targeted smoke evidence verifies a public/local allowed URL redirecting to private/metadata is blocked before private-target fetch.
+- Egress smoke or targeted smoke evidence verifies proxy-required mode fails closed when proxy URL is missing or unreachable.
+- MinIO and Redis smoke tests still run and prove create/read/cleanup plus BullMQ persistence.
+- Workflow name/comment/evidence states dependency-container smoke unless compose-based production topology checks are added.
+
+Non-goals:
+
+- Do not re-implement URL fetcher SSRF semantics; #319 already owns runtime behavior.
+- Do not add admin model or Docmost outbound probe safety; #322 owns that.
+- Do not triage all unrelated OpenSpec artifacts; #321 owns global delivery integrity.
+- Do not make smoke depend on external public internet.
+
+Review focus:
+
+- Smoke cannot pass with zero tests.
+- Egress smoke fails if URL fetcher dependencies or package imports are broken.
+- Runtime `UrlFetcher` behavior, not only isolated `IpValidator`, is covered.
+- Existing MinIO/Redis/BullMQ evidence remains active.
+- Workflow naming and evidence do not overclaim production compose coverage.

--- a/openspec/changes/round2-review-remediation/tasks.md
+++ b/openspec/changes/round2-review-remediation/tasks.md
@@ -16,12 +16,12 @@
 
 ## 3. Live-Stack Smoke Reliability
 
-- [ ] 3.1 Update `.github/workflows/live-stack-smoke.yml` so the Vitest smoke command fails when zero tests are discovered.
-- [ ] 3.2 Install URL fetcher Python dependencies in the smoke workflow or run the egress smoke inside a prepared worker environment.
-- [ ] 3.3 Replace direct `ip_validator.py` file loading in egress smoke with normal package import or a small runtime `UrlFetcher` scenario.
-- [ ] 3.4 Add smoke/integration coverage for redirect-to-private blocking and proxy-required fail-closed behavior.
-- [ ] 3.5 Decide whether the workflow proves production compose topology; either add compose-based runtime checks or rename/document it as dependency smoke.
-- [ ] 3.6 Retain MinIO create/read/cleanup and Redis/BullMQ persistence checks and document their environment assumptions.
+- [x] 3.1 Update `.github/workflows/live-stack-smoke.yml` so the Vitest smoke command fails when zero tests are discovered.
+- [x] 3.2 Install URL fetcher Python dependencies in the smoke workflow or run the egress smoke inside a prepared worker environment.
+- [x] 3.3 Replace direct `ip_validator.py` file loading in egress smoke with normal package import or a small runtime `UrlFetcher` scenario.
+- [x] 3.4 Add smoke/integration coverage for redirect-to-private blocking and proxy-required fail-closed behavior.
+- [x] 3.5 Decide whether the workflow proves production compose topology; either add compose-based runtime checks or rename/document it as dependency smoke.
+- [x] 3.6 Retain MinIO create/read/cleanup and Redis/BullMQ persistence checks and document their environment assumptions.
 
 ## 4. OpenSpec Delivery Integrity
 
@@ -100,3 +100,33 @@ Non-goals for #319:
 - No admin model or Docmost outbound probe safety changes; those remain in #322.
 - No new secret-hygiene behavior beyond consuming the already merged #318 repo hygiene baseline.
 - No replacement of the URL fetcher architecture or broad HTTP client migration.
+
+## Issue #320 Evidence Mapping
+
+Selected risk packs:
+
+- Public API / CLI / script entry: covered by 3.1 and the smoke workflow command used by CI.
+- Config / project setup: covered by 3.2 and 3.3, including URL fetcher worker dependency installation and normal package import setup.
+- Resource limits / large input / discovery: covered by 3.1 and 3.4, proving test discovery fails closed and egress scenarios stay local/bounded.
+- Legacy compatibility / examples: covered by 3.6, retaining MinIO create/read/cleanup and Redis/BullMQ persistence checks.
+- Error handling / rollback / partial outputs: covered by 3.1, 3.2, 3.3, and 3.4, requiring CI failure for zero tests, missing deps/imports, unsafe redirects, and proxy-required misconfiguration.
+- Release / packaging / dependency compatibility: covered by 3.2 and 3.3, proving smoke uses the URL fetcher runtime dependency set.
+- Documentation / migration notes: covered by 3.5 and 3.6, requiring workflow scope and environment assumptions to be explicit.
+
+Required evidence for #320:
+
+- Run `pnpm exec vitest run tests/smoke/ --config vitest.config.ts --passWithNoTests=false`; expected result is pass with discovered smoke tests.
+- Show the smoke workflow command includes `--passWithNoTests=false`; expected result is CI cannot pass when `tests/smoke/` discovers zero tests.
+- Show URL fetcher worker dependencies are installed or available before egress smoke; expected result is missing `requests`/`dnspython` or broken `src.*` imports fail smoke.
+- Show egress smoke imports URL fetcher via normal package path such as `src.fetcher`/`src.main`; expected result is no direct `ip_validator.py` file loading remains.
+- Add/retain egress smoke for redirect-to-private or metadata blocking; expected result is blocked before private-target fetch.
+- Add/retain egress smoke for proxy-required missing or unreachable proxy; expected result is fail-closed and no direct egress fallback.
+- Retain MinIO and Redis/BullMQ smoke assertions; expected result is object create/read/cleanup and queue persistence still pass.
+- Document or name workflow scope accurately; expected result is dependency-container smoke unless compose topology checks are added.
+
+Non-goals for #320:
+
+- No URL fetcher SSRF semantic redesign; #319 already implemented additive CIDRs, redirect revalidation, and proxy fail-closed semantics.
+- No admin outbound probe changes; #322 owns model/Docmost safety.
+- No global OpenSpec artifact triage; #321 owns delivery integrity.
+- No reliance on public internet for smoke success.

--- a/tests/smoke/egress-smoke.test.ts
+++ b/tests/smoke/egress-smoke.test.ts
@@ -164,8 +164,11 @@ print(
         PYTHONPATH: path.join(rootDir, 'apps/url-fetcher-worker'),
       },
       encoding: 'utf8',
+      maxBuffer: 64 * 1024,
+      timeout: 10_000,
     });
 
+    expect(result.error, result.error?.message ?? result.stderr ?? result.stdout).toBeUndefined();
     expect(result.status, result.stderr || result.stdout).toBe(0);
     expect(JSON.parse(result.stdout)).toMatchObject({
       missing_proxy_error: 'EGRESS_PROXY_REQUIRED=true requires EGRESS_PROXY_URL',

--- a/tests/smoke/egress-smoke.test.ts
+++ b/tests/smoke/egress-smoke.test.ts
@@ -1,60 +1,163 @@
 import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
 const rootDir = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const localWorkerPython = path.join(rootDir, 'apps/url-fetcher-worker/.venv/bin/python');
+const pythonBin =
+  process.env.URL_FETCHER_PYTHON ?? (existsSync(localWorkerPython) ? localWorkerPython : 'python3');
 
-describe('egress SSRF smoke', () => {
-  it('blocks private and metadata IPs while allowing public IPs', () => {
+describe('URL fetcher egress dependency-container smoke', () => {
+  it('uses URL fetcher runtime imports for redirect blocking and proxy fail-closed behavior', () => {
     const script = String.raw`
-import importlib.util
 import json
-import pathlib
-import sys
-import types
+import os
+from typing import Any
 
-root = pathlib.Path("apps/url-fetcher-worker/src").resolve()
-src_package = types.ModuleType("src")
-src_package.__path__ = [str(root)]
-sys.modules["src"] = src_package
-ssrf_package = types.ModuleType("src.ssrf")
-ssrf_package.__path__ = [str(root / "ssrf")]
-sys.modules["src.ssrf"] = ssrf_package
+import requests
 
-errors_spec = importlib.util.spec_from_file_location("src.errors", root / "errors.py")
-errors_module = importlib.util.module_from_spec(errors_spec)
-sys.modules["src.errors"] = errors_module
-errors_spec.loader.exec_module(errors_module)
+from src.errors import FetchError, SsrfBlockedError
+from src.fetcher import UrlFetcher
+from src.main import _build_fetcher_from_env
+from src.ssrf import IpValidator, ResolvedAddress
 
-validator_spec = importlib.util.spec_from_file_location(
-    "src.ssrf.ip_validator",
-    root / "ssrf" / "ip_validator.py",
+
+class FakeResolver:
+    def __init__(self, records: dict[str, list[str]]) -> None:
+        self.records = records
+        self.calls: list[str] = []
+
+    def resolve(self, hostname: str, *, target_url: str = "") -> list[ResolvedAddress]:
+        self.calls.append(hostname)
+        validated = IpValidator().validate_all(
+            self.records[hostname],
+            target_url=target_url,
+        )
+        return [
+            ResolvedAddress(ip=item.ip, original_ip=item.original_ip)
+            for item in validated
+        ]
+
+
+class FakeSession:
+    def __init__(
+        self,
+        responses: list["FakeResponse"] | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        self.responses = responses or []
+        self.error = error
+        self.requests: list[dict[str, Any]] = []
+        self.cookies = FakeCookies()
+
+    def get(self, url: str, headers: dict[str, str], **kwargs: Any) -> "FakeResponse":
+        self.requests.append({"url": url, "headers": headers, "kwargs": kwargs})
+        if self.error is not None:
+            raise self.error
+        if not self.responses:
+            raise AssertionError("unexpected direct fetch fallback")
+        return self.responses.pop(0)
+
+
+class FakeCookies:
+    def clear(self) -> None:
+        return
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, body: bytes, headers: dict[str, str]) -> None:
+        self.status_code = status_code
+        self.body = body
+        self.headers = headers
+        self.reason = "OK"
+
+    def iter_content(self, chunk_size: int) -> list[bytes]:
+        return [self.body]
+
+    def close(self) -> None:
+        return
+
+
+redirect_session = FakeSession(
+    [FakeResponse(302, b"", {"location": "http://metadata.example/latest"})]
 )
-validator_module = importlib.util.module_from_spec(validator_spec)
-sys.modules["src.ssrf.ip_validator"] = validator_module
-validator_spec.loader.exec_module(validator_module)
+redirect_resolver = FakeResolver(
+    {
+        "public.example": ["93.184.216.34"],
+        "metadata.example": ["169.254.169.254"],
+    }
+)
+redirect_fetcher = UrlFetcher(resolver=redirect_resolver, session=redirect_session)
 
-from src.errors import SsrfBlockedError
+try:
+    redirect_fetcher.fetch("http://public.example/start")
+except SsrfBlockedError as exc:
+    redirect_block = exc.metadata
+else:
+    raise AssertionError("metadata redirect was allowed")
 
-IpValidator = validator_module.IpValidator
+if len(redirect_session.requests) != 1:
+    raise AssertionError("redirect target was fetched before SSRF revalidation")
 
-validator = IpValidator()
-blocked = {}
-for ip in ("169.254.169.254", "10.0.0.1", "127.0.0.1"):
+previous_required = os.environ.get("EGRESS_PROXY_REQUIRED")
+previous_proxy = os.environ.get("EGRESS_PROXY_URL")
+try:
+    os.environ["EGRESS_PROXY_REQUIRED"] = "true"
+    os.environ.pop("EGRESS_PROXY_URL", None)
     try:
-        validator.validate_ip(ip, target_url=f"http://{ip}/")
-    except SsrfBlockedError as exc:
-        blocked[ip] = exc.metadata["block_reason"]
+        _build_fetcher_from_env()
+    except RuntimeError as exc:
+        missing_proxy_error = str(exc)
     else:
-        raise AssertionError(f"{ip} was allowed")
+        raise AssertionError("proxy-required startup allowed a missing proxy")
+finally:
+    if previous_required is None:
+        os.environ.pop("EGRESS_PROXY_REQUIRED", None)
+    else:
+        os.environ["EGRESS_PROXY_REQUIRED"] = previous_required
+    if previous_proxy is None:
+        os.environ.pop("EGRESS_PROXY_URL", None)
+    else:
+        os.environ["EGRESS_PROXY_URL"] = previous_proxy
 
-allowed = validator.validate_ip("8.8.8.8", target_url="http://8.8.8.8/")
-print(json.dumps({"blocked": blocked, "allowed": allowed.ip}, sort_keys=True))
+proxy_session = FakeSession(error=requests.exceptions.ProxyError("proxy down"))
+proxy_fetcher = UrlFetcher(
+    resolver=FakeResolver({"example.com": ["93.184.216.34"]}),
+    session=proxy_session,
+    proxy_url="http://127.0.0.1:1",
+    proxy_required=True,
+)
+
+try:
+    proxy_fetcher.fetch("http://example.com/proxied")
+except FetchError as exc:
+    proxy_error = str(exc)
+else:
+    raise AssertionError("unreachable required proxy was allowed")
+
+if len(proxy_session.requests) != 1:
+    raise AssertionError("fetch retried without the required proxy")
+
+print(
+    json.dumps(
+        {
+            "missing_proxy_error": missing_proxy_error,
+            "proxy_error": proxy_error,
+            "proxy_request_count": len(proxy_session.requests),
+            "proxy_request_proxies": proxy_session.requests[0]["kwargs"]["proxies"],
+            "redirect_block": redirect_block,
+            "redirect_request_count": len(redirect_session.requests),
+            "resolver_calls": redirect_resolver.calls,
+        },
+        sort_keys=True,
+    )
+)
 `;
 
-    const result = spawnSync('python3', ['-c', script], {
+    const result = spawnSync(pythonBin, ['-c', script], {
       cwd: rootDir,
       env: {
         ...process.env,
@@ -64,13 +167,20 @@ print(json.dumps({"blocked": blocked, "allowed": allowed.ip}, sort_keys=True))
     });
 
     expect(result.status, result.stderr || result.stdout).toBe(0);
-    expect(JSON.parse(result.stdout)).toEqual({
-      allowed: '8.8.8.8',
-      blocked: {
-        '10.0.0.1': 'private_ip_rfc1918',
-        '127.0.0.1': 'private_ip_localhost',
-        '169.254.169.254': 'link_local_metadata',
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      missing_proxy_error: 'EGRESS_PROXY_REQUIRED=true requires EGRESS_PROXY_URL',
+      proxy_request_count: 1,
+      proxy_request_proxies: {
+        http: 'http://127.0.0.1:1',
+        https: 'http://127.0.0.1:1',
       },
+      redirect_block: {
+        block_reason: 'redirect_to_private_ip',
+        original_block_reason: 'link_local_metadata',
+        resolved_ip: '169.254.169.254',
+      },
+      redirect_request_count: 1,
+      resolver_calls: ['public.example', 'metadata.example'],
     });
   });
 });

--- a/tests/smoke/minio-smoke.test.ts
+++ b/tests/smoke/minio-smoke.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../apps/api/node_modules/@aws-sdk/client-s3';
 import { describe, expect, it } from 'vitest';
 
-describe('MinIO live-stack smoke', () => {
+describe('MinIO dependency-container smoke', () => {
   it('uploads, reads back, and cleans up an object', async () => {
     const bucket = `cherrywiki-smoke-${randomUUID()}`;
     const key = 'smoke.txt';

--- a/tests/smoke/redis-smoke.test.ts
+++ b/tests/smoke/redis-smoke.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { createBullMQConnection } from '@cherrygraph/job-core';
 
-describe('Redis and BullMQ live-stack smoke', () => {
+describe('Redis and BullMQ dependency-container smoke', () => {
   it('pings Redis and persists a queued BullMQ job', async () => {
     const connection = createBullMQConnection(process.env.REDIS_URL ?? 'redis://localhost:6379');
     const queueName = `cherrywiki-smoke-${process.pid}-${Date.now()}`;


### PR DESCRIPTION
## Summary
- Rename live-stack smoke workflow to dependency-container smoke scope
- Install URL fetcher Python dependencies before smoke tests and fail closed on zero discovered smoke tests
- Replace direct ip_validator.py loading with normal URL fetcher package imports and runtime-path smoke coverage for redirect and proxy fail-closed behavior
- Keep MinIO object create/read/cleanup and Redis/BullMQ persistence smoke checks

## OpenSpec
- Change: openspec/changes/round2-review-remediation/
- Spec: specs/live-stack-smoke-reliability/spec.md
- Fixture level: expanded
- Selected risk packs: Public API / CLI / script entry; Config / project setup; Resource limits / large input / discovery; Legacy compatibility / examples; Error handling / rollback / partial outputs; Release / packaging / dependency compatibility; Documentation / migration notes

## Verification
- Fixture review: pass
- openspec validate round2-review-remediation --strict --no-interactive
- pnpm exec vitest run tests/smoke/ --config vitest.config.ts --passWithNoTests=false (3 passed)
- PYTHONPATH=apps/url-fetcher-worker apps/url-fetcher-worker/.venv/bin/pytest apps/url-fetcher-worker/tests -q (36 passed)
- pnpm exec prettier --check .github/workflows/live-stack-smoke.yml .github/workflows/ci.yml tests/smoke/egress-smoke.test.ts tests/smoke/minio-smoke.test.ts tests/smoke/redis-smoke.test.ts

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security and Performance Reviewer, Independent Final Reviewer
- Reviewed head SHA: `7117272a60922fa786f258f7302e2f23aa4f7c13`
- Review evidence: [Spec Compliance](https://github.com/DankerMu/CherryWiki/pull/325#issuecomment-4448768880) | [Correctness](https://github.com/DankerMu/CherryWiki/pull/325#issuecomment-4448770333) | [Integration](https://github.com/DankerMu/CherryWiki/pull/325#issuecomment-4448771282) | [Security and Performance](https://github.com/DankerMu/CherryWiki/pull/325#issuecomment-4448772583) | [Final Review](https://github.com/DankerMu/CherryWiki/pull/325#issuecomment-4448773310)
- Key findings addressed: Closed subprocess timeout/maxBuffer gap, Node CI URL fetcher Python dependency gap, and dependency-container smoke path-filter gap; latest full cross-review and independent final review are clean.

Closes #320