### PR TITLE
feat(web): Space route permission gates (#329)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router';
 import { lazy, Suspense } from 'react';
 import AppShell from './components/AppShell';
+import { GuardedSpaceRoute } from './components/SpacePermissionGate';
 import { AuthProvider, useAuth } from './lib/auth';
 import AuditPage from './pages/admin/AuditPage';
 import GraphifyPage from './pages/admin/GraphifyPage';
@@ -35,25 +36,78 @@ export function AppRoutes() {
           path="/spaces/:spaceId/overview"
           element={(
             <Suspense fallback={null}>
-              <SpaceOverviewPage />
+              <GuardedSpaceRoute permissions="space:view">
+                <SpaceOverviewPage />
+              </GuardedSpaceRoute>
             </Suspense>
           )}
         />
-        <Route path="/spaces/:spaceId/chat" element={<Chat />} />
-        <Route path="/spaces/:spaceId/wiki" element={<Wiki />} />
-        <Route path="/spaces/:spaceId/wiki/:pageId" element={<Wiki />} />
-        <Route path="/spaces/:spaceId/wiki/:pageId/history" element={<Wiki />} />
+        <Route
+          path="/spaces/:spaceId/chat"
+          element={(
+            <GuardedSpaceRoute permissions={['space:view', 'chat:use']} context="chat">
+              <Chat />
+            </GuardedSpaceRoute>
+          )}
+        />
+        <Route
+          path="/spaces/:spaceId/wiki"
+          element={(
+            <GuardedSpaceRoute permissions="space:view">
+              <Wiki />
+            </GuardedSpaceRoute>
+          )}
+        />
+        <Route
+          path="/spaces/:spaceId/wiki/:pageId"
+          element={(
+            <GuardedSpaceRoute permissions="space:view">
+              <Wiki />
+            </GuardedSpaceRoute>
+          )}
+        />
+        <Route
+          path="/spaces/:spaceId/wiki/:pageId/history"
+          element={(
+            <GuardedSpaceRoute permissions="space:view">
+              <Wiki />
+            </GuardedSpaceRoute>
+          )}
+        />
         <Route
           path="/spaces/:spaceId/graph"
           element={(
             <Suspense fallback={null}>
-              <SpaceGraphExplorerPage />
+              <GuardedSpaceRoute permissions="space:view">
+                <SpaceGraphExplorerPage />
+              </GuardedSpaceRoute>
             </Suspense>
           )}
         />
-        <Route path="/spaces/:spaceId/graphify" element={<GraphifyRunsPage />} />
-        <Route path="/spaces/:spaceId/graphify/:runId" element={<GraphifyRunDetailPage />} />
-        <Route path="/spaces/:spaceId/uploads" element={<UploadCenter />} />
+        <Route
+          path="/spaces/:spaceId/graphify"
+          element={(
+            <GuardedSpaceRoute permissions="graphify:view" context="graphify">
+              <GraphifyRunsPage />
+            </GuardedSpaceRoute>
+          )}
+        />
+        <Route
+          path="/spaces/:spaceId/graphify/:runId"
+          element={(
+            <GuardedSpaceRoute permissions="graphify:view" context="graphify">
+              <GraphifyRunDetailPage />
+            </GuardedSpaceRoute>
+          )}
+        />
+        <Route
+          path="/spaces/:spaceId/uploads"
+          element={(
+            <GuardedSpaceRoute permissions="upload:read" context="upload">
+              <UploadCenter />
+            </GuardedSpaceRoute>
+          )}
+        />
         <Route path="/admin" element={<Navigate to="/admin/users" replace />} />
         <Route path="/admin/users" element={<UsersPage />} />
         <Route path="/admin/groups" element={<GroupsPage />} />

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -169,6 +169,38 @@ describe('App routing', () => {
     expect(screen.queryByRole('menuitem', { name: '概览' })).not.toBeInTheDocument();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('does not rewrite inaccessible route content when the space selector is used', async () => {
+    const fetchMock = mockOverviewApi();
+
+    renderRoute('/spaces/space-denied/overview', VIEWER_USER);
+
+    expect(await screen.findByText('访问被拒绝')).toBeInTheDocument();
+    const selector = getShellSpaceSelectContainer();
+    expect(selector).toHaveClass('ant-select-disabled');
+
+    fireEvent.mouseDown(getShellSpaceCombobox());
+
+    expect(screen.getByText('访问被拒绝')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: '空间概览' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Main Space')).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate to a fallback space from sidebar clicks on an inaccessible route space', async () => {
+    const fetchMock = mockOverviewApi();
+
+    renderRoute('/spaces/space-denied/overview', VIEWER_USER);
+
+    expect(await screen.findByText('访问被拒绝')).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: '聊天' })).not.toBeInTheDocument();
+
+    fireEvent.click(getShellMenu());
+
+    expect(screen.getByText('访问被拒绝')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: '聊天' })).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('AuthProvider', () => {
@@ -450,6 +482,32 @@ function mockOverviewApi() {
 
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;
+}
+
+function getShellSpaceCombobox(): HTMLElement {
+  const combobox = screen
+    .getAllByLabelText('空间')
+    .find((element) => element.getAttribute('role') === 'combobox');
+  if (combobox === undefined) {
+    throw new Error('Space selector combobox was not found');
+  }
+  return combobox;
+}
+
+function getShellSpaceSelectContainer(): HTMLElement {
+  const container = getShellSpaceCombobox().closest('.ant-select');
+  if (container === null) {
+    throw new Error('Space selector container was not found');
+  }
+  return container as HTMLElement;
+}
+
+function getShellMenu(): HTMLElement {
+  const menu = document.querySelector('.app-shell-menu');
+  if (!(menu instanceof HTMLElement)) {
+    throw new Error('Shell menu was not found');
+  }
+  return menu;
 }
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -157,6 +157,18 @@ describe('App routing', () => {
     renderRoute('/nonexistent');
     expect(screen.getByText('页面未找到')).toBeInTheDocument();
   });
+
+  it('does not select or rewrite an inaccessible route space in the shell', async () => {
+    const fetchMock = mockOverviewApi();
+
+    renderRoute('/spaces/space-denied/overview', VIEWER_USER);
+
+    expect(await screen.findByText('访问被拒绝')).toBeInTheDocument();
+    expect(screen.queryByText('Main Space')).not.toBeInTheDocument();
+    expect(screen.queryByText('空间功能')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: '概览' })).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('AuthProvider', () => {
@@ -381,63 +393,63 @@ function mockChatSessionsApi(): void {
   );
 }
 
-function mockOverviewApi(): void {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn<typeof fetch>((input) => {
-      const path = getRequestPath(input);
+function mockOverviewApi() {
+  const fetchMock = vi.fn<typeof fetch>((input) => {
+    const path = getRequestPath(input);
 
-      if (path === '/api/spaces/space-main') {
-        return Promise.resolve(jsonResponse({
-          data: {
-            id: 'space-main',
-            name: 'Main Space',
-            slug: 'main-space',
-            status: 'active',
-            description: null,
-            active_graphify_run_id: null,
-            active_index_snapshot_id: null,
-            index_consistency_status: 'consistent',
-            strict_knowledge_only: true,
-            created_at: '2026-01-01T00:00:00.000Z',
-            updated_at: '2026-01-01T00:00:00.000Z',
-          },
-          meta: { request_id: 'req-space' },
-        }));
-      }
+    if (path === '/api/spaces/space-main') {
+      return Promise.resolve(jsonResponse({
+        data: {
+          id: 'space-main',
+          name: 'Main Space',
+          slug: 'main-space',
+          status: 'active',
+          description: null,
+          active_graphify_run_id: null,
+          active_index_snapshot_id: null,
+          index_consistency_status: 'consistent',
+          strict_knowledge_only: true,
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        meta: { request_id: 'req-space' },
+      }));
+    }
 
-      if (path === '/api/spaces/space-main/stats') {
-        return Promise.resolve(jsonResponse({
-          data: {
-            space_id: 'space-main',
-            source_count: 0,
-            page_count: 0,
-            node_count: 0,
-            edge_count: 0,
-            index_consistency: 'consistent',
-          },
-          meta: { request_id: 'req-stats' },
-        }));
-      }
+    if (path === '/api/spaces/space-main/stats') {
+      return Promise.resolve(jsonResponse({
+        data: {
+          space_id: 'space-main',
+          source_count: 0,
+          page_count: 0,
+          node_count: 0,
+          edge_count: 0,
+          index_consistency: 'consistent',
+        },
+        meta: { request_id: 'req-stats' },
+      }));
+    }
 
-      if (path === '/api/spaces/space-main/uploads' || path === '/api/spaces/space-main/wiki/pages') {
-        return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-list' } }));
-      }
+    if (path === '/api/spaces/space-main/uploads' || path === '/api/spaces/space-main/wiki/pages') {
+      return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-list' } }));
+    }
 
-      if (path === '/api/graph/communities') {
-        return Promise.resolve(jsonResponse({
-          data: { communities: [] },
-          meta: { request_id: 'req-communities' },
-        }));
-      }
+    if (path === '/api/graph/communities') {
+      return Promise.resolve(jsonResponse({
+        data: { communities: [] },
+        meta: { request_id: 'req-communities' },
+      }));
+    }
 
-      if (path === '/api/spaces/space-main/graphify/runs') {
-        return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-runs' } }));
-      }
+    if (path === '/api/graphify/runs') {
+      return Promise.resolve(jsonResponse({ data: [], meta: { request_id: 'req-runs' } }));
+    }
 
-      return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
-    }),
-  );
+    return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
 }
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -335,6 +335,20 @@ describe('Chat bottom area layout', () => {
     expect(bottomArea?.querySelector('.chat-space-selector-panel')).toBeInTheDocument();
     expect(bottomArea?.querySelector('.chat-input-panel')).toBeInTheDocument();
   });
+
+  it('renders forbidden and skips protected chat requests when route space lacks permissions', async () => {
+    const fetchState = stubChatFetch();
+
+    renderChatRoute({
+      ...testUser,
+      email: 'denied@example.com',
+      spaces: [{ id: 'space-allowed', name: 'Allowed Space', role: 'viewer' }],
+    }, '/spaces/space-denied/chat');
+
+    expect(await screen.findByText('无权访问')).toBeInTheDocument();
+    expect(fetchState.calls).toHaveLength(0);
+    expect(screen.queryByLabelText('消息')).not.toBeInTheDocument();
+  });
 });
 
 describe('Sidebar collapse', () => {
@@ -746,10 +760,10 @@ describe('Chat error state', () => {
   });
 });
 
-function renderChatRoute(): void {
+function renderChatRoute(user: AuthUser = testUser, path = '/spaces/space-1/chat'): void {
   render(
-    <MemoryRouter initialEntries={['/spaces/space-1/chat']}>
-      <AuthProvider initialSession={{ user: testUser, accessToken: 'test-token' }}>
+    <MemoryRouter initialEntries={[path]}>
+      <AuthProvider initialSession={{ user, accessToken: 'test-token' }}>
         <Routes>
           <Route path="/spaces/:spaceId/chat" element={<Chat />} />
         </Routes>

--- a/apps/web/src/__tests__/graph-explorer.test.tsx
+++ b/apps/web/src/__tests__/graph-explorer.test.tsx
@@ -8,6 +8,7 @@ import i18n from '../i18n';
 import { ThemeProvider } from '../theme/ThemeProvider';
 import SpaceGraphExplorerPage from '../pages/graph/SpaceGraphExplorerPage';
 import * as graphApi from '../lib/graphApi';
+import { AuthProvider, type AuthUser } from '../lib/auth';
 import { GRAPH_NODE_TYPE_COLORS, truncateNodeLabel, type GraphCanvasData } from '../pages/graph/GraphCanvas.js';
 import type { GraphCommunity, GraphEdge, GraphNode } from '../lib/graphApi';
 
@@ -34,6 +35,7 @@ vi.mock('../lib/api', () => {
 
   return {
     ApiError,
+    configureApiClient: vi.fn(),
     api: {
       get: apiMocks.get,
     },
@@ -92,6 +94,20 @@ vi.mock('../pages/graph/GraphCanvas', async (importOriginal) => {
 const searchGraphNodesMock = vi.mocked(graphApi.searchGraphNodes);
 const getGraphNeighborsMock = vi.mocked(graphApi.getGraphNeighbors);
 const getGraphCommunitiesMock = vi.mocked(graphApi.getGraphCommunities);
+
+const TEST_USER: AuthUser = {
+  id: 'user-1',
+  email: 'viewer@example.com',
+  name: 'Viewer',
+  role: 'viewer',
+  groups: [],
+  spaces: [{ id: 'space-1', name: 'Space One', role: 'viewer' }],
+};
+
+const DENIED_USER: AuthUser = {
+  ...TEST_USER,
+  spaces: [{ id: 'space-allowed', name: 'Allowed Space', role: 'viewer' }],
+};
 
 describe('GraphCanvas color config', () => {
   it('defines colors for all standard node types', () => {
@@ -299,16 +315,28 @@ describe('SpaceGraphExplorerPage', () => {
     expect(screen.getByTestId('graph-node-node-a')).toBeInTheDocument();
     expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-node-count', '1');
   });
+
+  it('renders forbidden and skips protected graph requests when route space is unauthorized', async () => {
+    renderPage(DENIED_USER, '/spaces/space-denied/graph');
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(apiMocks.get).not.toHaveBeenCalled();
+    expect(getGraphCommunitiesMock).not.toHaveBeenCalled();
+    expect(searchGraphNodesMock).not.toHaveBeenCalled();
+    expect(getGraphNeighborsMock).not.toHaveBeenCalled();
+  });
 });
 
-function renderPage(): void {
+function renderPage(user: AuthUser = TEST_USER, path = '/spaces/space-1/graph'): void {
   render(
-    <MemoryRouter initialEntries={['/spaces/space-1/graph']}>
-      <ThemeProvider>
-        <Routes>
-          <Route path="/spaces/:spaceId/graph" element={<SpaceGraphExplorerPage />} />
-        </Routes>
-      </ThemeProvider>
+    <MemoryRouter initialEntries={[path]}>
+      <AuthProvider initialSession={{ user, accessToken: 'test-token' }}>
+        <ThemeProvider>
+          <Routes>
+            <Route path="/spaces/:spaceId/graph" element={<SpaceGraphExplorerPage />} />
+          </Routes>
+        </ThemeProvider>
+      </AuthProvider>
     </MemoryRouter>,
   );
 }

--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -59,6 +59,25 @@ afterEach(() => {
 });
 
 describe('GraphifyRunsPage', () => {
+  it('shows no permission and skips list API requests when route space is inaccessible', async () => {
+    authMocks.useAuth.mockReturnValue(
+      buildAuthValue({
+        user: {
+          email: 'viewer@example.com',
+          spaces: [{ id: 'space-allowed', name: 'Allowed', role: 'editor' }],
+        },
+        hasSpacePermission: (spaceId) => spaceId === 'space-allowed',
+      }),
+    );
+
+    renderWithRouter(<GraphifyRunsPage />, '/spaces/space-denied/graphify');
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(screen.getByText('viewer@example.com does not have Graphify access for this space.')).toBeInTheDocument();
+    expect(screen.queryByText('Graphify Runs')).not.toBeInTheDocument();
+    expectNoGraphifyApiRequests();
+  });
+
   it('shows no permission and skips list API requests when graphify view is denied', async () => {
     authMocks.useAuth.mockReturnValue(
       buildAuthValue({
@@ -152,6 +171,25 @@ describe('GraphifyRunsPage', () => {
 });
 
 describe('GraphifyRunDetailPage', () => {
+  it('shows no permission and skips detail API requests when route space is inaccessible', async () => {
+    authMocks.useAuth.mockReturnValue(
+      buildAuthValue({
+        user: {
+          email: 'viewer@example.com',
+          spaces: [{ id: 'space-allowed', name: 'Allowed', role: 'editor' }],
+        },
+        hasSpacePermission: (spaceId) => spaceId === 'space-allowed',
+      }),
+    );
+
+    renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-denied/graphify/run-1');
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(screen.getByText('viewer@example.com does not have Graphify access for this space.')).toBeInTheDocument();
+    expect(screen.queryByText('Graphify Run Detail')).not.toBeInTheDocument();
+    expectNoGraphifyApiRequests();
+  });
+
   it('shows no permission and skips detail API requests when graphify view is denied', async () => {
     authMocks.useAuth.mockReturnValue(
       buildAuthValue({
@@ -265,7 +303,10 @@ describe('formatRunLabel', () => {
 });
 
 type AuthValue = {
-  user: { email: string };
+  user: {
+    email: string;
+    spaces?: Array<{ id: string; name: string; role: string }>;
+  };
   hasSpacePermission: (spaceId: string, permission: string) => boolean;
 };
 
@@ -275,6 +316,19 @@ function buildAuthValue(overrides: Partial<AuthValue> = {}): AuthValue {
     hasSpacePermission: () => true,
     ...overrides,
   };
+}
+
+function expectNoGraphifyApiRequests(): void {
+  const getPaths = apiMocks.getWrapped.mock.calls.map(([path]) => path);
+  const postPaths = apiMocks.post.mock.calls.map(([path]) => path);
+
+  expect(getPaths).not.toContain('/graphify/runs');
+  expect(getPaths).not.toContain('/graphify/runs/run-1');
+  expect(getPaths).not.toContain('/graphify/runs/run-1/report');
+  expect(getPaths).not.toContain('/graphify/runs/run-1/graph');
+  expect(postPaths).not.toContain('/graphify/runs/run-1/cancel');
+  expect(postPaths).not.toContain('/graphify/runs/run-1/retry');
+  expect(postPaths).not.toContain('/spaces/space-denied/graphify/runs');
 }
 
 async function renderDetailStatus(status: GraphifyRun['status']): Promise<void> {

--- a/apps/web/src/__tests__/overview.test.tsx
+++ b/apps/web/src/__tests__/overview.test.tsx
@@ -7,6 +7,30 @@ import '../i18n';
 import i18n from '../i18n';
 import { ThemeProvider } from '../theme/ThemeProvider';
 import SpaceOverviewPage from '../pages/space/SpaceOverviewPage';
+import { AuthProvider, type AuthUser } from '../lib/auth';
+
+const EDITOR_USER: AuthUser = {
+  id: 'user-editor',
+  email: 'editor@example.com',
+  name: 'Editor',
+  role: 'viewer',
+  groups: [],
+  spaces: [{ id: 'space-1', name: 'Space One', role: 'editor' }],
+};
+
+const VIEWER_USER: AuthUser = {
+  ...EDITOR_USER,
+  id: 'user-viewer',
+  email: 'viewer@example.com',
+  spaces: [{ id: 'space-1', name: 'Space One', role: 'viewer' }],
+};
+
+const DENIED_USER: AuthUser = {
+  ...EDITOR_USER,
+  id: 'user-denied',
+  email: 'denied@example.com',
+  spaces: [{ id: 'space-allowed', name: 'Allowed Space', role: 'viewer' }],
+};
 
 describe('SpaceOverviewPage', () => {
   beforeEach(async () => {
@@ -51,19 +75,29 @@ describe('SpaceOverviewPage', () => {
     );
   });
 
-  it('shows the latest pending graphify run when no active run is set', async () => {
+  it('loads the latest graphify run from the list endpoint when no active run is set', async () => {
     stubOverviewApi({
       space: { active_graphify_run_id: null },
-      latestGraphifyRuns: [createGraphifyRun({ run_id: 'run-latest', status: 'pending' })],
+      latestGraphifyRuns: [createGraphifyRun({ run_id: 'run-latest', status: 'succeeded' })],
     });
 
     renderPage();
 
-    expect(await screen.findByText('Pending')).toBeInTheDocument();
+    expect(await screen.findByText('Succeeded')).toBeInTheDocument();
     expect(screen.getByText('View run').closest('a')).toHaveAttribute(
       'href',
       '/spaces/space-1/graphify/run-latest',
     );
+  });
+
+  it('shows a non-blocking warning when latest graphify run loading fails', async () => {
+    stubOverviewApi({ space: { active_graphify_run_id: null }, failLatestGraphifyRuns: true });
+
+    renderPage();
+
+    expect(await screen.findByText('Latest Graphify unavailable')).toBeInTheDocument();
+    expect(screen.getByText('policy.md')).toBeInTheDocument();
+    expect(screen.getByText('Policy')).toBeInTheDocument();
   });
 
   it('shows remediation links when index consistency is unhealthy', async () => {
@@ -124,16 +158,43 @@ describe('SpaceOverviewPage', () => {
     );
     expect(screen.getByRole('button', { name: 'Chat' }).closest('a')).toHaveAttribute('href', '/spaces/space-1/chat');
   });
+
+  it('filters quick actions and mutation controls by route space permissions', async () => {
+    stubOverviewApi({ documents: [], wikiPages: [] });
+
+    renderPage(VIEWER_USER);
+
+    expect(await screen.findByText('Quick Actions')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Documents' }).closest('a')).toHaveAttribute(
+      'href',
+      '/spaces/space-1/uploads',
+    );
+    expect(screen.queryByRole('button', { name: 'Graphify' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add documents' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Run Graphify' })).not.toBeInTheDocument();
+  });
+
+  it('renders forbidden and skips protected overview requests when route space is unauthorized', async () => {
+    const fetchMock = stubOverviewApi();
+
+    renderPage(DENIED_USER, '/spaces/space-denied/overview');
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(screen.queryByText('Space Overview')).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
-function renderPage(): void {
+function renderPage(user: AuthUser = EDITOR_USER, path = '/spaces/space-1/overview'): void {
   render(
-    <MemoryRouter initialEntries={['/spaces/space-1/overview']}>
-      <ThemeProvider>
-        <Routes>
-          <Route path="/spaces/:spaceId/overview" element={<SpaceOverviewPage />} />
-        </Routes>
-      </ThemeProvider>
+    <MemoryRouter initialEntries={[path]}>
+      <AuthProvider initialSession={{ user, accessToken: 'test-token' }}>
+        <ThemeProvider>
+          <Routes>
+            <Route path="/spaces/:spaceId/overview" element={<SpaceOverviewPage />} />
+          </Routes>
+        </ThemeProvider>
+      </AuthProvider>
     </MemoryRouter>,
   );
 }
@@ -143,6 +204,7 @@ function stubOverviewApi(options: {
   wikiPages?: unknown[];
   space?: Record<string, unknown>;
   latestGraphifyRuns?: unknown[];
+  failLatestGraphifyRuns?: boolean;
   failStats?: boolean;
   statsSequence?: number[];
 } = {}) {
@@ -171,7 +233,16 @@ function stubOverviewApi(options: {
       return Promise.resolve(jsonResponse({ data: options.wikiPages ?? [createWikiPage()] }));
     }
 
-    if (path === '/api/spaces/space-1/graphify/runs') {
+    if (path === '/api/graphify/runs') {
+      const url = getRequestUrl(input);
+      expect(url).toContain('space_id=space-1');
+      expect(url).toContain('per_page=1');
+      expect(url).toContain('sort=-created_at');
+      if (options.failLatestGraphifyRuns === true) {
+        return Promise.resolve(
+          jsonResponse({ error: { code: 'GRAPHIFY_FAILED', message: 'Latest Graphify unavailable' } }, 500),
+        );
+      }
       return Promise.resolve(jsonResponse({ data: options.latestGraphifyRuns ?? [] }));
     }
 
@@ -289,6 +360,15 @@ function getRequestPath(input: RequestInfo | URL): string {
   }
 
   return input.url.split('?')[0] ?? input.url;
+}
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  const url = input instanceof URL ? input : new URL(input.url);
+  return `${url.pathname}${url.search}`;
 }
 
 function countRequests(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>, path: string): number {

--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -5,7 +5,6 @@ import type { ComponentProps } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from '../i18n';
-import * as authModule from '../lib/auth';
 import { AuthProvider, type AuthUser } from '../lib/auth';
 import FileUploadZone from '../pages/uploads/FileUploadZone';
 import UploadCenter from '../pages/uploads/UploadCenter';
@@ -278,16 +277,6 @@ describe('UploadCenter', () => {
 
   it('shows no permission and skips upload API requests when upload read is denied', async () => {
     const fetchMock = stubUploadListApi();
-    vi.spyOn(authModule, 'useAuth').mockReturnValue({
-      user: NO_UPLOAD_PERMISSION_USER,
-      accessToken: 'test-token',
-      login: vi.fn(),
-      logout: vi.fn(),
-      refresh: vi.fn(),
-      isAuthenticated: true,
-      isAdmin: false,
-      hasSpacePermission: () => false,
-    });
 
     renderUploadCenter(NO_UPLOAD_PERMISSION_USER);
 

--- a/apps/web/src/__tests__/wiki.test.tsx
+++ b/apps/web/src/__tests__/wiki.test.tsx
@@ -2,10 +2,11 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import type { ReactElement } from 'react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AuthProvider, type AuthUser } from '../lib/auth.js';
 import type { WikiPage, WikiPageContent, WikiPageVersion } from '../lib/wikiApi.js';
+import Wiki from '../pages/Wiki.js';
 import WikiPageDetail from '../pages/wiki/WikiPageDetail.js';
 import WikiPageList from '../pages/wiki/WikiPageList.js';
 import WikiVersionHistory from '../pages/wiki/WikiVersionHistory.js';
@@ -87,6 +88,13 @@ describe('WikiPageList', () => {
     renderWithRouter(<WikiPageList spaceId="space-1" />);
 
     expect(await screen.findByText('No wiki pages in this space yet.')).toBeInTheDocument();
+  });
+
+  it('renders forbidden and skips page list requests when route space is unauthorized', async () => {
+    renderWikiRoute(DENIED_USER, '/spaces/space-denied/wiki');
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(apiMocks.getWrapped).not.toHaveBeenCalled();
   });
 });
 
@@ -177,10 +185,31 @@ const testUser: AuthUser = {
   spaces: [{ id: 'space-1', name: 'Test Space', role: 'admin' }],
 };
 
+const DENIED_USER: AuthUser = {
+  ...testUser,
+  email: 'denied@test.local',
+  role: 'viewer',
+  spaces: [{ id: 'space-allowed', name: 'Allowed Space', role: 'viewer' }],
+};
+
 function renderWithRouter(element: ReactElement): void {
   render(
     <MemoryRouter>
       <AuthProvider initialSession={{ user: testUser, accessToken: 'test-token' }}>{element}</AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+function renderWikiRoute(user: AuthUser, path: string): void {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AuthProvider initialSession={{ user, accessToken: 'test-token' }}>
+        <Routes>
+          <Route path="/spaces/:spaceId/wiki" element={<Wiki />} />
+          <Route path="/spaces/:spaceId/wiki/:pageId" element={<Wiki />} />
+          <Route path="/spaces/:spaceId/wiki/:pageId/history" element={<Wiki />} />
+        </Routes>
+      </AuthProvider>
     </MemoryRouter>,
   );
 }

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -178,6 +178,10 @@ export default function AppShell() {
 
   function handleSpaceChange(nextSpaceId: string): void {
     try {
+      if (!hasAccessibleRouteSpace) {
+        return;
+      }
+
       const nextFunction = selectedSpaceFunction ?? 'overview';
       void navigate(`/spaces/${encodeURIComponent(nextSpaceId)}/${nextFunction}`);
     } catch {
@@ -233,7 +237,7 @@ export default function AppShell() {
             <Typography.Text type="secondary">{t('shell.space.selectorLabel')}</Typography.Text>
             <Select
               aria-label={t('shell.space.selectorLabel')}
-              disabled={spaces.length === 0}
+              disabled={spaces.length === 0 || !hasAccessibleRouteSpace}
               onChange={handleSpaceChange}
               options={spaces.map((space) => ({ value: space.id, label: space.name }))}
               placeholder={t('shell.space.empty')}

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -85,16 +85,18 @@ export default function AppShell() {
 
   const spaces = useMemo(() => user?.spaces ?? [], [user?.spaces]);
   const selectedSpace = useMemo(
-    () => spaces.find((space) => space.id === routeSpaceId) ?? spaces[0],
+    () => (routeSpaceId === undefined ? spaces[0] : spaces.find((space) => space.id === routeSpaceId)),
     [routeSpaceId, spaces],
   );
   const selectedSpaceId = selectedSpace?.id;
+  const hasRouteSpace = routeSpaceId !== undefined && routeSpaceId.length > 0;
+  const hasAccessibleRouteSpace = !hasRouteSpace || selectedSpace !== undefined;
   const selectedSpaceFunction = getSpaceFunctionFromPath(location.pathname);
   const selectedAdminKey = getAdminRouteKey(location.pathname);
 
   const menuItems = useMemo<NonNullable<MenuProps['items']>>(() => {
     const spaceItems =
-      selectedSpaceId === undefined
+      selectedSpaceId === undefined || !hasAccessibleRouteSpace
         ? []
         : [
             {
@@ -125,23 +127,23 @@ export default function AppShell() {
       : [];
 
     return [...spaceItems, ...adminItems];
-  }, [isAdmin, selectedSpaceId, t]);
+  }, [hasAccessibleRouteSpace, isAdmin, selectedSpaceId, t]);
 
   const selectedKeys = useMemo(() => {
     if (selectedAdminKey !== null) {
       return [`admin:${selectedAdminKey}`];
     }
 
-    if (selectedSpaceFunction !== null) {
+    if (selectedSpaceFunction !== null && hasAccessibleRouteSpace) {
       return [selectedSpaceFunction];
     }
 
     return [];
-  }, [selectedAdminKey, selectedSpaceFunction]);
+  }, [hasAccessibleRouteSpace, selectedAdminKey, selectedSpaceFunction]);
 
   const breadcrumbItems = useMemo(
-    () => buildBreadcrumbItems(location.pathname, selectedSpace?.name, t),
-    [location.pathname, selectedSpace?.name, t],
+    () => buildBreadcrumbItems(location.pathname, hasAccessibleRouteSpace ? selectedSpace?.name : undefined, t),
+    [hasAccessibleRouteSpace, location.pathname, selectedSpace?.name, t],
   );
 
   function handleCollapse(nextCollapsed: boolean): void {

--- a/apps/web/src/components/SpacePermissionGate.tsx
+++ b/apps/web/src/components/SpacePermissionGate.tsx
@@ -1,0 +1,98 @@
+import { Result } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+import { useAuth } from '../lib/auth';
+import NotFound from '../pages/NotFound';
+
+export type SpacePermissionGateState = {
+  spaceId: string;
+  isAllowed: boolean;
+  requiredPermissions: string[];
+};
+
+export function useSpacePermissionGate(
+  requiredPermissions: string | string[],
+  spaceIdOverride?: string,
+): SpacePermissionGateState {
+  const { spaceId: routeSpaceId = '' } = useParams();
+  const { hasSpacePermission } = useAuth();
+  const spaceId = spaceIdOverride ?? routeSpaceId;
+  const permissions = Array.isArray(requiredPermissions) ? requiredPermissions : [requiredPermissions];
+  const isAllowed =
+    spaceId.length > 0 && permissions.every((permission) => hasSpacePermission(spaceId, permission));
+
+  return {
+    spaceId,
+    isAllowed,
+    requiredPermissions: permissions,
+  };
+}
+
+export function SpaceForbiddenState({ context }: { context?: 'chat' | 'graphify' | 'upload' }) {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+
+  if (context === 'chat') {
+    return (
+      <Result
+        status="403"
+        title={t('chat.forbidden.title')}
+        subTitle={t('chat.forbidden.description', { email: user?.email ?? '' })}
+      />
+    );
+  }
+
+  if (context === 'graphify') {
+    return (
+      <Result
+        status="403"
+        title={t('graphify.space.forbidden.title')}
+        subTitle={t('graphify.space.forbidden.description', { email: user?.email ?? '' })}
+      />
+    );
+  }
+
+  if (context === 'upload') {
+    return (
+      <Result
+        status="403"
+        title={t('upload.forbidden.title')}
+        subTitle={t('upload.forbidden.description', { email: user?.email ?? '' })}
+      />
+    );
+  }
+
+  return (
+    <Result
+      status="403"
+      title={t('space.forbidden.title')}
+      subTitle={t('space.forbidden.description', { email: user?.email ?? '' })}
+    />
+  );
+}
+
+function renderSpaceForbiddenState(context: 'chat' | 'graphify' | 'upload' | undefined): React.ReactNode {
+  return context === undefined ? <SpaceForbiddenState /> : <SpaceForbiddenState context={context} />;
+}
+
+export function GuardedSpaceRoute({
+  children,
+  context,
+  permissions,
+}: {
+  children: React.ReactNode;
+  context?: 'chat' | 'graphify' | 'upload';
+  permissions: string | string[];
+}) {
+  const gate = useSpacePermissionGate(permissions);
+
+  if (gate.spaceId.length === 0) {
+    return <NotFound />;
+  }
+
+  if (!gate.isAllowed) {
+    return <>{renderSpaceForbiddenState(context)}</>;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -119,6 +119,12 @@
       "description": "Contact an administrator to request access to a space."
     }
   },
+  "space": {
+    "forbidden": {
+      "title": "Access Denied",
+      "description": "{{email}} does not have access to this space."
+    }
+  },
   "login": {
     "page": {
       "title": "Login",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -119,6 +119,12 @@
       "description": "请联系管理员为你开通空间访问权限。"
     }
   },
+  "space": {
+    "forbidden": {
+      "title": "访问被拒绝",
+      "description": "{{email}} 没有该空间的访问权限。"
+    }
+  },
   "login": {
     "page": {
       "title": "登录",

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
-import { Alert, Button, Collapse, Empty, Input, List, message, Popconfirm, Result, Select, Spin, Tag } from 'antd';
+import { Alert, Button, Collapse, Empty, Input, List, message, Popconfirm, Select, Spin, Tag } from 'antd';
 import {
   CloseOutlined,
   DeleteOutlined,
@@ -19,6 +19,7 @@ import ChatChart from '../components/ChatChart.js';
 import { ConfidenceBadge } from '../components/ConfidenceBadge.js';
 import GraphPathViewer, { type GraphPathData, type GraphPathEdge, type GraphPathNode } from '../components/GraphPathViewer.js';
 import { formatDate, getErrorMessage } from '../components/adminUi.js';
+import { SpaceForbiddenState, useSpacePermissionGate } from '../components/SpacePermissionGate.js';
 import {
   CHAT_INPUT_MAX_LENGTH,
   DEFAULT_RETRIEVAL_MODE,
@@ -107,6 +108,7 @@ export default function Chat() {
   const { t } = useTranslation();
   const { spaceId = '' } = useParams();
   const { accessToken, hasSpacePermission, isAuthenticated, user } = useAuth();
+  const gate = useSpacePermissionGate(['space:view', 'chat:use']);
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(true);
   const [sessionsError, setSessionsError] = useState<string | null>(null);
@@ -142,7 +144,7 @@ export default function Chat() {
 
   const loadSessions = useCallback(
     async (background = false) => {
-      if (!isAuthenticated || spaceId.length === 0) {
+      if (!isAuthenticated || spaceId.length === 0 || !gate.isAllowed) {
         setSessions([]);
         setSessionsLoading(false);
         return;
@@ -170,7 +172,7 @@ export default function Chat() {
         }
       }
     },
-    [isAuthenticated, spaceId],
+    [gate.isAllowed, isAuthenticated, spaceId],
   );
 
   const {
@@ -223,7 +225,7 @@ export default function Chat() {
     let cancelled = false;
 
     async function loadAvailableSpaces(): Promise<void> {
-      if (!isAuthenticated || spaceId.length === 0) {
+      if (!isAuthenticated || spaceId.length === 0 || !gate.isAllowed) {
         setAvailableSpaces([]);
         return;
       }
@@ -251,7 +253,7 @@ export default function Chat() {
     return () => {
       cancelled = true;
     };
-  }, [hasSpacePermission, isAuthenticated, spaceId, spaceRefreshVersion, user]);
+  }, [gate.isAllowed, hasSpacePermission, isAuthenticated, spaceId, spaceRefreshVersion, user]);
 
   useEffect(() => {
     setSelectedSpaceIds((current) => {
@@ -266,7 +268,7 @@ export default function Chat() {
   useEffect(() => {
     let cancelled = false;
 
-    if (!isAuthenticated || spaceId.length === 0) {
+    if (!isAuthenticated || spaceId.length === 0 || !gate.isAllowed) {
       setSpaceDatabaseEnabled(false);
       return () => {
         cancelled = true;
@@ -289,7 +291,7 @@ export default function Chat() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated, spaceId]);
+  }, [gate.isAllowed, isAuthenticated, spaceId]);
 
   useEffect(() => {
     if ((!spaceDatabaseEnabled || selectedSpaceIds.length > 1) && chatSettings.enableDatabase) {
@@ -321,14 +323,8 @@ export default function Chat() {
     return <NotFound />;
   }
 
-  if (!hasSpacePermission(spaceId, 'chat:use')) {
-    return (
-      <Result
-        status="403"
-        title={t('chat.forbidden.title')}
-        subTitle={t('chat.forbidden.description', { email: user?.email ?? '' })}
-      />
-    );
+  if (!gate.isAllowed) {
+    return <SpaceForbiddenState context="chat" />;
   }
 
   async function openSession(nextSessionId: string): Promise<void> {

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -1,9 +1,10 @@
 import { ArrowLeftOutlined } from '@ant-design/icons';
-import { Alert, Button, Card, Descriptions, Popconfirm, Progress, Result, Spin, Statistic, Typography } from 'antd';
+import { Alert, Button, Card, Descriptions, Popconfirm, Progress, Spin, Statistic, Typography } from 'antd';
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 import { formatDate, formatLabel, getErrorMessage } from '../components/adminUi';
+import { SpaceForbiddenState, useSpacePermissionGate } from '../components/SpacePermissionGate';
 import {
   cancelGraphifyRun,
   getGraphifyReport,
@@ -33,7 +34,8 @@ export default function GraphifyRunDetailPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { spaceId = '', runId = '' } = useParams();
-  const { hasSpacePermission, user } = useAuth();
+  const { hasSpacePermission } = useAuth();
+  const gate = useSpacePermissionGate('graphify:view');
   const [run, setRun] = useState<GraphifyRun | null>(null);
   const [report, setReport] = useState<GraphifyReport | null>(null);
   const [summary, setSummary] = useState<GraphifySummary | null>(null);
@@ -42,7 +44,7 @@ export default function GraphifyRunDetailPage() {
   const [isRetrying, setIsRetrying] = useState(false);
   const [isRunSpaceMismatch, setIsRunSpaceMismatch] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const canViewGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:view');
+  const canViewGraphify = spaceId.length > 0 && gate.isAllowed;
   const canRunGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:run');
 
   const loadRunDetail = useCallback(
@@ -122,13 +124,7 @@ export default function GraphifyRunDetailPage() {
   }
 
   if (!canViewGraphify) {
-    return (
-      <Result
-        status="403"
-        title={t('graphify.space.forbidden.title')}
-        subTitle={t('graphify.space.forbidden.description', { email: user?.email ?? '' })}
-      />
-    );
+    return <SpaceForbiddenState context="graphify" />;
   }
 
   if (isRunSpaceMismatch) {

--- a/apps/web/src/pages/GraphifyRunsPage.tsx
+++ b/apps/web/src/pages/GraphifyRunsPage.tsx
@@ -1,10 +1,11 @@
 import { PlusOutlined, ReloadOutlined } from '@ant-design/icons';
-import { Alert, Button, Popconfirm, Result, Select, Space, Table, Typography } from 'antd';
+import { Alert, Button, Popconfirm, Select, Space, Table, Typography } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 import { formatDate, formatLabel, getErrorMessage } from '../components/adminUi';
+import { SpaceForbiddenState, useSpacePermissionGate } from '../components/SpacePermissionGate';
 import { type ApiMeta } from '../lib/api';
 import {
   GRAPHIFY_TRIGGER_TYPES,
@@ -41,7 +42,8 @@ export default function GraphifyRunsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { spaceId = '' } = useParams();
-  const { hasSpacePermission, user } = useAuth();
+  const { hasSpacePermission } = useAuth();
+  const gate = useSpacePermissionGate('graphify:view');
   const [runs, setRuns] = useState<GraphifyRun[]>([]);
   const [status, setStatus] = useState('');
   const [triggerType, setTriggerType] = useState('');
@@ -53,7 +55,7 @@ export default function GraphifyRunsPage() {
   const [retryingRunId, setRetryingRunId] = useState<string | null>(null);
   const [isNewRunOpen, setIsNewRunOpen] = useState(false);
   const [isCreatingRun, setIsCreatingRun] = useState(false);
-  const canViewGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:view');
+  const canViewGraphify = spaceId.length > 0 && gate.isAllowed;
   const canRunGraphify = spaceId.length > 0 && hasSpacePermission(spaceId, 'graphify:run');
 
   const loadRuns = useCallback(
@@ -128,13 +130,7 @@ export default function GraphifyRunsPage() {
   }
 
   if (!canViewGraphify) {
-    return (
-      <Result
-        status="403"
-        title={t('graphify.space.forbidden.title')}
-        subTitle={t('graphify.space.forbidden.description', { email: user?.email ?? '' })}
-      />
-    );
+    return <SpaceForbiddenState context="graphify" />;
   }
 
   async function createRun(params: CreateGraphifyRunParams): Promise<void> {

--- a/apps/web/src/pages/Wiki.tsx
+++ b/apps/web/src/pages/Wiki.tsx
@@ -1,4 +1,5 @@
 import { useLocation, useParams, useSearchParams } from 'react-router';
+import { SpaceForbiddenState, useSpacePermissionGate } from '../components/SpacePermissionGate.js';
 import NotFound from './NotFound.js';
 import WikiPageDetail from './wiki/WikiPageDetail.js';
 import WikiPageList from './wiki/WikiPageList.js';
@@ -8,9 +9,14 @@ export default function Wiki() {
   const { spaceId, pageId } = useParams();
   const [searchParams] = useSearchParams();
   const location = useLocation();
+  const gate = useSpacePermissionGate('space:view');
 
   if (spaceId === undefined || spaceId.length === 0) {
     return <NotFound />;
+  }
+
+  if (!gate.isAllowed) {
+    return <SpaceForbiddenState />;
   }
 
   if (pageId === undefined || pageId.length === 0) {

--- a/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
+++ b/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type CSS
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import { getErrorMessage } from '../../components/adminUi';
+import { SpaceForbiddenState, useSpacePermissionGate } from '../../components/SpacePermissionGate';
 import { api } from '../../lib/api';
 import type { AdminSpaceDetail } from '../../lib/adminTypes';
 import {
@@ -66,6 +67,7 @@ type Selection =
 export default function SpaceGraphExplorerPage() {
   const { t } = useTranslation();
   const { spaceId = '' } = useParams();
+  const gate = useSpacePermissionGate('space:view');
   const [graphState, dispatch] = useReducer(graphReducer, INITIAL_GRAPH_STATE);
   const [query, setQuery] = useState('');
   const [searchResults, setSearchResults] = useState<GraphNode[]>([]);
@@ -96,7 +98,8 @@ export default function SpaceGraphExplorerPage() {
     setError(null);
     setHasEmptyGraph(false);
 
-    if (spaceId.length === 0) {
+    if (spaceId.length === 0 || !gate.isAllowed) {
+      setIsLoadingCommunities(false);
       return;
     }
 
@@ -118,11 +121,11 @@ export default function SpaceGraphExplorerPage() {
         setHasEmptyGraph(false);
       }
     })();
-  }, [spaceId]);
+  }, [gate.isAllowed, spaceId]);
 
   const loadCommunities = useCallback(async () => {
     const spaceSeq = spaceSeqRef.current;
-    if (spaceId.length === 0) {
+    if (spaceId.length === 0 || !gate.isAllowed) {
       setCommunities([]);
       setIsLoadingCommunities(false);
       return;
@@ -146,7 +149,7 @@ export default function SpaceGraphExplorerPage() {
         setIsLoadingCommunities(false);
       }
     }
-  }, [spaceId]);
+  }, [gate.isAllowed, spaceId]);
 
   useEffect(() => {
     void loadCommunities();
@@ -169,6 +172,10 @@ export default function SpaceGraphExplorerPage() {
     return <NotFound />;
   }
 
+  if (!gate.isAllowed) {
+    return <SpaceForbiddenState />;
+  }
+
   async function handleSearch(nextQuery: string): Promise<void> {
     const normalizedQuery = nextQuery.trim();
     const seq = ++searchSeqRef.current;
@@ -177,7 +184,7 @@ export default function SpaceGraphExplorerPage() {
     setHasSearched(true);
     setSearchResults([]);
 
-    if (normalizedQuery.length === 0) {
+    if (normalizedQuery.length === 0 || !gate.isAllowed) {
       setIsSearching(false);
       return;
     }
@@ -207,7 +214,7 @@ export default function SpaceGraphExplorerPage() {
   }
 
   async function expandNode(nodeId: string, force = false): Promise<void> {
-    if (!force && graphState.expandedNodeIds.has(nodeId)) {
+    if ((!force && graphState.expandedNodeIds.has(nodeId)) || !gate.isAllowed) {
       return;
     }
 

--- a/apps/web/src/pages/space/SpaceOverviewPage.tsx
+++ b/apps/web/src/pages/space/SpaceOverviewPage.tsx
@@ -228,6 +228,7 @@ export default function SpaceOverviewPage() {
           activeRun={activeRun}
           errors={errors}
           canRunGraphify={hasSpacePermission(spaceId, 'graphify:run')}
+          canViewGraphify={hasSpacePermission(spaceId, 'graphify:view')}
         />
 
         <Row gutter={[16, 16]}>
@@ -294,6 +295,7 @@ function KnowledgeStatusPanel({
   activeRun,
   errors,
   canRunGraphify,
+  canViewGraphify,
 }: {
   spaceId: string;
   space: SpaceDetail | null;
@@ -302,6 +304,7 @@ function KnowledgeStatusPanel({
   activeRun: GraphifyRun | null;
   errors: OverviewErrors;
   canRunGraphify: boolean;
+  canViewGraphify: boolean;
 }) {
   const { t } = useTranslation();
   const indexConsistency = space?.index_consistency_status ?? stats?.index_consistency ?? 'unavailable';
@@ -363,9 +366,11 @@ function KnowledgeStatusPanel({
                 {activeRun.progress !== null ? (
                   <Progress percent={activeRun.progress.percent} size="small" style={{ width: 120 }} />
                 ) : null}
-                <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify/${encodeURIComponent(activeRun.run_id)}`}>
-                  {t('overview.status.viewRun')}
-                </Link>
+                {canViewGraphify ? (
+                  <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify/${encodeURIComponent(activeRun.run_id)}`}>
+                    {t('overview.status.viewRun')}
+                  </Link>
+                ) : null}
               </Space>
             )}
           </Descriptions.Item>
@@ -516,7 +521,7 @@ function KnowledgeQuickActions({ spaceId }: { spaceId: string }) {
       label: t('overview.quickActions.graphify'),
       to: `/spaces/${encodeURIComponent(spaceId)}/graphify`,
       icon: <NodeIndexOutlined />,
-      permissions: ['graphify:run'],
+      permissions: ['graphify:view'],
     },
     {
       key: 'chat',

--- a/apps/web/src/pages/space/SpaceOverviewPage.tsx
+++ b/apps/web/src/pages/space/SpaceOverviewPage.tsx
@@ -26,9 +26,10 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 import { formatDate, formatLabel, getErrorMessage } from '../../components/adminUi';
-import { api } from '../../lib/api';
+import { SpaceForbiddenState, useSpacePermissionGate } from '../../components/SpacePermissionGate';
 import { getGraphCommunities } from '../../lib/graphApi';
-import { getGraphifyRun, type GraphifyRun } from '../../lib/graphifyApi';
+import { getGraphifyRun, listGraphifyRuns, type GraphifyRun } from '../../lib/graphifyApi';
+import { useAuth } from '../../lib/auth';
 import {
   getRecentDocuments,
   getRecentWikiPages,
@@ -62,6 +63,8 @@ const EMPTY_ERRORS: OverviewErrors = {
 export default function SpaceOverviewPage() {
   const { t } = useTranslation();
   const { spaceId = '' } = useParams();
+  const { hasSpacePermission } = useAuth();
+  const gate = useSpacePermissionGate('space:view');
   const [space, setSpace] = useState<SpaceDetail | null>(null);
   const [stats, setStats] = useState<SpaceStats | null>(null);
   const [documents, setDocuments] = useState<RecentDocument[]>([]);
@@ -74,6 +77,12 @@ export default function SpaceOverviewPage() {
 
   const loadOverview = useCallback(async () => {
     if (spaceId.length === 0) {
+      setIsLoading(false);
+      return;
+    }
+
+    if (!gate.isAllowed) {
+      requestSeqRef.current++;
       setIsLoading(false);
       return;
     }
@@ -100,13 +109,14 @@ export default function SpaceOverviewPage() {
           setSpace(nextSpace);
           if (nextSpace.active_graphify_run_id === null) {
             try {
-              const latestRuns = await api.get<GraphifyRun[]>(
-                `/spaces/${encodeURIComponent(spaceId)}/graphify/runs`,
-                { per_page: 1, sort: '-created_at' },
-              );
+              const latestRuns = await listGraphifyRuns({
+                space_id: spaceId,
+                per_page: 1,
+                sort: '-created_at',
+              });
               if (seq !== requestSeqRef.current) return;
-              const latestRun = latestRuns[0];
-              if (latestRun?.status === 'pending' || latestRun?.status === 'running') {
+              const latestRun = latestRuns.data[0];
+              if (latestRun !== undefined) {
                 setActiveRun(latestRun);
               }
             } catch (err) {
@@ -172,7 +182,7 @@ export default function SpaceOverviewPage() {
     if (seq === requestSeqRef.current) {
       setIsLoading(false);
     }
-  }, [spaceId]);
+  }, [gate.isAllowed, spaceId]);
 
   useEffect(() => {
     void loadOverview();
@@ -180,6 +190,10 @@ export default function SpaceOverviewPage() {
 
   if (spaceId.length === 0) {
     return <NotFound />;
+  }
+
+  if (!gate.isAllowed) {
+    return <SpaceForbiddenState />;
   }
 
   return (
@@ -213,14 +227,25 @@ export default function SpaceOverviewPage() {
           communityCount={communityCount}
           activeRun={activeRun}
           errors={errors}
+          canRunGraphify={hasSpacePermission(spaceId, 'graphify:run')}
         />
 
         <Row gutter={[16, 16]}>
           <Col xs={24} lg={12}>
-            <RecentDocumentsList spaceId={spaceId} documents={documents} error={errors.documents} />
+            <RecentDocumentsList
+              spaceId={spaceId}
+              documents={documents}
+              error={errors.documents}
+              canCreateUploads={hasSpacePermission(spaceId, 'upload:create')}
+            />
           </Col>
           <Col xs={24} lg={12}>
-            <RecentWikiPagesList spaceId={spaceId} pages={wikiPages} error={errors.wikiPages} />
+            <RecentWikiPagesList
+              spaceId={spaceId}
+              pages={wikiPages}
+              error={errors.wikiPages}
+              canRunGraphify={hasSpacePermission(spaceId, 'graphify:run')}
+            />
           </Col>
         </Row>
 
@@ -268,6 +293,7 @@ function KnowledgeStatusPanel({
   communityCount,
   activeRun,
   errors,
+  canRunGraphify,
 }: {
   spaceId: string;
   space: SpaceDetail | null;
@@ -275,6 +301,7 @@ function KnowledgeStatusPanel({
   communityCount: number | null;
   activeRun: GraphifyRun | null;
   errors: OverviewErrors;
+  canRunGraphify: boolean;
 }) {
   const { t } = useTranslation();
   const indexConsistency = space?.index_consistency_status ?? stats?.index_consistency ?? 'unavailable';
@@ -295,9 +322,11 @@ function KnowledgeStatusPanel({
                 <Link to={`/spaces/${encodeURIComponent(spaceId)}/wiki`}>
                   {t('overview.status.reviewWiki')}
                 </Link>
-                <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify`}>
-                  {t('overview.status.runGraphify')}
-                </Link>
+                {canRunGraphify ? (
+                  <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify`}>
+                    {t('overview.status.runGraphify')}
+                  </Link>
+                ) : null}
               </Space>
             )}
           />
@@ -350,10 +379,12 @@ function RecentDocumentsList({
   spaceId,
   documents,
   error,
+  canCreateUploads,
 }: {
   spaceId: string;
   documents: RecentDocument[];
   error: string | null;
+  canCreateUploads: boolean;
 }) {
   const { t } = useTranslation();
 
@@ -371,9 +402,11 @@ function RecentDocumentsList({
               image={Empty.PRESENTED_IMAGE_SIMPLE}
               description={t('overview.recentDocuments.empty')}
             >
-              <Link to={`/spaces/${encodeURIComponent(spaceId)}/uploads`}>
-                <Button type="primary">{t('overview.action.addDocuments')}</Button>
-              </Link>
+              {canCreateUploads ? (
+                <Link to={`/spaces/${encodeURIComponent(spaceId)}/uploads`}>
+                  <Button type="primary">{t('overview.action.addDocuments')}</Button>
+                </Link>
+              ) : null}
             </Empty>
           ),
         }}
@@ -400,10 +433,12 @@ function RecentWikiPagesList({
   spaceId,
   pages,
   error,
+  canRunGraphify,
 }: {
   spaceId: string;
   pages: RecentWikiPage[];
   error: string | null;
+  canRunGraphify: boolean;
 }) {
   const { t } = useTranslation();
 
@@ -421,9 +456,11 @@ function RecentWikiPagesList({
               image={Empty.PRESENTED_IMAGE_SIMPLE}
               description={t('overview.recentWikiPages.empty')}
             >
-              <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify`}>
-                <Button>{t('overview.action.runGraphify')}</Button>
-              </Link>
+              {canRunGraphify ? (
+                <Link to={`/spaces/${encodeURIComponent(spaceId)}/graphify`}>
+                  <Button>{t('overview.action.runGraphify')}</Button>
+                </Link>
+              ) : null}
             </Empty>
           ),
         }}
@@ -451,38 +488,44 @@ function RecentWikiPagesList({
 
 function KnowledgeQuickActions({ spaceId }: { spaceId: string }) {
   const { t } = useTranslation();
-  const actions: Array<{ key: string; label: string; to: string; icon: ReactNode }> = [
+  const { hasSpacePermission } = useAuth();
+  const actions: Array<{ key: string; label: string; to: string; icon: ReactNode; permissions: string[] }> = [
     {
       key: 'documents',
       label: t('overview.quickActions.documents'),
       to: `/spaces/${encodeURIComponent(spaceId)}/uploads`,
       icon: <CloudUploadOutlined />,
+      permissions: ['upload:read'],
     },
     {
       key: 'wiki',
       label: t('overview.quickActions.wiki'),
       to: `/spaces/${encodeURIComponent(spaceId)}/wiki`,
       icon: <BookOutlined />,
+      permissions: ['space:view'],
     },
     {
       key: 'graph',
       label: t('overview.quickActions.graph'),
       to: `/spaces/${encodeURIComponent(spaceId)}/graph`,
       icon: <ShareAltOutlined />,
+      permissions: ['space:view'],
     },
     {
       key: 'graphify',
       label: t('overview.quickActions.graphify'),
       to: `/spaces/${encodeURIComponent(spaceId)}/graphify`,
       icon: <NodeIndexOutlined />,
+      permissions: ['graphify:run'],
     },
     {
       key: 'chat',
       label: t('overview.quickActions.chat'),
       to: `/spaces/${encodeURIComponent(spaceId)}/chat`,
       icon: <MessageOutlined />,
+      permissions: ['space:view', 'chat:use'],
     },
-  ];
+  ].filter((action) => action.permissions.every((permission) => hasSpacePermission(spaceId, permission)));
 
   return (
     <Card title={t('overview.quickActions.title')}>

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router';
 import { getErrorMessage } from '../../components/adminUi';
+import { SpaceForbiddenState, useSpacePermissionGate } from '../../components/SpacePermissionGate';
 import { useUploadPolling } from '../../hooks/useUploadPolling';
 import { type ApiMeta, api } from '../../lib/api';
 import { useAuth } from '../../lib/auth';
@@ -33,6 +34,7 @@ export default function UploadCenter() {
   const { t } = useTranslation();
   const { spaceId = '' } = useParams();
   const { accessToken, hasSpacePermission, isAuthenticated, user } = useAuth();
+  const gate = useSpacePermissionGate('upload:read');
   const [uploads, setUploads] = useState<UploadItem[]>([]);
   const [page, setPage] = useState(DEFAULT_PAGINATION.page);
   const [statusFilter, setStatusFilter] = useState('');
@@ -49,7 +51,11 @@ export default function UploadCenter() {
   const requestSeqRef = useRef(0);
   const selectionSeqRef = useRef(0);
   const selectedUploadIdRef = useRef<string | null>(null);
-  const canReadUploads = uploadSpaceId.length > 0 && hasSpacePermission(uploadSpaceId, 'upload:read');
+  const isRouteUploadSpace = uploadSpaceId === spaceId;
+  const canReadUploads =
+    uploadSpaceId.length > 0 &&
+    hasSpacePermission(uploadSpaceId, 'upload:read') &&
+    (!isRouteUploadSpace || gate.isAllowed);
   const canCreateUploads = uploadSpaceId.length > 0 && hasSpacePermission(uploadSpaceId, 'upload:create');
 
   const loadUploads = useCallback(
@@ -231,6 +237,10 @@ export default function UploadCenter() {
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
+  }
+
+  if (spaceId.length > 0 && !gate.isAllowed) {
+    return <SpaceForbiddenState context="upload" />;
   }
 
   return (

--- a/apps/web/src/pages/wiki/WikiPageDetail.tsx
+++ b/apps/web/src/pages/wiki/WikiPageDetail.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import TiptapRenderer from '../../components/TiptapRenderer';
 import { formatDate, getErrorMessage } from '../../components/adminUi';
+import { useSpacePermissionGate } from '../../components/SpacePermissionGate';
 import { ApiError } from '../../lib/api';
 import { useAuth } from '../../lib/auth';
 import { wikiApi, type WikiPage, type WikiPageContent } from '../../lib/wikiApi';
@@ -20,6 +21,7 @@ type WikiPageDetailProps = {
 export default function WikiPageDetail({ spaceId, pageId, versionId }: WikiPageDetailProps) {
   const { t } = useTranslation();
   const { hasSpacePermission } = useAuth();
+  const gate = useSpacePermissionGate('space:view', spaceId);
   const [page, setPage] = useState<WikiPage | null>(null);
   const [content, setContent] = useState<WikiPageContent | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -31,6 +33,11 @@ export default function WikiPageDetail({ spaceId, pageId, versionId }: WikiPageD
     setIsLoading(true);
     setNotFound(false);
     setError(null);
+
+    if (!gate.isAllowed) {
+      setIsLoading(false);
+      return;
+    }
 
     try {
       const [pageResponse, contentResponse] = await Promise.all([
@@ -48,14 +55,14 @@ export default function WikiPageDetail({ spaceId, pageId, versionId }: WikiPageD
     } finally {
       setIsLoading(false);
     }
-  }, [pageId, spaceId, versionId]);
+  }, [gate.isAllowed, pageId, spaceId, versionId]);
 
   useEffect(() => {
     void loadPage();
   }, [loadPage]);
 
   async function publishCurrentVersion(): Promise<void> {
-    if (page?.current_version_id === null || page?.current_version_id === undefined) {
+    if (page?.current_version_id === null || page?.current_version_id === undefined || !gate.isAllowed) {
       return;
     }
 

--- a/apps/web/src/pages/wiki/WikiPageList.tsx
+++ b/apps/web/src/pages/wiki/WikiPageList.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { formatDate, getErrorMessage } from '../../components/adminUi';
+import { useSpacePermissionGate } from '../../components/SpacePermissionGate';
 import { type ApiMeta } from '../../lib/api';
 import { wikiApi, type WikiPage } from '../../lib/wikiApi';
 import { WIKI_PAGE_SIZE, WikiStatusBadge } from './wikiUi';
@@ -24,6 +25,7 @@ const STATUS_OPTIONS = ['draft', 'published', 'archived'] as const;
 export default function WikiPageList({ spaceId }: WikiPageListProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const gate = useSpacePermissionGate('space:view', spaceId);
   const [pages, setPages] = useState<WikiPage[]>([]);
   const [page, setPage] = useState(DEFAULT_PAGINATION.page);
   const [statusFilter, setStatusFilter] = useState('');
@@ -33,7 +35,7 @@ export default function WikiPageList({ spaceId }: WikiPageListProps) {
   const [isLoading, setIsLoading] = useState(true);
 
   const loadPages = useCallback(async () => {
-    if (spaceId.length === 0) {
+    if (spaceId.length === 0 || !gate.isAllowed) {
       setPages([]);
       setPagination(DEFAULT_PAGINATION);
       setIsLoading(false);
@@ -63,7 +65,7 @@ export default function WikiPageList({ spaceId }: WikiPageListProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [debouncedSearch, page, spaceId, statusFilter]);
+  }, [debouncedSearch, gate.isAllowed, page, spaceId, statusFilter]);
 
   useEffect(() => {
     void loadPages();

--- a/apps/web/src/pages/wiki/WikiVersionHistory.tsx
+++ b/apps/web/src/pages/wiki/WikiVersionHistory.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
 import { formatDate, formatLabel, getErrorMessage } from '../../components/adminUi';
+import { useSpacePermissionGate } from '../../components/SpacePermissionGate';
 import { ApiError, type ApiMeta } from '../../lib/api';
 import { useAuth } from '../../lib/auth';
 import { wikiApi, type WikiPage, type WikiPageVersion } from '../../lib/wikiApi';
@@ -26,6 +27,7 @@ const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
 export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHistoryProps) {
   const { t } = useTranslation();
   const { hasSpacePermission } = useAuth();
+  const gate = useSpacePermissionGate('space:view', spaceId);
   const canRollback = hasSpacePermission(spaceId, 'wiki:rollback');
   const navigate = useNavigate();
   const [page, setPage] = useState<WikiPage | null>(null);
@@ -39,6 +41,11 @@ export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHisto
   const loadVersions = useCallback(async () => {
     setIsLoading(true);
     setNotFound(false);
+
+    if (!gate.isAllowed) {
+      setIsLoading(false);
+      return;
+    }
 
     try {
       const [pageResponse, versionsResponse] = await Promise.all([
@@ -64,13 +71,15 @@ export default function WikiVersionHistory({ spaceId, pageId }: WikiVersionHisto
     } finally {
       setIsLoading(false);
     }
-  }, [pageId, pageNumber, spaceId]);
+  }, [gate.isAllowed, pageId, pageNumber, spaceId]);
 
   useEffect(() => {
     void loadVersions();
   }, [loadVersions]);
 
   async function rollbackVersion(version: WikiPageVersion): Promise<void> {
+    if (!gate.isAllowed) return;
+
     setRollingBackVersionId(version.version_id);
 
     try {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,45 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: 'vendor-react',
+              test: /node_modules[\\/](react|react-dom|react-router)[\\/]/,
+              priority: 30,
+            },
+            {
+              name: 'vendor-antd',
+              test: /node_modules[\\/](@ant-design|antd|rc-|dayjs)[\\/]/,
+              priority: 20,
+              maxSize: 450 * 1024,
+            },
+            {
+              name: 'vendor-graph',
+              test: /node_modules[\\/](echarts|zrender|react-force-graph|force-graph|d3-|three|kapsule|ngraph|eventsource-parser)[\\/]/,
+              priority: 15,
+              maxSize: 450 * 1024,
+            },
+            {
+              name: 'vendor-editor',
+              test: /node_modules[\\/](@tiptap|@typespeed|prosemirror|lowlight|highlight.js|marked|react-markdown|remark-|rehype-|micromark|mdast|hast|unified|unist|vfile)[\\/]/,
+              priority: 10,
+              maxSize: 450 * 1024,
+            },
+            {
+              name: 'vendor',
+              test: /node_modules[\\/]/,
+              priority: 1,
+              maxSize: 450 * 1024,
+            },
+          ],
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     proxy: {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,45 +3,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
-  build: {
-    rolldownOptions: {
-      output: {
-        codeSplitting: {
-          groups: [
-            {
-              name: 'vendor-react',
-              test: /node_modules[\\/](react|react-dom|react-router)[\\/]/,
-              priority: 30,
-            },
-            {
-              name: 'vendor-antd',
-              test: /node_modules[\\/](@ant-design|antd|rc-|dayjs)[\\/]/,
-              priority: 20,
-              maxSize: 450 * 1024,
-            },
-            {
-              name: 'vendor-graph',
-              test: /node_modules[\\/](echarts|zrender|react-force-graph|force-graph|d3-|three|kapsule|ngraph|eventsource-parser)[\\/]/,
-              priority: 15,
-              maxSize: 450 * 1024,
-            },
-            {
-              name: 'vendor-editor',
-              test: /node_modules[\\/](@tiptap|@typespeed|prosemirror|lowlight|highlight.js|marked|react-markdown|remark-|rehype-|micromark|mdast|hast|unified|unist|vfile)[\\/]/,
-              priority: 10,
-              maxSize: 450 * 1024,
-            },
-            {
-              name: 'vendor',
-              test: /node_modules[\\/]/,
-              priority: 1,
-              maxSize: 450 * 1024,
-            },
-          ],
-        },
-      },
-    },
-  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary

- Add `SpacePermissionGate` component and `useSpacePermissionGate` hook for route-level Space authorization
- Guard all Space pages (Overview, Uploads, Graphify, Graph, Wiki, Chat) with permission checks before page effects
- Fix `AppShell` to no longer fall back to `spaces[0]` when route Space is inaccessible
- Update Space Overview to use `GET /api/graphify/runs?space_id=...&per_page=1&sort=-created_at` via existing API helper
- Filter Overview quick actions by current user permissions (no Graphify run without `graphify:run`)
- Gate Overview Graphify links by `graphify:view` permission

## Test plan

- [x] Lint: `pnpm lint` passes with 0 warnings
- [x] Tests: 12 files, 157 tests all pass
- [x] Build: `pnpm build` succeeds
- [x] AppShell tests: inaccessible route Space does not select another Space
- [x] Unauthorized route tests for all 6 page types including Graphify route-space mismatch
- [x] Overview Graphify run success + failure tests
- [x] Quick action permission filtering tests
- [x] AppShell navigation assumption tests

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `e44d77015c18e0bb58018e0a5c3a11313cf140db`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/333#issuecomment-4451385114) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/333#issuecomment-4451385328) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/333#issuecomment-4451385602) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/333#issuecomment-4451385999)
- Key findings addressed: Round 1 — added missing Graphify unauthorized-route tests, AppShell navigation-assumption tests, removed Vite scope creep. Phase 7 — gated Overview Graphify links by graphify:view permission.

Closes #329