### PR TITLE
feat(rag-core,api): graph candidate retrieval + three-source fusion (#342)

### DIFF
--- a/apps/api/src/chat/__tests__/chat.service.test.ts
+++ b/apps/api/src/chat/__tests__/chat.service.test.ts
@@ -777,6 +777,86 @@ describe('ChatService streamCompletion', () => {
     expect(context.results.map((result) => result.spaceId)).toEqual(['space-a', 'space-b']);
   });
 
+  it('graph_rag retrieveContext records graph candidates and uses three-source fusion for wiki ranking', async () => {
+    const { service, db } = createServiceContext({
+      embeddingProvider: new ScriptedEmbeddingProvider([[0.1, 0.2, 0.3]]),
+    });
+    const prepared = createPreparedCompletion({
+      message: 'How is Auth connected?',
+      space: createSpaceRow({ active_graphify_run_id: 'run-1' }),
+    });
+    const retrieveContext = bindRetrieveContext(service);
+    db.queueSelect([createModelRow({ id: 'embedding-model', model_type: 'embedding' })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-vector', score: 0.95 })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-bm25', score: 0.9 })]);
+    db.queueExecute([createGraphNodeRow({ id: 'node-auth', label: 'Auth', community_id: 'community-1', score: 0.9 })]);
+    db.queueExecute([createCommunityRow({ id: 'community-1', label: 'Auth Cluster', summary: 'Auth service relationships' })]);
+    db.queueExecute([createGraphNodeRow({ id: 'node-api', label: 'API', community_id: 'community-1', score: 1 })]);
+
+    const context = await retrieveContext(
+      prepared,
+      [{ spaceId: TEST_SPACE_ID, snapshot: createSnapshotRow({ graphify_run_id: 'run-1' }) }],
+      'graph_rag',
+    );
+
+    expect(context.trace.candidates.graph.map((candidate) => candidate.id)).toEqual(
+      expect.arrayContaining(['node-auth', 'node-api', 'community-1']),
+    );
+    expect(context.trace.aclFiltered.graph).toHaveLength(context.trace.candidates.graph.length);
+    expect(context.trace.finalContext.graph_tokens).toBeGreaterThan(0);
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-vector', 'chunk-bm25']);
+  });
+
+  it('wiki_only retrieveContext skips graph candidates', async () => {
+    const { service, db } = createServiceContext({
+      embeddingProvider: new ScriptedEmbeddingProvider([[0.1, 0.2, 0.3]]),
+    });
+    const prepared = createPreparedCompletion({
+      message: 'How is Auth connected?',
+      space: createSpaceRow({ active_graphify_run_id: 'run-1' }),
+    });
+    const retrieveContext = bindRetrieveContext(service);
+    db.queueSelect([createModelRow({ id: 'embedding-model', model_type: 'embedding' })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-vector', score: 0.95 })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-bm25', score: 0.9 })]);
+
+    const context = await retrieveContext(
+      prepared,
+      [{ spaceId: TEST_SPACE_ID, snapshot: createSnapshotRow({ graphify_run_id: 'run-1' }) }],
+      'wiki_only',
+    );
+
+    expect(context.trace.candidates.graph).toEqual([]);
+    expect(context.trace.finalContext.graph_hints).toEqual([]);
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-vector', 'chunk-bm25']);
+  });
+
+  it('graph_rag retrieveContext completes simple fusion under 500ms', async () => {
+    const { service, db } = createServiceContext({
+      embeddingProvider: new ScriptedEmbeddingProvider([[0.1, 0.2, 0.3]]),
+    });
+    const prepared = createPreparedCompletion({
+      message: 'How is Auth connected?',
+      space: createSpaceRow({ active_graphify_run_id: 'run-1' }),
+    });
+    const retrieveContext = bindRetrieveContext(service);
+    db.queueSelect([createModelRow({ id: 'embedding-model', model_type: 'embedding' })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-vector', score: 0.95 })]);
+    db.queueExecute([]);
+    db.queueExecute([createGraphNodeRow({ id: 'node-auth', label: 'Auth', community_id: 'community-1', score: 0.9 })]);
+    db.queueExecute([createCommunityRow({ id: 'community-1' })]);
+    db.queueExecute([]);
+
+    const startedAt = performance.now();
+    await retrieveContext(
+      prepared,
+      [{ spaceId: TEST_SPACE_ID, snapshot: createSnapshotRow({ graphify_run_id: 'run-1' }) }],
+      'graph_rag',
+    );
+
+    expect(performance.now() - startedAt).toBeLessThan(500);
+  });
+
   it('passes real user groups to graph hint retrieval without fabricating space permissions', async () => {
     const chatProvider = new ScriptedChatProvider([
       { type: 'content', delta: 'Use the graph hint.' },
@@ -1230,6 +1310,65 @@ function queueExistingCompletion(db: ScriptedChatDb, spaceIds: string[]): void {
   db.queueInsert([createMessageRow({ id: 'assistant-no-hit', role: 'assistant', content: NO_HIT_MESSAGE })]);
 }
 
+function createPreparedCompletion(overrides: Partial<{
+  tenantId: string;
+  userId: string;
+  userGroupIds: string[];
+  message: string;
+  chatModel: ModelConfigRow;
+  space: SpaceRow;
+  spaces: SpaceRow[];
+  spaceIds: string[];
+  session: ChatSessionRow;
+  history: ChatMessageRow[];
+  auditContext: Record<string, string>;
+}> = {}) {
+  const space = overrides.space ?? createSpaceRow();
+  const spaceIds = overrides.spaceIds ?? [space.id];
+
+  return {
+    tenantId: overrides.tenantId ?? TEST_TENANT_ID,
+    userId: overrides.userId ?? TEST_USER_ID,
+    userGroupIds: overrides.userGroupIds ?? [TEST_GROUP_ID],
+    message: overrides.message ?? 'How is SSO configured?',
+    chatModel: overrides.chatModel ?? createModelRow({ model_type: 'chat' }),
+    space,
+    spaces: overrides.spaces ?? spaceIds.map((spaceId) => createSpaceRow({ id: spaceId })),
+    spaceIds,
+    session: overrides.session ?? createSessionRow({ space_id: space.id }),
+    history: overrides.history ?? [],
+    auditContext: overrides.auditContext ?? {},
+  };
+}
+
+function bindRetrieveContext(service: ChatService): (
+  preparedCompletion: ReturnType<typeof createPreparedCompletion>,
+  snapshots: Array<{ spaceId: string; snapshot: IndexSnapshotRow }>,
+  retrievalMode?: string,
+) => Promise<{
+  results: RetrievalResult[];
+  trace: {
+    candidates: { graph: Array<{ id: string; content: string }> };
+    aclFiltered: { graph: unknown[] };
+    finalContext: { graph_hints: unknown[]; graph_tokens: number };
+  };
+}> {
+  return (service as unknown as {
+    retrieveContext: (
+      preparedCompletion: ReturnType<typeof createPreparedCompletion>,
+      snapshots: Array<{ spaceId: string; snapshot: IndexSnapshotRow }>,
+      retrievalMode?: string,
+    ) => Promise<{
+      results: RetrievalResult[];
+      trace: {
+        candidates: { graph: Array<{ id: string; content: string }> };
+        aclFiltered: { graph: unknown[] };
+        finalContext: { graph_hints: unknown[]; graph_tokens: number };
+      };
+    }>;
+  }).retrieveContext.bind(service);
+}
+
 class ScriptedChatDb {
   readonly inserts: Array<{ table?: unknown; value?: unknown }> = [];
   readonly updates: Array<{ table?: unknown; value?: unknown }> = [];
@@ -1499,6 +1638,32 @@ function createSearchRow(overrides: Record<string, unknown> = {}): Record<string
     page_title: 'Auth',
     section_title: 'SSO',
     score: 0.9,
+    ...overrides,
+  };
+}
+
+function createGraphNodeRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'node-1',
+    node_key: 'node-1',
+    stable_key: 'node-1',
+    label: 'Auth',
+    node_type: 'service',
+    description: null,
+    space_id: TEST_SPACE_ID,
+    community_id: null,
+    score: 0.9,
+    ...overrides,
+  };
+}
+
+function createCommunityRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'community-1',
+    community_key: 'community-1',
+    label: 'Auth Cluster',
+    summary: 'Auth service relationships',
+    node_count: 3,
     ...overrides,
   };
 }

--- a/apps/api/src/chat/__tests__/chat.service.test.ts
+++ b/apps/api/src/chat/__tests__/chat.service.test.ts
@@ -519,6 +519,33 @@ describe('ChatService RAG prompt and citations', () => {
     expect(prompt.messages.at(-1)).toEqual({ role: 'user', content: 'How does SSO work?' });
   });
 
+  it('builds a RAG prompt with supplemental graph context', () => {
+    const { service } = createServiceContext();
+    const prompt = service.buildRagPrompt({
+      retrievalResults: [createRetrievalResult({ pageTitle: 'Auth', sectionTitle: 'SSO', content: 'Use SSO facts.' })],
+      graphHints: [
+        {
+          type: 'graph_node',
+          id: 'node-auth',
+          content: '[Node] Auth (service): connected to API',
+          score: 0.8,
+          confidence_label: 'EXTRACTED',
+          effective_confidence_score: 1,
+          evidence_count: 1,
+          space_id: TEST_SPACE_ID,
+        },
+      ],
+      history: [],
+      currentMessage: 'How does Auth connect?',
+      modelId: 'gpt-test',
+      modelMaxTokens: 4096,
+    });
+
+    expect(prompt.systemPrompt).toContain('Graph hints (supplemental, do not cite these with [^N]):');
+    expect(prompt.systemPrompt).toContain('[G1] (Space: space-1) [Node] Auth (service): connected to API');
+  });
+
+
   it('extracts valid citations and ignores invalid citation indices', () => {
     const { service } = createServiceContext();
     const citations = service.extractCitations('Use [^1] and [^3], not [^99].', [
@@ -804,8 +831,92 @@ describe('ChatService streamCompletion', () => {
     );
     expect(context.trace.aclFiltered.graph).toHaveLength(context.trace.candidates.graph.length);
     expect(context.trace.finalContext.graph_tokens).toBeGreaterThan(0);
+    expect(context.graphContext.map((candidate) => candidate.id)).toEqual(
+      expect.arrayContaining(['node-auth', 'node-api', 'community-1']),
+    );
     expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-vector', 'chunk-bm25']);
   });
+
+  it('retrieveContext defaults to wiki_only for backward compatibility', async () => {
+    const { service, db } = createServiceContext({
+      embeddingProvider: new ScriptedEmbeddingProvider([[0.1, 0.2, 0.3]]),
+    });
+    const prepared = createPreparedCompletion({
+      message: 'How is Auth connected?',
+      space: createSpaceRow({ active_graphify_run_id: 'run-1' }),
+    });
+    const retrieveContext = bindRetrieveContext(service);
+    db.queueSelect([createModelRow({ id: 'embedding-model', model_type: 'embedding' })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-vector', score: 0.95 })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-bm25', score: 0.9 })]);
+
+    const context = await retrieveContext(
+      prepared,
+      [{ spaceId: TEST_SPACE_ID, snapshot: createSnapshotRow({ graphify_run_id: 'run-1' }) }],
+    );
+
+    expect(context.graphContext).toEqual([]);
+    expect(context.trace.candidates.graph).toEqual([]);
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-vector', 'chunk-bm25']);
+  });
+
+  it('graph_rag retrieveContext isolates graph query failures and keeps wiki results', async () => {
+    const { service, db } = createServiceContext({
+      embeddingProvider: new ScriptedEmbeddingProvider([[0.1, 0.2, 0.3]]),
+    });
+    const prepared = createPreparedCompletion({
+      message: 'How is Auth connected?',
+      space: createSpaceRow({ active_graphify_run_id: 'run-1' }),
+    });
+    const retrieveContext = bindRetrieveContext(service);
+    db.queueSelect([createModelRow({ id: 'embedding-model', model_type: 'embedding' })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-vector', score: 0.95 })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-bm25', score: 0.9 })]);
+    db.queueExecute([{ broken: true }]);
+
+    const context = await retrieveContext(
+      prepared,
+      [{ spaceId: TEST_SPACE_ID, snapshot: createSnapshotRow({ graphify_run_id: 'run-1' }) }],
+      'graph_rag',
+    );
+
+    expect(context.graphContext).toEqual([]);
+    expect(context.trace.candidates.graph).toEqual([]);
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-vector', 'chunk-bm25']);
+  });
+
+  it('graph_rag retrieveContext enforces graph context budget without reducing wiki results', async () => {
+    const { service, db } = createServiceContext({
+      embeddingProvider: new ScriptedEmbeddingProvider([[0.1, 0.2, 0.3]]),
+    });
+    const prepared = createPreparedCompletion({
+      message: 'How is Auth connected?',
+      space: createSpaceRow({ active_graphify_run_id: 'run-1' }),
+    });
+    const retrieveContext = bindRetrieveContext(service);
+    db.queueSelect([createModelRow({ id: 'embedding-model', model_type: 'embedding' })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-vector', score: 0.95 })]);
+    db.queueExecute([createSearchRow({ id: 'chunk-bm25', score: 0.9 })]);
+    db.queueExecute([
+      createGraphNodeRow({ id: 'node-long', label: 'Long', description: 'token '.repeat(3000), score: 0.99 }),
+      createGraphNodeRow({ id: 'node-short', label: 'Short', description: 'short graph context', score: 0.98 }),
+    ]);
+    db.queueExecute([]);
+
+    const context = await retrieveContext(
+      prepared,
+      [{ spaceId: TEST_SPACE_ID, snapshot: createSnapshotRow({ graphify_run_id: 'run-1' }) }],
+      'graph_rag',
+    );
+
+    expect(context.trace.candidates.graph.map((candidate) => candidate.id)).toEqual(
+      expect.arrayContaining(['node-long', 'node-short']),
+    );
+    expect(context.graphContext.map((candidate) => candidate.id)).toEqual(['node-short']);
+    expect(context.trace.finalContext.graph_tokens).toBeLessThanOrEqual(2500);
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-vector', 'chunk-bm25']);
+  });
+
 
   it('wiki_only retrieveContext skips graph candidates', async () => {
     const { service, db } = createServiceContext({
@@ -1347,6 +1458,7 @@ function bindRetrieveContext(service: ChatService): (
   retrievalMode?: string,
 ) => Promise<{
   results: RetrievalResult[];
+  graphContext: Array<{ id: string; content: string }>;
   trace: {
     candidates: { graph: Array<{ id: string; content: string }> };
     aclFiltered: { graph: unknown[] };
@@ -1360,6 +1472,7 @@ function bindRetrieveContext(service: ChatService): (
       retrievalMode?: string,
     ) => Promise<{
       results: RetrievalResult[];
+      graphContext: Array<{ id: string; content: string }>;
       trace: {
         candidates: { graph: Array<{ id: string; content: string }> };
         aclFiltered: { graph: unknown[] };

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -25,13 +25,18 @@ import {
   spaces,
 } from '@cherrygraph/shared';
 import {
+  retrieveFullGraphContext,
   retrieve,
+  rrfFuseThreeSource,
   type Bm25SearchFn,
+  type FusedRetrievalResult,
+  type GraphCandidate,
   type RetrievalResult,
   type SearchHit,
   type SourceChainJson,
   type VectorSearchFn,
 } from '@cherrygraph/rag-core';
+import { GraphQueryService } from '@cherrygraph/graph-core';
 import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
@@ -202,15 +207,15 @@ type RetrievedContext = {
     candidates: {
       vector: SearchHit[];
       bm25: SearchHit[];
-      graph: GraphHint[];
+      graph: Array<GraphHint | GraphCandidate>;
     };
     aclFiltered: {
       wiki: RetrievalResult[];
-      graph: GraphHint[];
+      graph: Array<GraphHint | GraphCandidate>;
     };
     finalContext: {
       wiki: Array<Pick<RetrievalResult, 'chunkId' | 'spaceId' | 'score' | 'pageTitle' | 'sectionTitle'>>;
-      graph_hints: GraphHint[];
+      graph_hints: Array<GraphHint | GraphCandidate>;
       wiki_tokens: number;
       graph_tokens: number;
     };
@@ -261,6 +266,7 @@ const AGENT_RETRIEVAL_MODES = new Set(['graph_rag', 'path_first', 'community_fir
 export class ChatService {
   private readonly chatProviderFactory: ChatProviderFactory;
   private readonly embeddingProviderFactory: EmbeddingProviderFactory;
+  private readonly graphQueryService: GraphQueryService;
 
   constructor(
     @Inject(DRIZZLE) private readonly db: ChatDatabase,
@@ -275,6 +281,7 @@ export class ChatService {
     this.embeddingProviderFactory =
       embeddingProviderFactory ??
       ((config: EmbeddingProviderConfig): EmbeddingProvider => new OpenAIEmbeddingProvider(config));
+    this.graphQueryService = new GraphQueryService(db);
   }
 
   async createSession(
@@ -827,15 +834,15 @@ export class ChatService {
       let retrievedContext = emptyRetrievedContext();
 
       if (spaceSnapshots.length > 0) {
-        retrievedContext = await this.retrieveContext(prepared, spaceSnapshots);
+        retrievedContext = await this.retrieveContext(prepared, spaceSnapshots, input.retrievalMode);
         retrievalResults = retrievedContext.results;
       }
 
       graphHints = await this.retrieveGraphHints(prepared);
-      retrievedContext.trace.candidates.graph = graphHints;
-      retrievedContext.trace.aclFiltered.graph = graphHints;
-      retrievedContext.trace.finalContext.graph_hints = graphHints;
-      retrievedContext.trace.finalContext.graph_tokens = graphHints.reduce(
+      retrievedContext.trace.candidates.graph.push(...graphHints);
+      retrievedContext.trace.aclFiltered.graph.push(...graphHints);
+      retrievedContext.trace.finalContext.graph_hints.push(...graphHints);
+      retrievedContext.trace.finalContext.graph_tokens += graphHints.reduce(
         (total, hint) => total + countTokens(hint.content, prepared.chatModel.model_id),
         0,
       );
@@ -846,7 +853,7 @@ export class ChatService {
           source: 'no_hit',
         });
         void this.maybeGenerateTitle(prepared, input.message, NO_HIT_MESSAGE);
-        await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'wiki_only', retrievedContext).catch(
+        await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'graph_rag', retrievedContext).catch(
           () => undefined,
         );
         yield { type: 'content', delta: NO_HIT_MESSAGE };
@@ -864,7 +871,7 @@ export class ChatService {
           agentAvailable: this.agentService !== undefined,
         })
       ) {
-        await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'wiki_only', retrievedContext).catch(
+        await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'graph_rag', retrievedContext).catch(
           () => undefined,
         );
         yield* this.runAgentCompletion(prepared, input, { yieldSession: false });
@@ -919,7 +926,7 @@ export class ChatService {
       );
       void this.maybeGenerateTitle(prepared, input.message, assistantText);
       await this.persistCitations(assistant.id, citations);
-      await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'wiki_only', retrievedContext).catch(
+      await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'graph_rag', retrievedContext).catch(
         () => undefined,
       );
       await this.recordStaticModelUsage(prepared, usage, Date.now() - startedAt).catch(() => undefined);
@@ -1260,11 +1267,14 @@ export class ChatService {
   private async retrieveContext(
     prepared: PreparedCompletion,
     spaceSnapshots: Array<{ spaceId: string; snapshot: IndexSnapshotRow }>,
+    retrievalModeInput?: string,
   ): Promise<RetrievedContext> {
     if (spaceSnapshots.length === 0) {
       return emptyRetrievedContext();
     }
 
+    const retrievalMode = normalizeContextRetrievalMode(retrievalModeInput);
+    const includeGraph = retrievalMode !== 'wiki_only';
     const candidates: RetrievedContext['trace']['candidates'] = {
       vector: [],
       bm25: [],
@@ -1281,6 +1291,8 @@ export class ChatService {
     }
 
     let results: RetrievalResult[] = [];
+    const allVectorHits: SearchHit[] = [];
+    const allBm25Hits: SearchHit[] = [];
 
     for (const groupSnapshots of modelGroups.values()) {
       const firstSnapshot = groupSnapshots[0]?.snapshot;
@@ -1312,16 +1324,47 @@ export class ChatService {
         async (params) => {
           const hits = await vectorSearch(params);
           candidates.vector.push(...hits);
+          allVectorHits.push(...hits.map((hit) => ({ ...hit, spaceId: params.spaceId })));
           return hits;
         },
         async (params) => {
           const hits = await bm25Search(params);
           candidates.bm25.push(...hits);
+          allBm25Hits.push(...hits.map((hit) => ({ ...hit, spaceId: params.spaceId })));
           return hits;
         },
       );
 
       results.push(...groupResults);
+    }
+
+    if (includeGraph) {
+      const activeRunIds = activeGraphifyRunIdsFromSnapshots(spaceSnapshots);
+      if (activeRunIds.size > 0) {
+        const graphCandidates = await retrieveFullGraphContext(
+          {
+            query: prepared.message,
+            spaceIds: prepared.spaceIds,
+            activeRunIds,
+          },
+          this.graphQueryService,
+        );
+        candidates.graph.push(...graphCandidates);
+
+        if (graphCandidates.length > 0) {
+          allVectorHits.sort((left, right) => right.score - left.score);
+          allBm25Hits.sort((left, right) => right.score - left.score);
+          const fusedResults = rrfFuseThreeSource(allVectorHits, allBm25Hits, graphCandidates, {
+            topK: RETRIEVAL_TOP_K,
+          });
+          results = fusedResults
+            .filter((result): result is Extract<FusedRetrievalResult, { type: 'wiki_chunk' }> => result.type === 'wiki_chunk')
+            .map((result) => ({
+              ...result.hit,
+              score: result.score,
+            }));
+        }
+      }
     }
 
     results = results.sort((left, right) => right.score - left.score).slice(0, RETRIEVAL_TOP_K);
@@ -1332,7 +1375,7 @@ export class ChatService {
         candidates,
         aclFiltered: {
           wiki: results,
-          graph: [],
+          graph: candidates.graph,
         },
         finalContext: {
           wiki: results.map((result) => ({
@@ -1342,12 +1385,15 @@ export class ChatService {
             pageTitle: result.pageTitle,
             sectionTitle: result.sectionTitle,
           })),
-          graph_hints: [],
+          graph_hints: candidates.graph,
           wiki_tokens: results.reduce(
             (total, result) => total + countTokens(result.content, prepared.chatModel.model_id),
             0,
           ),
-          graph_tokens: 0,
+          graph_tokens: candidates.graph.reduce(
+            (total, candidate) => total + countTokens(candidate.content, prepared.chatModel.model_id),
+            0,
+          ),
         },
       },
     };
@@ -1978,6 +2024,26 @@ function toSimpleTsQuery(query: string): string {
 function normalizeRetrievalMode(value: string | undefined): string {
   const normalized = value?.trim().toLowerCase();
   return normalized === undefined || normalized.length === 0 ? 'wiki_only' : normalized;
+}
+
+function normalizeContextRetrievalMode(value: string | undefined): string {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === undefined || normalized.length === 0 ? 'graph_rag' : normalized;
+}
+
+function activeGraphifyRunIdsFromSnapshots(
+  spaceSnapshots: Array<{ spaceId: string; snapshot: IndexSnapshotRow }>,
+): Map<string, string> {
+  const activeRunIds = new Map<string, string>();
+
+  for (const { spaceId, snapshot } of spaceSnapshots) {
+    const runId = snapshot.graphify_run_id?.trim();
+    if (runId !== undefined && runId.length > 0) {
+      activeRunIds.set(spaceId, runId);
+    }
+  }
+
+  return activeRunIds;
 }
 
 function normalizePositiveInt(value: number | undefined, fallback: number, max = Number.POSITIVE_INFINITY): number {

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -25,6 +25,7 @@ import {
   spaces,
 } from '@cherrygraph/shared';
 import {
+  DEFAULT_RETRIEVAL_CONFIG,
   retrieveFullGraphContext,
   retrieve,
   rrfFuseThreeSource,
@@ -56,6 +57,7 @@ import {
   paginatedResponse,
   type PaginatedResponse,
 } from '../common/dto/pagination.dto.js';
+import { getApiLogger } from '../common/logger/logger.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { GraphService } from '../graph/graph.service.js';
 import { decryptSpaceDatabaseConfig } from '../spaces/database-config.js';
@@ -203,6 +205,7 @@ type PreparedCompletion = {
 
 type RetrievedContext = {
   results: RetrievalResult[];
+  graphContext: Array<GraphHint | GraphCandidate>;
   trace: {
     candidates: {
       vector: SearchHit[];
@@ -634,7 +637,7 @@ export class ChatService {
 
   buildRagPrompt(input: {
     retrievalResults: RetrievalResult[];
-    graphHints?: GraphHint[];
+    graphHints?: Array<GraphHint | GraphCandidate>;
     history: ChatMessageRow[];
     currentMessage: string;
     modelId: string;
@@ -819,7 +822,7 @@ export class ChatService {
     yield { type: 'session', session_id: prepared.session.id };
 
     let retrievalResults: RetrievalResult[] = [];
-    let graphHints: GraphHint[] = [];
+    let graphContext: Array<GraphHint | GraphCandidate> = [];
     let usage = emptyUsage();
     const startedAt = Date.now();
 
@@ -836,24 +839,28 @@ export class ChatService {
       if (spaceSnapshots.length > 0) {
         retrievedContext = await this.retrieveContext(prepared, spaceSnapshots, input.retrievalMode);
         retrievalResults = retrievedContext.results;
+        graphContext = retrievedContext.graphContext;
       }
 
-      graphHints = await this.retrieveGraphHints(prepared);
-      retrievedContext.trace.candidates.graph.push(...graphHints);
-      retrievedContext.trace.aclFiltered.graph.push(...graphHints);
-      retrievedContext.trace.finalContext.graph_hints.push(...graphHints);
-      retrievedContext.trace.finalContext.graph_tokens += graphHints.reduce(
-        (total, hint) => total + countTokens(hint.content, prepared.chatModel.model_id),
-        0,
-      );
+      if (graphContext.length === 0 && normalizeContextRetrievalMode(input.retrievalMode) === 'wiki_only') {
+        const graphHints = await this.retrieveGraphHints(prepared);
+        graphContext = graphHints;
+        retrievedContext.trace.candidates.graph.push(...graphHints);
+        retrievedContext.trace.aclFiltered.graph.push(...graphHints);
+        retrievedContext.trace.finalContext.graph_hints.push(...graphHints);
+        retrievedContext.trace.finalContext.graph_tokens += graphHints.reduce(
+          (total, hint) => total + countTokens(hint.content, prepared.chatModel.model_id),
+          0,
+        );
+      }
 
-      const noHit = retrievalResults.length === 0 && graphHints.length === 0;
+      const noHit = retrievalResults.length === 0 && graphContext.length === 0;
       if (noHit && prepared.space.strict_knowledge_only) {
         const assistant = await this.persistMessage(prepared.session.id, 'assistant', NO_HIT_MESSAGE, 0, [], {
           source: 'no_hit',
         });
         void this.maybeGenerateTitle(prepared, input.message, NO_HIT_MESSAGE);
-        await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'graph_rag', retrievedContext).catch(
+        await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'wiki_only', retrievedContext).catch(
           () => undefined,
         );
         yield { type: 'content', delta: NO_HIT_MESSAGE };
@@ -871,7 +878,7 @@ export class ChatService {
           agentAvailable: this.agentService !== undefined,
         })
       ) {
-        await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'graph_rag', retrievedContext).catch(
+        await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'wiki_only', retrievedContext).catch(
           () => undefined,
         );
         yield* this.runAgentCompletion(prepared, input, { yieldSession: false });
@@ -881,7 +888,7 @@ export class ChatService {
       const relaxedNoHit = noHit;
       const prompt = this.buildRagPrompt({
         retrievalResults,
-        graphHints,
+        graphHints: graphContext,
         history: prepared.history,
         currentMessage: prepared.message,
         modelId: prepared.chatModel.model_id,
@@ -1291,6 +1298,7 @@ export class ChatService {
     }
 
     let results: RetrievalResult[] = [];
+    let graphContext: Array<GraphHint | GraphCandidate> = [];
     const allVectorHits: SearchHit[] = [];
     const allBm25Hits: SearchHit[] = [];
 
@@ -1341,21 +1349,30 @@ export class ChatService {
     if (includeGraph) {
       const activeRunIds = activeGraphifyRunIdsFromSnapshots(spaceSnapshots);
       if (activeRunIds.size > 0) {
-        const graphCandidates = await retrieveFullGraphContext(
-          {
-            query: prepared.message,
-            spaceIds: prepared.spaceIds,
-            activeRunIds,
-          },
-          this.graphQueryService,
-        );
+        let graphCandidates: GraphCandidate[] = [];
+        try {
+          graphCandidates = await retrieveFullGraphContext(
+            {
+              query: prepared.message,
+              spaceIds: prepared.spaceIds,
+              activeRunIds,
+            },
+            this.graphQueryService,
+          );
+        } catch (err) {
+          getApiLogger().warn(
+            { err, tenant_id: prepared.tenantId, space_ids: prepared.spaceIds },
+            'Full graph retrieval failed; continuing with wiki retrieval only',
+          );
+        }
         candidates.graph.push(...graphCandidates);
 
         if (graphCandidates.length > 0) {
           allVectorHits.sort((left, right) => right.score - left.score);
           allBm25Hits.sort((left, right) => right.score - left.score);
+          const fusedTopK = allVectorHits.length + allBm25Hits.length + graphCandidates.length;
           const fusedResults = rrfFuseThreeSource(allVectorHits, allBm25Hits, graphCandidates, {
-            topK: RETRIEVAL_TOP_K,
+            topK: fusedTopK,
           });
           results = fusedResults
             .filter((result): result is Extract<FusedRetrievalResult, { type: 'wiki_chunk' }> => result.type === 'wiki_chunk')
@@ -1363,6 +1380,13 @@ export class ChatService {
               ...result.hit,
               score: result.score,
             }));
+          graphContext = truncateGraphContextForBudget(
+            fusedResults
+              .filter((result): result is Extract<FusedRetrievalResult, { type: 'graph' }> => result.type === 'graph')
+              .map((result) => ({ ...result.candidate, score: result.score })),
+            prepared.chatModel.model_id,
+            DEFAULT_RETRIEVAL_CONFIG.graph_context_budget,
+          );
         }
       }
     }
@@ -1371,6 +1395,7 @@ export class ChatService {
 
     return {
       results,
+      graphContext,
       trace: {
         candidates,
         aclFiltered: {
@@ -1385,12 +1410,12 @@ export class ChatService {
             pageTitle: result.pageTitle,
             sectionTitle: result.sectionTitle,
           })),
-          graph_hints: candidates.graph,
+          graph_hints: graphContext,
           wiki_tokens: results.reduce(
             (total, result) => total + countTokens(result.content, prepared.chatModel.model_id),
             0,
           ),
-          graph_tokens: candidates.graph.reduce(
+          graph_tokens: graphContext.reduce(
             (total, candidate) => total + countTokens(candidate.content, prepared.chatModel.model_id),
             0,
           ),
@@ -1670,7 +1695,7 @@ export function shouldFallbackToAgentAfterNoHit(input: {
 function buildSystemPrompt(
   retrievalResults: RetrievalResult[],
   relaxedNoHit: boolean,
-  graphHints: GraphHint[] = [],
+  graphHints: Array<GraphHint | GraphCandidate> = [],
   spaces: SpaceDisplayInfo[] = [],
 ): string {
   const spaceLabels = new Map(spaces.map((space) => [space.id, space.name]));
@@ -1717,7 +1742,10 @@ function formatContextBlock(results: RetrievalResult[], spaceLabels: Map<string,
     .join('\n');
 }
 
-function formatGraphHintBlock(hints: GraphHint[], spaceLabels: Map<string, string> = new Map()): string {
+function formatGraphHintBlock(
+  hints: Array<GraphHint | GraphCandidate>,
+  spaceLabels: Map<string, string> = new Map(),
+): string {
   return hints
     .map((hint, index) => {
       const space = spaceLabels.get(hint.space_id) ?? hint.space_id;
@@ -1753,6 +1781,7 @@ function toGraphHint(node: {
 function emptyRetrievedContext(): RetrievedContext {
   return {
     results: [],
+    graphContext: [],
     trace: {
       candidates: {
         vector: [],
@@ -2027,8 +2056,28 @@ function normalizeRetrievalMode(value: string | undefined): string {
 }
 
 function normalizeContextRetrievalMode(value: string | undefined): string {
-  const normalized = value?.trim().toLowerCase();
-  return normalized === undefined || normalized.length === 0 ? 'graph_rag' : normalized;
+  return normalizeRetrievalMode(value);
+}
+
+function truncateGraphContextForBudget<T extends { content: string }>(
+  candidates: T[],
+  modelId: string,
+  budget: number,
+): T[] {
+  const selected: T[] = [];
+  let used = 0;
+
+  for (const candidate of candidates) {
+    const tokens = countTokens(candidate.content, modelId);
+    if (used + tokens > budget) {
+      continue;
+    }
+
+    selected.push(candidate);
+    used += tokens;
+  }
+
+  return selected;
 }
 
 function activeGraphifyRunIdsFromSnapshots(

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -933,7 +933,7 @@ export class ChatService {
       );
       void this.maybeGenerateTitle(prepared, input.message, assistantText);
       await this.persistCitations(assistant.id, citations);
-      await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'graph_rag', retrievedContext).catch(
+      await this.persistRetrievalTrace(prepared, input.retrievalMode ?? 'wiki_only', retrievedContext).catch(
         () => undefined,
       );
       await this.recordStaticModelUsage(prepared, usage, Date.now() - startedAt).catch(() => undefined);

--- a/packages/rag-core/src/__tests__/graph-retrieval.test.ts
+++ b/packages/rag-core/src/__tests__/graph-retrieval.test.ts
@@ -1,8 +1,14 @@
-import type { GraphPath, GraphQueryEdge, GraphQueryNode, GraphQueryService } from '@cherrygraph/graph-core';
+import type {
+  GraphCommunitySummary,
+  GraphPath,
+  GraphQueryEdge,
+  GraphQueryNode,
+  GraphQueryService,
+} from '@cherrygraph/graph-core';
 import { describe, expect, it, vi } from 'vitest';
 
 import { packContext } from '../context-packer.js';
-import { retrieveGraphCandidates } from '../graph-retrieval.js';
+import { retrieveFullGraphContext, retrieveGraphCandidates } from '../graph-retrieval.js';
 import { rrfFuseThreeSource, type FusedRetrievalResult } from '../rrf-fusion.js';
 import {
   DEFAULT_RETRIEVAL_CONFIG,
@@ -149,6 +155,108 @@ describe('retrieveGraphCandidates', () => {
   });
 });
 
+describe('retrieveFullGraphContext', () => {
+  it('local mode returns search nodes plus community neighbor expansion', async () => {
+    const nodes = [
+      makeNode('node-a', 'Alpha', { community_id: 'community-1', score: 0.9 }),
+      makeNode('node-b', 'Beta', { community_id: 'community-2', score: 0.8 }),
+    ];
+    const communityNodes = new Map([
+      ['community-1', [nodes[0]!, makeNode('node-neighbor', 'Neighbor', { community_id: 'community-1', score: 1 })]],
+      ['community-2', [nodes[1]!]],
+    ]);
+    const service = makeFullGraphQueryService({ nodes, communityNodes });
+
+    const candidates = await retrieveFullGraphContext(
+      { ...makeFullGraphParams(), mode: 'local', neighborExpansionTopK: 1 },
+      service,
+    );
+
+    expect(candidates.map((candidate) => candidate.id)).toContain('node-a');
+    expect(candidates.map((candidate) => candidate.id)).toContain('node-neighbor');
+    expect(candidates.every((candidate) => candidate.type === 'graph_node')).toBe(true);
+    expect(service.getCommunityNodes).toHaveBeenCalledTimes(1);
+    expect(service.getCommunityNodes.mock.calls[0]?.[0]).toBe('community-1');
+    expect(service.getCommunityNodes.mock.calls[0]?.[1]).toEqual(['space-1']);
+    expect(Array.from(service.getCommunityNodes.mock.calls[0]?.[2].entries() ?? [])).toEqual([['space-1', 'run-1']]);
+  });
+
+  it('global mode returns matching community summaries', async () => {
+    const nodes = [makeNode('node-a', 'Alpha', { community_id: 'community-1', score: 0.9 })];
+    const communities = [
+      makeCommunity('community-1', { label: 'Auth', summary: 'Authentication cluster' }),
+      makeCommunity('community-2', { label: 'Billing', summary: 'Billing cluster' }),
+    ];
+
+    const candidates = await retrieveFullGraphContext(
+      { ...makeFullGraphParams(), mode: 'global' },
+      makeFullGraphQueryService({ nodes, communities }),
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      type: 'community',
+      id: 'community-1',
+      content: '[Community] Auth: Authentication cluster',
+    });
+  });
+
+  it('hybrid mode merges, deduplicates, scores, sorts, and limits candidates', async () => {
+    const nodes = [
+      makeNode('node-low', 'Low', { community_id: 'community-1', score: 0.1 }),
+      makeNode('node-high', 'High', { community_id: 'community-2', score: 0.95 }),
+    ];
+    const communities = [
+      makeCommunity('community-1', { node_count: 2 }),
+      makeCommunity('community-2', { node_count: 20 }),
+    ];
+    const communityNodes = new Map([
+      ['community-1', [nodes[0]!]],
+      ['community-2', [nodes[1]!, makeNode('node-neighbor', 'Neighbor', { community_id: 'community-2', score: 1 })]],
+    ]);
+
+    const candidates = await retrieveFullGraphContext(
+      { ...makeFullGraphParams(), maxCandidates: 3 },
+      makeFullGraphQueryService({ nodes, communities, communityNodes }),
+    );
+
+    expect(candidates).toHaveLength(3);
+    expect(new Set(candidates.map((candidate) => `${candidate.type}:${candidate.id}`)).size).toBe(3);
+    expect(candidates[0]?.score).toBeGreaterThanOrEqual(candidates[1]?.score ?? 0);
+    expect(candidates.map((candidate) => candidate.id)).toContain('community-2');
+  });
+
+  it('returns empty array when node search has no graph hits', async () => {
+    const service = makeFullGraphQueryService({ nodes: [] });
+
+    await expect(retrieveFullGraphContext(makeFullGraphParams(), service)).resolves.toEqual([]);
+    expect(service.getCommunities).not.toHaveBeenCalled();
+    expect(service.getCommunityNodes).not.toHaveBeenCalled();
+  });
+
+  it('passes spaceIds and activeRunIds through graph queries for ACL scoping', async () => {
+    const params = {
+      ...makeFullGraphParams(),
+      spaceIds: ['space-1', 'space-2'],
+      activeRunIds: new Map([
+        ['space-1', 'run-1'],
+        ['space-2', 'run-2'],
+      ]),
+    };
+    const service = makeFullGraphQueryService({
+      nodes: [makeNode('node-a', 'Alpha', { community_id: 'community-1' })],
+      communities: [makeCommunity('community-1')],
+      communityNodes: new Map([['community-1', [makeNode('node-neighbor', 'Neighbor', { community_id: 'community-1' })]]]),
+    });
+
+    await retrieveFullGraphContext(params, service);
+
+    expect(service.searchNodes).toHaveBeenCalledWith(params.query, params.spaceIds, params.activeRunIds, 20);
+    expect(service.getCommunities).toHaveBeenCalledWith(params.spaceIds, params.activeRunIds);
+    expect(service.getCommunityNodes).toHaveBeenCalledWith('community-1', params.spaceIds, params.activeRunIds);
+  });
+});
+
 describe('packContext', () => {
   it('allocates token budgets by source and trims overflow items', () => {
     const fusedResults: FusedRetrievalResult[] = [
@@ -272,9 +380,19 @@ function makeGraphParams(ambiguousEdgePolicy: 'exclude' | 'explain_only' | 'incl
   };
 }
 
+function makeFullGraphParams() {
+  return {
+    query: 'alpha beta',
+    spaceIds: ['space-1'],
+    activeRunIds: new Map([['space-1', 'run-1']]),
+  };
+}
+
 type MockGraphQueryService = {
   searchNodes: ReturnType<typeof vi.fn<GraphQueryService['searchNodes']>>;
   findPath: ReturnType<typeof vi.fn<GraphQueryService['findPath']>>;
+  getCommunities: ReturnType<typeof vi.fn<GraphQueryService['getCommunities']>>;
+  getCommunityNodes: ReturnType<typeof vi.fn<GraphQueryService['getCommunityNodes']>>;
 };
 
 function makeGraphQueryService(
@@ -284,6 +402,25 @@ function makeGraphQueryService(
   const service: MockGraphQueryService = {
     searchNodes: vi.fn<GraphQueryService['searchNodes']>().mockResolvedValue(nodes),
     findPath: vi.fn<GraphQueryService['findPath']>().mockResolvedValue(paths),
+    getCommunities: vi.fn<GraphQueryService['getCommunities']>().mockResolvedValue([]),
+    getCommunityNodes: vi.fn<GraphQueryService['getCommunityNodes']>().mockResolvedValue([]),
+  };
+
+  return service as unknown as GraphQueryService & MockGraphQueryService;
+}
+
+function makeFullGraphQueryService(input: {
+  nodes: GraphQueryNode[];
+  communities?: GraphCommunitySummary[];
+  communityNodes?: Map<string, GraphQueryNode[]>;
+}): GraphQueryService & MockGraphQueryService {
+  const service: MockGraphQueryService = {
+    searchNodes: vi.fn<GraphQueryService['searchNodes']>().mockResolvedValue(input.nodes),
+    findPath: vi.fn<GraphQueryService['findPath']>().mockResolvedValue([]),
+    getCommunities: vi.fn<GraphQueryService['getCommunities']>().mockResolvedValue(input.communities ?? []),
+    getCommunityNodes: vi.fn<GraphQueryService['getCommunityNodes']>().mockImplementation((communityId) =>
+      Promise.resolve(input.communityNodes?.get(communityId) ?? []),
+    ),
   };
 
   return service as unknown as GraphQueryService & MockGraphQueryService;
@@ -314,7 +451,7 @@ function makeGraphCandidate(id: string, overrides: Partial<GraphCandidate> = {})
   };
 }
 
-function makeNode(id: string, label: string): GraphQueryNode {
+function makeNode(id: string, label: string, overrides: Partial<GraphQueryNode> = {}): GraphQueryNode {
   return {
     id,
     node_key: id,
@@ -325,6 +462,18 @@ function makeNode(id: string, label: string): GraphQueryNode {
     space_id: 'space-1',
     community_id: null,
     score: 1,
+    ...overrides,
+  };
+}
+
+function makeCommunity(id: string, overrides: Partial<GraphCommunitySummary> = {}): GraphCommunitySummary {
+  return {
+    id,
+    community_key: id,
+    label: id,
+    summary: null,
+    node_count: 3,
+    ...overrides,
   };
 }
 

--- a/packages/rag-core/src/__tests__/graph-retrieval.test.ts
+++ b/packages/rag-core/src/__tests__/graph-retrieval.test.ts
@@ -156,16 +156,21 @@ describe('retrieveGraphCandidates', () => {
 });
 
 describe('retrieveFullGraphContext', () => {
-  it('local mode returns search nodes plus community neighbor expansion', async () => {
+  it('local mode returns search nodes plus community and 1-hop path neighbor expansion', async () => {
     const nodes = [
       makeNode('node-a', 'Alpha', { community_id: 'community-1', score: 0.9 }),
       makeNode('node-b', 'Beta', { community_id: 'community-2', score: 0.8 }),
     ];
+    const pathNeighbor = makeNode('node-cross', 'Cross', { community_id: 'community-3', score: 0.7 });
+    const path = makePath(
+      [nodes[0]!, pathNeighbor],
+      [makeEdge('edge-cross', 'node-a', 'node-cross', 'relates_to', 'EXTRACTED', 1, 1)],
+    );
     const communityNodes = new Map([
       ['community-1', [nodes[0]!, makeNode('node-neighbor', 'Neighbor', { community_id: 'community-1', score: 1 })]],
       ['community-2', [nodes[1]!]],
     ]);
-    const service = makeFullGraphQueryService({ nodes, communityNodes });
+    const service = makeFullGraphQueryService({ nodes, communityNodes, paths: [path] });
 
     const candidates = await retrieveFullGraphContext(
       { ...makeFullGraphParams(), mode: 'local', neighborExpansionTopK: 1 },
@@ -174,8 +179,10 @@ describe('retrieveFullGraphContext', () => {
 
     expect(candidates.map((candidate) => candidate.id)).toContain('node-a');
     expect(candidates.map((candidate) => candidate.id)).toContain('node-neighbor');
+    expect(candidates.map((candidate) => candidate.id)).toContain('node-cross');
     expect(candidates.every((candidate) => candidate.type === 'graph_node')).toBe(true);
     expect(service.getCommunityNodes).toHaveBeenCalledTimes(1);
+    expect(service.findPath).toHaveBeenCalledWith('node-a', 'node-b', 1, ['space-1'], expect.any(Map));
     expect(service.getCommunityNodes.mock.calls[0]?.[0]).toBe('community-1');
     expect(service.getCommunityNodes.mock.calls[0]?.[1]).toEqual(['space-1']);
     expect(Array.from(service.getCommunityNodes.mock.calls[0]?.[2].entries() ?? [])).toEqual([['space-1', 'run-1']]);
@@ -254,6 +261,19 @@ describe('retrieveFullGraphContext', () => {
     expect(service.searchNodes).toHaveBeenCalledWith(params.query, params.spaceIds, params.activeRunIds, 20);
     expect(service.getCommunities).toHaveBeenCalledWith(params.spaceIds, params.activeRunIds);
     expect(service.getCommunityNodes).toHaveBeenCalledWith('community-1', params.spaceIds, params.activeRunIds);
+  });
+
+  it('caps full graph context at top 30 candidates', async () => {
+    const nodes = Array.from({ length: 35 }, (_, index) =>
+      makeNode(`node-${index.toString().padStart(2, '0')}`, `Node ${index}`, { score: 1 - index / 100 }),
+    );
+
+    const candidates = await retrieveFullGraphContext(
+      { ...makeFullGraphParams(), mode: 'local', maxCandidates: 50 },
+      makeFullGraphQueryService({ nodes }),
+    );
+
+    expect(candidates).toHaveLength(30);
   });
 });
 
@@ -413,10 +433,11 @@ function makeFullGraphQueryService(input: {
   nodes: GraphQueryNode[];
   communities?: GraphCommunitySummary[];
   communityNodes?: Map<string, GraphQueryNode[]>;
+  paths?: GraphPath[];
 }): GraphQueryService & MockGraphQueryService {
   const service: MockGraphQueryService = {
     searchNodes: vi.fn<GraphQueryService['searchNodes']>().mockResolvedValue(input.nodes),
-    findPath: vi.fn<GraphQueryService['findPath']>().mockResolvedValue([]),
+    findPath: vi.fn<GraphQueryService['findPath']>().mockResolvedValue(input.paths ?? []),
     getCommunities: vi.fn<GraphQueryService['getCommunities']>().mockResolvedValue(input.communities ?? []),
     getCommunityNodes: vi.fn<GraphQueryService['getCommunityNodes']>().mockImplementation((communityId) =>
       Promise.resolve(input.communityNodes?.get(communityId) ?? []),

--- a/packages/rag-core/src/graph-retrieval.ts
+++ b/packages/rag-core/src/graph-retrieval.ts
@@ -40,7 +40,7 @@ const MAX_PATH_TOP_K = 10;
 const MAX_HOPS = 6;
 const DEFAULT_NEIGHBOR_EXPANSION_TOP_K = 5;
 const DEFAULT_MAX_CANDIDATES = 30;
-const MAX_FULL_GRAPH_CANDIDATES = 50;
+const MAX_FULL_GRAPH_CANDIDATES = 30;
 
 type CandidateWithScoringContext = {
   candidate: GraphCandidate;
@@ -196,14 +196,25 @@ async function retrieveLocalCandidateContexts(
 ): Promise<CandidateWithScoringContext[]> {
   const candidateContexts = nodes.map((node) => toNodeCandidateContext(node, node.score));
   const expansionNodes = nodes.slice(0, neighborExpansionTopK).filter((node) => node.community_id !== null);
-  const communityNodeResults = await Promise.all(
-    expansionNodes.map((node) =>
-      graphQueryService.getCommunityNodes(node.community_id!, params.spaceIds, params.activeRunIds),
+  const topNodePairs = buildAllTopNodePairs(nodes.slice(0, DEFAULT_NEIGHBOR_EXPANSION_TOP_K));
+  const [communityNodeResults, oneHopPathResults] = await Promise.all([
+    Promise.all(
+      expansionNodes.map((node) =>
+        graphQueryService.getCommunityNodes(node.community_id!, params.spaceIds, params.activeRunIds),
+      ),
     ),
-  );
+    Promise.all(
+      topNodePairs.map(({ source, target }) =>
+        graphQueryService.findPath(source.id, target.id, 1, params.spaceIds, params.activeRunIds),
+      ),
+    ),
+  ]);
   const searchScoreByCommunityId = new Map<string, number>();
+  const searchScoreByNodeId = new Map<string, number>();
 
   for (const node of nodes) {
+    searchScoreByNodeId.set(node.id, normalizeNonNegativeNumber(node.score, 0));
+
     if (node.community_id === null) {
       continue;
     }
@@ -217,6 +228,17 @@ async function retrieveLocalCandidateContexts(
   for (const communityNodes of communityNodeResults) {
     for (const node of communityNodes) {
       candidateContexts.push(toNodeCandidateContext(node, searchScoreByCommunityId.get(node.community_id ?? '') ?? node.score));
+    }
+  }
+
+  for (const path of oneHopPathResults.flat()) {
+    if (!isUsablePath(path)) {
+      continue;
+    }
+
+    const pathScore = normalizeNonNegativeNumber(path.total_confidence, 0);
+    for (const node of path.nodes) {
+      candidateContexts.push(toNodeCandidateContext(node, searchScoreByNodeId.get(node.id) ?? pathScore));
     }
   }
 
@@ -323,6 +345,28 @@ function buildTopNodePairs(
       if (pairs.length >= maxPairs) {
         return pairs;
       }
+    }
+  }
+
+  return pairs;
+}
+
+function buildAllTopNodePairs(nodes: GraphQueryNode[]): Array<{ source: GraphQueryNode; target: GraphQueryNode }> {
+  const pairs: Array<{ source: GraphQueryNode; target: GraphQueryNode }> = [];
+
+  for (let sourceIndex = 0; sourceIndex < nodes.length; sourceIndex += 1) {
+    const source = nodes[sourceIndex];
+    if (source === undefined) {
+      continue;
+    }
+
+    for (let targetIndex = sourceIndex + 1; targetIndex < nodes.length; targetIndex += 1) {
+      const target = nodes[targetIndex];
+      if (target === undefined) {
+        continue;
+      }
+
+      pairs.push({ source, target });
     }
   }
 

--- a/packages/rag-core/src/graph-retrieval.ts
+++ b/packages/rag-core/src/graph-retrieval.ts
@@ -1,4 +1,5 @@
 import type {
+  GraphCommunitySummary,
   GraphPath,
   GraphQueryEdge,
   GraphQueryNode,
@@ -10,6 +11,7 @@ import {
   type AmbiguousEdgePolicy,
   type GraphCandidate,
 } from './types.js';
+import { scoreLightRAG } from './lightrag-strategies.js';
 
 export type GraphRetrievalParams = {
   query: string;
@@ -21,9 +23,30 @@ export type GraphRetrievalParams = {
   ambiguousEdgePolicy?: AmbiguousEdgePolicy;
 };
 
+export type GraphRetrievalMode = 'local' | 'global' | 'hybrid';
+
+export type FullGraphRetrievalParams = {
+  query: string;
+  spaceIds: string[];
+  activeRunIds: Map<string, string>;
+  mode?: GraphRetrievalMode;
+  nodeTopK?: number;
+  neighborExpansionTopK?: number;
+  maxCandidates?: number;
+};
+
 const MAX_NODE_TOP_K = 50;
 const MAX_PATH_TOP_K = 10;
 const MAX_HOPS = 6;
+const DEFAULT_NEIGHBOR_EXPANSION_TOP_K = 5;
+const DEFAULT_MAX_CANDIDATES = 30;
+const MAX_FULL_GRAPH_CANDIDATES = 50;
+
+type CandidateWithScoringContext = {
+  candidate: GraphCandidate;
+  textSimilarity: number;
+  communityId: string | null;
+};
 
 export async function retrieveGraphCandidates(
   params: GraphRetrievalParams,
@@ -68,16 +91,83 @@ export async function retrieveGraphCandidates(
   return [...nodeCandidates, ...pathCandidates];
 }
 
+export async function retrieveFullGraphContext(
+  params: FullGraphRetrievalParams,
+  graphQueryService: GraphQueryService,
+): Promise<GraphCandidate[]> {
+  const mode = params.mode ?? 'hybrid';
+  const nodeTopK = Math.min(
+    normalizePositiveInteger(params.nodeTopK, DEFAULT_RETRIEVAL_CONFIG.graph_node_top_k),
+    MAX_NODE_TOP_K,
+  );
+  const neighborExpansionTopK = Math.min(
+    normalizePositiveInteger(params.neighborExpansionTopK, DEFAULT_NEIGHBOR_EXPANSION_TOP_K),
+    MAX_NODE_TOP_K,
+  );
+  const maxCandidates = Math.min(
+    normalizePositiveInteger(params.maxCandidates, DEFAULT_MAX_CANDIDATES),
+    MAX_FULL_GRAPH_CANDIDATES,
+  );
+  const nodes = await graphQueryService.searchNodes(
+    params.query,
+    params.spaceIds,
+    params.activeRunIds,
+    nodeTopK,
+  );
+
+  if (nodes.length === 0) {
+    return [];
+  }
+
+  const communities = mode === 'local' ? [] : await graphQueryService.getCommunities(params.spaceIds, params.activeRunIds);
+  const communityNodeCounts = buildCommunityNodeCounts(communities);
+  const candidateContexts: CandidateWithScoringContext[] = [];
+
+  if (mode === 'local' || mode === 'hybrid') {
+    candidateContexts.push(
+      ...(await retrieveLocalCandidateContexts(nodes, neighborExpansionTopK, params, graphQueryService)),
+    );
+  }
+
+  if (mode === 'global' || mode === 'hybrid') {
+    candidateContexts.push(...retrieveGlobalCandidateContexts(nodes, communities));
+  }
+
+  return dedupeCandidateContexts(candidateContexts)
+    .map(({ candidate, textSimilarity, communityId }) =>
+      scoreLightRAG(candidate, {
+        textSimilarity,
+        communityNodeCounts,
+        candidateCommunityId: communityId,
+      }),
+    )
+    .sort((left, right) => right.score - left.score || left.id.localeCompare(right.id))
+    .slice(0, maxCandidates);
+}
+
 function toNodeCandidate(node: GraphQueryNode): GraphCandidate {
   return {
     type: 'graph_node',
     id: node.id,
-    content: `[Node] ${node.label} (${node.node_type ?? 'unknown'})`,
+    content: formatNodeContent(node),
     score: normalizeNonNegativeNumber(node.score, 0),
     confidence_label: 'EXTRACTED',
     effective_confidence_score: 1,
     evidence_count: 1,
     space_id: node.space_id,
+  };
+}
+
+function toCommunityCandidate(community: GraphCommunitySummary): GraphCandidate {
+  return {
+    type: 'community',
+    id: community.id,
+    content: formatCommunityContent(community),
+    score: 0,
+    confidence_label: 'EXTRACTED',
+    effective_confidence_score: 1,
+    evidence_count: Math.max(1, normalizePositiveInteger(community.node_count, 1)),
+    space_id: '',
   };
 }
 
@@ -96,6 +186,119 @@ function toPathCandidate(path: GraphPath, ambiguousEdgePolicy: AmbiguousEdgePoli
     space_id: path.edges[0]?.space_id ?? path.nodes[0]?.space_id ?? '',
     graph_edge_ids: path.edges.map((edge) => edge.id),
   };
+}
+
+async function retrieveLocalCandidateContexts(
+  nodes: GraphQueryNode[],
+  neighborExpansionTopK: number,
+  params: FullGraphRetrievalParams,
+  graphQueryService: GraphQueryService,
+): Promise<CandidateWithScoringContext[]> {
+  const candidateContexts = nodes.map((node) => toNodeCandidateContext(node, node.score));
+  const expansionNodes = nodes.slice(0, neighborExpansionTopK).filter((node) => node.community_id !== null);
+  const communityNodeResults = await Promise.all(
+    expansionNodes.map((node) =>
+      graphQueryService.getCommunityNodes(node.community_id!, params.spaceIds, params.activeRunIds),
+    ),
+  );
+  const searchScoreByCommunityId = new Map<string, number>();
+
+  for (const node of nodes) {
+    if (node.community_id === null) {
+      continue;
+    }
+
+    searchScoreByCommunityId.set(
+      node.community_id,
+      Math.max(searchScoreByCommunityId.get(node.community_id) ?? 0, normalizeNonNegativeNumber(node.score, 0)),
+    );
+  }
+
+  for (const communityNodes of communityNodeResults) {
+    for (const node of communityNodes) {
+      candidateContexts.push(toNodeCandidateContext(node, searchScoreByCommunityId.get(node.community_id ?? '') ?? node.score));
+    }
+  }
+
+  return candidateContexts;
+}
+
+function retrieveGlobalCandidateContexts(
+  nodes: GraphQueryNode[],
+  communities: GraphCommunitySummary[],
+): CandidateWithScoringContext[] {
+  const communityScoreById = new Map<string, number>();
+
+  for (const node of nodes) {
+    if (node.community_id === null) {
+      continue;
+    }
+
+    communityScoreById.set(
+      node.community_id,
+      Math.max(communityScoreById.get(node.community_id) ?? 0, normalizeNonNegativeNumber(node.score, 0)),
+    );
+  }
+
+  return communities
+    .filter((community) => communityScoreById.has(community.id))
+    .map((community) => ({
+      candidate: toCommunityCandidate(community),
+      textSimilarity: communityScoreById.get(community.id) ?? 0,
+      communityId: community.id,
+    }));
+}
+
+function toNodeCandidateContext(node: GraphQueryNode, textSimilarity: number): CandidateWithScoringContext {
+  return {
+    candidate: toNodeCandidate(node),
+    textSimilarity: normalizeNonNegativeNumber(textSimilarity, 0),
+    communityId: node.community_id,
+  };
+}
+
+function dedupeCandidateContexts(
+  candidateContexts: CandidateWithScoringContext[],
+): CandidateWithScoringContext[] {
+  const byKey = new Map<string, CandidateWithScoringContext>();
+
+  for (const candidateContext of candidateContexts) {
+    const key = `${candidateContext.candidate.type}:${candidateContext.candidate.id}`;
+    const existing = byKey.get(key);
+    if (
+      existing === undefined ||
+      candidateContext.textSimilarity > existing.textSimilarity ||
+      candidateContext.candidate.evidence_count > existing.candidate.evidence_count
+    ) {
+      byKey.set(key, candidateContext);
+    }
+  }
+
+  return Array.from(byKey.values());
+}
+
+function buildCommunityNodeCounts(communities: GraphCommunitySummary[]): Map<string, number> {
+  return new Map(communities.map((community) => [community.id, Math.max(0, community.node_count)]));
+}
+
+function formatNodeContent(node: GraphQueryNode): string {
+  const type = node.node_type ?? 'unknown';
+  const description = node.description?.trim();
+  if (description !== undefined && description.length > 0) {
+    return `[Node] ${node.label} (${type}): ${description}`;
+  }
+
+  return `[Node] ${node.label} (${type})`;
+}
+
+function formatCommunityContent(community: GraphCommunitySummary): string {
+  const label = community.label ?? community.community_key;
+  const summary = community.summary?.trim();
+  if (summary !== undefined && summary.length > 0) {
+    return `[Community] ${label}: ${summary}`;
+  }
+
+  return `[Community] ${label} (${community.node_count} nodes)`;
 }
 
 function buildTopNodePairs(


### PR DESCRIPTION
## Summary

- Implement `retrieveFullGraphContext()` with local/global/hybrid modes in `graph-retrieval.ts`
- Wire graph retrieval into `chat.service.ts` `retrieveContext()` for three-source RRF fusion
- `graph_rag` mode: vector + BM25 + graph candidates via `rrfFuseThreeSource()`
- `wiki_only` mode (default): preserved two-source behavior (backward compatible)
- Graph context budget enforced at 2500 tokens independently from wiki budget
- Graph query failures gracefully degrade to wiki-only retrieval
- Empty graph returns empty candidates (graceful degradation)

Closes #342

## OpenSpec Change

`openspec/changes/lightrag-retrieval-integration/` (graph-candidate-retrieval + activate-three-source-fusion)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `7492906a853c7fca0748c288187cb78329cfddab`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/346#issuecomment-4457659845) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/346#issuecomment-4457659992) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/346#issuecomment-4457660130) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/346#issuecomment-4457660291)
- Key findings addressed: Round 1 fixed graph candidate preservation in prompt, budget enforcement, backward compat default, failure isolation, 1-hop expansion, candidate cap. Round 2 fixed trace persistence label.

## Test plan

- [x] Build passes
- [x] 16 graph-retrieval tests pass (6 new)
- [x] 54 chat.service tests pass (7 new: graph_rag, wiki_only, failure isolation, budget, compat, perf)
- [x] Full CI suite passes