### PR TITLE
feat(chat): pre-check chat model availability on page load (#359)

### DIFF
--- a/apps/api/src/models/__tests__/model-config.service.test.ts
+++ b/apps/api/src/models/__tests__/model-config.service.test.ts
@@ -38,6 +38,26 @@ afterEach(() => {
 });
 
 describe('ModelConfigService', () => {
+  it('returns chat availability true when an enabled chat model exists', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([{ total: 1 }]);
+
+    const result = await service.hasAvailableChatModel(createContext());
+
+    expect(result).toEqual({ available: true });
+    expect(result).not.toHaveProperty('id');
+    expect(result).not.toHaveProperty('model_id');
+    expect(result).not.toHaveProperty('provider');
+    expect(db.limitCalls).toEqual([1]);
+  });
+
+  it('returns chat availability false when no enabled chat model exists', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([{ total: 0 }]);
+
+    await expect(service.hasAvailableChatModel(createContext())).resolves.toEqual({ available: false });
+  });
+
   it('lists models with API field mapping', async () => {
     const { service, db } = createServiceContext();
     db.queueSelect([

--- a/apps/api/src/models/model-config.controller.ts
+++ b/apps/api/src/models/model-config.controller.ts
@@ -20,6 +20,7 @@ import { PaginationQueryDto } from '../common/dto/pagination.dto.js';
 import {
   ModelConfigService,
   type AdminModelConfigResponse,
+  type ChatModelAvailabilityResponse,
   type ModelConnectivityTestResponse,
 } from './model-config.service.js';
 
@@ -156,6 +157,20 @@ class TestModelConnectivityDto {
 type RequestWithAuth = {
   user?: AuthenticatedRequestUser;
 };
+
+@Controller('models')
+export class PublicModelConfigController {
+  constructor(private readonly modelConfigService: ModelConfigService) {}
+
+  @Get('chat-available')
+  async isChatModelAvailable(@Req() request: RequestWithAuth): Promise<ChatModelAvailabilityResponse> {
+    const user = getAuthenticatedUser(request);
+    return this.modelConfigService.hasAvailableChatModel({
+      tenantId: user.tenant_id,
+      actorUserId: user.sub,
+    });
+  }
+}
 
 @Permissions('admin:model_manage')
 @Controller('admin/models')

--- a/apps/api/src/models/model-config.module.ts
+++ b/apps/api/src/models/model-config.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 
-import { ModelConfigController } from './model-config.controller.js';
+import { ModelConfigController, PublicModelConfigController } from './model-config.controller.js';
 import { ModelConfigService } from './model-config.service.js';
 
 @Module({
-  controllers: [ModelConfigController],
+  controllers: [ModelConfigController, PublicModelConfigController],
   providers: [ModelConfigService],
   exports: [ModelConfigService],
 })

--- a/apps/api/src/models/model-config.service.ts
+++ b/apps/api/src/models/model-config.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { ErrorCode, model_configs, tenants } from '@cherrygraph/shared';
-import { and, asc, count, desc, eq, ne, type SQL } from 'drizzle-orm';
+import { and, asc, count, desc, eq, isNotNull, ne, type SQL } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { randomUUID } from 'node:crypto';
 
@@ -483,7 +483,7 @@ export class ModelConfigService {
     const [row] = await this.db
       .select({ total: count() })
       .from(model_configs)
-      .where(and(eq(model_configs.tenant_id, tenantId), eq(model_configs.model_type, 'chat'), eq(model_configs.enabled, true)))
+      .where(and(eq(model_configs.tenant_id, tenantId), eq(model_configs.model_type, 'chat'), eq(model_configs.enabled, true), isNotNull(model_configs.encrypted_api_key_ref)))
       .limit(1);
 
     return {

--- a/apps/api/src/models/model-config.service.ts
+++ b/apps/api/src/models/model-config.service.ts
@@ -95,6 +95,10 @@ export type ModelConnectivityTestResponse = {
   error?: string;
 };
 
+export type ChatModelAvailabilityResponse = {
+  available: boolean;
+};
+
 type ModelSortField = keyof Pick<
   typeof model_configs,
   'created_at' | 'updated_at' | 'provider' | 'model_id' | 'model_type' | 'display_name' | 'enabled'
@@ -472,6 +476,19 @@ export class ModelConfigService {
     await targetValidation.dispatcher.close().catch(() => undefined);
     this.auditModelTest(tenantId, existing, result, context);
     return result;
+  }
+
+  async hasAvailableChatModel(context: AdminContext = {}): Promise<ChatModelAvailabilityResponse> {
+    const tenantId = await this.resolveTenantId(context);
+    const [row] = await this.db
+      .select({ total: count() })
+      .from(model_configs)
+      .where(and(eq(model_configs.tenant_id, tenantId), eq(model_configs.model_type, 'chat'), eq(model_configs.enabled, true)))
+      .limit(1);
+
+    return {
+      available: normalizeCount(row?.total) > 0,
+    };
   }
 
   resolveApiKey(encryptedApiKeyRef: string | null): string {

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -351,6 +351,39 @@ describe('Chat bottom area layout', () => {
   });
 });
 
+describe('Chat model availability pre-check', () => {
+  it('shows a no-model banner and disables input when chat models are unavailable', async () => {
+    stubChatFetch({ chatModelAvailable: false });
+
+    renderChatRoute();
+
+    expect(await screen.findByText('请联系管理员配置聊天模型')).toBeInTheDocument();
+    const textarea = screen.getByLabelText<HTMLTextAreaElement>('消息');
+    expect(textarea).toBeDisabled();
+    expect(screen.getByRole('button', { name: /发送/ })).toBeDisabled();
+  });
+
+  it('shows no no-model banner and keeps input enabled when chat models are available', async () => {
+    stubChatFetch({ chatModelAvailable: true });
+
+    renderChatRoute();
+
+    const textarea = await screen.findByLabelText<HTMLTextAreaElement>('消息');
+    await waitFor(() => expect(screen.queryByText('请联系管理员配置聊天模型')).not.toBeInTheDocument());
+    expect(textarea).not.toBeDisabled();
+  });
+
+  it('shows no no-model banner and keeps input enabled when the availability API fails', async () => {
+    stubChatFetch({ chatModelAvailableStatus: 500 });
+
+    renderChatRoute();
+
+    const textarea = await screen.findByLabelText<HTMLTextAreaElement>('消息');
+    await waitFor(() => expect(screen.queryByText('请联系管理员配置聊天模型')).not.toBeInTheDocument());
+    expect(textarea).not.toBeDisabled();
+  });
+});
+
 describe('Sidebar collapse', () => {
   it('renders collapse toggle button in sidebar header', async () => {
     stubChatFetch();
@@ -722,6 +755,10 @@ describe('Chat error state', () => {
           return Promise.resolve(jsonResponse({ data: { id: 'space-1', database_config: { enabled: false } } }));
         }
 
+        if (path === '/api/models/chat-available') {
+          return Promise.resolve(jsonResponse({ data: { available: true }, meta: { request_id: 'req-chat-model' } }));
+        }
+
         if (path === '/api/chat/completions') {
           return Promise.resolve(
             jsonResponse(
@@ -862,6 +899,8 @@ type StubSessionDetail = {
 
 function stubChatFetch({
   databaseEnabled = false,
+  chatModelAvailable = true,
+  chatModelAvailableStatus = 200,
   spaces = [
     { id: 'space-1', name: 'Space One' },
     { id: 'space-2', name: 'Space Two' },
@@ -872,6 +911,8 @@ function stubChatFetch({
   patchSessionSpacesStatus = 200,
 }: {
   databaseEnabled?: boolean;
+  chatModelAvailable?: boolean;
+  chatModelAvailableStatus?: number;
   spaces?: StubSpace[];
   sessions?: StubSession[];
   sessionDetails?: Record<string, StubSessionDetail>;
@@ -886,6 +927,17 @@ function stubChatFetch({
       const path = getRequestPath(input);
       const requestBody = parseRequestBody(init?.body);
       calls.push({ path, body: requestBody });
+
+      if (path === '/api/models/chat-available') {
+        return Promise.resolve(
+          chatModelAvailableStatus >= 200 && chatModelAvailableStatus < 300
+            ? jsonResponse({ data: { available: chatModelAvailable }, meta: { request_id: 'req-chat-model' } })
+            : jsonResponse(
+                { error: { code: 'INTERNAL_ERROR', message: 'Failed to check model availability' } },
+                chatModelAvailableStatus,
+              ),
+        );
+      }
 
       if (path === '/api/spaces') {
         return Promise.resolve(

--- a/apps/web/src/hooks/useChatModelAvailable.ts
+++ b/apps/web/src/hooks/useChatModelAvailable.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+import { api } from '../lib/api.js';
+
+type ChatModelAvailabilityResponse = {
+  available: boolean;
+};
+
+type ChatModelAvailabilityState = {
+  available: boolean;
+  loading: boolean;
+};
+
+export function useChatModelAvailable(enabled = true): ChatModelAvailabilityState {
+  const [state, setState] = useState<ChatModelAvailabilityState>({ available: true, loading: enabled });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!enabled) {
+      setState({ available: true, loading: false });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setState((current) => ({ ...current, loading: true }));
+
+    api
+      .getWrapped<ChatModelAvailabilityResponse>('/models/chat-available')
+      .then((response) => {
+        if (!cancelled) {
+          setState({ available: response.data.available, loading: false });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ available: true, loading: false });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return state;
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -941,6 +941,10 @@
     "agentThinking": "Agent is thinking",
     "completed": "Completed",
     "responseInterrupted": "Response interrupted, please retry",
+    "noModelAdminPrefix": "Enable a chat model on the ",
+    "noModelAdminLink": "Models page",
+    "noModelAdminSuffix": "",
+    "noModelUser": "Contact an administrator to configure a chat model",
     "forbidden": {
       "code": "403",
       "title": "Access Denied",

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -941,6 +941,10 @@
     "agentThinking": "Agent 思考中",
     "completed": "完成",
     "responseInterrupted": "响应中断，请重试",
+    "noModelAdminPrefix": "请先在 ",
+    "noModelAdminLink": "Models 页面",
+    "noModelAdminSuffix": "启用聊天模型",
+    "noModelUser": "请联系管理员配置聊天模型",
     "forbidden": {
       "code": "403",
       "title": "无权访问",

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -420,7 +420,7 @@ export default function Chat() {
 
   const chatErrorMessage = getChatErrorMessage(streamError, selectedSpaceIds.length);
   const selectorLocked = isStreaming;
-  const chatInputDisabled = isStreaming || (!chatModelAvailable.loading && !chatModelAvailable.available);
+  const chatInputDisabled = isStreaming || chatModelAvailable.loading || !chatModelAvailable.available;
 
   return (
     <div className={`chat-page${isSidebarCollapsed ? ' sidebar-collapsed' : ''}`}>

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
-import { Navigate, useNavigate, useParams } from 'react-router';
+import { Link, Navigate, useNavigate, useParams } from 'react-router';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
 import { Alert, Button, Collapse, Empty, Input, List, message, Popconfirm, Select, Spin, Tag } from 'antd';
@@ -35,6 +35,7 @@ import {
   type SendMessageOptions,
   type SpaceDisplayInfo,
 } from '../hooks/useChatStream.js';
+import { useChatModelAvailable } from '../hooks/useChatModelAvailable.js';
 import { api } from '../lib/api.js';
 import { useAuth, type AuthUser } from '../lib/auth.js';
 import NotFound from './NotFound.js';
@@ -107,8 +108,9 @@ const CHAT_SIDEBAR_COLLAPSED_KEY = 'cherry-chat-sidebar-collapsed';
 export default function Chat() {
   const { t } = useTranslation();
   const { spaceId = '' } = useParams();
-  const { accessToken, hasSpacePermission, isAuthenticated, user } = useAuth();
+  const { accessToken, hasSpacePermission, isAdmin, isAuthenticated, user } = useAuth();
   const gate = useSpacePermissionGate(['space:view', 'chat:use']);
+  const chatModelAvailable = useChatModelAvailable(isAuthenticated && gate.isAllowed);
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(true);
   const [sessionsError, setSessionsError] = useState<string | null>(null);
@@ -418,6 +420,7 @@ export default function Chat() {
 
   const chatErrorMessage = getChatErrorMessage(streamError, selectedSpaceIds.length);
   const selectorLocked = isStreaming;
+  const chatInputDisabled = isStreaming || (!chatModelAvailable.loading && !chatModelAvailable.available);
 
   return (
     <div className={`chat-page${isSidebarCollapsed ? ' sidebar-collapsed' : ''}`}>
@@ -511,6 +514,24 @@ export default function Chat() {
         </section>
 
         <div className="chat-bottom-area">
+          {!chatModelAvailable.loading && !chatModelAvailable.available ? (
+            <Alert
+              type="warning"
+              showIcon
+              message={
+                isAdmin ? (
+                  <span>
+                    {t('chat.noModelAdminPrefix')}
+                    <Link to="/admin/models">{t('chat.noModelAdminLink')}</Link>
+                    {t('chat.noModelAdminSuffix')}
+                  </span>
+                ) : (
+                  t('chat.noModelUser')
+                )
+              }
+            />
+          ) : null}
+
           {chatErrorMessage !== null ? (
             <div className="chat-error-bar" role="alert">
               <span>{chatErrorMessage}</span>
@@ -537,7 +558,7 @@ export default function Chat() {
             onStartNewSession={newChat}
           />
           <MessageInput
-            disabled={isStreaming}
+            disabled={chatInputDisabled}
             isStreaming={isStreaming}
             settings={chatSettings}
             databaseAvailable={selectedSpaceIds.length === 1 && spaceDatabaseEnabled}


### PR DESCRIPTION
## Summary

- Add `GET /api/models/chat-available` endpoint — boolean-only, no admin permission required
- Add `useChatModelAvailable` hook with graceful degradation
- Show Alert banner on Chat page when no chat model is enabled (admin: link to Models; non-admin: contact admin)
- Disable message input + send button when unavailable or checking
- i18n support (zh-CN + en)

Closes #359

## Changes

| File | Change |
|------|--------|
| `apps/api/src/models/model-config.controller.ts` | New `PublicModelConfigController` with boolean-only endpoint |
| `apps/api/src/models/model-config.service.ts` | Add `hasAvailableChatModel()` with api_key_ref check |
| `apps/api/src/models/model-config.module.ts` | Register new controller |
| `apps/web/src/hooks/useChatModelAvailable.ts` | New hook with cancel + error fallback |
| `apps/web/src/pages/Chat.tsx` | Alert banner + disabled input (loading + unavailable) |
| `apps/web/src/locales/{en,zh-CN}.json` | i18n strings |

## Test plan

- [x] No model → banner shown + input disabled (37 chat tests pass)
- [x] Model available → no banner
- [x] API failure → graceful degradation (available=true)
- [x] hasAvailableChatModel returns correct boolean (46 model tests pass)
- [x] Input disabled during loading state
- [x] All 83 tests pass

## Agent Review

Reviewer agents used: Spec Compliance, Correctness, Integration, Security & Performance
Reviewed head SHA: `e67dfb92d9730b5b18f79b2ec94883b0a8b51fb2`
Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/361#issuecomment-4465008261) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/361#issuecomment-4465008347) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/361#issuecomment-4465008402) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/361#issuecomment-4465008480)
Key findings addressed: Disable input during loading state to prevent race; require non-null api_key_ref in availability check to align with send-path validation