### PR TITLE
ci(backup): backup/restore regression gates (#332)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Backup/restore shell regression
+        run: bash scripts/__tests__/backup-restore.sh
+
       - name: Secret scanner self-test
         run: node scripts/secret-hygiene-scan.mjs --self-test
 

--- a/docs/engineering/15_部署运维规范.md
+++ b/docs/engineering/15_部署运维规范.md
@@ -192,6 +192,15 @@ Compose `healthcheck` 仅检查 HTTP 200；cherry-api 的 `/api/admin/system/hea
 
 演练结果记录到 `system_settings` 中，包含：演练时间、恢复耗时、验证结果、发现的问题。管理员面板展示最近一次演练状态。
 
+### 8.2 备份/恢复验证分层
+
+| 验证 | 执行方式 | 覆盖范围 |
+|---|---|---|
+| 自动化 shell 回归 | CI 执行 `bash scripts/__tests__/backup-restore.sh`，本地可执行 `pnpm test:backup-restore` | 验证备份/恢复脚本的参数校验、失败中止和测试计数输出。 |
+| 手动 live restore acceptance | 手动执行 `tests/integration/backup-restore.test.ts` 中记录的流程，需要真实 PostgreSQL、MinIO、API、Graphify 输出和 Wiki Repo | 验证恢复后的 API 健康、PostgreSQL 数据、MinIO 对象、Wiki Repo、Graphify 节点/边以及 Chat/RAG 数据完整性。 |
+
+恢复证据必须 value-free：日志和截图只能包含路径、计数、哈希、健康状态、耗时和汇总结论，不得输出密码、访问密钥、JWT、API token、MinIO secret、数据库连接串或原始业务敏感内容。
+
 ## 9. 日志与监控
 
 必须监控：

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "pnpm -r --if-present lint",
     "typecheck": "pnpm -r --if-present typecheck",
     "test": "pnpm -r --if-present test",
+    "test:backup-restore": "bash scripts/__tests__/backup-restore.sh",
     "secret:scan": "node scripts/secret-hygiene-scan.mjs"
   },
   "pnpm": {


### PR DESCRIPTION
## Summary

- Add `test:backup-restore` script to package.json
- Add backup/restore shell regression step to main CI workflow
- Document the split between automated shell regression and manual live restore acceptance
- Require value-free restore evidence in documentation

## Test plan

- [x] Shell test: 6 tests pass (`bash scripts/__tests__/backup-restore.sh`)
- [x] Script uses `set -euo pipefail` for proper error handling
- [x] Output includes test count on success
- [x] Manual test file remains documented and skipped in CI

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `1f1cf709573b7c7204683f455dfb43fafdf4debd`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/336#issuecomment-4452267546) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/336#issuecomment-4452267843) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/336#issuecomment-4452268080) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/336#issuecomment-4452268345)
- Key findings addressed: Clean review — no findings across all 4 reviewers.

Closes #332