### PR TITLE
fix(auth): refresh_token cookie Secure flag breaks HTTP dev sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,9 @@ APP_URL=http://localhost
 JWT_SECRET=change-me-in-production-32-characters-minimum
 JWT_EXPIRES_IN=1h
 REFRESH_TOKEN_EXPIRES_IN=7d
-# Set to "false" for HTTP dev environments; defaults to true when NODE_ENV=production
-COOKIE_SECURE=false
+# Cookie Secure flag: omit or set to "true" for production (HTTPS).
+# Uncomment and set to "false" only for HTTP-only dev environments.
+# COOKIE_SECURE=false
 
 # --- Stage 1 Admin Seed / Tenant ---
 ADMIN_EMAIL=admin@cherrywiki.local

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ APP_URL=http://localhost
 JWT_SECRET=change-me-in-production-32-characters-minimum
 JWT_EXPIRES_IN=1h
 REFRESH_TOKEN_EXPIRES_IN=7d
+# Set to "false" for HTTP dev environments; defaults to true when NODE_ENV=production
+COOKIE_SECURE=false
 
 # --- Stage 1 Admin Seed / Tenant ---
 ADMIN_EMAIL=admin@cherrywiki.local

--- a/apps/api/src/auth/__tests__/auth.controller.test.ts
+++ b/apps/api/src/auth/__tests__/auth.controller.test.ts
@@ -70,6 +70,8 @@ type SessionServiceMock = {
 };
 
 const originalJwtSecret = process.env.JWT_SECRET;
+const originalNodeEnv = process.env.NODE_ENV;
+const originalCookieSecure = process.env.COOKIE_SECURE;
 
 let app: NestFastifyApplication | undefined;
 let authServiceMock: AuthServiceMock;
@@ -87,6 +89,7 @@ describe('AuthController', () => {
     app = undefined;
     vi.restoreAllMocks();
     restoreJwtSecret();
+    restoreCookieEnv();
   });
 
   it('applies the login rate-limit decorator', () => {
@@ -238,6 +241,96 @@ describe('AuthController', () => {
       expect.objectContaining({ refreshToken: undefined }),
       expect.any(Object),
     );
+  });
+
+  describe('cookie Secure flag', () => {
+    it('sets Secure on login when NODE_ENV=production and COOKIE_SECURE is unset', async () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.COOKIE_SECURE;
+      app = await createTestApp();
+      authServiceMock.login.mockResolvedValue(createLoginResponse());
+
+      const response = await request(app.getHttpAdapter().getInstance().server)
+        .post('/api/auth/login')
+        .send({ email: TEST_EMAIL, password: 'Correct1!' })
+        .expect(200);
+
+      expect(getSetCookieHeader(response)).toContain('; Secure');
+    });
+
+    it('sets Secure on login when NODE_ENV=production and COOKIE_SECURE=true', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.COOKIE_SECURE = 'true';
+      app = await createTestApp();
+      authServiceMock.login.mockResolvedValue(createLoginResponse());
+
+      const response = await request(app.getHttpAdapter().getInstance().server)
+        .post('/api/auth/login')
+        .send({ email: TEST_EMAIL, password: 'Correct1!' })
+        .expect(200);
+
+      expect(getSetCookieHeader(response)).toContain('; Secure');
+    });
+
+    it('omits Secure on login when NODE_ENV=development', async () => {
+      process.env.NODE_ENV = 'development';
+      delete process.env.COOKIE_SECURE;
+      app = await createTestApp();
+      authServiceMock.login.mockResolvedValue(createLoginResponse());
+
+      const response = await request(app.getHttpAdapter().getInstance().server)
+        .post('/api/auth/login')
+        .send({ email: TEST_EMAIL, password: 'Correct1!' })
+        .expect(200);
+
+      expect(getSetCookieHeader(response)).not.toContain('; Secure');
+    });
+
+    it('omits Secure on login when COOKIE_SECURE=false regardless of NODE_ENV', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.COOKIE_SECURE = 'false';
+      app = await createTestApp();
+      authServiceMock.login.mockResolvedValue(createLoginResponse());
+
+      const response = await request(app.getHttpAdapter().getInstance().server)
+        .post('/api/auth/login')
+        .send({ email: TEST_EMAIL, password: 'Correct1!' })
+        .expect(200);
+
+      expect(getSetCookieHeader(response)).not.toContain('; Secure');
+    });
+
+    it('sets Secure on logout cookie clearing in production', async () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.COOKIE_SECURE;
+      app = await createTestApp();
+      authServiceMock.logout.mockResolvedValue({ success: true });
+
+      const response = await request(app.getHttpAdapter().getInstance().server)
+        .post('/api/auth/logout')
+        .set('Authorization', `Bearer ${await createAccessToken()}`)
+        .set('Cookie', ['refresh_token=refresh-token'])
+        .expect(200);
+
+      expect(getSetCookieHeader(response)).toContain('Max-Age=0');
+      expect(getSetCookieHeader(response)).toContain('; Secure');
+    });
+
+    it('omits Secure on logout cookie clearing in development', async () => {
+      process.env.NODE_ENV = 'development';
+      delete process.env.COOKIE_SECURE;
+      app = await createTestApp();
+      authServiceMock.logout.mockResolvedValue({ success: true });
+
+      const response = await request(app.getHttpAdapter().getInstance().server)
+        .post('/api/auth/logout')
+        .set('Authorization', `Bearer ${await createAccessToken()}`)
+        .set('Cookie', ['refresh_token=refresh-token'])
+        .expect(200);
+
+      expect(getSetCookieHeader(response)).toContain('Max-Age=0');
+      expect(getSetCookieHeader(response)).not.toContain('; Secure');
+    });
   });
 
   it('GET /api/auth/me requires auth and returns the current user shape', async () => {
@@ -442,6 +535,15 @@ function getControllerMethod(prototype: object, methodName: string): object {
   return value;
 }
 
+function getSetCookieHeader(response: request.Response): string {
+  const value = response.headers['set-cookie'];
+  if (!Array.isArray(value) || typeof value[0] !== 'string') {
+    throw new Error('Expected Set-Cookie header');
+  }
+
+  return value[0];
+}
+
 function restoreJwtSecret(): void {
   if (originalJwtSecret === undefined) {
     delete process.env.JWT_SECRET;
@@ -449,4 +551,19 @@ function restoreJwtSecret(): void {
   }
 
   process.env.JWT_SECRET = originalJwtSecret;
+}
+
+function restoreCookieEnv(): void {
+  if (originalNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+
+  if (originalCookieSecure === undefined) {
+    delete process.env.COOKIE_SECURE;
+    return;
+  }
+
+  process.env.COOKIE_SECURE = originalCookieSecure;
 }

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -229,19 +229,25 @@ function getRequestMetadata(request: RequestWithAuth): AuthRequestMetadata {
 }
 
 function setRefreshCookie(response: CookieResponse, refreshToken: string): void {
+  const securePart = isCookieSecure() ? '; Secure' : '';
   setResponseHeader(
     response,
     'Set-Cookie',
-    `${REFRESH_COOKIE_NAME}=${encodeURIComponent(refreshToken)}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}; Path=/api/auth; HttpOnly; Secure; SameSite=Lax`,
+    `${REFRESH_COOKIE_NAME}=${encodeURIComponent(refreshToken)}; Max-Age=${REFRESH_COOKIE_MAX_AGE_SECONDS}; Path=/api/auth; HttpOnly${securePart}; SameSite=Lax`,
   );
 }
 
 function clearRefreshCookie(response: CookieResponse): void {
+  const securePart = isCookieSecure() ? '; Secure' : '';
   setResponseHeader(
     response,
     'Set-Cookie',
-    `${REFRESH_COOKIE_NAME}=; Max-Age=0; Path=/api/auth; HttpOnly; Secure; SameSite=Lax`,
+    `${REFRESH_COOKIE_NAME}=; Max-Age=0; Path=/api/auth; HttpOnly${securePart}; SameSite=Lax`,
   );
+}
+
+function isCookieSecure(): boolean {
+  return process.env.COOKIE_SECURE !== 'false' && process.env.NODE_ENV === 'production';
 }
 
 function getRefreshTokenCookie(request: RequestWithAuth): string | undefined {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       JWT_SECRET: ${JWT_SECRET:-dev-secret-minimum-32-characters-long-replace-in-production}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-1h}
       REFRESH_TOKEN_EXPIRES_IN: ${REFRESH_TOKEN_EXPIRES_IN:-7d}
-      COOKIE_SECURE: "false"
+      COOKIE_SECURE: "${COOKIE_SECURE:-false}"
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@cherrywiki.local}
       ADMIN_PASSWORD: "${ADMIN_PASSWORD:-ChangeMe123!}"
       DEFAULT_TENANT_ID: ${DEFAULT_TENANT_ID:-default}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       JWT_SECRET: ${JWT_SECRET:-dev-secret-minimum-32-characters-long-replace-in-production}
       JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:-1h}
       REFRESH_TOKEN_EXPIRES_IN: ${REFRESH_TOKEN_EXPIRES_IN:-7d}
+      COOKIE_SECURE: "false"
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@cherrywiki.local}
       ADMIN_PASSWORD: "${ADMIN_PASSWORD:-ChangeMe123!}"
       DEFAULT_TENANT_ID: ${DEFAULT_TENANT_ID:-default}

--- a/openspec/changes/auth-cookie-session-fix/tasks.md
+++ b/openspec/changes/auth-cookie-session-fix/tasks.md
@@ -1,0 +1,15 @@
+## Tasks
+
+### cookie-secure-env
+
+- [ ] 1.1 修改 `apps/api/src/auth/auth.controller.ts` 中 `setRefreshCookie` 函数，将硬编码 `Secure` 改为根据 `COOKIE_SECURE` 环境变量和 `NODE_ENV` 动态决定
+- [ ] 1.2 同步修改 `clearRefreshCookie` 函数使用相同的 Secure 策略
+- [ ] 1.3 在 `docker-compose.yml` 的 cherry-api 服务中添加 `COOKIE_SECURE: "false"`
+- [ ] 1.4 在 `.env.example` 中添加 `COOKIE_SECURE` 变量说明
+- [ ] 1.5 补充 `apps/api/src/auth/__tests__/` 中 cookie 属性的单元测试：
+  - [ ] 1.5.1 REQ-1 Scenario 1: NODE_ENV=production 且未设 COOKIE_SECURE → cookie 包含 Secure
+  - [ ] 1.5.2 REQ-1 Scenario 2: NODE_ENV=production 且 COOKIE_SECURE=true → cookie 包含 Secure
+  - [ ] 1.5.3 REQ-1 Scenario 3: NODE_ENV=development → cookie 不包含 Secure
+  - [ ] 1.5.4 REQ-1 Scenario 4: COOKIE_SECURE=false（任意 NODE_ENV）→ cookie 不包含 Secure
+  - [ ] 1.5.5 REQ-2: clearRefreshCookie 的 Secure 策略与 setRefreshCookie 一致（至少 2 个 scenario）
+- [ ] 1.6 手动验证：HTTP 环境下登录后刷新页面不跳回登录页


### PR DESCRIPTION
## Summary

- HTTP dev 环境（`http://localhost`）下 refresh_token cookie 硬编码 `Secure` 标志，浏览器拒绝保存 cookie，每次刷新丢失登录状态
- 引入 `COOKIE_SECURE` 环境变量（fallback 到 `NODE_ENV=production`），仅在生产环境设置 Secure
- docker-compose.yml 开发配置使用 `${COOKIE_SECURE:-false}` 可覆盖

## Changes

- `apps/api/src/auth/auth.controller.ts`: 新增 `isCookieSecure()` 辅助函数，`setRefreshCookie` 和 `clearRefreshCookie` 使用动态 Secure 标志
- `apps/api/src/auth/__tests__/auth.controller.test.ts`: 6 个测试覆盖 REQ-1 的 4 个 scenario + REQ-2 的 2 个 scenario
- `docker-compose.yml`: cherry-api 添加 `COOKIE_SECURE: "${COOKIE_SECURE:-false}"`
- `.env.example`: 添加 `COOKIE_SECURE` 变量说明（注释状态，生产安全）

## Test plan

- [x] 20 个单元测试通过（包括 6 个新增 cookie Secure 测试）
- [x] 构建成功（npm run build）
- [ ] HTTP 环境下登录后刷新页面不跳回登录

Closes #348

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `7bd27972fa38a187787aa67f3a8cb259e2c5a204`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/352#issuecomment-4459462816) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/352#issuecomment-4459463058) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/352#issuecomment-4459463275) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/352#issuecomment-4459463536)
- Key findings addressed: docker-compose COOKIE_SECURE hardcode → env passthrough; .env.example unsafe default → commented out