### PR TITLE
feat(rag-core): add LightRAG retrieval strategy adapter (#341)

### DIFF
--- a/packages/rag-core/src/__tests__/lightrag-strategies.test.ts
+++ b/packages/rag-core/src/__tests__/lightrag-strategies.test.ts
@@ -1,0 +1,188 @@
+import type { GraphEdge, GraphNode } from '@cherrygraph/graph-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+  communityFirstRanking,
+  DEFAULT_LIGHTRAG_CONFIG,
+  entityRelationshipScoring,
+  hierarchicalContextAssembly,
+  scoreLightRAG,
+  type LightRAGConfig,
+} from '../lightrag-strategies.js';
+import type { GraphCandidate } from '../types.js';
+
+describe('scoreLightRAG', () => {
+  it('uses default weights to produce the expected ranking', () => {
+    const communityNodeCounts = new Map([
+      ['small', 2],
+      ['large', 10],
+    ]);
+    const weaker = scoreLightRAG(makeCandidate('weaker', { effective_confidence_score: 0.3 }), {
+      textSimilarity: 0.2,
+      communityNodeCounts,
+      candidateCommunityId: 'small',
+    });
+    const stronger = scoreLightRAG(makeCandidate('stronger', { effective_confidence_score: 0.8 }), {
+      textSimilarity: 0.9,
+      communityNodeCounts,
+      candidateCommunityId: 'large',
+    });
+
+    expect(DEFAULT_LIGHTRAG_CONFIG).toEqual({
+      textSimilarityWeight: 0.4,
+      confidenceWeight: 0.3,
+      evidenceWeight: 0.2,
+      communityNodeRatioWeight: 0.1,
+    });
+    expect(stronger.score).toBeCloseTo(0.9 * 0.4 + 0.8 * 0.3 + Math.log(3) * 0.2 + 1 * 0.1);
+    expect(weaker.score).toBeCloseTo(0.2 * 0.4 + 0.3 * 0.3 + Math.log(3) * 0.2 + 0.2 * 0.1);
+    expect([weaker, stronger].sort((left, right) => right.score - left.score).map(({ id }) => id)).toEqual([
+      'stronger',
+      'weaker',
+    ]);
+  });
+
+  it('uses custom weights to change ranking behavior', () => {
+    const confidenceOnly: LightRAGConfig = {
+      textSimilarityWeight: 0,
+      confidenceWeight: 1,
+      evidenceWeight: 0,
+      communityNodeRatioWeight: 0,
+    };
+    const lowConfidence = makeCandidate('low-confidence', { effective_confidence_score: 0.1 });
+    const highConfidence = makeCandidate('high-confidence', { effective_confidence_score: 0.9 });
+    const context = {
+      textSimilarity: 1,
+      communityNodeCounts: new Map([['community', 10]]),
+      candidateCommunityId: 'community',
+    };
+
+    const scored = [
+      scoreLightRAG(lowConfidence, context, confidenceOnly),
+      scoreLightRAG(highConfidence, { ...context, textSimilarity: 0.1 }, confidenceOnly),
+    ];
+
+    expect(scored.map(({ score }) => score)).toEqual([0.1, 0.9]);
+    expect(scored.sort((left, right) => right.score - left.score).map(({ id }) => id)).toEqual([
+      'high-confidence',
+      'low-confidence',
+    ]);
+  });
+
+  it('handles zero evidence and null community', () => {
+    const scored = scoreLightRAG(makeCandidate('edge-case', { evidence_count: 0 }), {
+      textSimilarity: 0.5,
+      communityNodeCounts: new Map([['community', 10]]),
+      candidateCommunityId: null,
+    });
+
+    expect(scored.score).toBeCloseTo(0.5 * 0.4 + 1 * 0.3);
+  });
+});
+
+describe('communityFirstRanking', () => {
+  it('sorts candidates by community size and summary relevance', () => {
+    const candidates = [
+      makeCandidate('small-community', { score: 0.8, type: 'community' }),
+      makeCandidate('large-community', { score: 0.2, type: 'community' }),
+      makeCandidate('medium-community', { score: 0.3, type: 'community' }),
+    ];
+    const communityNodeCounts = new Map([
+      ['small-community', 2],
+      ['large-community', 10],
+      ['medium-community', 6],
+    ]);
+
+    const ranked = communityFirstRanking(candidates, communityNodeCounts);
+
+    expect(ranked.map(({ id }) => id)).toEqual([
+      'large-community',
+      'small-community',
+      'medium-community',
+    ]);
+    expect(candidates.map(({ id }) => id)).toEqual([
+      'small-community',
+      'large-community',
+      'medium-community',
+    ]);
+  });
+
+  it('handles empty candidates and missing community IDs', () => {
+    expect(communityFirstRanking([], new Map())).toEqual([]);
+
+    const ranked = communityFirstRanking(
+      [
+        makeCandidate('node-without-community', { score: 0.4, type: 'graph_node' }),
+        makeCandidate('community', { score: 0.1, type: 'community' }),
+      ],
+      new Map([['community', 10]]),
+    );
+
+    expect(ranked.map(({ id }) => id)).toEqual(['community', 'node-without-community']);
+  });
+});
+
+describe('entityRelationshipScoring', () => {
+  it('returns edge multiplicity times graph candidate confidence', () => {
+    expect(entityRelationshipScoring(makeCandidate('entity', { effective_confidence_score: 0.7 }), 4)).toBeCloseTo(
+      2.8,
+    );
+  });
+
+  it('accepts graph-core edge confidence scores', () => {
+    const edge: GraphEdge = {
+      source: 'alpha',
+      target: 'beta',
+      relation: 'depends_on',
+      confidence: 'EXTRACTED',
+      confidence_score: 0.5,
+    };
+
+    expect(entityRelationshipScoring(edge, 3)).toBeCloseTo(1.5);
+  });
+});
+
+describe('hierarchicalContextAssembly', () => {
+  it('produces local, community, and global context layers', () => {
+    const node: GraphNode = {
+      id: 'node-1',
+      label: 'Alpha',
+      norm_label: 'alpha',
+      type: 'Concept',
+      community: 'community-1',
+    };
+    const content = hierarchicalContextAssembly(
+      [node, makeCandidate('local-entity', { content: '[Node] Beta' })],
+      [makeCandidate('community-summary', { content: 'Community summary' })],
+      'Global summary',
+    );
+
+    expect(content).toBe(
+      [
+        '## Local Entities',
+        'Alpha (Concept)',
+        '[Node] Beta',
+        '',
+        '## Community Context',
+        'Community summary',
+        '',
+        '## Global Summary',
+        'Global summary',
+      ].join('\n'),
+    );
+  });
+});
+
+function makeCandidate(id: string, overrides: Partial<GraphCandidate> = {}): GraphCandidate {
+  return {
+    type: 'graph_node',
+    id,
+    content: `[Node] ${id}`,
+    score: 0,
+    confidence_label: 'EXTRACTED',
+    effective_confidence_score: 1,
+    evidence_count: 2,
+    space_id: 'space-1',
+    ...overrides,
+  };
+}

--- a/packages/rag-core/src/index.ts
+++ b/packages/rag-core/src/index.ts
@@ -3,6 +3,7 @@ export * from './chunker.js';
 export * from './context-packer.js';
 export * from './graph-retrieval.js';
 export * from './injection-scanner.js';
+export * from './lightrag-strategies.js';
 export * from './prompt-injection-patterns.js';
 export * from './retrieval-engine.js';
 export * from './rrf-fusion.js';

--- a/packages/rag-core/src/lightrag-strategies.ts
+++ b/packages/rag-core/src/lightrag-strategies.ts
@@ -1,0 +1,203 @@
+/*
+ * LightRAG retrieval strategy adaptations.
+ *
+ * Source project: https://github.com/HKUDS/LightRAG
+ * License note: LightRAG is MIT licensed, which is compatible with this
+ * project's AGPL-3.0 license for adapted algorithmic ideas.
+ * Adapted algorithms: local_query, global_query, and hybrid_query retrieval
+ * ranking/context assembly patterns from lightrag/operate.py.
+ *
+ * This module is a native TypeScript implementation. It does not import or
+ * execute LightRAG Python code at runtime.
+ */
+
+import type { GraphEdge, GraphNode } from '@cherrygraph/graph-core';
+
+import type { GraphCandidate } from './types.js';
+
+export type LightRAGConfig = {
+  textSimilarityWeight: number;
+  confidenceWeight: number;
+  evidenceWeight: number;
+  communityNodeRatioWeight: number;
+};
+
+export const DEFAULT_LIGHTRAG_CONFIG: LightRAGConfig = {
+  textSimilarityWeight: 0.4,
+  confidenceWeight: 0.3,
+  evidenceWeight: 0.2,
+  communityNodeRatioWeight: 0.1,
+};
+
+export type ScoringContext = {
+  textSimilarity: number;
+  communityNodeCounts: Map<string, number>;
+  candidateCommunityId: string | null;
+};
+
+type CandidateWithCommunity = GraphCandidate & {
+  community_id?: string | null;
+  communityId?: string | null;
+  community?: string | null;
+};
+
+export function communityFirstRanking<TCandidate extends GraphCandidate>(
+  candidates: readonly TCandidate[],
+  communityNodeCounts: Map<string, number>,
+): TCandidate[] {
+  const maxCommunityNodeCount = maxMapValue(communityNodeCounts);
+
+  return [...candidates].sort((left, right) => {
+    const leftScore = communityFirstScore(left, communityNodeCounts, maxCommunityNodeCount);
+    const rightScore = communityFirstScore(right, communityNodeCounts, maxCommunityNodeCount);
+
+    if (rightScore !== leftScore) {
+      return rightScore - leftScore;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function entityRelationshipScoring(
+  candidate: Pick<GraphCandidate, 'effective_confidence_score'> | GraphEdge,
+  edgeMultiplicity: number,
+): number {
+  return normalizeNonNegativeNumber(edgeMultiplicity) * confidenceScore(candidate);
+}
+
+export function hierarchicalContextAssembly(
+  localEntities: readonly (GraphCandidate | GraphNode | string)[],
+  communityContexts: readonly (GraphCandidate | string)[],
+  globalSummary: GraphCandidate | string | null | undefined,
+): string {
+  const sections = [
+    formatSection('Local Entities', localEntities.map(formatContextItem)),
+    formatSection('Community Context', communityContexts.map(formatContextItem)),
+    formatSection('Global Summary', globalSummary == null ? [] : [formatContextItem(globalSummary)]),
+  ];
+
+  return sections.filter((section) => section.length > 0).join('\n\n');
+}
+
+export function scoreLightRAG<TCandidate extends GraphCandidate>(
+  candidate: TCandidate,
+  context: ScoringContext,
+  config: LightRAGConfig = DEFAULT_LIGHTRAG_CONFIG,
+): TCandidate {
+  const score =
+    normalizeNonNegativeNumber(context.textSimilarity) * normalizeNumber(config.textSimilarityWeight) +
+    normalizeNonNegativeNumber(candidate.effective_confidence_score) * normalizeNumber(config.confidenceWeight) +
+    Math.log(1 + normalizeNonNegativeNumber(candidate.evidence_count)) * normalizeNumber(config.evidenceWeight) +
+    communityNodeRatio(context.candidateCommunityId, context.communityNodeCounts) *
+      normalizeNumber(config.communityNodeRatioWeight);
+
+  return {
+    ...candidate,
+    score,
+  };
+}
+
+function communityFirstScore(
+  candidate: GraphCandidate,
+  communityNodeCounts: Map<string, number>,
+  maxCommunityNodeCount: number,
+): number {
+  const communityId = communityIdForCandidate(candidate);
+  const ratio =
+    communityId === null || maxCommunityNodeCount <= 0
+      ? 0
+      : normalizeNonNegativeNumber(communityNodeCounts.get(communityId)) / maxCommunityNodeCount;
+
+  return normalizeNonNegativeNumber(candidate.score) + ratio;
+}
+
+function communityIdForCandidate(candidate: GraphCandidate): string | null {
+  const candidateWithCommunity = candidate as CandidateWithCommunity;
+
+  if (typeof candidateWithCommunity.community_id === 'string') {
+    return candidateWithCommunity.community_id;
+  }
+
+  if (typeof candidateWithCommunity.communityId === 'string') {
+    return candidateWithCommunity.communityId;
+  }
+
+  if (typeof candidateWithCommunity.community === 'string') {
+    return candidateWithCommunity.community;
+  }
+
+  if (candidate.type === 'community') {
+    return candidate.id;
+  }
+
+  return null;
+}
+
+function communityNodeRatio(
+  candidateCommunityId: string | null,
+  communityNodeCounts: Map<string, number>,
+): number {
+  if (candidateCommunityId === null) {
+    return 0;
+  }
+
+  const maxCommunityNodeCount = maxMapValue(communityNodeCounts);
+  if (maxCommunityNodeCount <= 0) {
+    return 0;
+  }
+
+  return normalizeNonNegativeNumber(communityNodeCounts.get(candidateCommunityId)) / maxCommunityNodeCount;
+}
+
+function maxMapValue(values: Map<string, number>): number {
+  let maxValue = 0;
+
+  for (const value of values.values()) {
+    maxValue = Math.max(maxValue, normalizeNonNegativeNumber(value));
+  }
+
+  return maxValue;
+}
+
+function confidenceScore(candidate: Pick<GraphCandidate, 'effective_confidence_score'> | GraphEdge): number {
+  if ('effective_confidence_score' in candidate) {
+    return normalizeNonNegativeNumber(candidate.effective_confidence_score);
+  }
+
+  return normalizeNonNegativeNumber(candidate.confidence_score);
+}
+
+function formatContextItem(item: GraphCandidate | GraphNode | string): string {
+  if (typeof item === 'string') {
+    return item.trim();
+  }
+
+  if ('content' in item) {
+    return item.content.trim();
+  }
+
+  const typeSuffix = item.type.length > 0 ? ` (${item.type})` : '';
+  return `${item.label}${typeSuffix}`.trim();
+}
+
+function formatSection(label: string, items: string[]): string {
+  const content = items.map((item) => item.trim()).filter((item) => item.length > 0);
+  if (content.length === 0) {
+    return '';
+  }
+
+  return [`## ${label}`, ...content].join('\n');
+}
+
+function normalizeNumber(value: number): number {
+  return Number.isFinite(value) ? value : 0;
+}
+
+function normalizeNonNegativeNumber(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary

- Port LightRAG local/global/hybrid ranking algorithms to TypeScript in `packages/rag-core/src/lightrag-strategies.ts`
- Exports `scoreLightRAG()`, `LightRAGConfig`, `DEFAULT_LIGHTRAG_CONFIG`, `communityFirstRanking()`, `entityRelationshipScoring()`, `hierarchicalContextAssembly()`
- No new npm dependencies, no Python runtime imports
- 8 unit tests covering all exported functions with edge cases

Closes #341

## OpenSpec Change

`openspec/changes/lightrag-retrieval-integration/` (lightrag-adapter section)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `4af1b396e944452bcb7c92b9c1a0538a34209967`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/345#issuecomment-4457250421) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/345#issuecomment-4457250521) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/345#issuecomment-4457250628) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/345#issuecomment-4457250737)
- Key findings addressed: All reviewers clean, no findings.

## Test plan

- [x] Build passes (`npm run build`)
- [x] 8 new unit tests pass for lightrag-strategies
- [x] Full test suite (1320 tests) unaffected
- [x] scoreLightRAG with default and custom weights verified
- [x] Edge cases: zero evidence, null community, empty candidates