### PR TITLE
fix(web): bootstrap refresh on page reload — session lost after F5 (#356)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router';
+import { Spin } from 'antd';
 import { lazy, Suspense } from 'react';
 import AppShell from './components/AppShell';
 import { GuardedSpaceRoute } from './components/SpacePermissionGate';
@@ -124,9 +125,17 @@ export function AppRoutes() {
   );
 }
 
-function ProtectedShell() {
+export function ProtectedShell() {
   const location = useLocation();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isBootstrapping } = useAuth();
+
+  if (isBootstrapping) {
+    return (
+      <div style={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace state={{ from: location.pathname }} />;

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -45,7 +45,20 @@ const VIEWER_NO_SPACES: AuthUser = {
   spaces: [],
 };
 
+function stubBootstrapRefresh(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>(() =>
+      Promise.resolve(jsonResponse({ error: { code: 'NO_SESSION', message: 'Unauthorized' } }, 401)),
+    ),
+  );
+}
+
 function renderRoute(path: string, user?: AuthUser) {
+  if (user === undefined && !vi.isMockFunction(globalThis.fetch)) {
+    stubBootstrapRefresh();
+  }
+
   const routes = <AppRoutes />;
 
   return render(

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -65,6 +65,7 @@ function renderRoute(path: string, user?: AuthUser) {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -101,9 +102,9 @@ describe('App routing', () => {
     expect(screen.getByRole('heading', { name: '登录' })).toBeInTheDocument();
   });
 
-  it('redirects unauthenticated chat access to /login', () => {
+  it('redirects unauthenticated chat access to /login', async () => {
     renderRoute('/spaces/test-space/chat');
-    expect(screen.getByRole('heading', { name: '登录' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
   });
 
   it('renders Chat for /spaces/:spaceId/chat', async () => {
@@ -112,9 +113,9 @@ describe('App routing', () => {
     expect(await screen.findByRole('heading', { name: '聊天' })).toBeInTheDocument();
   });
 
-  it('redirects unauthenticated admin users to /login', () => {
+  it('redirects unauthenticated admin users to /login', async () => {
     renderRoute('/admin');
-    expect(screen.getByRole('heading', { name: '登录' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
   });
 
   it('redirects non-admin from admin routes to /', { timeout: 30000 }, async () => {
@@ -251,7 +252,8 @@ describe('AuthProvider', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Logout' }));
 
     expect(await screen.findByText('anonymous')).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/refresh', expect.objectContaining({ method: 'POST' }));
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -45,18 +45,14 @@ const VIEWER_NO_SPACES: AuthUser = {
   spaces: [],
 };
 
-function stubBootstrapRefresh(): void {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn<typeof fetch>(() =>
-      Promise.resolve(jsonResponse({ error: { code: 'NO_SESSION', message: 'Unauthorized' } }, 401)),
-    ),
-  );
-}
-
 function renderRoute(path: string, user?: AuthUser) {
   if (user === undefined && !vi.isMockFunction(globalThis.fetch)) {
-    stubBootstrapRefresh();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>(() =>
+        Promise.resolve(jsonResponse({ error: { code: 'NO_SESSION', message: 'Unauthorized' } }, 401)),
+      ),
+    );
   }
 
   const routes = <AppRoutes />;
@@ -87,9 +83,9 @@ describe('App routing', () => {
     await i18n.changeLanguage('zh-CN');
   });
 
-  it('redirects unauthenticated / to /login', async () => {
+  it('redirects unauthenticated / to /login', { timeout: 15000 }, async () => {
     renderRoute('/');
-    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: '登录' }, { timeout: 10000 })).toBeInTheDocument();
   });
 
   it('redirects authenticated admin with spaces to first space overview', { timeout: 30000 }, async () => {

--- a/apps/web/src/__tests__/auth-bootstrap.test.tsx
+++ b/apps/web/src/__tests__/auth-bootstrap.test.tsx
@@ -1,0 +1,350 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../i18n';
+import { ProtectedShell } from '../App';
+import { AuthProvider, type AuthUser } from '../lib/auth';
+import Login from '../pages/Login';
+import { ThemeProvider } from '../theme/ThemeProvider';
+
+const BOOTSTRAP_USER: AuthUser = {
+  id: 'user-bootstrap',
+  email: 'bootstrap@example.com',
+  name: 'Bootstrap User',
+  role: 'admin',
+  groups: [],
+  spaces: [{ id: 'space-main', name: 'Main Space', role: 'admin' }],
+};
+
+beforeEach(async () => {
+  await i18n.changeLanguage('zh-CN');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('auth bootstrap session persistence', () => {
+  it('restores a valid cookie session and renders protected content instead of login', async () => {
+    const fetchMock = stubBootstrapApi();
+
+    renderApp('/');
+
+    expect(await screen.findByText('protected-home')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: '登录' })).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/me',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.any(Headers),
+      }),
+    );
+    expect(new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get('Authorization')).toBe('Bearer access-bootstrap');
+  });
+
+  it('redirects to /login after bootstrap when no refresh cookie exists', async () => {
+    stubBootstrapRefreshFailure('NO_REFRESH_TOKEN');
+
+    renderApp('/spaces/space-main/protected');
+
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    expect(screen.queryByText('protected-space')).not.toBeInTheDocument();
+  });
+
+  it('redirects to /login after bootstrap when the refresh token is revoked', async () => {
+    stubBootstrapRefreshFailure('REFRESH_TOKEN_REVOKED');
+
+    renderApp('/spaces/space-main/protected');
+
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    expect(screen.queryByText('protected-space')).not.toBeInTheDocument();
+  });
+
+  it('shows loading and does not render the login page while refresh is delayed', async () => {
+    const refreshRequest = createDeferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/auth/refresh') {
+        return refreshRequest.promise;
+      }
+
+      if (path === '/api/auth/me') {
+        return Promise.resolve(jsonResponse({ data: BOOTSTRAP_USER }));
+      }
+
+      return Promise.resolve(notFoundResponse());
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderApp('/spaces/space-main/protected');
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/auth/refresh', expect.objectContaining({ method: 'POST' })));
+    expect(document.querySelector('.ant-spin')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: '登录' })).not.toBeInTheDocument();
+    expect(screen.queryByText('protected-space')).not.toBeInTheDocument();
+
+    refreshRequest.resolve(jsonResponse({ data: { access_token: 'access-bootstrap', expires_in: 3600 } }));
+
+    expect(await screen.findByText('protected-space')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: '登录' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the login flow working after a fresh visitor bootstrap refresh fails', async () => {
+    const fetchMock = vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/auth/refresh') {
+        return Promise.resolve(unauthorizedResponse('NO_REFRESH_TOKEN'));
+      }
+
+      if (path === '/api/auth/login') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            access_token: 'access-login',
+            expires_in: 3600,
+            user: BOOTSTRAP_USER,
+          },
+        }));
+      }
+
+      if (path === '/api/auth/me') {
+        return Promise.resolve(jsonResponse({ data: BOOTSTRAP_USER }));
+      }
+
+      return Promise.resolve(notFoundResponse());
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderApp('/login');
+
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'bootstrap@example.com' } });
+    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: /登\s*录/ }));
+
+    expect(await screen.findByText('protected-home')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('does not let a delayed login-page bootstrap overwrite a submitted login session', async () => {
+    const refreshRequest = createDeferred<Response>();
+    const seenAuthHeaders: Array<string | null> = [];
+    const fetchMock = vi.fn<typeof fetch>((input, init) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/auth/refresh') {
+        return refreshRequest.promise;
+      }
+
+      if (path === '/api/auth/login') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            access_token: 'access-login',
+            expires_in: 3600,
+            user: BOOTSTRAP_USER,
+          },
+        }));
+      }
+
+      if (path === '/api/auth/me') {
+        seenAuthHeaders.push(new Headers(init?.headers).get('Authorization'));
+        return Promise.resolve(jsonResponse({ data: BOOTSTRAP_USER }));
+      }
+
+      return Promise.resolve(notFoundResponse());
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderApp('/login');
+
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'bootstrap@example.com' } });
+    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: /登\s*录/ }));
+
+    expect(await screen.findByText('protected-home')).toBeInTheDocument();
+    refreshRequest.resolve(jsonResponse({ data: { access_token: 'access-bootstrap', expires_in: 3600 } }));
+
+    await waitFor(() => expect(document.querySelector('.ant-spin')).not.toBeInTheDocument());
+    expect(seenAuthHeaders).toEqual(['Bearer access-login']);
+  });
+
+  it('does not authenticate login when /auth/me returns 401 during delayed bootstrap', async () => {
+    const refreshRequest = createDeferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/auth/refresh') {
+        return refreshRequest.promise;
+      }
+
+      if (path === '/api/auth/login') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            access_token: 'access-login',
+            expires_in: 3600,
+            user: BOOTSTRAP_USER,
+          },
+        }));
+      }
+
+      if (path === '/api/auth/me') {
+        return Promise.resolve(unauthorizedResponse('TOKEN_INVALID'));
+      }
+
+      return Promise.resolve(notFoundResponse());
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderApp('/login');
+
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'bootstrap@example.com' } });
+    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: /登\s*录/ }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unauthorized');
+    expect(screen.queryByText('protected-home')).not.toBeInTheDocument();
+
+    refreshRequest.resolve(jsonResponse({ data: { access_token: 'access-bootstrap', expires_in: 3600 } }));
+    await waitFor(() => expect(document.querySelector('.ant-spin')).not.toBeInTheDocument());
+    expect(screen.getByRole('heading', { name: '登录' })).toBeInTheDocument();
+  });
+
+  it('deduplicates bootstrap refresh under StrictMode effect replay', async () => {
+    const fetchMock = stubBootstrapApi();
+
+    renderApp('/', { strictMode: true });
+
+    expect(await screen.findByText('protected-home')).toBeInTheDocument();
+    const refreshCalls = fetchMock.mock.calls.filter((call) => getRequestPath(call[0]) === '/api/auth/refresh');
+    expect(refreshCalls).toHaveLength(1);
+  });
+
+  it('does not stay bootstrapping when /auth/me fails after a successful refresh', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>((input) => {
+        const path = getRequestPath(input);
+
+        if (path === '/api/auth/refresh') {
+          return Promise.resolve(jsonResponse({ data: { access_token: 'access-bootstrap', expires_in: 3600 } }));
+        }
+
+        if (path === '/api/auth/me') {
+          return Promise.resolve(jsonResponse({ error: { code: 'API_ERROR', message: 'Profile unavailable' } }, 500));
+        }
+
+        return Promise.resolve(notFoundResponse());
+      }),
+    );
+
+    renderApp('/spaces/space-main/protected');
+
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    expect(document.querySelector('.ant-spin')).not.toBeInTheDocument();
+    expect(screen.queryByText('protected-space')).not.toBeInTheDocument();
+  });
+});
+
+function renderApp(path: string, options: { strictMode?: boolean } = {}): void {
+  const tree = (
+    <MemoryRouter initialEntries={[path]}>
+      <AuthProvider>
+        <ThemeProvider>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route element={<ProtectedShell />}>
+              <Route path="/" element={<div>protected-home</div>} />
+              <Route path="/spaces/:spaceId/protected" element={<div>protected-space</div>} />
+            </Route>
+          </Routes>
+        </ThemeProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+
+  render(
+    options.strictMode === true ? (
+      <StrictMode>{tree}</StrictMode>
+    ) : (
+      tree
+    ),
+  );
+}
+
+function stubBootstrapApi(): ReturnType<typeof vi.fn<typeof fetch>> {
+  const fetchMock = vi.fn<typeof fetch>((input) => {
+    const path = getRequestPath(input);
+
+    if (path === '/api/auth/refresh') {
+      return Promise.resolve(jsonResponse({ data: { access_token: 'access-bootstrap', expires_in: 3600 } }));
+    }
+
+    if (path === '/api/auth/me') {
+      return Promise.resolve(jsonResponse({ data: BOOTSTRAP_USER }));
+    }
+
+    return Promise.resolve(notFoundResponse());
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  return fetchMock;
+}
+
+function stubBootstrapRefreshFailure(code: string): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<typeof fetch>((input) => {
+      if (getRequestPath(input) === '/api/auth/refresh') {
+        return Promise.resolve(unauthorizedResponse(code));
+      }
+
+      return Promise.resolve(notFoundResponse());
+    }),
+  );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function unauthorizedResponse(code: string): Response {
+  return jsonResponse({ error: { code, message: 'Unauthorized' } }, 401);
+}
+
+function notFoundResponse(): Response {
+  return jsonResponse({ error: { code: 'NOT_FOUND', message: 'Not found' } }, 404);
+}
+
+function getRequestPath(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input.split('?')[0] ?? input;
+  }
+
+  if (input instanceof URL) {
+    return input.pathname;
+  }
+
+  return input.url.split('?')[0] ?? input.url;
+}
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}

--- a/apps/web/src/__tests__/auth-bootstrap.test.tsx
+++ b/apps/web/src/__tests__/auth-bootstrap.test.tsx
@@ -95,7 +95,7 @@ describe('auth bootstrap session persistence', () => {
     expect(screen.queryByRole('heading', { name: '登录' })).not.toBeInTheDocument();
   });
 
-  it('keeps the login flow working after a fresh visitor bootstrap refresh fails', async () => {
+  it('keeps the login flow working after a fresh visitor bootstrap refresh fails', { timeout: 15000 }, async () => {
     const fetchMock = vi.fn<typeof fetch>((input) => {
       const path = getRequestPath(input);
 
@@ -128,7 +128,7 @@ describe('auth bootstrap session persistence', () => {
     fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'password' } });
     fireEvent.click(screen.getByRole('button', { name: /登\s*录/ }));
 
-    expect(await screen.findByText('protected-home')).toBeInTheDocument();
+    expect(await screen.findByText('protected-home', {}, { timeout: 10000 })).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({ method: 'POST' }));
   });
 

--- a/apps/web/src/__tests__/auth-bootstrap.test.tsx
+++ b/apps/web/src/__tests__/auth-bootstrap.test.tsx
@@ -41,7 +41,7 @@ describe('auth bootstrap session persistence', () => {
       '/api/auth/me',
       expect.objectContaining({
         method: 'GET',
-        headers: expect.any(Headers),
+        headers: expect.any(Headers) as Headers,
       }),
     );
     expect(new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get('Authorization')).toBe('Bearer access-bootstrap');

--- a/apps/web/src/__tests__/auth-bootstrap.test.tsx
+++ b/apps/web/src/__tests__/auth-bootstrap.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import i18n from '../i18n';
 import { ProtectedShell } from '../App';
-import { AuthProvider, type AuthUser } from '../lib/auth';
+import { AuthProvider, type AuthUser, useAuth } from '../lib/auth';
 import Login from '../pages/Login';
 import { ThemeProvider } from '../theme/ThemeProvider';
 
@@ -175,6 +175,97 @@ describe('auth bootstrap session persistence', () => {
     expect(seenAuthHeaders).toEqual(['Bearer access-login']);
   });
 
+  it('delayed bootstrap refresh 401 does not clear a login session established during bootstrap', async () => {
+    const refreshRequest = createDeferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/auth/refresh') {
+        return refreshRequest.promise;
+      }
+
+      if (path === '/api/auth/login') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            access_token: 'access-login',
+            expires_in: 3600,
+            user: BOOTSTRAP_USER,
+          },
+        }));
+      }
+
+      if (path === '/api/auth/me') {
+        return Promise.resolve(jsonResponse({ data: BOOTSTRAP_USER }));
+      }
+
+      return Promise.resolve(notFoundResponse());
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderApp('/login');
+
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'bootstrap@example.com' } });
+    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: /登\s*录/ }));
+
+    expect(await screen.findByText('protected-home')).toBeInTheDocument();
+    refreshRequest.resolve(unauthorizedResponse('NO_REFRESH_TOKEN'));
+    await waitForMicrotasks();
+
+    expect(screen.getByText('protected-home')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: '登录' })).not.toBeInTheDocument();
+  });
+
+  it('delayed bootstrap does not resurrect a logged-out session', async () => {
+    const refreshRequest = createDeferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>((input) => {
+      const path = getRequestPath(input);
+
+      if (path === '/api/auth/refresh') {
+        return refreshRequest.promise;
+      }
+
+      if (path === '/api/auth/login') {
+        return Promise.resolve(jsonResponse({
+          data: {
+            access_token: 'access-login',
+            expires_in: 3600,
+            user: BOOTSTRAP_USER,
+          },
+        }));
+      }
+
+      if (path === '/api/auth/me') {
+        return Promise.resolve(jsonResponse({ data: BOOTSTRAP_USER }));
+      }
+
+      if (path === '/api/auth/logout') {
+        return Promise.resolve(jsonResponse({ data: { success: true } }));
+      }
+
+      return Promise.resolve(notFoundResponse());
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderApp('/login');
+
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'bootstrap@example.com' } });
+    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'password' } });
+    fireEvent.click(screen.getByRole('button', { name: /登\s*录/ }));
+
+    expect(await screen.findByText('protected-home')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'logout-test' }));
+    expect(await screen.findByRole('heading', { name: '登录' })).toBeInTheDocument();
+
+    refreshRequest.resolve(jsonResponse({ data: { access_token: 'access-bootstrap', expires_in: 3600 } }));
+    await waitForMicrotasks();
+
+    expect(screen.getByRole('heading', { name: '登录' })).toBeInTheDocument();
+    expect(screen.queryByText('protected-home')).not.toBeInTheDocument();
+  });
+
   it('does not authenticate login when /auth/me returns 401 during delayed bootstrap', async () => {
     const refreshRequest = createDeferred<Response>();
     const fetchMock = vi.fn<typeof fetch>((input) => {
@@ -261,7 +352,7 @@ function renderApp(path: string, options: { strictMode?: boolean } = {}): void {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route element={<ProtectedShell />}>
-              <Route path="/" element={<div>protected-home</div>} />
+              <Route path="/" element={<ProtectedHome />} />
               <Route path="/spaces/:spaceId/protected" element={<div>protected-space</div>} />
             </Route>
           </Routes>
@@ -276,6 +367,19 @@ function renderApp(path: string, options: { strictMode?: boolean } = {}): void {
     ) : (
       tree
     ),
+  );
+}
+
+function ProtectedHome() {
+  const { logout } = useAuth();
+
+  return (
+    <div>
+      <div>protected-home</div>
+      <button type="button" onClick={() => void logout()}>
+        logout-test
+      </button>
+    </div>
   );
 }
 
@@ -347,4 +451,10 @@ function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void
   });
 
   return { promise, resolve, reject };
+}
+
+async function waitForMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -79,6 +79,8 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
   const accessTokenRef = useRef<string | null>(initialSession?.accessToken ?? null);
   const refreshTimerRef = useRef<number | undefined>(undefined);
   const isBootstrappingRef = useRef(initialSession === undefined);
+  const bootstrapRefreshInFlightRef = useRef(false);
+  const sessionGenRef = useRef(0);
 
   const clearRefreshTimer = useCallback(() => {
     if (refreshTimerRef.current !== undefined) {
@@ -93,6 +95,7 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
   }, []);
 
   const clearSession = useCallback(() => {
+    sessionGenRef.current += 1;
     clearRefreshTimer();
     setAccessToken(null);
     setUser(null);
@@ -111,6 +114,7 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
 
   const login = useCallback(
     async (email: string, password: string): Promise<AuthUser> => {
+      sessionGenRef.current += 1;
       const result = await api.post<LoginResponse>('/auth/login', { email, password });
       setAccessToken(result.access_token);
       scheduleRefresh(result.expires_in, refreshTimerRef, refresh);
@@ -162,7 +166,7 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
     configureApiClient({
       getAccessToken: () => accessTokenRef.current,
       onUnauthorized: () => {
-        if (isBootstrappingRef.current) {
+        if (isBootstrappingRef.current || bootstrapRefreshInFlightRef.current) {
           return;
         }
 
@@ -185,25 +189,31 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
 
     async function bootstrapSession(): Promise<void> {
       setBootstrapping(true);
-      const startingAccessToken = accessTokenRef.current;
-      let bootstrapAccessToken: string | null = null;
+      const gen = sessionGenRef.current;
 
       try {
-        const tokenPair = await getBootstrapRefreshTokenPair();
-        if (isCancelled || accessTokenRef.current !== startingAccessToken) {
+        bootstrapRefreshInFlightRef.current = true;
+        let tokenPair: TokenPairResponse;
+        try {
+          tokenPair = await getBootstrapRefreshTokenPair();
+        } finally {
+          bootstrapRefreshInFlightRef.current = false;
+        }
+
+        if (isCancelled || sessionGenRef.current !== gen) {
           return;
         }
 
-        bootstrapAccessToken = tokenPair.access_token;
         setAccessToken(tokenPair.access_token);
         scheduleRefresh(tokenPair.expires_in, refreshTimerRef, refresh);
 
         const me = await api.get<CurrentUserResponse>('/auth/me');
-        if (!isCancelled && accessTokenRef.current === bootstrapAccessToken) {
-          setUser({ ...me, spaces: me.spaces });
+        if (isCancelled || sessionGenRef.current !== gen) {
+          return;
         }
+        setUser({ ...me, spaces: me.spaces });
       } catch {
-        if (!isCancelled && bootstrapAccessToken !== null && accessTokenRef.current === bootstrapAccessToken) {
+        if (!isCancelled && sessionGenRef.current === gen) {
           clearSession();
         }
       } finally {

--- a/apps/web/src/lib/auth.tsx
+++ b/apps/web/src/lib/auth.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from 'react';
 import { useNavigate } from 'react-router';
-import { api, configureApiClient } from './api';
+import { ApiError, api, configureApiClient } from './api';
 
 export type SpaceRole = 'viewer' | 'editor' | 'admin';
 
@@ -49,6 +49,7 @@ type AuthContextValue = {
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
   refreshUser: () => Promise<void>;
+  isBootstrapping: boolean;
   isAuthenticated: boolean;
   isAdmin: boolean;
   hasSpacePermission: (spaceId: string, permission: string) => boolean;
@@ -68,13 +69,16 @@ export type AuthProviderProps = {
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 const REFRESH_LEEWAY_SECONDS = 5 * 60;
 const DEFAULT_EXPIRES_IN_SECONDS = 60 * 60;
+let bootstrapRefreshPromise: Promise<TokenPairResponse> | null = null;
 
 export function AuthProvider({ children, initialSession }: AuthProviderProps) {
   const navigate = useNavigate();
   const [user, setUser] = useState<AuthUser | null>(initialSession?.user ?? null);
   const [accessToken, setAccessTokenState] = useState<string | null>(initialSession?.accessToken ?? null);
+  const [isBootstrapping, setIsBootstrapping] = useState(initialSession === undefined);
   const accessTokenRef = useRef<string | null>(initialSession?.accessToken ?? null);
   const refreshTimerRef = useRef<number | undefined>(undefined);
+  const isBootstrappingRef = useRef(initialSession === undefined);
 
   const clearRefreshTimer = useCallback(() => {
     if (refreshTimerRef.current !== undefined) {
@@ -94,6 +98,11 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
     setUser(null);
   }, [clearRefreshTimer, setAccessToken]);
 
+  const setBootstrapping = useCallback((nextValue: boolean) => {
+    isBootstrappingRef.current = nextValue;
+    setIsBootstrapping(nextValue);
+  }, []);
+
   const refresh = useCallback(async () => {
     const tokenPair = await api.post<TokenPairResponse>('/auth/refresh');
     setAccessToken(tokenPair.access_token);
@@ -109,13 +118,21 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
         const me = await api.get<CurrentUserResponse>('/auth/me');
         const enriched: AuthUser = { ...result.user, spaces: me.spaces };
         setUser(enriched);
+        setBootstrapping(false);
         return enriched;
-      } catch {
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 401) {
+          clearSession();
+          setBootstrapping(false);
+          throw err;
+        }
+
         setUser(result.user);
+        setBootstrapping(false);
         return result.user;
       }
     },
-    [refresh, setAccessToken],
+    [clearSession, refresh, setAccessToken, setBootstrapping],
   );
 
   const refreshUser = useCallback(async () => {
@@ -145,6 +162,10 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
     configureApiClient({
       getAccessToken: () => accessTokenRef.current,
       onUnauthorized: () => {
+        if (isBootstrappingRef.current) {
+          return;
+        }
+
         clearSession();
         void navigate('/login', { replace: true });
       },
@@ -153,13 +174,52 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
 
   useEffect(() => {
     if (initialSession?.accessToken !== undefined) {
+      setBootstrapping(false);
       scheduleRefresh(initialSession.expiresIn ?? DEFAULT_EXPIRES_IN_SECONDS, refreshTimerRef, refresh);
+      return () => {
+        clearRefreshTimer();
+      };
     }
 
+    let isCancelled = false;
+
+    async function bootstrapSession(): Promise<void> {
+      setBootstrapping(true);
+      const startingAccessToken = accessTokenRef.current;
+      let bootstrapAccessToken: string | null = null;
+
+      try {
+        const tokenPair = await getBootstrapRefreshTokenPair();
+        if (isCancelled || accessTokenRef.current !== startingAccessToken) {
+          return;
+        }
+
+        bootstrapAccessToken = tokenPair.access_token;
+        setAccessToken(tokenPair.access_token);
+        scheduleRefresh(tokenPair.expires_in, refreshTimerRef, refresh);
+
+        const me = await api.get<CurrentUserResponse>('/auth/me');
+        if (!isCancelled && accessTokenRef.current === bootstrapAccessToken) {
+          setUser({ ...me, spaces: me.spaces });
+        }
+      } catch {
+        if (!isCancelled && bootstrapAccessToken !== null && accessTokenRef.current === bootstrapAccessToken) {
+          clearSession();
+        }
+      } finally {
+        if (!isCancelled) {
+          setBootstrapping(false);
+        }
+      }
+    }
+
+    void bootstrapSession();
+
     return () => {
+      isCancelled = true;
       clearRefreshTimer();
     };
-  }, [clearRefreshTimer, initialSession?.accessToken, initialSession?.expiresIn, refresh]);
+  }, [clearRefreshTimer, clearSession, initialSession?.accessToken, initialSession?.expiresIn, refresh, setBootstrapping]);
 
   const hasSpacePermission = useCallback(
     (spaceId: string, permission: string): boolean => checkSpacePermission(user, spaceId, permission),
@@ -174,11 +234,12 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
       logout,
       refresh,
       refreshUser,
+      isBootstrapping,
       isAuthenticated: accessToken !== null && user !== null,
       isAdmin: user !== null && isAdminRole(user.role),
       hasSpacePermission,
     }),
-    [accessToken, hasSpacePermission, login, logout, refresh, refreshUser, user],
+    [accessToken, hasSpacePermission, isBootstrapping, login, logout, refresh, refreshUser, user],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
@@ -249,4 +310,14 @@ function scheduleRefresh(
   timerRef.current = window.setTimeout(() => {
     void refresh().catch(() => undefined);
   }, delaySeconds * 1000);
+}
+
+function getBootstrapRefreshTokenPair(): Promise<TokenPairResponse> {
+  if (bootstrapRefreshPromise === null) {
+    bootstrapRefreshPromise = api.post<TokenPairResponse>('/auth/refresh').finally(() => {
+      bootstrapRefreshPromise = null;
+    });
+  }
+
+  return bootstrapRefreshPromise;
 }

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -1,0 +1,122 @@
+# CherryWiki Bug 追踪（P0 复测轮次 2026-05-15）
+
+> P0 级功能测试中发现的 bug。修复后勾选并注明修复 commit。
+
+---
+
+## P0 — 阻塞性
+
+### BUG-005: 页面刷新丢失登录状态（AuthProvider 缺少 bootstrap refresh）
+
+- **现象**: 登录后的任何页面，按 F5 或 `location.reload()` 后跳回登录页。在 agent-browser 和用户真实浏览器中均可复现。
+- **根因**: `AuthProvider`（`apps/web/src/lib/auth.tsx:72`）初始化时，若无 `initialSession` prop（页面刷新场景），`accessToken` 和 `user` 均为 `null`。没有 useEffect 在 mount 时调用 `POST /api/auth/refresh`（携带 HttpOnly cookie）来恢复 session。路由守卫检测到未认证后立即重定向到 `/login`。
+- **复现**:
+  1. 正常登录进入任意页面
+  2. 按 F5 刷新页面
+  3. 页面跳回登录页
+- **API 端无问题**: `POST /api/auth/refresh` 配合 HttpOnly cookie 可正常返回新 access_token（API 测试已验证）
+- **影响**: P0 阻塞 — 用户每次刷新页面都需重新登录，严重影响可用性
+- **修复方向**: 在 `AuthProvider` 的 mount useEffect 中，当 `initialSession` 未提供时，自动调用 `refresh()` 尝试恢复 session。成功则设置 token+user（调用 `/auth/me`），失败则导航到 `/login`。需要添加 `isBootstrapping` 状态避免闪烁。
+- **关联文件**: 
+  - `apps/web/src/lib/auth.tsx:72-162` — AuthProvider
+  - `apps/web/src/App.tsx:141` — AuthProvider 初始化（未传 initialSession）
+- **发现日期**: 2026-05-15
+- **状态**: [x] 已修复 — AuthProvider bootstrap refresh + `isBootstrapping` 路由守卫 + 回归测试
+
+---
+
+## P1 — 功能缺陷
+
+（暂无）
+
+---
+
+## 已修复（本轮）
+
+- BUG-005: 页面刷新丢失登录状态 → 当前分支：bootstrap refresh + route guard loading ✅
+
+## 已修复（上一轮）
+
+- BUG-001: cookie Secure 标志 → `ae11d58` ✅
+- BUG-002: Space 选择器刷新 → `eb85819` ✅
+- BUG-003: 文档列表不显示 → `b698f10` ✅
+- BUG-004: Docmost Bridge Unhealthy → `19c40fa` + `.env` 修复 ✅
+
+---
+
+## P0 测试进度记录（2026-05-15）
+
+### §1 认证与用户管理
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §1.1 登录成功 | ✅ PASS | admin 登录跳转 Overview |
+| §1.1 refresh_token HttpOnly cookie | ✅ PASS | 无 Secure 标志，HttpOnly; SameSite=Lax |
+| §1.1 错误密码 | ✅ PASS | 已在上轮验证 |
+| §1.2 登出清除 cookie | ✅ PASS | Set-Cookie Max-Age=0 |
+| §1.2 登出后 token 失效 | ✅ PASS | TOKEN_REVOKED |
+| §1.3 Token 刷新（valid cookie） | ✅ PASS | 200 OK + 新 access_token |
+| §1.3 Token 刷新（invalid cookie） | ✅ PASS | 401 |
+| §1.4 GET /auth/me | ✅ PASS | 返回 role/groups/spaces |
+| §1.4 未登录 /auth/me | ✅ PASS | 401 |
+| §1.x 页面刷新保持 session | ✅ PASS | BUG-005 已修复，新增 auth bootstrap 回归测试 |
+
+### §2 Space 管理
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §2.1 创建 Space | ✅ PASS | |
+| §2.1 Space 选择器更新 | ✅ PASS | BUG-002 已修复 |
+| §2.2 Overview stats | ✅ PASS | Documents=1, Wiki=0, Nodes=0, Edges=0 |
+| §2.2 Knowledge Status | ✅ PASS | Index consistency Healthy, Strict mode Enabled |
+| §2.2 Recent Documents | ✅ PASS | test-knowledge.md 显示 |
+| §2.2 Quick actions | ✅ PASS | 6 个按钮路由正确 |
+
+### §3 文档上传与解析
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §3.1 上传 Markdown | ✅ PASS | API 验证通过 |
+| §3.1 文档列表 UI 显示 | ✅ PASS | BUG-003 已修复，1016B/Graphify Pending |
+| §3.4 Ingestion 解析 | ✅ PASS | status=graphify_pending, parsed_uri 存在 |
+
+### §4 知识图谱
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §4.3 Graph Explorer | ✅ PASS | 空状态正确，有搜索/Communities/Legend |
+
+### §5 Wiki 管理
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §5.1 Wiki 页面列表 | ✅ PASS | 空状态 + 搜索/过滤 |
+
+### §7 Chat（RAG）
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §7.1 Chat 页面布局 | ✅ PASS | New Chat/input/Deep Analysis/Retrieval mode |
+| §7.1 发送消息获得回答 | ✅ PASS | SSE 流完成，fallback 响应（strict mode） |
+| §7.5 多轮对话 | ✅ PASS | 同一 session 两轮 Q&A |
+| §7.5 Session 历史 | ✅ PASS | 左侧列表显示 session |
+
+### §8 Model 配置
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §8.1 Chat Model 显示 | ✅ PASS | 上轮验证 |
+| §8.3 Embedding Model | ✅ PASS | 上轮验证 |
+
+### §9 管理后台
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §9.2 Health 全组件 | ✅ PASS | 6 组件 Healthy，BUG-004 已修复 |
+
+### §10 UI/UX
+
+| 测试项 | 结果 | 备注 |
+|--------|------|------|
+| §10.3 侧边栏折叠/展开 | ✅ PASS | icon 导航可用 |
+| §10.3 折叠跨刷新保持 | ⚠️ 被 BUG-005 阻塞 | localStorage 有存储但刷新回到登录页 |

--- a/openspec/changes/auth-session-persist/.openspec.yaml
+++ b/openspec/changes/auth-session-persist/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/auth-session-persist/design.md
+++ b/openspec/changes/auth-session-persist/design.md
@@ -1,0 +1,37 @@
+## Technical Approach
+
+单组件改动，集中在 `AuthProvider`。不涉及 API 端修改。
+
+### 方案：useEffect bootstrap + isBootstrapping 状态
+
+在 AuthProvider 中新增 `isBootstrapping` state（初始值 `true`）。mount useEffect 中：
+
+1. 如果 `initialSession` 已提供（SSR 场景），直接设置 token/user，`isBootstrapping = false`
+2. 否则调用 `refresh()`（client path `POST /auth/refresh`，HTTP path `POST /api/auth/refresh`，浏览器自动携带 HttpOnly cookie）
+   - 成功：设置 accessToken → 调用 `/auth/me` 设置 user → `isBootstrapping = false`
+   - 失败：`isBootstrapping = false`，保持 null state，路由守卫正常重定向到 /login
+
+bootstrap 期间 `POST /auth/refresh` 的预期 401（无 cookie / expired / revoked）必须由 bootstrap 本地处理，不能触发 API client 的全局 `onUnauthorized` 提前导航到 `/login`。可通过 bootstrap-aware unauthorized handler 或等价机制实现；bootstrap 完成后仍由现有路由守卫执行 `/login` 重定向。
+
+### 路由守卫处理
+
+`isAuthenticated` 判断增加 bootstrapping 守卫：
+- `isBootstrapping === true` 时：显示全屏 loading（Spin 组件），不触发重定向
+- `isBootstrapping === false && !isAuthenticated` 时：重定向到 /login
+- `isBootstrapping === false && isAuthenticated` 时：正常渲染
+
+AuthProvider 包裹整个 SPA，因此 `/login` 页面也会执行 silent refresh。若 `/login` 上存在有效 refresh cookie，AuthProvider 可恢复内存 session，但 Login 页面本身不需要自动跳转；后续用户提交登录表单仍按现有流程设置 token/user 并导航。
+
+### 备选方案（已排除）
+
+- **localStorage 持久化 access_token**：违反安全最佳实践，XSS 可窃取 token
+- **SSR bootstrap**：当前为纯 SPA，引入 SSR 成本过高
+
+## Risks
+
+| 风险 | 缓解 |
+|------|------|
+| 刷新期间短暂 loading 闪烁 | refresh 调用通常 <100ms（本地网络），loading 几乎不可感知 |
+| 竞态：bootstrap refresh 与手动 login 同时发生 | login 页面不在 AuthProvider 保护的路由内，不会冲突 |
+| refresh 401 被全局 unauthorized handler 提前重定向 | bootstrap 期间 suppress/ignore 全局 unauthorized 导航，由 route guard 在 isBootstrapping=false 后统一处理 |
+| refresh 失败导致无限重定向 | refresh 失败时设置 isBootstrapping=false，一次性逻辑不会循环 |

--- a/openspec/changes/auth-session-persist/proposal.md
+++ b/openspec/changes/auth-session-persist/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+页面刷新后登录状态丢失（BUG-005, P0）。access_token 仅存内存，刷新后 React state 重置，前端 AuthProvider 没有 bootstrap 逻辑用 HttpOnly refresh_token cookie 调用 `POST /api/auth/refresh` 恢复 session。用户每次刷新都需重新登录，严重影响可用性。
+
+## What Changes
+
+- AuthProvider mount 时自动尝试 silent refresh（用 HttpOnly cookie 调用 `POST /auth/refresh`）
+- 新增 `isBootstrapping` 加载态，避免刷新瞬间闪烁登录页
+- refresh 成功后调用 `/auth/me` 恢复用户信息和 Space 列表
+- refresh 失败（无 cookie / expired / revoked）时正常导航到 `/login`
+- 路由守卫在 bootstrap 期间显示 loading 而非重定向
+
+## Capabilities
+
+### New Capabilities
+- `auth-bootstrap-refresh`: AuthProvider mount 阶段的 silent token refresh 和 session 恢复逻辑
+
+### Modified Capabilities
+
+（无已有 spec 需要修改）
+
+## Impact
+
+- `apps/web/src/lib/auth.tsx` — AuthProvider 核心改动
+- `apps/web/src/App.tsx` — 可能需要在路由守卫层处理 bootstrapping 状态
+- 无 API 端改动，`POST /auth/refresh` 已正常工作
+- 无数据库变更
+- 无 breaking change

--- a/openspec/changes/auth-session-persist/specs/auth-bootstrap-refresh/spec.md
+++ b/openspec/changes/auth-session-persist/specs/auth-bootstrap-refresh/spec.md
@@ -1,0 +1,74 @@
+# auth-bootstrap-refresh
+
+AuthProvider mount 阶段 silent token refresh 和 session 恢复。
+
+## ADDED Requirements
+
+### Requirement: 页面刷新后自动恢复 session
+
+AuthProvider MUST automatically call the refresh endpoint during mount when no initialSession prop is provided, and SHALL restore authenticated state from the returned access token and user profile. Endpoint references in this requirement use the web client path, which resolves to `/api/*` HTTP paths.
+
+#### Scenario: 有效 refresh_token cookie 存在时恢复 session
+
+- WHEN 用户刷新页面且浏览器持有有效的 HttpOnly refresh_token cookie
+- THEN AuthProvider 调用 `POST /auth/refresh`
+- AND 使用返回的 access_token 调用 `GET /auth/me` 获取用户信息
+- AND 设置 accessToken 和 user state
+- AND 调度 scheduleRefresh 定时器
+- AND isBootstrapping 变为 false
+
+#### Scenario: 无 refresh_token cookie 时跳转登录
+
+- WHEN 用户刷新页面且浏览器无 refresh_token cookie（首次访问或 cookie 已过期）
+- THEN AuthProvider 调用 `POST /auth/refresh` 收到 401
+- AND the global API unauthorized handler does not navigate before bootstrap completes
+- AND isBootstrapping 变为 false
+- AND accessToken 和 user 保持 null
+- AND 路由守卫检测到未认证，重定向到 /login
+
+#### Scenario: refresh_token 已被 revoke 时跳转登录
+
+- WHEN 用户刷新页面且 refresh_token cookie 存在但已被 revoke（登出后）
+- THEN AuthProvider 调用 `POST /auth/refresh` 收到 401 REFRESH_TOKEN_REVOKED
+- AND the global API unauthorized handler does not navigate before bootstrap completes
+- AND isBootstrapping 变为 false
+- AND 重定向到 /login
+
+### Requirement: Bootstrap 期间显示 loading 而非闪烁登录页
+
+Protected routes MUST render a full-screen loading indicator while authentication bootstrap is in progress and SHALL NOT redirect to login until bootstrap completes.
+
+#### Scenario: bootstrap 进行中不触发重定向
+
+- WHEN isBootstrapping 为 true
+- THEN 受保护路由显示全屏 loading 指示器
+- AND 不触发任何导航/重定向，包括 API client 全局 onUnauthorized 导航
+
+#### Scenario: bootstrap 完成后正常路由
+
+- WHEN isBootstrapping 变为 false 且 isAuthenticated 为 true
+- THEN 受保护路由正常渲染目标页面
+- AND 侧边栏折叠状态从 localStorage 恢复
+
+### Requirement: 与现有 login 流程兼容
+
+AuthProvider MUST preserve the existing login flow and SHALL treat initialSession as authoritative without issuing a bootstrap refresh.
+
+#### Scenario: 正常登录不受影响
+
+- WHEN 用户从 /login 页面输入凭证登录
+- THEN 登录流程与之前一致（login callback 设置 token + user）
+- AND bootstrap useEffect 不会与 login 冲突（login 页面不在保护路由内）
+
+#### Scenario: login 页面存在有效 refresh cookie
+
+- WHEN 用户直接访问 /login 且浏览器持有有效的 HttpOnly refresh_token cookie
+- THEN AuthProvider 可在后台执行 silent refresh 并恢复内存 session
+- AND Login 页面不自动跳转
+- AND 用户提交登录表单后仍按现有 login 流程导航
+
+#### Scenario: initialSession prop 优先
+
+- WHEN AuthProvider 接收到 initialSession prop（未来 SSR 场景）
+- THEN 直接使用 initialSession，不触发 refresh 调用
+- AND isBootstrapping 立即为 false

--- a/openspec/changes/auth-session-persist/tasks.md
+++ b/openspec/changes/auth-session-persist/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: auth-session-persist
+
+## auth-bootstrap-refresh
+
+- [x] 1.1 在 AuthProvider 中新增 `isBootstrapping` state（初始 true），mount useEffect 中当无 initialSession 时调用 `refresh()` → `/auth/me` 恢复 session，最终设置 `isBootstrapping = false`
+- [x] 1.2 在 App.tsx 路由守卫层添加 bootstrapping 判断：`isBootstrapping` 时渲染全屏 Spin/Loading，不触发重定向
+- [x] 1.3 AuthContext value 导出 `isBootstrapping` 字段供外部消费
+- [x] 1.4 写单元测试覆盖 REQ-1 三个 scenario（valid cookie → session restored, no cookie → redirect, revoked → redirect）
+- [x] 1.5 写单元测试覆盖 REQ-2（bootstrap 期间不重定向）和 REQ-3（login 流程不受影响）
+- [x] 1.6 覆盖 bootstrap refresh 401 不触发 API client 全局 onUnauthorized 提前导航，确保重定向仅在 isBootstrapping=false 后由路由守卫处理
+- [ ] 1.7 浏览器手工验证：登录 → F5 刷新 → 页面保持登录态，侧边栏折叠状态恢复

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,109 @@
+# CherryWiki 项目进度
+
+> 本文件是 session 间的状态接力棒。每次重大变更后更新。上限 200 行。
+> 最后更新: 2026-05-15
+
+## 1. 系统架构一句话
+
+知识管理 + RAG 问答平台：上传文档 → Graphify 提取知识图谱 → 生成 Wiki → 建索引 → Chat 检索问答。13 个 Docker 容器，monorepo (pnpm workspace)。
+
+## 2. 技术栈
+
+| 层 | 技术 |
+|---|---|
+| API | NestJS (TypeScript), `apps/api/` |
+| Web | React + Ant Design, `apps/web/` |
+| Workers | ingestion(Python), url-fetcher(Python), graphify(Python+ClaudeCode), indexer(Node), wiki-sync(Node) |
+| 数据库 | PostgreSQL 16 (pgvector), Redis, MinIO |
+| 外部 | Docmost (Wiki 编辑器), dmxapi (LLM 代理) |
+| 图谱 | graphify 库 (Claude Code runner 模式) |
+
+## 3. 环境状态
+
+- **所有容器 healthy**（13/13），nginx 端口 80，API 端口 8081
+- `.env` 已配置: MODEL_API_KEY (dmxapi), AGENT_ANTHROPIC_API_KEY (Graphify 用), WORKER_API_KEY
+- **Claude Code 和 Graphify 可用**: graphify-worker 容器内 claude-code 已安装，GRAPHIFY_RUNNER_MODE=claude_code
+- **Docmost Bridge healthy**: DOCMOST_BASE_URL=http://docmost:3000
+- **Python venv**: `apps/graphify-worker/.venv/`
+
+## 4. 当前里程碑
+
+**M8: Production Readiness** (Epic #337)
+- Phase 1 Real E2E Pipeline (#340) — 进行中
+
+## 5. 已完成 Stages (按 git 历史)
+
+| Stage | 内容 | 关键 PR |
+|---|---|---|
+| 1-5 | 基础架构、上传、解析、用户管理 | 早期 |
+| 6 | Indexer: vector + BM25 + source chain | openspec change |
+| 7 | Chat Engine: RAG + citations | openspec change |
+| 8 | Graphify worker production metrics | #338 |
+| 9 | Docmost fork + bridge | openspec change |
+| Bug fixes | cookie/upload-list/space-selector/docmost-health | #348-#355 |
+
+## 6. 功能测试状态
+
+详见 `docs/e2e-functional-test-checklist.md` (160+ 项)
+
+| 类别 | 已通过 | 有BUG | 未测 | 覆盖率 |
+|---|---|---|---|---|
+| P0 核心路径 | 37 | 2 | 55 | ~40% |
+| P1 管理功能 | — | — | ~75 | 未开始 |
+| P2 边界安全 | — | — | ~15 | 未开始 |
+| E2E 自动化 | 11 pass | 0 | ~60 | ~15% |
+
+### P0 已测通过的模块
+
+- §1 认证: 登录/登出/token 刷新/auth-me/页面刷新恢复 (10/10 ✅)
+- §2 Space: 创建/Overview stats/recent docs/quick actions (6/6 ✅)
+- §3 上传: Markdown 上传+解析+UI 列表 (3/3 ✅, 多格式未测)
+- §7 Chat: 基础对话/多轮/session 历史 (4/4 ✅, citation 需索引)
+- §9 Health: 6 组件全 healthy (1/1 ✅)
+- §10 侧边栏: 折叠/展开/icon 导航 (2/2 ✅, 刷新登录态阻塞已解除)
+
+### P0 未测项分类 (55 项)
+
+**可立即测 (~20 项)**: §1.1 登录锁定、§2.3 Space 权限 (7项)、§3.1 多格式上传 PDF/DOCX/TXT/PPTX/XLSX、§7.2 SSE 事件 (5项)、§8.1 Model 启用/禁用
+**需 Graphify 数据 (~20 项)**: §4 Graph 显示+Wiki 生成、§5 Wiki 浏览/状态、§6 索引构建/快照、§7.1+7.3 Citation
+**需多用户 (~5 项)**: §2.3 权限隔离部分、§7.8 Chat 权限隔离
+
+## 7. 活跃 BUG
+
+| ID | 优先级 | 状态 | 描述 | Issue |
+|---|---|---|---|---|
+| BUG-005 | P0 | 已修复 | 页面刷新丢登录 — AuthProvider bootstrap refresh | #356 |
+
+### 已修复 BUG (本轮)
+
+| ID | 描述 | Fix |
+|---|---|---|
+| BUG-005 | 页面刷新丢登录 | 当前分支：bootstrap refresh + `isBootstrapping` 路由守卫 |
+| BUG-001 | cookie Secure 标志 HTTP 下不持久 | `ae11d58` |
+| BUG-002 | Space 创建后选择器不刷新 | `eb85819` |
+| BUG-003 | 文档列表 UI 不显示 | `b698f10` |
+| BUG-004 | Docmost Bridge Unhealthy | `19c40fa` + .env 修复 |
+
+## 8. OpenSpec Changes (活跃)
+
+| Change | 状态 | 说明 |
+|---|---|---|
+| auth-session-persist | 4/4 complete, issue #356 | BUG-005 修复 |
+
+## 9. 下一步
+
+1. **继续 P0 测试** — 可立即测的 ~20 项（权限、多格式上传、SSE 事件、Model 管理）
+2. **运行 Graphify** — 容器内 Claude Code 可用，运行后解锁 Graph/Wiki/Index/Citation 相关 P0 测试
+3. **E2E 自动化** — `tests/e2e/` 已有 11 用例框架，待扩展
+
+## 10. 关键文件索引
+
+| 文件 | 用途 |
+|---|---|
+| `docs/e2e-functional-test-checklist.md` | 160+ 项功能测试清单 |
+| `docs/bugs.md` | BUG 追踪（当前轮次） |
+| `docs/project/26_需求追踪矩阵.md` | Stage 开工门禁对齐 |
+| `openspec/changes/` | 30 个 change（含已归档） |
+| `docker-compose.yml` | 13 服务编排 |
+| `.env` | 所有密钥和配置（已配齐） |
+| `tests/e2e/` | E2E 自动化测试 |


### PR DESCRIPTION
## Summary

- AuthProvider now attempts silent `POST /auth/refresh` on mount using HttpOnly cookie, then fetches `/auth/me` to restore the full session (user + spaces)
- Protected routes show a centered AntD `Spin` during bootstrap instead of flashing the login page
- Added `isBootstrapping` to AuthContext for external consumers
- StrictMode-safe: bootstrap refresh request is deduplicated via a module-level promise singleton
- Login `/auth/me` 401 is properly handled (session cleared + error re-thrown) rather than being swallowed by the bootstrap suppression
- Session generation counter prevents stale bootstrap from resurrecting logged-out sessions
- Bootstrap-scoped 401 suppression prevents delayed refresh failures from clearing active login sessions

## Key Files

| File | Change |
|------|--------|
| `apps/web/src/lib/auth.tsx` | Bootstrap refresh useEffect, isBootstrapping state, 401 suppression, StrictMode dedup, sessionGenRef |
| `apps/web/src/App.tsx` | ProtectedShell shows Spin during bootstrap, redirects only after bootstrap completes |
| `apps/web/src/__tests__/auth-bootstrap.test.tsx` | 11 regression tests covering all bootstrap scenarios |
| `apps/web/src/__tests__/App.test.tsx` | Updated existing tests for async bootstrap behavior |

## Test Plan

- [x] Valid refresh cookie → session restored, protected content renders
- [x] No cookie → redirects to /login after bootstrap
- [x] Revoked token → redirects to /login after bootstrap
- [x] Delayed refresh → shows Spin loading, no premature redirect
- [x] Login flow works after failed bootstrap (fresh visitor)
- [x] Delayed bootstrap doesn't overwrite a submitted login session
- [x] Login `/auth/me` 401 properly clears session
- [x] StrictMode: bootstrap refresh deduplicated (1 call, not 2)
- [x] `/auth/me` failure after successful refresh → graceful degradation to /login
- [x] Delayed bootstrap 401 does not clear established login session
- [x] Login→logout→delayed bootstrap does not resurrect session
- [x] Full test suite: 14 files, 176 tests passing
- [ ] Manual browser F5 validation (post-merge)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `89af47bccdb872994a6bca92d6438bc319b1a098`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/357#issuecomment-4461322978) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/357#issuecomment-4461323229) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/357#issuecomment-4461323630) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/357#issuecomment-4461324050)
- Key findings addressed: Round 1 found 2 major race conditions (bootstrap 401 clearing login session, login→logout→bootstrap resurrection) — both fixed with sessionGenRef + bootstrapRefreshInFlightRef. Round 2 clean.

Closes #356