### PR TITLE
feat(agent): TurnEventQueue inject + side-channel mechanism (#364)

### DIFF
--- a/apps/api/src/agent/__tests__/agent-inject-chart.test.ts
+++ b/apps/api/src/agent/__tests__/agent-inject-chart.test.ts
@@ -1,0 +1,129 @@
+import 'reflect-metadata';
+
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AuditService } from '../../audit/audit.service.js';
+import type { DrizzleDatabase } from '../../database/drizzle.module.js';
+import { AgentService, buildAgentEnv } from '../agent.service.js';
+import { AuditCapture } from '../audit-capture.js';
+import { ClaudeMdGenerator } from '../claude-md-generator.js';
+import type { AgentSessionRecord } from '../dto/agent.dto.js';
+import { PersistentStreamParser } from '../persistent-stream-parser.js';
+import { SessionManager } from '../session-manager.js';
+import { SettingsGenerator } from '../settings-generator.js';
+import { StreamParser } from '../stream-parser.js';
+import { AgentTestDb, collectAsync } from './agent-test-utils.js';
+
+type ServiceWithParsers = {
+  persistentParsers: Map<string, PersistentStreamParser>;
+};
+
+const managers: SessionManager[] = [];
+const parsers: PersistentStreamParser[] = [];
+
+afterEach(async () => {
+  for (const parser of parsers.splice(0)) {
+    parser.stop();
+  }
+  await Promise.all(managers.splice(0).map((manager) => manager.onModuleDestroy()));
+});
+
+describe('AgentService.injectChartEvent', () => {
+  it("returns 'injected' when parser exists and turn is active", async () => {
+    const { service } = createService();
+    const conversationId = 'conversation-chart-active';
+    const { parser, stdout } = createStartedParser();
+    const turn = parser.createTurn();
+    const events = collectAsync(turn);
+    parserMap(service).set(conversationId, parser);
+    const chartData = {
+      chart_type: 'bar',
+      echarts_option: { xAxis: { type: 'category' }, series: [{ data: [1, 2, 3] }] },
+      rows: [{ label: 'A', value: 1 }],
+    };
+
+    expect(service.injectChartEvent(conversationId, chartData)).toBe('injected');
+    stdout.end();
+
+    await expect(events).resolves.toEqual([
+      {
+        type: 'chart.data',
+        chart_type: 'bar',
+        echarts_option: chartData.echarts_option,
+        data: chartData,
+      },
+    ]);
+  });
+
+  it("returns 'not_found' when conversationId has no parser", () => {
+    const { service } = createService();
+
+    expect(service.injectChartEvent('missing-conversation', { chart_type: 'bar' })).toBe('not_found');
+  });
+
+  it("returns 'not_found' when parser has no active turn", () => {
+    const { service } = createService();
+    const conversationId = 'conversation-chart-idle';
+    const { parser } = createStartedParser();
+    parserMap(service).set(conversationId, parser);
+
+    expect(service.injectChartEvent(conversationId, { chart_type: 'line' })).toBe('not_found');
+  });
+});
+
+describe('buildAgentEnv', () => {
+  it('sets chart callback URL and conversation id', () => {
+    const env = buildAgentEnv(
+      createSession({
+        conversationId: 'conversation-env',
+        apiInternalUrl: 'http://api.internal:8081',
+      }),
+    );
+
+    expect(env.CHERRY_CHART_CALLBACK_URL).toBe('http://api.internal:8081/api/internal/agent/chart-event');
+    expect(env.CHERRY_CONVERSATION_ID).toBe('conversation-env');
+  });
+});
+
+function createService(): { service: AgentService; manager: SessionManager } {
+  const manager = new SessionManager();
+  managers.push(manager);
+  const auditService = { push: vi.fn() } as unknown as AuditService;
+  const service = new AgentService(
+    new AgentTestDb() as unknown as DrizzleDatabase,
+    manager,
+    new StreamParser(),
+    new AuditCapture(auditService),
+    new ClaudeMdGenerator(),
+    new SettingsGenerator(),
+  );
+
+  return { service, manager };
+}
+
+function createStartedParser(): { parser: PersistentStreamParser; stdout: PassThrough } {
+  const parser = new PersistentStreamParser();
+  const stdout = new PassThrough();
+  parser.startReading(stdout);
+  parsers.push(parser);
+  return { parser, stdout };
+}
+
+function parserMap(service: AgentService): Map<string, PersistentStreamParser> {
+  return (service as unknown as ServiceWithParsers).persistentParsers;
+}
+
+function createSession(input: { conversationId: string; apiInternalUrl: string }): AgentSessionRecord {
+  return {
+    conversationId: input.conversationId,
+    spaceId: 'space-1',
+    sessionId: 'session-1',
+    workDir: '/tmp/cherry-agent/conversation-env',
+    agentHome: '/tmp/cherry-agent/conversation-env/.home',
+    lastActivityAt: Date.now(),
+    options: {
+      apiInternalUrl: input.apiInternalUrl,
+    },
+  };
+}

--- a/apps/api/src/agent/__tests__/persistent-stream-parser.test.ts
+++ b/apps/api/src/agent/__tests__/persistent-stream-parser.test.ts
@@ -156,6 +156,26 @@ describe('PersistentStreamParser', () => {
       { type: 'message.error', code: 'error_during_execution', message: 'tool failed' },
     ]);
   });
+
+  it('injectToActiveTurn delegates to activeTurn.inject and returns true when turn exists', async () => {
+    const proc = createMockProcess();
+    const parser = createParser();
+    parser.startReading(proc.stdout);
+    const turn = parser.createTurn();
+
+    expect(parser.injectToActiveTurn({ type: 'message.delta', delta: 'injected' })).toBe(true);
+    proc.stdout.end();
+
+    await expect(collectAsync(turn)).resolves.toEqual([{ type: 'message.delta', delta: 'injected' }]);
+  });
+
+  it('injectToActiveTurn returns false when no active turn', () => {
+    const proc = createMockProcess();
+    const parser = createParser();
+    parser.startReading(proc.stdout);
+
+    expect(parser.injectToActiveTurn({ type: 'message.delta', delta: 'ignored' })).toBe(false);
+  });
 });
 
 function createParser(): PersistentStreamParser {

--- a/apps/api/src/agent/__tests__/turn-event-queue.test.ts
+++ b/apps/api/src/agent/__tests__/turn-event-queue.test.ts
@@ -66,6 +66,52 @@ describe('TurnEventQueue', () => {
     await expect(collectAsync(queue)).resolves.toEqual([]);
   });
 
+  it('inject returns true and event is yielded when queue is active', async () => {
+    const queue = new TurnEventQueue();
+
+    expect(queue.inject(delta('injected'))).toBe(true);
+    queue.complete();
+
+    await expect(collectAsync(queue)).resolves.toEqual([delta('injected')]);
+  });
+
+  it('inject returns false after complete()', async () => {
+    const queue = new TurnEventQueue();
+
+    queue.complete();
+
+    expect(queue.inject(delta('late'))).toBe(false);
+    await expect(collectAsync(queue)).resolves.toEqual([]);
+  });
+
+  it('inject returns false after dispose()', async () => {
+    const queue = new TurnEventQueue();
+
+    queue.dispose();
+
+    expect(queue.inject(delta('late'))).toBe(false);
+    await expect(collectAsync(queue)).resolves.toEqual([]);
+  });
+
+  it('inject returns false after error()', () => {
+    const queue = new TurnEventQueue();
+
+    queue.error(new Error('stream failed'));
+
+    expect(queue.inject(delta('late'))).toBe(false);
+  });
+
+  it('inject resolves a pending consumer (like push)', async () => {
+    const queue = new TurnEventQueue();
+    const iterator = queue[Symbol.asyncIterator]();
+    const next = iterator.next();
+
+    expect(queue.inject(delta('live injected'))).toBe(true);
+
+    await expect(next).resolves.toEqual({ value: delta('live injected'), done: false });
+    queue.dispose();
+  });
+
   it('delivers multiple events in sequence', async () => {
     const queue = new TurnEventQueue();
     const events = [delta('one'), toolUse('Bash'), delta('two')];

--- a/apps/api/src/agent/agent.service.ts
+++ b/apps/api/src/agent/agent.service.ts
@@ -184,10 +184,11 @@ export class AgentService implements OnModuleDestroy {
       return 'not_found';
     }
 
+    const chartType = chartData.chart_type;
     const event: AgentEvent = {
       type: 'chart.data',
-      chart_type: chartData.chart_type as string | undefined,
-      echarts_option: chartData.echarts_option,
+      ...(typeof chartType === 'string' ? { chart_type: chartType } : {}),
+      ...(chartData.echarts_option !== undefined ? { echarts_option: chartData.echarts_option } : {}),
       data: chartData,
     };
 

--- a/apps/api/src/agent/agent.service.ts
+++ b/apps/api/src/agent/agent.service.ts
@@ -178,6 +178,22 @@ export class AgentService implements OnModuleDestroy {
     return this.queue.length;
   }
 
+  injectChartEvent(conversationId: string, chartData: Record<string, unknown>): 'injected' | 'not_found' {
+    const parser = this.persistentParsers.get(conversationId);
+    if (parser === undefined) {
+      return 'not_found';
+    }
+
+    const event: AgentEvent = {
+      type: 'chart.data',
+      chart_type: chartData.chart_type as string | undefined,
+      echarts_option: chartData.echarts_option,
+      data: chartData,
+    };
+
+    return parser.injectToActiveTurn(event) ? 'injected' : 'not_found';
+  }
+
   close(conversationId: string): Promise<void> {
     this.timings.delete(conversationId);
     return this.sessionManager.close(conversationId);
@@ -964,7 +980,7 @@ function buildPersistentClaudeArgs(session: PersistentAgentSession): string[] {
   return args;
 }
 
-function buildAgentEnv(session: AgentSessionRecord): NodeJS.ProcessEnv {
+export function buildAgentEnv(session: AgentSessionRecord): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     PATH: process.env.PATH ?? '',
     HOME: session.agentHome,
@@ -973,6 +989,9 @@ function buildAgentEnv(session: AgentSessionRecord): NodeJS.ProcessEnv {
     CHERRY_API_INTERNAL_URL:
       session.options.apiInternalUrl ?? process.env.CHERRY_API_INTERNAL_URL ?? DEFAULT_INTERNAL_API_URL,
   };
+  env.CHERRY_CHART_CALLBACK_URL = `${env.CHERRY_API_INTERNAL_URL}/api/internal/agent/chart-event`;
+  env.CHERRY_CONVERSATION_ID = session.conversationId;
+
   const apiKey = process.env.AGENT_ANTHROPIC_API_KEY ?? process.env.ANTHROPIC_API_KEY;
   const baseUrl = process.env.AGENT_ANTHROPIC_BASE_URL ?? process.env.ANTHROPIC_BASE_URL;
   const model = session.options.model ?? process.env.AGENT_ANTHROPIC_MODEL ?? process.env.ANTHROPIC_MODEL;

--- a/apps/api/src/agent/persistent-stream-parser.ts
+++ b/apps/api/src/agent/persistent-stream-parser.ts
@@ -4,6 +4,7 @@ import type { Interface } from 'node:readline';
 import type { Readable } from 'node:stream';
 
 import { isRecord, mapClaudeEvent, parseJsonLine } from './claude-event-mapper.js';
+import type { AgentEvent } from './dto/agent.dto.js';
 import { TurnEventQueue } from './turn-event-queue.js';
 
 export type PersistentParserCallbacks = {
@@ -38,6 +39,10 @@ export class PersistentStreamParser {
     const queue = new TurnEventQueue();
     this.activeTurn = queue;
     return queue;
+  }
+
+  injectToActiveTurn(event: AgentEvent): boolean {
+    return this.activeTurn?.inject(event) ?? false;
   }
 
   cancelActiveTurn(): void {

--- a/apps/api/src/agent/turn-event-queue.ts
+++ b/apps/api/src/agent/turn-event-queue.ts
@@ -20,18 +20,27 @@ export class TurnEventQueue implements AsyncIterable<AgentEvent> {
   private iterating = false;
 
   push(event: AgentEvent): void {
+    this.enqueue(event);
+  }
+
+  inject(event: AgentEvent): boolean {
+    return this.enqueue(event);
+  }
+
+  private enqueue(event: AgentEvent): boolean {
     if (this.done || this.disposed || this.failure !== undefined) {
-      return;
+      return false;
     }
 
     const pending = this.pending;
     if (pending !== undefined) {
       this.pending = undefined;
       pending.resolve(event);
-      return;
+      return true;
     }
 
     this.buffer.push(event);
+    return true;
   }
 
   complete(): void {

--- a/apps/api/src/internal/internal-jobs.service.ts
+++ b/apps/api/src/internal/internal-jobs.service.ts
@@ -763,10 +763,10 @@ export class InternalJobsService {
     try {
       const { bucket, key } = parseS3Uri(graphJsonUri);
       const stream = await this.storageService.download(bucket, key);
-      const chunks: Buffer[] = [];
+      const chunks: Uint8Array[] = [];
       let totalBytes = 0;
       for await (const chunk of stream) {
-        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        const buffer: Uint8Array = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
         totalBytes += buffer.byteLength;
         if (totalBytes > MAX_GRAPH_JSON_BYTES) {
           getApiLogger().warn(

--- a/progress.md
+++ b/progress.md
@@ -1,7 +1,7 @@
 # CherryWiki 项目进度
 
 > 本文件是 session 间的状态接力棒。每次重大变更后更新。上限 200 行。
-> 最后更新: 2026-05-15
+> 最后更新: 2026-05-16
 
 ## 1. 系统架构一句话
 
@@ -74,7 +74,7 @@
 
 | ID | 优先级 | 状态 | 描述 | Issue |
 |---|---|---|---|---|
-| BUG-008 | P1 | 未修复 | chart.data SSE 事件未触发 — persistent runner 不转发 tool_result 到 event mapper | — |
+| BUG-008 | P1 | 部分修复 | chart.data SSE 事件未触发 — #364 已实现 active turn 事件注入机制；待 #365/#366 接入 HTTP callback 与 CLI 调用 | #364 |
 
 ### 已修复 BUG (本轮)
 
@@ -94,6 +94,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
+| agent-chart-event-injection | issue #364 complete | TurnEventQueue/PersistentStreamParser/AgentService 注入机制 + env 注入，待 endpoint/CLI callback |
 | auth-session-persist | 4/4 complete, issue #356 | BUG-005 修复 |
 | fix-xlsx-mime-validation | 4/4 complete, issue #358 | BUG-006 修复 |
 | chat-no-model-precheck | 4/4 complete, issue #359 | BUG-007 修复 |


### PR DESCRIPTION
## Summary

Implements issue #364 — the event injection mechanism for chart.data SSE side-channel (BUG-008 Sub1).

- `TurnEventQueue.inject(event): boolean` — shared `enqueue()` helper ensures push/inject cannot drift
- `PersistentStreamParser.injectToActiveTurn(event): boolean` — delegates to activeTurn
- `AgentService.injectChartEvent(conversationId, chartData): 'injected' | 'not_found'` — routes by conversationId
- `buildAgentEnv()` now injects `CHERRY_CHART_CALLBACK_URL` and `CHERRY_CONVERSATION_ID` into agent subprocess

## Test plan

- [x] TurnEventQueue.inject: active yields true, completed/disposed/errored returns false, resolves pending consumer
- [x] PersistentStreamParser.injectToActiveTurn: delegates when turn exists, returns false when no turn
- [x] AgentService.injectChartEvent: injected/not_found scenarios
- [x] buildAgentEnv: verifies env vars set correctly
- [x] All 110 agent tests pass, lint clean, TypeScript clean

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `e75ef58e7b2e0c37c4ef604542e58919387fe409`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/368#issuecomment-4467187018) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/368#issuecomment-4467187070) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/368#issuecomment-4467187118) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/368#issuecomment-4467187210)
- Key findings addressed: All major findings wontfix with spec citation (turn correlation addressed by synchronous callback design; validation scoped to #365 controller layer); CI type error and pre-existing lint error fixed

Closes #364
Part of #363