### PR TITLE
fix(web): Documents page not displaying uploaded files

### DIFF
--- a/apps/web/src/__tests__/uploads.test.tsx
+++ b/apps/web/src/__tests__/uploads.test.tsx
@@ -210,6 +210,93 @@ describe('UploadList', () => {
 });
 
 describe('UploadCenter', () => {
+  it('renders upload items when the API returns paginated data', async () => {
+    const upload = buildUpload({
+      id: 'source-visible',
+      filename: 'visible-document.md',
+      status: 'parsed',
+      mime_type: 'text/markdown',
+    });
+    stubUploadListApiResponse({
+      data: [upload],
+      meta: {
+        pagination: {
+          page: 1,
+          per_page: 20,
+          total: 1,
+          has_next: false,
+        },
+      },
+    });
+
+    renderUploadCenter();
+
+    expect(await screen.findByText('visible-document.md')).toBeInTheDocument();
+    expect(screen.queryByText('No documents in this space yet.')).not.toBeInTheDocument();
+  });
+
+  it('renders upload items when paginated data is nested in the wrapped response', async () => {
+    const upload = buildUpload({
+      id: 'source-nested',
+      filename: 'nested-document.pdf',
+      status: 'parsed',
+      mime_type: 'application/pdf',
+    });
+    stubUploadListApiResponse({
+      data: {
+        data: [upload],
+        pagination: {
+          page: 1,
+          per_page: 20,
+          total: 1,
+          has_next: false,
+        },
+      },
+      meta: {
+        request_id: 'req-nested',
+      },
+    });
+
+    renderUploadCenter();
+
+    expect(await screen.findByText('nested-document.pdf')).toBeInTheDocument();
+    expect(screen.queryByText('No documents in this space yet.')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when the upload API returns no data', async () => {
+    stubUploadListApiResponse({
+      data: [],
+      meta: {
+        pagination: {
+          page: 1,
+          per_page: 20,
+          total: 0,
+          has_next: false,
+        },
+      },
+    });
+
+    renderUploadCenter();
+
+    expect(await screen.findByText('No documents in this space yet.')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the upload API fails', async () => {
+    stubUploadListApiResponse(
+      {
+        error: {
+          code: 'UPLOAD_LIST_FAILED',
+          message: 'Could not load uploads',
+        },
+      },
+      500,
+    );
+
+    renderUploadCenter();
+
+    expect(await screen.findByText('Could not load uploads')).toBeInTheDocument();
+  });
+
   it('loads documents with search, source type, and sort query parameters', { timeout: 30000 }, async () => {
     const fetchMock = stubUploadListApi();
 
@@ -527,21 +614,23 @@ function stubUploadListApi(upload: UploadItem = buildUpload({
   status: 'parsed',
   mime_type: 'application/pdf',
 })) {
+  return stubUploadListApiResponse({
+    data: [upload],
+    meta: {
+      pagination: {
+        page: 1,
+        per_page: 20,
+        total: 1,
+        has_next: false,
+      },
+    },
+  });
+}
+
+function stubUploadListApiResponse(body: unknown, status = 200) {
   const fetchMock = vi.fn<typeof fetch>((input, init) => {
     if (getRequestPath(input) === '/api/spaces/space-1/uploads' && init?.method === 'GET') {
-      return Promise.resolve(
-        jsonResponse({
-          data: [upload],
-          meta: {
-            pagination: {
-              page: 1,
-              per_page: 20,
-              total: 1,
-              has_next: false,
-            },
-          },
-        }),
-      );
+      return Promise.resolve(jsonResponse(body, status));
     }
 
     return Promise.resolve(jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404));

--- a/apps/web/src/pages/uploads/UploadCenter.tsx
+++ b/apps/web/src/pages/uploads/UploadCenter.tsx
@@ -6,7 +6,7 @@ import { Navigate, useParams } from 'react-router';
 import { getErrorMessage } from '../../components/adminUi';
 import { SpaceForbiddenState, useSpacePermissionGate } from '../../components/SpacePermissionGate';
 import { useUploadPolling } from '../../hooks/useUploadPolling';
-import { type ApiMeta, api } from '../../lib/api';
+import { type ApiMeta, type ApiWrappedResponse, api } from '../../lib/api';
 import { useAuth } from '../../lib/auth';
 import FileUploadZone from './FileUploadZone';
 import UploadDetail from './UploadDetail';
@@ -29,6 +29,13 @@ const DEFAULT_PAGINATION: NonNullable<ApiMeta['pagination']> = {
   total: 0,
   has_next: false,
 };
+
+type NestedUploadListResponse = {
+  data: UploadItem[];
+  pagination?: ApiMeta['pagination'];
+};
+
+type UploadListApiResponse = ApiWrappedResponse<UploadItem[] | NestedUploadListResponse>;
 
 export default function UploadCenter() {
   const { t } = useTranslation();
@@ -79,7 +86,7 @@ export default function UploadCenter() {
         const normalizedSourceType = normalizeUploadSourceTypeFilter(sourceTypeFilter);
         const normalizedSearch = searchTerm.trim();
         const normalizedSort = normalizeUploadSort(sortOrder);
-        const response = await api.getWrapped<UploadItem[]>(`/spaces/${encodeURIComponent(uploadSpaceId)}/uploads`, {
+        const response = await api.getWrapped<UploadItem[] | NestedUploadListResponse>(`/spaces/${encodeURIComponent(uploadSpaceId)}/uploads`, {
           page,
           per_page: UPLOAD_PAGE_SIZE,
           status: normalizedStatus,
@@ -87,16 +94,15 @@ export default function UploadCenter() {
           search: normalizedSearch,
           sort: normalizedSort,
         });
+        const normalized = normalizeUploadListResponse(response, {
+          page,
+          per_page: UPLOAD_PAGE_SIZE,
+          total: 0,
+          has_next: false,
+        });
         if (seq !== requestSeqRef.current) return;
-        setUploads(response.data);
-        setPagination(
-          response.meta?.pagination ?? {
-            page,
-            per_page: UPLOAD_PAGE_SIZE,
-            total: response.data.length,
-            has_next: false,
-          },
-        );
+        setUploads(normalized.uploads);
+        setPagination(normalized.pagination);
       } catch (err) {
         if (seq !== requestSeqRef.current) return;
         setError(getErrorMessage(err));
@@ -393,4 +399,35 @@ function uploadMatchesActiveFilters(
 
   const searchable = `${upload.filename} ${upload.classification ?? ''}`.toLowerCase();
   return searchable.includes(normalizedSearch);
+}
+
+function normalizeUploadListResponse(
+  response: UploadListApiResponse,
+  fallbackPagination: NonNullable<ApiMeta['pagination']>,
+): { uploads: UploadItem[]; pagination: NonNullable<ApiMeta['pagination']> } {
+  if (Array.isArray(response.data)) {
+    return {
+      uploads: response.data,
+      pagination: response.meta?.pagination ?? {
+        ...fallbackPagination,
+        total: response.data.length,
+      },
+    };
+  }
+
+  if (isRecord(response.data) && Array.isArray(response.data.data)) {
+    return {
+      uploads: response.data.data,
+      pagination: response.data.pagination ?? response.meta?.pagination ?? {
+        ...fallbackPagination,
+        total: response.data.data.length,
+      },
+    };
+  }
+
+  throw new Error('Upload list response was malformed');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }


### PR DESCRIPTION
## Summary

- Documents 页面始终显示 "No documents" 即使 API 返回 total>0 的数据
- 根因：`UploadCenter` 假设 `response.data` 总是扁平数组，但分页包装器可能产生嵌套 `{data: {data: [...], pagination}}` 结构
- 修复：添加 `normalizeUploadListResponse` 处理两种响应格式

## Changes

- `apps/web/src/pages/uploads/UploadCenter.tsx`: 新增响应格式标准化函数
- `apps/web/src/__tests__/uploads.test.tsx`: 新增 4 个测试覆盖正常/嵌套/空/错误场景

## Test plan

- [x] 24 个前端测试通过
- [x] 构建成功

Closes #350

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `b698f10205932c45dc7a8a1abb70d69ea51aa9a0`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/354#issuecomment-4459890961) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/354#issuecomment-4459891241) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/354#issuecomment-4459891508) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/354#issuecomment-4459891784)
- Key findings addressed: All reviewers found zero issues — clean pass