### PR TITLE
fix(api): Docmost Bridge health check shows Unhealthy when container is running

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ DEFAULT_CHAT_MODEL=gpt-4.1
 DEFAULT_EMBEDDING_MODEL=text-embedding-3-large
 # Admin model connectivity probes and Docmost health checks block local/private
 # targets unless explicitly approved. This local example allows dev services.
-ADMIN_OUTBOUND_PROBE_ALLOWLIST=localhost,127.0.0.1,::1
+ADMIN_OUTBOUND_PROBE_ALLOWLIST=localhost,127.0.0.1,::1,docmost
 
 # --- Graphify ---
 GRAPHIFY_WORKDIR=/work/graphify
@@ -86,7 +86,8 @@ NO_PROXY=cherry-api,minio,localhost,127.0.0.1
 COMPOSE_PROFILES=docmost
 
 # --- Docmost (Phase 2) ---
-DOCMOST_BASE_URL=http://localhost:3000
+DOCMOST_BASE_URL=http://docmost:3000
+DOCMOST_APP_URL=http://localhost:3000
 DOCMOST_APP_SECRET=dev-docmost-app-secret-minimum-32-chars
 DOCMOST_DB_PASSWORD=docmost_dev
 DOCMOST_BRIDGE_SECRET=dev-docmost-bridge-secret

--- a/apps/api/src/admin/__tests__/admin-health.test.ts
+++ b/apps/api/src/admin/__tests__/admin-health.test.ts
@@ -229,6 +229,25 @@ describe('AdminHealthController', () => {
     });
   });
 
+  it('allows the Docker Docmost hostname when it is explicitly allowlisted', async () => {
+    const { controller } = createController();
+    const fetchMock = mockFetchResponse(200);
+    setDnsRecords('172.16.0.20');
+
+    const result = await withEnv('ADMIN_OUTBOUND_PROBE_ALLOWLIST', 'localhost,127.0.0.1,::1,docmost', () =>
+      withEnv('DOCMOST_BASE_URL', 'http://docmost:3000', () => controller.getHealth()),
+    );
+
+    expect(result.status).toBe('healthy');
+    expect(result.components.docmost_bridge.status).toBe('healthy');
+    expect(fetchMock).toHaveBeenCalledWith('http://docmost:3000/api/health', {
+      method: 'GET',
+      redirect: 'manual',
+      signal: expect.any(AbortSignal) as unknown,
+      dispatcher: expect.any(Object) as unknown,
+    });
+  });
+
   it('rejects credential-bearing Docmost URLs before fetching', async () => {
     const { controller } = createController();
     const fetchMock = mockFetchResponse(200);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -458,7 +458,7 @@ services:
     image: ${DOCMOST_IMAGE:-docmost/docmost:0.80.1}
     restart: unless-stopped
     environment:
-      APP_URL: ${DOCMOST_APP_URL:-http://localhost:3000}
+      APP_URL: ${DOCMOST_APP_URL:-${DOCMOST_BASE_URL:-http://localhost:3000}}
       APP_SECRET: ${DOCMOST_APP_SECRET:-dev-docmost-app-secret-minimum-32-chars}
       DATABASE_URL: ${DOCMOST_DATABASE_URL:-postgresql://cherrygraph:${POSTGRES_PASSWORD:-cherrygraph_dev}@postgres:5432/docmost}
       REDIS_URL: ${DOCMOST_REDIS_URL:-redis://redis:6379}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -458,7 +458,7 @@ services:
     image: ${DOCMOST_IMAGE:-docmost/docmost:0.80.1}
     restart: unless-stopped
     environment:
-      APP_URL: ${DOCMOST_BASE_URL:-http://localhost:3000}
+      APP_URL: ${DOCMOST_APP_URL:-http://localhost:3000}
       APP_SECRET: ${DOCMOST_APP_SECRET:-dev-docmost-app-secret-minimum-32-chars}
       DATABASE_URL: ${DOCMOST_DATABASE_URL:-postgresql://cherrygraph:${POSTGRES_PASSWORD:-cherrygraph_dev}@postgres:5432/docmost}
       REDIS_URL: ${DOCMOST_REDIS_URL:-redis://redis:6379}

--- a/docs/ops/docker-compose.skeleton.yml
+++ b/docs/ops/docker-compose.skeleton.yml
@@ -235,7 +235,7 @@ services:
     image: ${DOCMOST_IMAGE:-docmost/docmost:0.80.1}
     restart: unless-stopped
     environment:
-      APP_URL: ${DOCMOST_BASE_URL}
+      APP_URL: ${DOCMOST_APP_URL:-${DOCMOST_BASE_URL}}
       APP_SECRET: ${DOCMOST_APP_SECRET}
       DATABASE_URL: ${DOCMOST_DATABASE_URL}
       REDIS_URL: ${DOCMOST_REDIS_URL:-redis://redis:6379}


### PR DESCRIPTION
## Summary

- Health 页面 Docmost Bridge 显示 Unhealthy (fetch failed)，但 Docmost 容器实际 healthy
- 根因：`.env.example` 的 `ADMIN_OUTBOUND_PROBE_ALLOWLIST` 缺少 `docmost`，SSRF 保护阻止对 Docker 内部服务的健康探测
- 修复：添加 `docmost` 到 allowlist，分离 `DOCMOST_BASE_URL`（容器内部）和 `DOCMOST_APP_URL`（浏览器），保留向后兼容 fallback

## Changes

- `.env.example`: allowlist 添加 `docmost`，`DOCMOST_BASE_URL` 改为 `http://docmost:3000`
- `docker-compose.yml`: Docmost 服务 APP_URL 使用 `DOCMOST_APP_URL` + `DOCMOST_BASE_URL` fallback chain
- `docs/ops/docker-compose.skeleton.yml`: 同步更新 APP_URL fallback
- `admin-health.test.ts`: 新增 allowlisted Docker hostname 回归测试

## Test plan

- [x] 22 个后端测试通过
- [x] 构建成功

Closes #351

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `0b4aeadafd1a77387d0e9868cd76e23193a4ea6d`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/355#issuecomment-4460154650) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/355#issuecomment-4460154944) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/355#issuecomment-4460155199) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/355#issuecomment-4460155541)
- Key findings addressed: DOCMOST_APP_URL backward compat fallback to DOCMOST_BASE_URL; ops skeleton synced