### PR TITLE
feat(scripts): add retrieval evaluation harness (#343)

### DIFF
--- a/scripts/__tests__/eval-retrieval.test.ts
+++ b/scripts/__tests__/eval-retrieval.test.ts
@@ -23,6 +23,14 @@ describe('retrieval evaluation metrics', () => {
     expect(computeRecallAtK(['A', 'B'], ['C', 'D'], 8)).toBe(0);
   });
 
+  it('returns 0 recall for empty expected pages', () => {
+    expect(computeRecallAtK([], ['A', 'B', 'C'], 8)).toBe(0);
+  });
+
+  it('excludes hits beyond the k cutoff', () => {
+    expect(computeRecallAtK(['Z'], ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'Z'], 8)).toBe(0);
+  });
+
   it('computes MRR with first hit at rank 1', () => {
     expect(computeMRR(['A', 'B'], ['A', 'C', 'B'])).toBe(1);
   });

--- a/scripts/__tests__/eval-retrieval.test.ts
+++ b/scripts/__tests__/eval-retrieval.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RetrievalEvaluator,
+  computeMRR,
+  computeRecallAtK,
+  formatComparisonTable,
+  createStaticRetriever,
+  type EvalEntry,
+  type ModeEvaluationResult,
+} from '../eval-retrieval.js';
+
+describe('retrieval evaluation metrics', () => {
+  it('computes recall@8 for full hits', () => {
+    expect(computeRecallAtK(['A', 'B'], ['A', 'C', 'B', 'D'], 8)).toBe(1);
+  });
+
+  it('computes recall@8 for partial hits', () => {
+    expect(computeRecallAtK(['A', 'B'], ['C', 'D', 'B'], 8)).toBe(0.5);
+  });
+
+  it('computes recall@8 with no hits', () => {
+    expect(computeRecallAtK(['A', 'B'], ['C', 'D'], 8)).toBe(0);
+  });
+
+  it('computes MRR with first hit at rank 1', () => {
+    expect(computeMRR(['A', 'B'], ['A', 'C', 'B'])).toBe(1);
+  });
+
+  it('computes MRR with first hit at rank 3', () => {
+    expect(computeMRR(['A'], ['C', 'D', 'A'])).toBeCloseTo(1 / 3, 3);
+  });
+
+  it('computes MRR with no hits', () => {
+    expect(computeMRR(['A'], ['C', 'D'])).toBe(0);
+  });
+});
+
+describe('RetrievalEvaluator', () => {
+  const evalSet: EvalEntry[] = [
+    {
+      query: 'alpha query',
+      expected_pages: ['A'],
+      expected_content_snippet: 'alpha',
+      space_id: 'test-space',
+    },
+    {
+      query: 'beta query',
+      expected_pages: ['B'],
+      expected_content_snippet: 'beta',
+      space_id: 'test-space',
+    },
+  ];
+
+  const deterministicRetriever = createStaticRetriever({
+    wiki_only: {
+      'alpha query': [
+        { page: 'A', score: 1 },
+        { page: 'B', score: 0.5 },
+      ],
+      'beta query': [
+        { page: 'C', score: 1 },
+        { page: 'B', score: 0.5 },
+      ],
+    },
+    graph_rag: {
+      'alpha query': [
+        { page: 'A', score: 1 },
+        { page: 'B', score: 0.5 },
+      ],
+      'beta query': [
+        { page: 'B', score: 1 },
+        { page: 'C', score: 0.5 },
+      ],
+    },
+  });
+
+  it('produces identical metrics on repeated runs with the same eval set', async () => {
+    const evaluator = new RetrievalEvaluator(deterministicRetriever);
+
+    const firstRun = await evaluator.evaluate(evalSet);
+    const secondRun = await evaluator.evaluate(evalSet);
+
+    expect(firstRun.map((result) => result.metrics)).toEqual(secondRun.map((result) => result.metrics));
+  });
+
+  it('formats the comparison table output', () => {
+    const results: ModeEvaluationResult[] = [
+      {
+        mode: 'wiki_only',
+        queries: [],
+        metrics: { recallAt8: 0.65, mrr: 0.542 },
+      },
+      {
+        mode: 'graph_rag',
+        queries: [],
+        metrics: { recallAt8: 0.85, mrr: 0.708 },
+      },
+    ];
+
+    expect(formatComparisonTable(results)).toBe(
+      [
+        '┌──────────────┬───────────┬───────────┐',
+        '│ Metric       │ wiki_only │ graph_rag │',
+        '├──────────────┼───────────┼───────────┤',
+        '│ recall@8     │ 0.650     │ 0.850     │',
+        '│ MRR          │ 0.542     │ 0.708     │',
+        '└──────────────┴───────────┴───────────┘',
+      ].join('\n'),
+    );
+  });
+});

--- a/scripts/eval-retrieval.ts
+++ b/scripts/eval-retrieval.ts
@@ -1,0 +1,381 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type RetrievalMode = 'wiki_only' | 'graph_rag';
+
+export interface EvalEntry {
+  query: string;
+  expected_pages: string[];
+  expected_content_snippet: string;
+  space_id: string;
+}
+
+export interface RetrievalRequest {
+  query: string;
+  spaceId: string;
+  mode: RetrievalMode;
+  k: number;
+}
+
+export interface RetrievalResult {
+  page: string;
+  score: number;
+}
+
+export type RetrievalFunction = (request: RetrievalRequest) => Promise<RetrievalResult[]> | RetrievalResult[];
+
+export type StaticRetrievalResults = Partial<Record<RetrievalMode, Record<string, RetrievalResult[]>>>;
+
+export interface QueryEvaluationResult {
+  entry: EvalEntry;
+  retrievedPages: string[];
+  recallAt8: number;
+  reciprocalRank: number;
+}
+
+export interface ModeEvaluationResult {
+  mode: RetrievalMode;
+  queries: QueryEvaluationResult[];
+  metrics: EvaluationMetrics;
+}
+
+export interface EvaluationMetrics {
+  recallAt8: number;
+  mrr: number;
+}
+
+const DEFAULT_EVAL_SET_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../tests/e2e/fixtures/golden/eval-set.json',
+);
+
+const PAGE_IDS = ['auth-system', 'jwt-authentication', 'permission-system', 'rbac-permission-model', 'index'] as const;
+
+type PageId = (typeof PAGE_IDS)[number];
+
+interface PageFixture {
+  id: PageId;
+  title: string;
+  aliases: string[];
+  keywords: string[];
+  graphNeighbors: PageId[];
+}
+
+const PAGE_FIXTURES: PageFixture[] = [
+  {
+    id: 'auth-system',
+    title: 'Auth System',
+    aliases: ['auth', 'authentication', 'login', 'session management', 'access control'],
+    keywords: [
+      'jwt',
+      'access',
+      'control',
+      'login',
+      'token',
+      'lifecycle',
+      'session',
+      'device',
+      'ip',
+      'activity',
+      'refresh',
+      'rotation',
+      'rbac',
+    ],
+    graphNeighbors: ['jwt-authentication', 'rbac-permission-model', 'permission-system'],
+  },
+  {
+    id: 'jwt-authentication',
+    title: 'JWT Authentication',
+    aliases: ['jwt', 'jwt authentication', 'bearer', 'access token', 'refresh token'],
+    keywords: [
+      'jwt',
+      'token',
+      'tokens',
+      'access',
+      'refresh',
+      'ttl',
+      'rotation',
+      'bearer',
+      'signature',
+      'sessions',
+      'revocation',
+      'audit',
+      'rate',
+      'limited',
+      'authorization',
+      'login',
+      'credentials',
+    ],
+    graphNeighbors: ['auth-system', 'rbac-permission-model'],
+  },
+  {
+    id: 'permission-system',
+    title: 'Permission System',
+    aliases: ['permission', 'permissions', 'space permissions', 'permission version'],
+    keywords: [
+      'permission',
+      'permissions',
+      'space',
+      'spaces',
+      'rbac',
+      'role',
+      'roles',
+      'group',
+      'groups',
+      'viewer',
+      'editor',
+      'admin',
+      'read',
+      'write',
+      'version',
+      'revocation',
+      'revocations',
+      '5',
+      'seconds',
+      'cache',
+    ],
+    graphNeighbors: ['rbac-permission-model', 'auth-system'],
+  },
+  {
+    id: 'rbac-permission-model',
+    title: 'RBAC Permission Model',
+    aliases: ['rbac', 'rbac permission model', 'role hierarchy', 'group-based assignment'],
+    keywords: [
+      'rbac',
+      'permission',
+      'permissions',
+      'role',
+      'roles',
+      'hierarchy',
+      'viewer',
+      'editor',
+      'admin',
+      'groups',
+      'group',
+      'spaces',
+      'space',
+      'effective',
+      'maximum',
+      'authorization',
+      'jwt',
+      'session',
+    ],
+    graphNeighbors: ['permission-system', 'jwt-authentication', 'auth-system'],
+  },
+  {
+    id: 'index',
+    title: 'Wiki Index',
+    aliases: ['wiki index', 'generated wiki', 'pages', 'communities', 'god nodes'],
+    keywords: ['wiki', 'index', 'generated', 'graphify', 'pages', 'communities', 'god', 'nodes', 'statistics'],
+    graphNeighbors: [],
+  },
+];
+
+export async function loadEvalSet(evalSetPath = DEFAULT_EVAL_SET_PATH): Promise<EvalEntry[]> {
+  const raw = await readFile(evalSetPath, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Eval set must be a JSON array: ${evalSetPath}`);
+  }
+
+  return parsed.map((entry, index) => validateEvalEntry(entry, index));
+}
+
+export function computeRecallAtK(expectedPages: string[], retrievedPages: string[], k = 8): number {
+  if (expectedPages.length === 0) {
+    return 0;
+  }
+
+  const topK = new Set(retrievedPages.slice(0, k));
+  const hits = expectedPages.filter((page) => topK.has(page)).length;
+  return hits / expectedPages.length;
+}
+
+export function computeMRR(expectedPages: string[], retrievedPages: string[]): number {
+  const expected = new Set(expectedPages);
+  const firstHitIndex = retrievedPages.findIndex((page) => expected.has(page));
+  return firstHitIndex === -1 ? 0 : 1 / (firstHitIndex + 1);
+}
+
+export function computeMeanMetrics(results: QueryEvaluationResult[]): EvaluationMetrics {
+  if (results.length === 0) {
+    return { recallAt8: 0, mrr: 0 };
+  }
+
+  const totals = results.reduce(
+    (acc, result) => ({
+      recallAt8: acc.recallAt8 + result.recallAt8,
+      mrr: acc.mrr + result.reciprocalRank,
+    }),
+    { recallAt8: 0, mrr: 0 },
+  );
+
+  return {
+    recallAt8: totals.recallAt8 / results.length,
+    mrr: totals.mrr / results.length,
+  };
+}
+
+export class RetrievalEvaluator {
+  constructor(
+    private readonly retrieve: RetrievalFunction = createDeterministicFixtureRetriever(),
+    private readonly k = 8,
+  ) {}
+
+  async evaluate(evalSet: EvalEntry[], modes: RetrievalMode[] = ['wiki_only', 'graph_rag']): Promise<ModeEvaluationResult[]> {
+    const modeResults: ModeEvaluationResult[] = [];
+
+    for (const mode of modes) {
+      const queryResults: QueryEvaluationResult[] = [];
+
+      for (const entry of evalSet) {
+        const retrievalResults = await this.retrieve({
+          query: entry.query,
+          spaceId: entry.space_id,
+          mode,
+          k: this.k,
+        });
+        const retrievedPages = retrievalResults.map((result) => result.page);
+
+        queryResults.push({
+          entry,
+          retrievedPages,
+          recallAt8: computeRecallAtK(entry.expected_pages, retrievedPages, this.k),
+          reciprocalRank: computeMRR(entry.expected_pages, retrievedPages),
+        });
+      }
+
+      modeResults.push({
+        mode,
+        queries: queryResults,
+        metrics: computeMeanMetrics(queryResults),
+      });
+    }
+
+    return modeResults;
+  }
+}
+
+export function createDeterministicFixtureRetriever(): RetrievalFunction {
+  return ({ query, mode, k }) => {
+    const queryTerms = tokenize(query);
+    const scoredPages = PAGE_FIXTURES.map((page) => {
+      const wikiScore = scorePage(queryTerms, page);
+      const graphScore =
+        mode === 'graph_rag'
+          ? page.graphNeighbors.reduce((total, neighborId) => {
+              const neighbor = PAGE_FIXTURES.find((candidate) => candidate.id === neighborId);
+              return total + (neighbor ? scorePage(queryTerms, neighbor) * 0.35 : 0);
+            }, 0)
+          : 0;
+
+      return {
+        page: page.id,
+        score: wikiScore + graphScore,
+      };
+    });
+
+    return scoredPages
+      .sort((a, b) => b.score - a.score || PAGE_IDS.indexOf(a.page as PageId) - PAGE_IDS.indexOf(b.page as PageId))
+      .slice(0, k);
+  };
+}
+
+export function createStaticRetriever(resultsByModeAndQuery: StaticRetrievalResults): RetrievalFunction {
+  return ({ query, mode, k }) => (resultsByModeAndQuery[mode]?.[query] ?? []).slice(0, k);
+}
+
+export function formatComparisonTable(results: ModeEvaluationResult[]): string {
+  const byMode = new Map(results.map((result) => [result.mode, result.metrics]));
+  const rows = [
+    ['Metric', 'wiki_only', 'graph_rag'],
+    ['recall@8', formatMetric(byMode.get('wiki_only')?.recallAt8), formatMetric(byMode.get('graph_rag')?.recallAt8)],
+    ['MRR', formatMetric(byMode.get('wiki_only')?.mrr), formatMetric(byMode.get('graph_rag')?.mrr)],
+  ];
+
+  const widths = [14, 11, 11];
+  const horizontal = (left: string, middle: string, right: string) =>
+    `${left}${widths.map((width) => '─'.repeat(width)).join(middle)}${right}`;
+  const row = (cells: string[]) =>
+    `│${cells.map((cell, index) => ` ${cell.padEnd(widths[index] - 2)} `).join('│')}│`;
+
+  return [
+    horizontal('┌', '┬', '┐'),
+    row(rows[0]),
+    horizontal('├', '┼', '┤'),
+    row(rows[1]),
+    row(rows[2]),
+    horizontal('└', '┴', '┘'),
+  ].join('\n');
+}
+
+export async function runEvaluation(options: { evalSetPath?: string; retrieve?: RetrievalFunction; k?: number } = {}): Promise<string> {
+  const evalSet = await loadEvalSet(options.evalSetPath);
+  const evaluator = new RetrievalEvaluator(options.retrieve, options.k ?? 8);
+  const results = await evaluator.evaluate(evalSet);
+  return formatComparisonTable(results);
+}
+
+function validateEvalEntry(entry: unknown, index: number): EvalEntry {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error(`Eval entry ${index} must be an object`);
+  }
+
+  const candidate = entry as Partial<EvalEntry>;
+  if (
+    typeof candidate.query !== 'string' ||
+    !Array.isArray(candidate.expected_pages) ||
+    candidate.expected_pages.some((page) => typeof page !== 'string') ||
+    typeof candidate.expected_content_snippet !== 'string' ||
+    typeof candidate.space_id !== 'string'
+  ) {
+    throw new Error(`Eval entry ${index} has invalid shape`);
+  }
+
+  return {
+    query: candidate.query,
+    expected_pages: candidate.expected_pages,
+    expected_content_snippet: candidate.expected_content_snippet,
+    space_id: candidate.space_id,
+  };
+}
+
+function scorePage(queryTerms: string[], page: PageFixture): number {
+  const titleTerms = tokenize(page.title);
+  const aliasTerms = page.aliases.flatMap((alias) => tokenize(alias));
+  const keywordSet = new Set(page.keywords);
+  const titleSet = new Set(titleTerms);
+  const aliasSet = new Set(aliasTerms);
+
+  return queryTerms.reduce((score, term) => {
+    if (titleSet.has(term)) {
+      return score + 3;
+    }
+    if (aliasSet.has(term)) {
+      return score + 2;
+    }
+    if (keywordSet.has(term)) {
+      return score + 1;
+    }
+    return score;
+  }, 0);
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .split(' ')
+    .filter(Boolean);
+}
+
+function formatMetric(value: number | undefined): string {
+  return (value ?? 0).toFixed(3);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const table = await runEvaluation();
+  console.log(table);
+}

--- a/tests/e2e/fixtures/golden/eval-set.json
+++ b/tests/e2e/fixtures/golden/eval-set.json
@@ -1,0 +1,122 @@
+[
+  {
+    "query": "How does JWT authentication work?",
+    "expected_pages": ["jwt-authentication", "auth-system"],
+    "expected_content_snippet": "short-lived access tokens (1h TTL) paired with rotating refresh tokens",
+    "space_id": "test-space"
+  },
+  {
+    "query": "What is the token refresh flow?",
+    "expected_pages": ["jwt-authentication", "auth-system"],
+    "expected_content_snippet": "Old refresh token is invalidated on rotation",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How long do access and refresh tokens last?",
+    "expected_pages": ["jwt-authentication", "auth-system"],
+    "expected_content_snippet": "Access tokens have a 1-hour TTL, while refresh tokens last 7 days",
+    "space_id": "test-space"
+  },
+  {
+    "query": "Where are refresh tokens stored for revocation?",
+    "expected_pages": ["jwt-authentication"],
+    "expected_content_snippet": "Refresh tokens are stored in the sessions table for explicit revocation",
+    "space_id": "test-space"
+  },
+  {
+    "query": "What happens when a user logs in?",
+    "expected_pages": ["jwt-authentication", "auth-system"],
+    "expected_content_snippet": "User submits credentials to `POST /api/auth/login`",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How are authentication events audited?",
+    "expected_pages": ["jwt-authentication"],
+    "expected_content_snippet": "All authentication events are logged to audit_logs",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How are failed login attempts limited?",
+    "expected_pages": ["jwt-authentication"],
+    "expected_content_snippet": "Failed login attempts are rate-limited (5/min per IP)",
+    "space_id": "test-space"
+  },
+  {
+    "query": "What does session management track?",
+    "expected_pages": ["auth-system", "jwt-authentication"],
+    "expected_content_snippet": "session records tracking device information, IP address, and last activity",
+    "space_id": "test-space"
+  },
+  {
+    "query": "What connects RBAC to JWT?",
+    "expected_pages": ["jwt-authentication", "rbac-permission-model", "auth-system"],
+    "expected_content_snippet": "Integrates with **RBAC Permission Model** for authorization",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How does the RBAC permission model work?",
+    "expected_pages": ["rbac-permission-model", "permission-system"],
+    "expected_content_snippet": "role hierarchies, group-based permission assignment, and space-scoped authorization",
+    "space_id": "test-space"
+  },
+  {
+    "query": "What roles exist in the permission system?",
+    "expected_pages": ["rbac-permission-model", "permission-system"],
+    "expected_content_snippet": "viewer | Read-only access to assigned Spaces",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How do groups grant access to spaces?",
+    "expected_pages": ["rbac-permission-model", "permission-system"],
+    "expected_content_snippet": "Users are assigned to Groups, and Groups hold permissions on Spaces",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How are permissions resolved across group memberships?",
+    "expected_pages": ["rbac-permission-model", "permission-system"],
+    "expected_content_snippet": "maximum level across all their group memberships for that Space",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How do permissions relate to spaces?",
+    "expected_pages": ["permission-system", "rbac-permission-model"],
+    "expected_content_snippet": "Permissions are scoped to individual Spaces",
+    "space_id": "test-space"
+  },
+  {
+    "query": "What are the space permission levels?",
+    "expected_pages": ["permission-system"],
+    "expected_content_snippet": "`space:read`, `space:write`, and `space:admin`",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How quickly do permission revocations take effect?",
+    "expected_pages": ["permission-system"],
+    "expected_content_snippet": "permission revocations take effect within 5 seconds",
+    "space_id": "test-space"
+  },
+  {
+    "query": "What triggers permission version updates?",
+    "expected_pages": ["permission-system"],
+    "expected_content_snippet": "Space Permissions **triggers** Permission Version updates",
+    "space_id": "test-space"
+  },
+  {
+    "query": "Which pages are in the generated wiki?",
+    "expected_pages": ["index"],
+    "expected_content_snippet": "Pages: 4",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How many communities and god nodes were generated?",
+    "expected_pages": ["index"],
+    "expected_content_snippet": "Communities: 4",
+    "space_id": "test-space"
+  },
+  {
+    "query": "How does session management enforce authorization?",
+    "expected_pages": ["auth-system", "permission-system", "rbac-permission-model"],
+    "expected_content_snippet": "Session Management **enforces** RBAC Model",
+    "space_id": "test-space"
+  }
+]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'apps/**/src/**/*.test.ts',
       'apps/**/src/**/*.spec.ts',
       'apps/**/src/**/*.test.tsx',
+      'scripts/**/*.test.ts',
       'tests/**/*.test.ts',
     ],
     exclude: runsExplicitWebTest ? configDefaults.exclude : [...configDefaults.exclude, 'apps/web/**'],


### PR DESCRIPTION
## Summary

- Create 20-entry golden eval set (`tests/e2e/fixtures/golden/eval-set.json`)
- Implement `scripts/eval-retrieval.ts` with pluggable retrieval, recall@8, MRR, and comparison table
- 10 unit tests covering metrics correctness, edge cases, determinism, and formatting

Closes #343

## OpenSpec Change

`openspec/changes/lightrag-retrieval-integration/` (retrieval-evaluation-harness)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `e76d7ad0775b6cd8f063de3d55778862a17ce046`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/347#issuecomment-4457856643) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/347#issuecomment-4457856890) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/347#issuecomment-4457857118) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/347#issuecomment-4457857424)
- Key findings addressed: Phase 7 identified missing k-cutoff boundary and empty expected_pages edge case tests — both added.

## Test plan

- [x] Build passes
- [x] 10 eval-retrieval tests pass (including edge cases)
- [x] eval-set.json has 20 entries covering auth/permission topics
- [x] Deterministic: repeated runs produce identical metrics
- [x] recall@8 correctly excludes hits beyond k cutoff