### PR TITLE
feat(api): Graphify API ACL contracts (#330)

### DIFF
--- a/apps/api/src/graphify/__tests__/graphify.controller.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.controller.test.ts
@@ -49,6 +49,15 @@ describe('GraphifyController', () => {
     ).resolves.toBe(true);
   });
 
+  it('allows a viewer API token with graphify:view scope to reach a resource route for service ACL enforcement', async () => {
+    const guard = new RbacGuard(new Reflector());
+    const request = createApiTokenRequest(['graphify:view'], ROLES.VIEWER);
+
+    await expect(
+      guard.canActivate(createGuardContext('getRun', { params: { runId: 'run-1' }, user: request.user })),
+    ).resolves.toBe(true);
+  });
+
   it.each([
     ['createRun' as const, { params: { spaceId: TEST_SPACE_ID } }],
     ['cancelRun' as const, { params: { runId: 'run-1' } }],

--- a/apps/api/src/graphify/__tests__/graphify.controller.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.controller.test.ts
@@ -1,7 +1,14 @@
 import 'reflect-metadata';
 
-import { HttpException, HttpStatus } from '@nestjs/common';
-import { PERMISSIONS_METADATA_KEY } from '@cherrygraph/auth-core';
+import { HttpException, HttpStatus, type ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  PERMISSIONS_METADATA_KEY,
+  RbacGuard,
+  ROLES,
+  type AuthenticatedRequestUser,
+  type SpacePermissionResolver,
+} from '@cherrygraph/auth-core';
 import { ErrorCode } from '@cherrygraph/shared';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -18,9 +25,66 @@ import type { GraphifyService } from '../graphify.service.js';
 describe('GraphifyController', () => {
   it('applies route permissions where the guard can authorize before resource lookup', () => {
     expect(getMetadata('createRun')).toEqual(['graphify:run']);
-    expect(getMetadata('getGraphSummary')).toEqual(['admin']);
+    expect(getMetadata('listRuns')).toEqual(['graphify:view']);
+    expect(getMetadata('getRun')).toEqual(['graphify:view']);
+    expect(getMetadata('getReport')).toEqual(['graphify:view']);
+    expect(getMetadata('getGraphSummary')).toEqual(['graphify:view']);
+    expect(getMetadata('cancelRun')).toEqual(['graphify:run']);
+    expect(getMetadata('retryRun')).toEqual(['graphify:run']);
     expect(getMetadata('adminListRuns')).toEqual(['admin']);
     expect(getMetadata('adminRetryRun')).toEqual(['admin']);
+  });
+
+  it.each([
+    ['listRuns' as const, { params: {} }],
+    ['getRun' as const, { params: { runId: 'run-1' } }],
+    ['getReport' as const, { params: { runId: 'run-1' } }],
+    ['getGraphSummary' as const, { params: { runId: 'run-1' } }],
+  ])('allows an API token with graphify:view scope to reach %s', async (methodName, requestShape) => {
+    const guard = new RbacGuard(new Reflector());
+    const request = createApiTokenRequest(['graphify:view']);
+
+    await expect(
+      guard.canActivate(createGuardContext(methodName, { ...requestShape, user: request.user })),
+    ).resolves.toBe(true);
+  });
+
+  it.each([
+    ['createRun' as const, { params: { spaceId: TEST_SPACE_ID } }],
+    ['cancelRun' as const, { params: { runId: 'run-1' } }],
+    ['retryRun' as const, { params: { runId: 'run-1' } }],
+  ])('allows an API token with graphify:run scope to reach %s', async (methodName, requestShape) => {
+    const resolver = createResolver(['graphify:run']);
+    const guard = new RbacGuard(new Reflector(), resolver);
+    const request = createApiTokenRequest(['graphify:run']);
+
+    await expect(
+      guard.canActivate(createGuardContext(methodName, { ...requestShape, user: request.user })),
+    ).resolves.toBe(true);
+  });
+
+  it.each([
+    ['listRuns' as const, ['graphify:run'], {}],
+    ['getRun' as const, ['graphify:run'], { runId: 'run-1' }],
+    ['getReport' as const, ['graphify:run'], { runId: 'run-1' }],
+    ['getGraphSummary' as const, ['graphify:run'], { runId: 'run-1' }],
+    ['createRun' as const, ['graphify:view'], { spaceId: TEST_SPACE_ID }],
+    ['cancelRun' as const, ['graphify:view'], { runId: 'run-1' }],
+    ['retryRun' as const, ['graphify:view'], { runId: 'run-1' }],
+  ])('denies an API token without the required scope for %s', async (methodName, scopes, params) => {
+    const guard = new RbacGuard(new Reflector(), createResolver(['graphify:run', 'graphify:view']));
+    const request = createApiTokenRequest(scopes);
+
+    try {
+      await guard.canActivate(createGuardContext(methodName, { params, user: request.user }));
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpException);
+      expect((err as HttpException).getStatus()).toBe(403);
+      expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+      return;
+    }
+
+    throw new Error(`Expected RBAC guard to reject ${String(methodName)}`);
   });
 
   it('dispatches create run requests to the service', async () => {
@@ -77,7 +141,7 @@ describe('GraphifyController', () => {
     await controller.cancelRun('run-1', createRequest());
     await controller.retryRun('run-1', createRequest());
     await controller.getReport('run-1', createRequest());
-    await controller.getGraphSummary('run-1', createAdminRequest());
+    await controller.getGraphSummary('run-1', createRequest());
 
     expect(service.getRun).toHaveBeenCalledWith('run-1', expect.any(Object));
     expect(service.cancelRun).toHaveBeenCalledWith('run-1', expect.any(Object));
@@ -213,6 +277,31 @@ function createAdminRequest(): ReturnType<typeof createRequest> {
   return createRequest('admin');
 }
 
+function createApiTokenRequest(
+  scopes: string[],
+  role: string = ROLES.EDITOR,
+): ReturnType<typeof createRequest> & {
+  user: AuthenticatedRequestUser & { scopes: string[]; token_id: string };
+} {
+  const request = createRequest(role);
+  return {
+    ...request,
+    user: {
+      ...request.user,
+      scopes,
+      token_id: 'api-token-1',
+    },
+  };
+}
+
+function createResolver(permissions: readonly string[]): SpacePermissionResolver {
+  return {
+    getPermissionsForUser() {
+      return Promise.resolve(permissions);
+    },
+  };
+}
+
 function createRunResponse(
   overrides: Partial<Awaited<ReturnType<GraphifyService['getRun']>>> = {},
 ): Awaited<ReturnType<GraphifyService['getRun']>> {
@@ -250,4 +339,25 @@ function createPaginatedResult<T>(data: T[]): PaginatedResponse<T> {
 function getMetadata(methodName: keyof GraphifyController): unknown {
   const descriptor = Object.getOwnPropertyDescriptor(GraphifyController.prototype, methodName);
   return Reflect.getMetadata(PERMISSIONS_METADATA_KEY, descriptor?.value as object);
+}
+
+function createGuardContext(
+  methodName: keyof GraphifyController,
+  request: {
+    params?: Record<string, string | undefined>;
+    body?: Record<string, unknown>;
+    user?: unknown;
+  },
+): ExecutionContext {
+  const descriptor = Object.getOwnPropertyDescriptor(GraphifyController.prototype, methodName);
+
+  return {
+    getHandler: () => descriptor?.value as () => undefined,
+    getClass: () => GraphifyController,
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => undefined,
+      getNext: () => undefined,
+    }),
+  } as unknown as ExecutionContext;
 }

--- a/apps/api/src/graphify/__tests__/graphify.service.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.service.test.ts
@@ -214,6 +214,7 @@ describe('GraphifyService', () => {
   it('getGraphSummary aggregates graph table counts', async () => {
     const { service, db } = createServiceContext();
     db.queueSelect([createRunRow({ status: 'succeeded' })]);
+    db.queueSelect([createSpaceRow()]);
     db.queueSelect([{ total: 3 }]);
     db.queueSelect([{ total: 4 }]);
     db.queueSelect([{ total: 2 }]);
@@ -334,6 +335,55 @@ describe('GraphifyService', () => {
 
     expect(err.getStatus()).toBe(403);
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+  });
+
+  describe('Space ACL enforcement', () => {
+    it.each([
+      ['listRuns' as const],
+      ['getRun' as const],
+      ['getReport' as const],
+      ['cancelRun' as const],
+      ['retryRun' as const],
+      ['getGraphSummary' as const],
+    ])('allows a user with Space permission to call %s', async (methodName) => {
+      const { service, db } = createServiceContext();
+      queueAllowedAclCall(db, methodName);
+
+      await expect(invokeAclMethod(service, methodName, createMemberContext())).resolves.toBeDefined();
+    });
+
+    it.each([
+      ['listRuns' as const],
+      ['getRun' as const],
+      ['getReport' as const],
+      ['cancelRun' as const],
+      ['retryRun' as const],
+      ['getGraphSummary' as const],
+    ])('denies a user without Space permission for %s', async (methodName) => {
+      const { service, db } = createServiceContext();
+      queueDeniedAclCall(db, methodName);
+
+      const err = await getRejectedHttpException(invokeAclMethod(service, methodName, createMemberContext()));
+
+      expect(err.getStatus()).toBe(403);
+      expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+      expect(db.inserts).toHaveLength(0);
+      expect(db.updates).toHaveLength(0);
+    });
+
+    it.each([
+      ['listRuns' as const],
+      ['getRun' as const],
+      ['getReport' as const],
+      ['cancelRun' as const],
+      ['retryRun' as const],
+      ['getGraphSummary' as const],
+    ])('allows admin implicit access to %s', async (methodName) => {
+      const { service, db } = createServiceContext();
+      queueAdminAclCall(db, methodName);
+
+      await expect(invokeAclMethod(service, methodName, createAdminContext())).resolves.toBeDefined();
+    });
   });
 
   describe('input_scope_resolved', () => {
@@ -509,6 +559,113 @@ function createAdminContext(): {
     actorRole: 'admin',
     userId: TEST_USER_ID,
   };
+}
+
+function createMemberContext(): {
+  tenantId: string;
+  actorUserId: string;
+  actorRole: string;
+  userId: string;
+} {
+  return {
+    tenantId: TEST_TENANT_ID,
+    actorUserId: TEST_USER_ID,
+    actorRole: 'editor',
+    userId: TEST_USER_ID,
+  };
+}
+
+type AclMethod = 'listRuns' | 'getRun' | 'getReport' | 'cancelRun' | 'retryRun' | 'getGraphSummary';
+
+function invokeAclMethod(
+  service: GraphifyService,
+  methodName: AclMethod,
+  context: ReturnType<typeof createMemberContext>,
+): Promise<unknown> {
+  if (methodName === 'listRuns') {
+    return service.listRuns({ space_id: TEST_SPACE_ID }, context);
+  }
+
+  return service[methodName]('run-1', context);
+}
+
+function queueAllowedAclCall(db: ScriptedDb, methodName: AclMethod): void {
+  if (methodName === 'listRuns') {
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([{ space_id: TEST_SPACE_ID }]);
+    db.queueSelect([{ run: createRunRow(), space_name: 'Knowledge' }]);
+    db.queueSelect([{ total: 1 }]);
+    return;
+  }
+
+  queueRunSpaceAndPermission(db, methodName);
+  queueAclMethodSuccessTail(db, methodName);
+}
+
+function queueDeniedAclCall(db: ScriptedDb, methodName: AclMethod): void {
+  if (methodName !== 'listRuns') {
+    db.queueSelect([createRunRow({ status: aclRunStatus(methodName), job_id: null })]);
+  }
+
+  db.queueSelect([createSpaceRow()]);
+  db.queueSelect([]);
+}
+
+function queueAdminAclCall(db: ScriptedDb, methodName: AclMethod): void {
+  if (methodName === 'listRuns') {
+    db.queueSelect([{ run: createRunRow(), space_name: 'Knowledge' }]);
+    db.queueSelect([{ total: 1 }]);
+    return;
+  }
+
+  db.queueSelect([createRunRow({ status: aclRunStatus(methodName), job_id: null })]);
+  db.queueSelect([createSpaceRow()]);
+  queueAclMethodSuccessTail(db, methodName);
+}
+
+function queueRunSpaceAndPermission(db: ScriptedDb, methodName: AclMethod): void {
+  db.queueSelect([createRunRow({ status: aclRunStatus(methodName), job_id: null })]);
+  db.queueSelect([createSpaceRow()]);
+  db.queueSelect([{ space_id: TEST_SPACE_ID }]);
+}
+
+function queueAclMethodSuccessTail(db: ScriptedDb, methodName: AclMethod): void {
+  if (methodName === 'getReport') {
+    db.queueSelect([createReportRow()]);
+    return;
+  }
+
+  if (methodName === 'cancelRun') {
+    db.queueUpdate([createRunRow({ status: 'cancelled', job_id: null })]);
+    return;
+  }
+
+  if (methodName === 'retryRun') {
+    db.queueSelect([]);
+    db.queueSelect([]);
+    db.queueInsert([createRunRow({ id: 'run-retry', job_id: null })]);
+    db.queueInsert([createJobRow({ id: 'job-retry' })]);
+    db.queueUpdate([createRunRow({ id: 'run-retry', job_id: 'job-retry' })]);
+    return;
+  }
+
+  if (methodName === 'getGraphSummary') {
+    db.queueSelect([{ total: 1 }]);
+    db.queueSelect([{ total: 2 }]);
+    db.queueSelect([{ total: 3 }]);
+  }
+}
+
+function aclRunStatus(methodName: AclMethod): GraphifyRunRow['status'] {
+  if (methodName === 'retryRun') {
+    return 'failed';
+  }
+
+  if (methodName === 'cancelRun') {
+    return 'pending';
+  }
+
+  return 'succeeded';
 }
 
 function hasEncodedParam(

--- a/apps/api/src/graphify/__tests__/graphify.service.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.service.test.ts
@@ -352,6 +352,33 @@ describe('GraphifyService', () => {
       await expect(invokeAclMethod(service, methodName, createMemberContext())).resolves.toBeDefined();
     });
 
+    it('allows a viewer with Space graphify:view permission but no global graphify permission', async () => {
+      const { service, db } = createServiceContext();
+      queueAllowedAclCall(db, 'getRun');
+
+      await expect(service.getRun('run-1', createViewerContext())).resolves.toMatchObject({
+        run_id: 'run-1',
+        space_id: TEST_SPACE_ID,
+      });
+    });
+
+    it('denies a user with global graphify:view but no Space graphify permission', async () => {
+      const { service, db } = createServiceContext();
+      db.queueSelect([createRunRow({ status: 'succeeded' })]);
+      db.queueSelect([createSpaceRow()]);
+      db.queueSelect([]);
+
+      const err = await getRejectedHttpException(
+        service.getRun('run-1', {
+          ...createMemberContext(),
+          actorPermissions: ['graphify:view'],
+        }),
+      );
+
+      expect(err.getStatus()).toBe(403);
+      expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+    });
+
     it.each([
       ['listRuns' as const],
       ['getRun' as const],
@@ -572,6 +599,13 @@ function createMemberContext(): {
     actorUserId: TEST_USER_ID,
     actorRole: 'editor',
     userId: TEST_USER_ID,
+  };
+}
+
+function createViewerContext(): ReturnType<typeof createMemberContext> {
+  return {
+    ...createMemberContext(),
+    actorRole: 'viewer',
   };
 }
 

--- a/apps/api/src/graphify/graphify.controller.ts
+++ b/apps/api/src/graphify/graphify.controller.ts
@@ -31,6 +31,7 @@ export class GraphifyController {
   }
 
   @Get('graphify/runs')
+  @Permissions('graphify:view')
   async listRuns(
     @Query() query: GraphifyRunsQueryDto,
     @Req() request: RequestWithAuth,
@@ -40,6 +41,7 @@ export class GraphifyController {
   }
 
   @Get('graphify/runs/:runId')
+  @Permissions('graphify:view')
   async getRun(
     @Param('runId') runId: string,
     @Req() request: RequestWithAuth,
@@ -49,6 +51,7 @@ export class GraphifyController {
   }
 
   @Post('graphify/runs/:runId/cancel')
+  @Permissions('graphify:run')
   @HttpCode(HttpStatus.OK)
   async cancelRun(
     @Param('runId') runId: string,
@@ -59,6 +62,7 @@ export class GraphifyController {
   }
 
   @Post('graphify/runs/:runId/retry')
+  @Permissions('graphify:run')
   async retryRun(
     @Param('runId') runId: string,
     @Req() request: RequestWithAuth,
@@ -68,6 +72,7 @@ export class GraphifyController {
   }
 
   @Get('graphify/runs/:runId/report')
+  @Permissions('graphify:view')
   async getReport(
     @Param('runId') runId: string,
     @Req() request: RequestWithAuth,
@@ -77,7 +82,7 @@ export class GraphifyController {
   }
 
   @Get('graphify/runs/:runId/graph')
-  @Permissions('admin')
+  @Permissions('graphify:view')
   async getGraphSummary(
     @Param('runId') runId: string,
     @Req() request: RequestWithAuth,

--- a/apps/api/src/graphify/graphify.service.ts
+++ b/apps/api/src/graphify/graphify.service.ts
@@ -582,10 +582,6 @@ export class GraphifyService {
     }
 
     const userId = resolveContextUserId(context);
-    if (context.actorPermissions !== undefined && permissionSetSatisfies(context.actorPermissions, permission)) {
-      return space;
-    }
-
     const allowed = await this.hasSpacePermission(tenantId, userId, spaceId, permission);
     if (!allowed) {
       throwApiError(ErrorCode.PERMISSION_DENIED, 'Permission denied', HttpStatus.FORBIDDEN);
@@ -1109,10 +1105,6 @@ function normalizeCount(value: unknown): number {
 
 function satisfyingPermissions(permission: GraphifyPermission): string[] {
   return [permission, 'space:admin'];
-}
-
-function permissionSetSatisfies(permissions: string[], permission: GraphifyPermission): boolean {
-  return permissions.includes(permission) || permissions.includes('space:admin');
 }
 
 function hasImplicitSpaceAccess(role: string | undefined): boolean {

--- a/apps/api/src/graphify/graphify.service.ts
+++ b/apps/api/src/graphify/graphify.service.ts
@@ -338,11 +338,7 @@ export class GraphifyService {
     runId: string,
     context: GraphifyContext = {},
   ): Promise<GraphifyGraphSummaryResponse> {
-    const tenantId = resolveTenantId(context);
-    const run = await this.findRunById(tenantId, runId);
-    if (run === undefined) {
-      throwGraphifyRunNotFound();
-    }
+    const run = await this.getAccessibleRun(runId, context, 'graphify:view');
 
     const [nodeCountRow] = await this.db
       .select({ total: count() })

--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -211,8 +211,8 @@ describe('GraphifyRunDetailPage', () => {
     renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-1/graphify/run-1');
 
     expect(await screen.findByText('Graphify Run Detail')).toBeInTheDocument();
-    expect(screen.getAllByText('run-1').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('space-1').length).toBeGreaterThanOrEqual(1);
+    expect((await screen.findAllByText('run-1')).length).toBeGreaterThanOrEqual(1);
+    expect((await screen.findAllByText('space-1')).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('Page Not Found')).not.toBeInTheDocument();
   });
 
@@ -225,7 +225,7 @@ describe('GraphifyRunDetailPage', () => {
 
     expect(await screen.findByText('Graphify Run Detail')).toBeInTheDocument();
     expect(await screen.findByText('Summary unavailable')).toBeInTheDocument();
-    expect(screen.getAllByText('run-1').length).toBeGreaterThanOrEqual(1);
+    expect((await screen.findAllByText('run-1')).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('Page Not Found')).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/__tests__/graphify.test.tsx
+++ b/apps/web/src/__tests__/graphify.test.tsx
@@ -216,6 +216,19 @@ describe('GraphifyRunDetailPage', () => {
     expect(screen.queryByText('Page Not Found')).not.toBeInTheDocument();
   });
 
+  it('keeps detail rendering when graph summary is unavailable', async () => {
+    mockDetailApis(buildRun({ run_id: 'run-1', space_id: 'space-1', status: 'succeeded' }), {
+      rejectSummary: true,
+    });
+
+    renderWithRouter(<GraphifyRunDetailPage />, '/spaces/space-1/graphify/run-1');
+
+    expect(await screen.findByText('Graphify Run Detail')).toBeInTheDocument();
+    expect(await screen.findByText('Summary unavailable')).toBeInTheDocument();
+    expect(screen.getAllByText('run-1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Page Not Found')).not.toBeInTheDocument();
+  });
+
   it('shows not found and blocks detail rendering when the run space does not match the route space', async () => {
     mockDetailApis(buildRun({ run_id: 'run-1', space_id: 'space-2', status: 'succeeded' }));
 
@@ -342,7 +355,7 @@ async function renderDetailStatus(status: GraphifyRun['status']): Promise<void> 
   expect(await screen.findByText('Graphify Run Detail')).toBeInTheDocument();
 }
 
-function mockDetailApis(run: GraphifyRun): void {
+function mockDetailApis(run: GraphifyRun, options: { rejectSummary?: boolean } = {}): void {
   apiMocks.getWrapped.mockImplementation((path: string) => {
     if (path === '/graphify/runs/run-1') {
       return Promise.resolve({
@@ -362,6 +375,10 @@ function mockDetailApis(run: GraphifyRun): void {
     }
 
     if (path === '/graphify/runs/run-1/graph') {
+      if (options.rejectSummary === true) {
+        return Promise.reject(new Error('summary unavailable'));
+      }
+
       return Promise.resolve({
         data: {
           run_id: 'run-1',

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -854,7 +854,8 @@
           "nodes": "Nodes",
           "edges": "Edges",
           "communities": "Communities",
-          "wikiPages": "Wiki pages"
+          "wikiPages": "Wiki pages",
+          "summaryUnavailable": "Summary unavailable"
         },
         "report": {
           "title": "GRAPH_REPORT.md",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -854,7 +854,8 @@
           "nodes": "节点",
           "edges": "边",
           "communities": "社区",
-          "wikiPages": "知识库页面"
+          "wikiPages": "知识库页面",
+          "summaryUnavailable": "摘要不可用"
         },
         "report": {
           "title": "GRAPH_REPORT.md",

--- a/apps/web/src/pages/GraphifyRunDetailPage.tsx
+++ b/apps/web/src/pages/GraphifyRunDetailPage.tsx
@@ -39,6 +39,7 @@ export default function GraphifyRunDetailPage() {
   const [run, setRun] = useState<GraphifyRun | null>(null);
   const [report, setReport] = useState<GraphifyReport | null>(null);
   const [summary, setSummary] = useState<GraphifySummary | null>(null);
+  const [isSummaryUnavailable, setIsSummaryUnavailable] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isCancelling, setIsCancelling] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
@@ -53,6 +54,7 @@ export default function GraphifyRunDetailPage() {
         setRun(null);
         setReport(null);
         setSummary(null);
+        setIsSummaryUnavailable(false);
         setIsRunSpaceMismatch(false);
         setIsLoading(false);
         return;
@@ -72,6 +74,7 @@ export default function GraphifyRunDetailPage() {
           setRun(null);
           setReport(null);
           setSummary(null);
+          setIsSummaryUnavailable(false);
           setIsRunSpaceMismatch(true);
           return;
         }
@@ -81,6 +84,7 @@ export default function GraphifyRunDetailPage() {
         if (isGraphifyRunActive(currentRun)) {
           setReport(null);
           setSummary(null);
+          setIsSummaryUnavailable(false);
           return;
         }
 
@@ -90,6 +94,7 @@ export default function GraphifyRunDetailPage() {
         ]);
         setReport(reportResult.status === 'fulfilled' ? reportResult.value.data : null);
         setSummary(summaryResult.status === 'fulfilled' ? summaryResult.value.data : null);
+        setIsSummaryUnavailable(summaryResult.status === 'rejected');
       } catch (err) {
         setError(getErrorMessage(err));
       } finally {
@@ -239,24 +244,28 @@ export default function GraphifyRunDetailPage() {
           <Card
             title={t('graphify.space.detail.stats.title')}
             style={{ marginBottom: 16 }}
-            styles={{ body: { display: 'flex', gap: 32 } }}
           >
-            <Statistic
-              title={t('graphify.space.detail.stats.nodes')}
-              value={formatCount(summary?.summary.node_count ?? getGraphifyStat(run, 'node_count'))}
-            />
-            <Statistic
-              title={t('graphify.space.detail.stats.edges')}
-              value={formatCount(summary?.summary.edge_count ?? getGraphifyStat(run, 'edge_count'))}
-            />
-            <Statistic
-              title={t('graphify.space.detail.stats.communities')}
-              value={formatCount(summary?.summary.community_count ?? getGraphifyStat(run, 'community_count'))}
-            />
-            <Statistic
-              title={t('graphify.space.detail.stats.wikiPages')}
-              value={formatCount(getGraphifyStat(run, 'wiki_page_count'))}
-            />
+            <div style={{ display: 'flex', gap: 32 }}>
+              <Statistic
+                title={t('graphify.space.detail.stats.nodes')}
+                value={formatCount(summary?.summary.node_count ?? getGraphifyStat(run, 'node_count'))}
+              />
+              <Statistic
+                title={t('graphify.space.detail.stats.edges')}
+                value={formatCount(summary?.summary.edge_count ?? getGraphifyStat(run, 'edge_count'))}
+              />
+              <Statistic
+                title={t('graphify.space.detail.stats.communities')}
+                value={formatCount(summary?.summary.community_count ?? getGraphifyStat(run, 'community_count'))}
+              />
+              <Statistic
+                title={t('graphify.space.detail.stats.wikiPages')}
+                value={formatCount(getGraphifyStat(run, 'wiki_page_count'))}
+              />
+            </div>
+            {isSummaryUnavailable && (
+              <Typography.Text type="secondary">{t('graphify.space.detail.stats.summaryUnavailable')}</Typography.Text>
+            )}
           </Card>
 
           <Card

--- a/packages/auth-core/src/__tests__/guards.test.ts
+++ b/packages/auth-core/src/__tests__/guards.test.ts
@@ -222,7 +222,7 @@ describe('RbacGuard', () => {
     ).rejects.toMatchObject({ status: 403 });
   });
 
-  it('throws 403 for a viewer requesting upload:create without a target space', async () => {
+  it('allows a viewer through the guard for deferrable upload:create without a target space', async () => {
     const guard = new RbacGuard(new Reflector());
     const handler = withPermissions(['upload:create']);
 
@@ -236,10 +236,10 @@ describe('RbacGuard', () => {
           },
         }),
       ),
-    ).rejects.toMatchObject({ status: 403 });
+    ).resolves.toBe(true);
   });
 
-  it('throws 403 for an auditor requesting upload:read without a target space', async () => {
+  it('allows an auditor through the guard for deferrable upload:read without a target space', async () => {
     const guard = new RbacGuard(new Reflector());
     const handler = withPermissions(['upload:read']);
 
@@ -253,7 +253,7 @@ describe('RbacGuard', () => {
           },
         }),
       ),
-    ).rejects.toMatchObject({ status: 403 });
+    ).resolves.toBe(true);
   });
 
   it('allows an admin to authorize a space-scoped permission without a target space', async () => {

--- a/packages/auth-core/src/constants.ts
+++ b/packages/auth-core/src/constants.ts
@@ -132,6 +132,8 @@ export const RESOURCE_ACL_DEFERRABLE_PERMISSIONS = [
   'space:read',
   'upload:read',
   'upload:create',
+  'graphify:view',
+  'graphify:run',
 ] as const satisfies readonly PermissionPoint[];
 
 const ROLE_ALIASES = new Map<string, Role>([

--- a/packages/auth-core/src/rbac.guard.ts
+++ b/packages/auth-core/src/rbac.guard.ts
@@ -124,7 +124,7 @@ export class RbacGuard implements CanActivate {
     const rolePermissions = new Set<string>(ROLE_PERMISSIONS[role]);
 
     if (spaceId === undefined && requiredPermissions.some(isSpaceScopedPermission)) {
-      if (requiredPermissions.every((permission) => isResourceAclDeferrable(permission) && rolePermissions.has(permission))) {
+      if (requiredPermissions.every(isResourceAclDeferrable)) {
         return true;
       }
       if (role === ROLES.ADMIN && requiredPermissions.every((permission) => isSpaceScopedPermission(permission) || rolePermissions.has(permission))) {


### PR DESCRIPTION
## Summary

- Add `@Permissions('graphify:view')` to list, detail, report, graph summary routes
- Add `@Permissions('graphify:run')` to cancel, retry routes
- Change graph summary from admin-only to `graphify:view` + service-level Space ACL
- Add `graphify:view`/`graphify:run` to `RESOURCE_ACL_DEFERRABLE_PERMISSIONS`
- Remove service ACL bypass via `actorPermissions` global shortcut
- Relax RBAC guard deferrable path for space-granted viewers
- Add controller token-scope, service ACL, and regression tests
- Make web Graphify detail graph summary failure non-blocking

## Test plan

- [x] API lint: 0 warnings
- [x] API tests: 1312 passed
- [x] Web tests: 158 passed
- [x] Controller: API token scope allow/deny for all routes
- [x] Service: allowed user, denied user, admin implicit access
- [x] Regression: space-granted viewer, global-permission-only denial
- [x] Web: graph summary failure shows "Summary unavailable"

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `04a4b2ca1e30a8e929929d7b191409be79da7588`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/334#issuecomment-4451932985) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/334#issuecomment-4451933231) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/334#issuecomment-4451933492) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/334#issuecomment-4451933754)
- Key findings addressed: Round 1 — removed service ACL bypass via actorPermissions, relaxed RBAC deferrable check for space-granted viewers, added regression tests. CI fix — async test assertions for timing stability.

Closes #330