### PR TITLE
fix(web): Space selector not refreshing after creation

### DIFF
--- a/apps/web/src/__tests__/spaces-page.test.tsx
+++ b/apps/web/src/__tests__/spaces-page.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../i18n';
+import AppShell from '../components/AppShell';
+import { AuthProvider, type AuthUser } from '../lib/auth';
+import type { AdminGroup, AdminSpace } from '../lib/adminTypes';
+import SpacesPage from '../pages/admin/SpacesPage';
+import { ThemeProvider } from '../theme/ThemeProvider';
+
+const ADMIN_NO_SPACES: AuthUser = {
+  id: 'user-admin',
+  email: 'admin@example.com',
+  name: 'Admin User',
+  role: 'admin',
+  groups: [],
+  spaces: [],
+};
+
+const CREATED_SPACE = buildAdminSpace({
+  id: 'space-new',
+  name: 'New Space',
+  slug: 'new-space',
+});
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('SpacesPage', () => {
+  it('refreshes the current user after successful space creation', async () => {
+    const fetchMock = stubSpacesPageApi({ createSucceeds: true });
+
+    renderSpacesPage();
+
+    await createSpace();
+
+    await waitFor(() => {
+      expect(getRequestPaths(fetchMock)).toContain('/api/auth/me');
+    });
+    expect(getRequestPaths(fetchMock).filter((path) => path === '/api/auth/me')).toHaveLength(1);
+  });
+
+  it('enables the shell space selector and includes the new space after creation', async () => {
+    stubSpacesPageApi({ createSucceeds: true });
+
+    renderSpacesPage();
+
+    await waitFor(() => {
+      expect(getShellSpaceSelectContainer()).toHaveClass('ant-select-disabled');
+    });
+    expect(screen.getAllByText('No spaces available').length).toBeGreaterThan(0);
+
+    await createSpace();
+
+    await waitFor(() => {
+      expect(getShellSpaceSelectContainer()).not.toHaveClass('ant-select-disabled');
+    });
+    expect(within(getShellSpaceSelectContainer()).getByText('New Space')).toBeInTheDocument();
+  });
+
+  it('keeps the selector disabled and does not refresh the current user when creation fails', async () => {
+    const fetchMock = stubSpacesPageApi({ createSucceeds: false });
+
+    renderSpacesPage();
+
+    await waitFor(() => {
+      expect(getShellSpaceSelectContainer()).toHaveClass('ant-select-disabled');
+    });
+
+    await createSpace();
+
+    await waitFor(() => {
+      expect(getRequestPaths(fetchMock).filter((path) => path === '/api/spaces')).toHaveLength(2);
+    });
+    expect(getShellSpaceSelectContainer()).toHaveClass('ant-select-disabled');
+    expect(screen.getAllByText('No spaces available').length).toBeGreaterThan(0);
+    expect(getRequestPaths(fetchMock)).not.toContain('/api/auth/me');
+    expect(screen.queryByText('New Space')).not.toBeInTheDocument();
+  });
+});
+
+function renderSpacesPage(user: AuthUser = ADMIN_NO_SPACES) {
+  return render(
+    <MemoryRouter initialEntries={['/admin/spaces']}>
+      <AuthProvider initialSession={{ user, accessToken: 'test-token' }}>
+        <ThemeProvider>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/admin/spaces" element={<SpacesPage />} />
+            </Route>
+            <Route path="/login" element={<h1>Login</h1>} />
+          </Routes>
+        </ThemeProvider>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+async function createSpace(): Promise<void> {
+  expect(await screen.findByRole('heading', { name: 'Space Management' })).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Create Space/ }));
+  const dialog = await screen.findByRole('dialog', { name: 'Create Space' });
+  fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'New Space' } });
+  fireEvent.change(within(dialog).getByLabelText('Slug'), { target: { value: 'new-space' } });
+  fireEvent.change(within(dialog).getByLabelText('Description'), { target: { value: 'A new knowledge space' } });
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Create Space' }));
+}
+
+function stubSpacesPageApi({ createSucceeds }: { createSucceeds: boolean }) {
+  let spaces: AdminSpace[] = [];
+
+  const fetchMock = vi.fn<typeof fetch>((input, init) => {
+    const path = getRequestPath(input);
+    const method = init?.method ?? 'GET';
+
+    if (path === '/api/spaces' && method === 'GET') {
+      return Promise.resolve(jsonResponse({ data: spaces, meta: { request_id: 'req-spaces' } }));
+    }
+
+    if (path === '/api/admin/groups' && method === 'GET') {
+      return Promise.resolve(jsonResponse({ data: [] satisfies AdminGroup[], meta: { request_id: 'req-groups' } }));
+    }
+
+    if (path === '/api/spaces' && method === 'POST') {
+      if (!createSucceeds) {
+        return Promise.resolve(jsonResponse({ error: { code: 'CREATE_FAILED', message: 'Create failed' } }, 500));
+      }
+
+      spaces = [CREATED_SPACE];
+      return Promise.resolve(jsonResponse({ data: buildAdminSpaceDetail(CREATED_SPACE), meta: { request_id: 'req-create' } }, 201));
+    }
+
+    if (path === '/api/auth/me' && method === 'GET') {
+      return Promise.resolve(
+        jsonResponse({
+          data: {
+            ...ADMIN_NO_SPACES,
+            groups: [],
+            spaces: [{ id: CREATED_SPACE.id, name: CREATED_SPACE.name, role: 'admin' }],
+          },
+          meta: { request_id: 'req-me' },
+        }),
+      );
+    }
+
+    return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function buildAdminSpace(overrides: Partial<AdminSpace> = {}): AdminSpace {
+  return {
+    id: 'space-1',
+    name: 'Space One',
+    slug: 'space-one',
+    status: 'active',
+    description: null,
+    stats: { page_count: 0, source_count: 0, node_count: 0 },
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildAdminSpaceDetail(space: AdminSpace) {
+  return {
+    ...space,
+    docmost_space_id: null,
+    wiki_repo_path: '/tmp/new-space',
+    active_graphify_run_id: null,
+    active_index_snapshot_id: null,
+    index_consistency_status: 'consistent',
+    strict_knowledge_only: false,
+    graphify_config: {},
+    default_publish_policy: 'manual',
+  };
+}
+
+function getShellSpaceSelectContainer(): HTMLElement {
+  const combobox = screen
+    .getAllByLabelText('Space')
+    .find((element) => element.getAttribute('role') === 'combobox');
+  const container = combobox?.closest('.ant-select');
+
+  if (!(container instanceof HTMLElement)) {
+    throw new Error('Shell space selector was not found');
+  }
+
+  return container;
+}
+
+function getRequestPaths(fetchMock: ReturnType<typeof vi.fn<typeof fetch>>): string[] {
+  return fetchMock.mock.calls.map(([input]) => getRequestPath(input));
+}
+
+function getRequestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input.split('?')[0] ?? input;
+  }
+
+  if (input instanceof URL) {
+    return input.pathname;
+  }
+
+  return input.url.split('?')[0] ?? input.url;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -48,6 +48,7 @@ type AuthContextValue = {
   login: (email: string, password: string) => Promise<AuthUser>;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
+  refreshUser: () => Promise<void>;
   isAuthenticated: boolean;
   isAdmin: boolean;
   hasSpacePermission: (spaceId: string, permission: string) => boolean;
@@ -117,6 +118,19 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
     [refresh, setAccessToken],
   );
 
+  const refreshUser = useCallback(async () => {
+    const previousUser = user;
+    const previousAccessToken = accessTokenRef.current;
+
+    try {
+      const me = await api.get<CurrentUserResponse>('/auth/me');
+      setUser({ ...me, spaces: me.spaces });
+    } catch {
+      setAccessToken(previousAccessToken);
+      setUser(previousUser);
+    }
+  }, [setAccessToken, user]);
+
   const logout = useCallback(async () => {
     try {
       await api.post<{ success: true }>('/auth/logout');
@@ -160,11 +174,12 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
       login,
       logout,
       refresh,
+      refreshUser,
       isAuthenticated: accessToken !== null && user !== null,
       isAdmin: user !== null && isAdminRole(user.role),
       hasSpacePermission,
     }),
-    [accessToken, hasSpacePermission, login, logout, refresh, user],
+    [accessToken, hasSpacePermission, login, logout, refresh, refreshUser, user],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -119,17 +119,16 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
   );
 
   const refreshUser = useCallback(async () => {
-    const previousUser = user;
-    const previousAccessToken = accessTokenRef.current;
-
     try {
       const me = await api.get<CurrentUserResponse>('/auth/me');
       setUser({ ...me, spaces: me.spaces });
     } catch {
-      setAccessToken(previousAccessToken);
-      setUser(previousUser);
+      // On 401 the API client's onUnauthorized handler already clears the
+      // session — restoring stale state here would fight that. For any other
+      // error the existing user/token remain untouched because we never
+      // overwrite them before the fetch succeeds.
     }
-  }, [setAccessToken, user]);
+  }, []);
 
   const logout = useCallback(async () => {
     try {

--- a/apps/web/src/pages/admin/SpacesPage.tsx
+++ b/apps/web/src/pages/admin/SpacesPage.tsx
@@ -22,6 +22,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { requireAdminPage } from '../../components/RequireAdminPage';
 import { api } from '../../lib/api';
+import { useAuth } from '../../lib/auth';
 import { getErrorMessage } from '../../components/adminUi';
 import {
   SPACE_PERMISSION_OPTIONS,
@@ -47,6 +48,7 @@ function statusColor(status: string): string {
 
 function SpacesPage() {
   const { t } = useTranslation();
+  const { refreshUser } = useAuth();
   const [spaces, setSpaces] = useState<AdminSpace[]>([]);
   const [groups, setGroups] = useState<AdminGroup[]>([]);
   const [selectedSpace, setSelectedSpace] = useState<AdminSpaceDetail | null>(null);
@@ -92,6 +94,7 @@ function SpacesPage() {
       setCreateForm(null);
       formInstance.resetFields();
       await loadSpaces();
+      await refreshUser();
     } catch (err) {
       if (err && typeof err === 'object' && 'errorFields' in err) return;
       void message.error(getErrorMessage(err));
@@ -157,6 +160,7 @@ function SpacesPage() {
       await api.delete(`/spaces/${space.id}`);
       void message.success(t('admin.spaces.archiveSuccess'));
       await loadSpaces();
+      await refreshUser();
     } catch (err) {
       void message.error(getErrorMessage(err));
       throw err;

--- a/openspec/changes/frontend-data-display-fixes/tasks.md
+++ b/openspec/changes/frontend-data-display-fixes/tasks.md
@@ -1,0 +1,33 @@
+## Tasks
+
+### space-selector-refresh (BUG-002)
+
+- [ ] 1.1 定位前端 Space 创建成功回调位置（Admin Spaces 页面组件）
+- [ ] 1.2 在创建成功后通过 AuthProvider 调用 `api.get('/auth/me')` 刷新用户 spaces 列表，触发侧边栏重渲染
+- [ ] 1.3 验证选择器从 disabled → enabled 且包含新 Space
+- [ ] 1.4 补充前端组件测试：
+  - [ ] 1.4.1 创建 Space 成功后 AuthProvider 刷新，选择器显示新 Space
+  - [ ] 1.4.2 创建 Space 失败时选择器状态不变
+  - [ ] 1.4.3 从 disabled（No spaces）→ enabled 状态转换
+
+### upload-list-display (BUG-003)
+
+- [ ] 2.1 在浏览器 DevTools 中排查 Documents 页面的 Network 请求（确认实际请求 URL 和响应）
+- [ ] 2.2 对比前端组件的 API 调用路径与实际 API 端点
+- [ ] 2.3 修复根因（可能是请求路径、响应解析或缓存问题）
+- [ ] 2.4 验证上传后 Documents 列表正确显示文档
+- [ ] 2.5 补充前端组件测试：
+  - [ ] 2.5.1 API 返回 total>0 时列表正确渲染文档条目
+  - [ ] 2.5.2 API 返回空列表时显示 empty state
+  - [ ] 2.5.3 API 出错时显示错误信息
+
+### docmost-bridge-health (BUG-004)
+
+- [ ] 3.1 检查 `apps/api/src/admin/admin-health.controller.ts` 中 Docmost 探测逻辑（当前探测 `${DOCMOST_BASE_URL}/api/health`）
+- [ ] 3.2 确认 `DOCMOST_BASE_URL` 环境变量在 docker-compose.yml 中的配置值和 Docker 内部 DNS 可达性
+- [ ] 3.3 修复探测 URL 或增加 DOCMOST_BASE_URL 未配置时的优雅降级（返回 Skipped 而非 Unhealthy）
+- [ ] 3.4 补充单元测试：
+  - [ ] 3.4.1 DOCMOST_BASE_URL 未设置时返回 not_configured + 'DOCMOST_BASE_URL not set'
+  - [ ] 3.4.2 DOCMOST_BASE_URL 设置且 Docmost 可达时返回 healthy
+  - [ ] 3.4.3 DOCMOST_BASE_URL 设置但 Docmost 不可达时返回 unhealthy + 具体错误
+- [ ] 3.5 验证 Health 页面 Docmost Bridge 显示正确状态


### PR DESCRIPTION
## Summary

- Admin > Spaces 创建新 Space 后，侧边栏 Space 选择器不刷新，仍显示 "No spaces available"
- 根因：`SpacesPage` 只刷新了本地 admin 表格，未更新 `AuthProvider` 的 `user.spaces`
- 修复：新增 `refreshUser()` 方法到 AuthProvider，创建/删除 Space 后调用

## Changes

- `apps/web/src/lib/auth.tsx`: 新增 `refreshUser()` callback，调用 `/auth/me` 更新用户 spaces
- `apps/web/src/pages/admin/SpacesPage.tsx`: 创建和归档成功后调用 `refreshUser()`
- `apps/web/src/__tests__/spaces-page.test.tsx`: 3 个测试覆盖 spec 全部 scenario

## Test plan

- [x] 3 个前端组件测试通过
- [x] 构建成功

Closes #349

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `b6f67a3977986cc185f354c27858d4efbd757e47`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/353#issuecomment-4459717208) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/353#issuecomment-4459717480) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/353#issuecomment-4459717709) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/353#issuecomment-4459718142)
- Key findings addressed: refreshUser catch block no longer restores stale auth state on 401 (session integrity fix)