### PR TITLE
feat(graphify): add production metrics to stats_json (#338)

### DIFF
--- a/apps/graphify-worker/src/claude_runner.py
+++ b/apps/graphify-worker/src/claude_runner.py
@@ -458,6 +458,7 @@ async def run_graphify(
             "state": RunState.FAILED.value,
             "reason": "runner_disabled",
             "retryable": True,
+            **_default_graphify_metrics(),
         }
 
     if not os.environ.get("AGENT_ANTHROPIC_API_KEY") or not os.environ.get(
@@ -468,11 +469,12 @@ async def run_graphify(
             "state": RunState.FAILED.value,
             "reason": "missing_api_key",
             "retryable": False,
+            **_default_graphify_metrics(),
         }
 
     preflight = preflight_check(input_dir)
     if not preflight.get("ok"):
-        return preflight
+        return _with_graphify_metrics(preflight, preflight)
 
     dirs = prepare_run_dirs(run_id)
     _copy_inputs(Path(input_dir), dirs.input_dir)
@@ -487,7 +489,8 @@ async def run_graphify(
     try:
         proc = spawn_claude(dirs.session_dir, dirs.config_dir, settings_path)
         write_user_message(proc, FIRST_GRAPHIFY_MESSAGE)
-        return await _run_stream_loop(proc, dirs.session_dir, float(timeout_seconds))
+        result = await _run_stream_loop(proc, dirs.session_dir, float(timeout_seconds))
+        return _with_graphify_metrics(result, preflight)
     finally:
         if proc is not None:
             await _cleanup_process(proc)
@@ -501,11 +504,16 @@ async def _run_stream_loop(
     state = RunState.STARTING
     session_id: str | None = None
     waiting_for_input = False
+    requires_interaction_count = 0
 
     while True:
         remaining = deadline - loop.time()
         if remaining <= 0:
-            return await _terminate_for_timeout(proc)
+            return await _terminate_for_timeout(
+                proc,
+                session_id=session_id,
+                requires_interaction_count=requires_interaction_count,
+            )
 
         try:
             line = await asyncio.wait_for(
@@ -513,7 +521,11 @@ async def _run_stream_loop(
                 timeout=remaining,
             )
         except TimeoutError:
-            return await _terminate_for_timeout(proc)
+            return await _terminate_for_timeout(
+                proc,
+                session_id=session_id,
+                requires_interaction_count=requires_interaction_count,
+            )
 
         if line == "":
             if output_complete(session_dir):
@@ -522,7 +534,7 @@ async def _run_stream_loop(
                     assistant_waiting_for_input=False,
                     proc=proc,
                     session_id=session_id,
-                )
+                ) | _stream_metrics(requires_interaction_count, 0)
             _log_and_remove_stderr(proc)
             return {
                 "status": "failed",
@@ -530,6 +542,7 @@ async def _run_stream_loop(
                 "reason": "claude_exited",
                 "retryable": True,
                 "session_id": session_id,
+                **_stream_metrics(requires_interaction_count, 0),
             }
 
         event = parse_stream_event(line)
@@ -551,9 +564,10 @@ async def _run_stream_loop(
             text = event.get("text", "")
             if text:
                 _LOGGER.debug("claude assistant: %.500s", text)
-            waiting_for_input = waiting_for_input or bool(
-                event.get("waiting_for_input")
-            )
+            event_waiting_for_input = bool(event.get("waiting_for_input"))
+            if event_waiting_for_input:
+                requires_interaction_count += 1
+            waiting_for_input = waiting_for_input or event_waiting_for_input
             continue
 
         if event["type"] == "error":
@@ -567,6 +581,7 @@ async def _run_stream_loop(
                 "message": event.get("message", ""),
                 "retryable": True,
                 "session_id": session_id,
+                **_stream_metrics(requires_interaction_count, 0),
             }
 
         if event["type"] == "result":
@@ -581,6 +596,7 @@ async def _run_stream_loop(
                     "message": event.get("message", ""),
                     "retryable": True,
                     "session_id": session_id,
+                    **_stream_metrics(requires_interaction_count, 0),
                 }
 
             state = RunState.IDLE
@@ -593,7 +609,7 @@ async def _run_stream_loop(
             await _wait_for_process_exit(proc, 10)
             if result.get("status") != "success":
                 _log_and_remove_stderr(proc)
-            return result
+            return result | _stream_metrics(requires_interaction_count, 0)
 
         if state == RunState.FAILED:
             return {
@@ -602,10 +618,16 @@ async def _run_stream_loop(
                 "reason": "unknown",
                 "retryable": True,
                 "session_id": session_id,
+                **_stream_metrics(requires_interaction_count, 0),
             }
 
 
-async def _terminate_for_timeout(proc: subprocess.Popen[str]) -> dict[str, Any]:
+async def _terminate_for_timeout(
+    proc: subprocess.Popen[str],
+    *,
+    session_id: str | None = None,
+    requires_interaction_count: int = 0,
+) -> dict[str, Any]:
     _request_terminate(proc)
     try:
         await _wait_for_process_exit(proc, 10)
@@ -618,6 +640,42 @@ async def _terminate_for_timeout(proc: subprocess.Popen[str]) -> dict[str, Any]:
         "state": RunState.FAILED.value,
         "reason": "timeout",
         "retryable": True,
+        "session_id": session_id,
+        **_stream_metrics(requires_interaction_count, 1),
+    }
+
+
+def _default_graphify_metrics() -> dict[str, Any]:
+    return {
+        "input_file_count": 0,
+        "input_total_words": 0,
+        "claude_session_id": None,
+        "requires_interaction_count": 0,
+        "timeout_count": 0,
+    }
+
+
+def _with_graphify_metrics(
+    result: dict[str, Any], preflight: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        **result,
+        "input_file_count": int(preflight.get("file_count") or 0),
+        "input_total_words": int(preflight.get("total_words") or 0),
+        "claude_session_id": result.get("session_id"),
+        "requires_interaction_count": int(
+            result.get("requires_interaction_count") or 0
+        ),
+        "timeout_count": int(result.get("timeout_count") or 0),
+    }
+
+
+def _stream_metrics(
+    requires_interaction_count: int, timeout_count: int
+) -> dict[str, int]:
+    return {
+        "requires_interaction_count": requires_interaction_count,
+        "timeout_count": timeout_count,
     }
 
 

--- a/apps/graphify-worker/src/runner.py
+++ b/apps/graphify-worker/src/runner.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import stat
+import time
 from pathlib import Path
 from typing import Any
 
@@ -27,12 +28,19 @@ _SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 async def run(job_data: dict[str, Any]) -> dict[str, Any]:
+    start_time = time.monotonic()
     if os.environ.get("GRAPHIFY_RUNNER_MODE", "claude_code") == "disabled":
-        raise RuntimeError(json.dumps({"reason": "runner_disabled", "retryable": True}))
+        _raise_runtime_error(
+            {"reason": "runner_disabled", "retryable": True},
+            _stats_json(duration_ms=_duration_ms(start_time)),
+        )
     if not os.environ.get("AGENT_ANTHROPIC_API_KEY") or not os.environ.get(
         "AGENT_ANTHROPIC_BASE_URL"
     ):
-        raise RuntimeError(json.dumps({"reason": "missing_api_key"}))
+        _raise_runtime_error(
+            {"reason": "missing_api_key"},
+            _stats_json(duration_ms=_duration_ms(start_time)),
+        )
 
     job_id = job_data.get("id") or job_data.get("job_id")
     payload = _payload(job_data)
@@ -57,6 +65,8 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
         extra={"job_id": job_id, "run_id": run_id, "input_count": len(input_uris)},
     )
 
+    stats_json = _stats_json()
+
     try:
         input_dir.mkdir(parents=True, exist_ok=True)
 
@@ -70,8 +80,10 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
         result = await claude_runner.run_graphify(
             run_id, str(input_dir), timeout=GRAPHIFY_TIMEOUT
         )
+        stats_json = _stats_json(claude_result=result)
         if result.get("status") != "success":
-            raise RuntimeError(json.dumps(result))
+            stats_json["duration_ms"] = _duration_ms(start_time)
+            _raise_runtime_error(result, stats_json)
 
         output_dir = _output_dir_from_result(result)
         if output_dir.is_symlink():
@@ -82,6 +94,12 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
         validation = _validate_output(
             output_dir, run_id=run_id, graphify_ref=GRAPHIFY_REF
         )
+        stats_json = _stats_json(
+            validation=validation,
+            claude_result=result,
+            output_dir=output_dir,
+            duration_ms=_duration_ms(start_time),
+        )
         report_path = output_dir / "validation_report.json"
         _write_validation_report(report_path, validation)
         if not validation["validation_passed"]:
@@ -91,7 +109,7 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
                 )
             except Exception:
                 logger.warning("Failed to upload validation report", exc_info=True)
-            raise RuntimeError(json.dumps(_validation_error(validation)))
+            _raise_runtime_error(_validation_error(validation), stats_json)
 
         storage.upload_directory(output_dir, OUTPUT_BUCKET, key_prefix)
 
@@ -99,6 +117,7 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
         graph_html_path = output_dir / "graph.html"
         report_md_path = output_dir / "GRAPH_REPORT.md"
 
+        stats_json["duration_ms"] = _duration_ms(start_time)
         return {
             "status": "success",
             "graph_json_uri": f"{base_uri}/graph.json",
@@ -111,13 +130,12 @@ async def run(job_data: dict[str, Any]) -> dict[str, Any]:
             else None,
             "validation_report_uri": f"{base_uri}/validation_report.json",
             "stats_json": {
-                "node_count": validation.get("node_count", 0),
-                "edge_count": validation.get("edge_count", 0),
-                "wiki_page_count": validation.get("wiki_page_count", 0),
-                "total_output_bytes": validation.get("total_output_bytes", 0),
+                **stats_json,
             },
             "schema_version": "v1",
         }
+    except RuntimeError as exc:
+        _raise_with_duration(exc, stats_json, start_time)
     finally:
         if workdir.exists():
             shutil.rmtree(workdir, ignore_errors=True)
@@ -142,6 +160,78 @@ def _write_validation_report(report_path: Path, validation: dict[str, Any]) -> N
         else:
             report_path.unlink()
     report_path.write_text(json.dumps(validation, indent=2), encoding="utf-8")
+
+
+def _duration_ms(start_time: float) -> int:
+    return max(1, int((time.monotonic() - start_time) * 1000))
+
+
+def _stats_json(
+    *,
+    validation: dict[str, Any] | None = None,
+    claude_result: dict[str, Any] | None = None,
+    output_dir: Path | None = None,
+    duration_ms: int = 0,
+) -> dict[str, Any]:
+    validation = validation or {}
+    claude_result = claude_result or {}
+    return {
+        "node_count": int(validation.get("node_count") or 0),
+        "edge_count": int(validation.get("edge_count") or 0),
+        "wiki_page_count": int(validation.get("wiki_page_count") or 0),
+        "total_output_bytes": int(validation.get("total_output_bytes") or 0),
+        "input_file_count": int(claude_result.get("input_file_count") or 0),
+        "input_total_words": int(claude_result.get("input_total_words") or 0),
+        "claude_session_id": claude_result.get("claude_session_id"),
+        "duration_ms": duration_ms,
+        "empty_output_count": _empty_output_count(validation, output_dir),
+        "timeout_count": int(claude_result.get("timeout_count") or 0),
+        "requires_interaction_count": int(
+            claude_result.get("requires_interaction_count") or 0
+        ),
+        "validation_failed_reason": _validation_failed_reason(validation),
+    }
+
+
+def _empty_output_count(
+    validation: dict[str, Any], output_dir: Path | None = None
+) -> int:
+    if output_dir is not None and not (output_dir / "graph.json").exists():
+        return 1
+    if validation and int(validation.get("node_count") or 0) == 0:
+        return 1
+    return 0
+
+
+def _validation_failed_reason(validation: dict[str, Any]) -> str | None:
+    if not validation or validation.get("validation_passed") is not False:
+        return None
+    for check in validation.get("checks", []):
+        if check.get("status") == "failed":
+            return f"{check.get('name', '')}: {check.get('details', '')}"
+    return None
+
+
+def _raise_runtime_error(error: dict[str, Any], stats_json: dict[str, Any]) -> None:
+    raise RuntimeError(json.dumps({**error, "stats_json": stats_json}))
+
+
+def _raise_with_duration(
+    exc: RuntimeError, stats_json: dict[str, Any], start_time: float
+) -> None:
+    try:
+        error = json.loads(str(exc))
+    except json.JSONDecodeError:
+        raise
+    if not isinstance(error, dict):
+        raise
+    error_stats = error.get("stats_json")
+    if isinstance(error_stats, dict):
+        error_stats["duration_ms"] = _duration_ms(start_time)
+    else:
+        stats_json["duration_ms"] = _duration_ms(start_time)
+        error["stats_json"] = stats_json
+    raise RuntimeError(json.dumps(error)) from exc
 
 
 def _validation_error(validation: dict[str, Any]) -> dict[str, Any]:

--- a/apps/graphify-worker/src/runner.py
+++ b/apps/graphify-worker/src/runner.py
@@ -184,7 +184,9 @@ def _stats_json(
         "input_total_words": int(claude_result.get("input_total_words") or 0),
         "claude_session_id": claude_result.get("claude_session_id"),
         "duration_ms": duration_ms,
-        "empty_output_count": _empty_output_count(validation, output_dir, claude_result),
+        "empty_output_count": _empty_output_count(
+            validation, output_dir, claude_result
+        ),
         "timeout_count": int(claude_result.get("timeout_count") or 0),
         "requires_interaction_count": int(
             claude_result.get("requires_interaction_count") or 0

--- a/apps/graphify-worker/src/runner.py
+++ b/apps/graphify-worker/src/runner.py
@@ -184,7 +184,7 @@ def _stats_json(
         "input_total_words": int(claude_result.get("input_total_words") or 0),
         "claude_session_id": claude_result.get("claude_session_id"),
         "duration_ms": duration_ms,
-        "empty_output_count": _empty_output_count(validation, output_dir),
+        "empty_output_count": _empty_output_count(validation, output_dir, claude_result),
         "timeout_count": int(claude_result.get("timeout_count") or 0),
         "requires_interaction_count": int(
             claude_result.get("requires_interaction_count") or 0
@@ -194,8 +194,12 @@ def _stats_json(
 
 
 def _empty_output_count(
-    validation: dict[str, Any], output_dir: Path | None = None
+    validation: dict[str, Any],
+    output_dir: Path | None = None,
+    claude_result: dict[str, Any] | None = None,
 ) -> int:
+    if claude_result and claude_result.get("reason") == "empty_output":
+        return 1
     if output_dir is not None and not (output_dir / "graph.json").exists():
         return 1
     if validation and int(validation.get("node_count") or 0) == 0:

--- a/apps/graphify-worker/tests/test_claude_runner.py
+++ b/apps/graphify-worker/tests/test_claude_runner.py
@@ -327,6 +327,82 @@ def test_timeout_sends_sigterm_after_timeout(
     assert fake_proc.killed is False
 
 
+def test_run_graphify_returns_input_metrics_and_claude_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    input_dir = _input_dir(tmp_path)
+    fake_proc = FakeProc(
+        stdout=LineStdout(
+            [
+                '{"type":"system","session_id":"session-1"}\n',
+                '{"type":"result","result":{"is_error":false}}\n',
+            ]
+        )
+    )
+    _enable_runner(monkeypatch, tmp_path)
+
+    def fake_spawn(
+        session_dir: Path, _config_dir: Path, _settings_path: Path
+    ) -> FakeProc:
+        output_dir = session_dir / "graphify-out"
+        output_dir.mkdir()
+        (output_dir / "graph.json").write_text(
+            '{"nodes":[{"id":"a"}],"links":[]}', encoding="utf-8"
+        )
+        wiki_dir = output_dir / "wiki"
+        wiki_dir.mkdir()
+        (wiki_dir / "index.md").write_text("# Index\n", encoding="utf-8")
+        return fake_proc
+
+    monkeypatch.setattr(claude_runner, "spawn_claude", fake_spawn)
+
+    result = asyncio.run(claude_runner.run_graphify("run-1", input_dir, timeout=1))
+
+    assert result["input_file_count"] == 1
+    assert result["input_total_words"] == 2
+    assert result["claude_session_id"] == "session-1"
+
+
+def test_stream_loop_counts_requires_interaction_events(tmp_path: Path) -> None:
+    proc = FakeProc(
+        stdout=LineStdout(
+            [
+                '{"type":"system","session_id":"session-1"}\n',
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Please confirm which option to use.",
+                                }
+                            ],
+                        },
+                    }
+                )
+                + "\n",
+                '{"type":"result","result":{"is_error":false}}\n',
+            ]
+        )
+    )
+
+    result = asyncio.run(claude_runner._run_stream_loop(proc, tmp_path, 1))
+
+    assert result["reason"] == "requires_interaction"
+    assert result["requires_interaction_count"] == 1
+
+
+def test_stream_loop_counts_timeout(tmp_path: Path) -> None:
+    proc = FakeProc(stdout=BlockingStdout())
+
+    result = asyncio.run(claude_runner._run_stream_loop(proc, tmp_path, 0.01))
+
+    assert result["reason"] == "timeout"
+    assert result["timeout_count"] == 1
+
+
 def test_preflight_151_files_fails_input_too_large(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/apps/graphify-worker/tests/test_runner.py
+++ b/apps/graphify-worker/tests/test_runner.py
@@ -292,6 +292,36 @@ def test_run_missing_graph_sets_empty_output_count(
     assert stats["empty_output_count"] == 1
 
 
+def test_run_claude_empty_output_reason_sets_empty_output_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    async def fake_run_graphify(
+        _run_id: str, _input_dir: str, *, timeout: float | None = None
+    ) -> dict[str, Any]:
+        return {
+            "status": "failed",
+            "state": "FAILED",
+            "reason": "empty_output",
+            "retryable": False,
+            "input_file_count": 1,
+            "input_total_words": 10,
+            "claude_session_id": None,
+            "timeout_count": 0,
+            "requires_interaction_count": 0,
+        }
+
+    monkeypatch.setattr(runner.claude_runner, "run_graphify", fake_run_graphify)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    stats = json.loads(str(exc_info.value))["stats_json"]
+    assert stats["empty_output_count"] == 1
+
+
 def test_run_validation_failure_sets_failed_reason(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/apps/graphify-worker/tests/test_runner.py
+++ b/apps/graphify-worker/tests/test_runner.py
@@ -50,6 +50,20 @@ def test_run_success_uploads_outputs_and_cleans_workdir(
     assert result["stats_json"]["node_count"] == fixture_count("nodes")
     assert result["stats_json"]["edge_count"] == fixture_count("edges")
     assert result["stats_json"]["wiki_page_count"] == 5
+    assert set(result["stats_json"]) == {
+        "node_count",
+        "edge_count",
+        "wiki_page_count",
+        "total_output_bytes",
+        "input_file_count",
+        "input_total_words",
+        "claude_session_id",
+        "duration_ms",
+        "empty_output_count",
+        "timeout_count",
+        "requires_interaction_count",
+        "validation_failed_reason",
+    }
     assert captured_manifest["space_id"] == "space-1"
     assert captured_manifest["run_id"] == "run-1"
     assert captured_manifest["mode"] == "full"
@@ -116,7 +130,9 @@ def test_run_disabled_mode_fails_before_download(
         asyncio.run(runner.run(job_data()))
 
     error = json.loads(str(exc_info.value))
-    assert error == {"reason": "runner_disabled", "retryable": True}
+    assert error["reason"] == "runner_disabled"
+    assert error["retryable"] is True
+    assert error["stats_json"]["duration_ms"] > 0
     assert storage.downloads == []
     assert not any(tmp_path.iterdir())
 
@@ -137,7 +153,9 @@ def test_run_missing_api_key_fails_before_download(
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(runner.run(job_data()))
 
-    assert json.loads(str(exc_info.value)) == {"reason": "missing_api_key"}
+    error = json.loads(str(exc_info.value))
+    assert error["reason"] == "missing_api_key"
+    assert error["stats_json"]["duration_ms"] > 0
     assert storage.downloads == []
     assert not any(tmp_path.iterdir())
 
@@ -166,6 +184,145 @@ def test_run_pipeline_error_reports_and_cleans_workdir(
 
     assert json.loads(str(exc_info.value))["reason"] == "llm_error"
     assert not (tmp_path / "run-1").exists()
+
+
+def test_run_stats_contains_claude_metrics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    install_fake_run_graphify(
+        monkeypatch,
+        input_file_count=2,
+        input_total_words=7,
+        claude_session_id="session-1",
+        timeout_count=1,
+        requires_interaction_count=3,
+    )
+
+    result = asyncio.run(runner.run(job_data()))
+
+    stats = result["stats_json"]
+    assert stats["input_file_count"] == 2
+    assert stats["input_total_words"] == 7
+    assert stats["claude_session_id"] == "session-1"
+    assert stats["timeout_count"] == 1
+    assert stats["requires_interaction_count"] == 3
+
+
+def test_run_duration_ms_is_positive_on_success_and_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    install_fake_run_graphify(monkeypatch)
+
+    result = asyncio.run(runner.run(job_data()))
+
+    assert isinstance(result["stats_json"]["duration_ms"], int)
+    assert result["stats_json"]["duration_ms"] > 0
+
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    async def fake_run_graphify(
+        _run_id: str, _input_dir: str, *, timeout: float | None = None
+    ) -> dict[str, Any]:
+        return {
+            "status": "failed",
+            "state": "FAILED",
+            "reason": "llm_error",
+            "input_file_count": 2,
+            "input_total_words": 4,
+            "claude_session_id": None,
+            "timeout_count": 0,
+            "requires_interaction_count": 0,
+        }
+
+    monkeypatch.setattr(runner.claude_runner, "run_graphify", fake_run_graphify)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    stats = json.loads(str(exc_info.value))["stats_json"]
+    assert isinstance(stats["duration_ms"], int)
+    assert stats["duration_ms"] > 0
+
+
+def test_run_empty_graph_sets_empty_output_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    def build_output(_input_dir: Path, output_dir: Path) -> None:
+        (output_dir / "graph.json").write_text(
+            '{"nodes":[],"edges":[]}', encoding="utf-8"
+        )
+        wiki_dir = output_dir / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "index.md").write_text("# Index", encoding="utf-8")
+        (output_dir / "GRAPH_REPORT.md").write_text("report", encoding="utf-8")
+
+    install_fake_run_graphify(monkeypatch, build_output)
+
+    result = asyncio.run(runner.run(job_data()))
+
+    assert result["stats_json"]["empty_output_count"] == 1
+
+
+def test_run_missing_graph_sets_empty_output_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    def build_output(_input_dir: Path, output_dir: Path) -> None:
+        wiki_dir = output_dir / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "index.md").write_text("# Index", encoding="utf-8")
+        (output_dir / "GRAPH_REPORT.md").write_text("report", encoding="utf-8")
+
+    install_fake_run_graphify(monkeypatch, build_output)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    stats = json.loads(str(exc_info.value))["stats_json"]
+    assert stats["empty_output_count"] == 1
+
+
+def test_run_validation_failure_sets_failed_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+
+    def build_output(_input_dir: Path, output_dir: Path) -> None:
+        (output_dir / "graph.json").write_text(
+            '{"nodes":[{"id":"a"}],"edges":[]}', encoding="utf-8"
+        )
+        (output_dir / "GRAPH_REPORT.md").write_text("report", encoding="utf-8")
+
+    install_fake_run_graphify(monkeypatch, build_output)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(runner.run(job_data()))
+
+    stats = json.loads(str(exc_info.value))["stats_json"]
+    assert stats["validation_failed_reason"] == "missing_wiki_dir: wiki/ not found"
+
+
+def test_run_validation_success_sets_failed_reason_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    install_fake_storage(monkeypatch)
+    install_runner_config(monkeypatch, tmp_path)
+    install_fake_run_graphify(monkeypatch)
+
+    result = asyncio.run(runner.run(job_data()))
+
+    assert result["stats_json"]["validation_failed_reason"] is None
 
 
 def test_run_missing_graph_json_fails_validation_and_cleans_workdir(
@@ -400,6 +557,11 @@ def install_fake_run_graphify(
     build_output: Callable[[Path, Path], None] | None = None,
     *,
     expected_run_id: str = "run-1",
+    input_file_count: int = 2,
+    input_total_words: int = 6,
+    claude_session_id: str | None = "session-1",
+    timeout_count: int = 0,
+    requires_interaction_count: int = 0,
 ) -> None:
     async def fake_run_graphify(
         run_id: str, input_dir: str, *, timeout: float | None = None
@@ -413,19 +575,40 @@ def install_fake_run_graphify(
             shutil.copytree(FIXTURE_OUTPUT, output_dir, dirs_exist_ok=True)
         else:
             build_output(input_path, output_dir)
-        return success_run_graphify_result(output_dir)
+        return success_run_graphify_result(
+            output_dir,
+            input_file_count=input_file_count,
+            input_total_words=input_total_words,
+            claude_session_id=claude_session_id,
+            timeout_count=timeout_count,
+            requires_interaction_count=requires_interaction_count,
+        )
 
     monkeypatch.setattr(runner.claude_runner, "run_graphify", fake_run_graphify)
 
 
-def success_run_graphify_result(output_dir: Path) -> dict[str, Any]:
+def success_run_graphify_result(
+    output_dir: Path,
+    *,
+    input_file_count: int = 2,
+    input_total_words: int = 6,
+    claude_session_id: str | None = "session-1",
+    timeout_count: int = 0,
+    requires_interaction_count: int = 0,
+) -> dict[str, Any]:
     return {
         "status": "success",
         "state": "SUCCEEDED",
+        "session_id": claude_session_id,
+        "claude_session_id": claude_session_id,
         "output_dir": str(output_dir),
         "graph_json_path": str(output_dir / "graph.json"),
         "wiki_output_path": str(output_dir / "wiki"),
         "report_path": str(output_dir / "GRAPH_REPORT.md"),
+        "input_file_count": input_file_count,
+        "input_total_words": input_total_words,
+        "timeout_count": timeout_count,
+        "requires_interaction_count": requires_interaction_count,
     }
 
 


### PR DESCRIPTION
## Summary

- Propagate 8 new metrics fields into `stats_json`: `input_file_count`, `input_total_words`, `claude_session_id`, `duration_ms`, `empty_output_count`, `timeout_count`, `requires_interaction_count`, `validation_failed_reason`
- All fields populated on both success and failure paths
- 71 tests passing (9 new test functions covering all spec scenarios)

Closes #338

## OpenSpec Change

`openspec/changes/graphify-worker-production-metrics/`

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `dcb82cf6e5fa3aa8cd96267cc68b6bd454a15b27`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/344#issuecomment-4457108289) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/344#issuecomment-4457108548) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/344#issuecomment-4457108685) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/344#issuecomment-4457108845)
- Key findings addressed: Round 1 found empty_output_count=0 when Claude returns reason=empty_output before validation — fixed by adding claude_result.reason check to _empty_output_count. Round 2 clean.

## Test plan

- [x] All 71 pytest tests pass locally
- [x] metrics-propagation: run_graphify returns input_file_count, input_total_words, claude_session_id
- [x] duration-tracking: duration_ms is positive integer on success and exception paths
- [x] failure-counters: requires_interaction_count, timeout_count, empty_output_count all tested
- [x] validation-failure-reason: format verified on failure, None on success
- [x] empty_output_count correctly set when Claude returns reason=empty_output