### PR TITLE
feat(cherrydb): chart CLI HTTP callback (#366)

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -74,12 +74,13 @@
 
 | ID | 优先级 | 状态 | 描述 | Issue |
 |---|---|---|---|---|
-| BUG-008 | P1 | 部分修复 | chart.data SSE 事件未触发 — #364 已实现 active turn 事件注入机制；#365 已接入内部 HTTP callback endpoint + nginx 阻断；待 #366 CLI 调用 | #364/#365 |
+| BUG-008 | P1 | 已修复待端到端复测 | chart.data SSE 事件未触发 — #364 active turn 事件注入、#365 内部 HTTP callback endpoint、#366 cherrydb chart CLI callback 已完成 | #364/#365/#366 |
 
 ### 已修复 BUG (本轮)
 
 | ID | 描述 | Fix |
 |---|---|---|
+| BUG-008/#366 | cherrydb chart CLI 未回调内部 chart-event endpoint | `tools/cherrydb/cli.py` 在输出 chart envelope 后 POST `CHERRY_CHART_CALLBACK_URL`，新增 callback 单测；`tools/cherrydb` 16 tests pass |
 | BUG-007 | Chat 页面无 model 时缺少前置提示 | 新增 `GET /api/models/chat-available` boolean-only endpoint；Chat 页预检查并显示无模型提示、禁用输入 |
 | PR-360-R1 | OOXML 文件被 `isZipUpload()` 当普通 ZIP 触发 ZipValidator 误拒 | `apps/api/src/uploads/validators/mime-validator.ts` 对 `.xlsx/.docx/.pptx` 返回 false，新增 MIME + pipeline 回归测试 |
 | BUG-006 | XLSX 上传被安全检查误拒 | 当前分支：OOXML MIME `application/zip` 通过，且排除普通 ZIP 解包校验 |
@@ -94,7 +95,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| agent-chart-event-injection | issue #364 complete | TurnEventQueue/PersistentStreamParser/AgentService 注入机制 + env 注入，待 endpoint/CLI callback |
+| agent-chart-event-injection | issues #364/#365/#366 complete | TurnEventQueue/PersistentStreamParser/AgentService 注入机制 + env 注入 + internal endpoint + cherrydb CLI callback，待端到端复测 |
 | auth-session-persist | 4/4 complete, issue #356 | BUG-005 修复 |
 | fix-xlsx-mime-validation | 4/4 complete, issue #358 | BUG-006 修复 |
 | chat-no-model-precheck | 4/4 complete, issue #359 | BUG-007 修复 |

--- a/tools/cherrydb/cli.py
+++ b/tools/cherrydb/cli.py
@@ -105,6 +105,44 @@ def _emit_audit(sql: str, row_count: int, duration_ms: int) -> None:
     print(json.dumps(payload, ensure_ascii=False, default=_json_default), file=sys.stderr)
 
 
+def _send_chart_callback(envelope: dict[str, Any]) -> None:
+    """POST chart envelope to the internal callback URL. Failures are non-fatal."""
+    callback_url = os.environ.get("CHERRY_CHART_CALLBACK_URL", "")
+    if not callback_url:
+        return
+
+    agent_token = os.environ.get("CHERRY_AGENT_TOKEN", "")
+    conversation_id = os.environ.get("CHERRY_CONVERSATION_ID", "")
+
+    if not agent_token or not conversation_id:
+        print("WARN: CHERRY_AGENT_TOKEN or CHERRY_CONVERSATION_ID missing - skipping chart callback", file=sys.stderr)
+        return
+
+    import urllib.request
+
+    body = json.dumps(
+        {
+            "conversationId": conversation_id,
+            "chart": envelope,
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        callback_url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {agent_token}",
+        },
+        method="POST",
+    )
+
+    try:
+        urllib.request.urlopen(req, timeout=3)
+    except Exception as exc:
+        print(f"WARN: chart callback failed: {exc}", file=sys.stderr)
+
+
 def _rows_to_dicts(columns: list[str], rows: Iterable[Iterable[Any]]) -> list[dict[str, Any]]:
     masked = _masked_columns()
     result: list[dict[str, Any]] = []
@@ -246,6 +284,7 @@ def chart_command(chart_type: str, sql: str) -> None:
             "echarts_option": build_echarts_option(chart_type, rows),
         }
         click.echo(json.dumps(envelope, ensure_ascii=False, default=_json_default))
+        _send_chart_callback(envelope)
     except (CherryDBError, ValueError) as exc:
         _fail(str(exc))
 

--- a/tools/cherrydb/tests/test_chart_callback.py
+++ b/tools/cherrydb/tests/test_chart_callback.py
@@ -1,0 +1,102 @@
+"""Tests for _send_chart_callback in cherrydb chart command."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cherrydb.cli import main
+
+
+def _chart_env(monkeypatch, **overrides):
+    """Set up full env for chart callback."""
+    defaults = {
+        "CHERRY_DB_DSN": "postgresql://readonly@example/cherry",
+        "CHERRY_DB_ALLOWED_TABLES": "daily_stats",
+        "CHERRY_CHART_CALLBACK_URL": "http://api.internal:8080/api/internal/agent/chart-event",
+        "CHERRY_AGENT_TOKEN": "test-token-123",
+        "CHERRY_CONVERSATION_ID": "conv-abc",
+    }
+    defaults.update(overrides)
+    for key, value in defaults.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+
+
+class TestChartCallback:
+    def test_sends_post_when_all_env_present(self, monkeypatch, fake_db):
+        _chart_env(monkeypatch)
+        fake_db(description=[("x",), ("y",)], rows=[("A", 1)])
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = MagicMock(status=202)
+            result = CliRunner().invoke(main, ["chart", "bar", "SELECT x, y FROM daily_stats"])
+
+        assert result.exit_code == 0
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer test-token-123"
+        assert req.get_header("Content-type") == "application/json"
+        body = json.loads(req.data)
+        assert body["conversationId"] == "conv-abc"
+        assert body["chart"]["type"] == "cherrywiki.chart"
+        assert body["chart"]["chart_type"] == "bar"
+
+    def test_skips_silently_when_callback_url_missing(self, monkeypatch, fake_db):
+        _chart_env(monkeypatch, CHERRY_CHART_CALLBACK_URL=None)
+        fake_db(description=[("x",), ("y",)], rows=[("A", 1)])
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = CliRunner().invoke(main, ["chart", "bar", "SELECT x, y FROM daily_stats"])
+
+        assert result.exit_code == 0
+        mock_urlopen.assert_not_called()
+        assert "WARN" not in result.output + result.stderr
+
+    def test_warns_on_stderr_when_token_missing(self, monkeypatch, fake_db):
+        _chart_env(monkeypatch, CHERRY_AGENT_TOKEN=None)
+        fake_db(description=[("x",), ("y",)], rows=[("A", 1)])
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = CliRunner().invoke(main, ["chart", "bar", "SELECT x, y FROM daily_stats"])
+
+        assert result.exit_code == 0
+        mock_urlopen.assert_not_called()
+        assert "CHERRY_AGENT_TOKEN" in result.stderr or "missing" in result.stderr.lower()
+
+    def test_warns_on_stderr_when_conversation_id_missing(self, monkeypatch, fake_db):
+        _chart_env(monkeypatch, CHERRY_CONVERSATION_ID=None)
+        fake_db(description=[("x",), ("y",)], rows=[("A", 1)])
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = CliRunner().invoke(main, ["chart", "bar", "SELECT x, y FROM daily_stats"])
+
+        assert result.exit_code == 0
+        mock_urlopen.assert_not_called()
+        assert "CHERRY_CONVERSATION_ID" in result.stderr or "missing" in result.stderr.lower()
+
+    def test_http_failure_does_not_affect_exit_code(self, monkeypatch, fake_db):
+        _chart_env(monkeypatch)
+        fake_db(description=[("x",), ("y",)], rows=[("A", 1)])
+
+        import urllib.error
+
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("connection refused")):
+            result = CliRunner().invoke(main, ["chart", "bar", "SELECT x, y FROM daily_stats"])
+
+        assert result.exit_code == 0
+        assert "callback failed" in result.stderr.lower() or "warn" in result.stderr.lower()
+
+    def test_timeout_3s_passed_to_urlopen(self, monkeypatch, fake_db):
+        _chart_env(monkeypatch)
+        fake_db(description=[("x",), ("y",)], rows=[("A", 1)])
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = MagicMock(status=202)
+            CliRunner().invoke(main, ["chart", "bar", "SELECT x, y FROM daily_stats"])
+
+        _, kwargs = mock_urlopen.call_args
+        assert kwargs.get("timeout") == 3


### PR DESCRIPTION
## Summary

Implements issue #366 — cherrydb chart command HTTP callback.

- `_send_chart_callback()` POSTs chart envelope to `CHERRY_CHART_CALLBACK_URL` after stdout output
- Uses `urllib.request` (stdlib only, no new deps), timeout=3s, Bearer token auth
- Graceful degradation: URL missing → silent skip; token/convId missing → stderr warn; HTTP fail → stderr warn + exit 0

## Test plan

- [x] All env present → POST sent with correct auth header and body
- [x] Callback URL missing → silent skip (no stderr)
- [x] Token missing → stderr warning + skip
- [x] ConversationId missing → stderr warning + skip
- [x] HTTP failure → stderr warning, exit code 0
- [x] Timeout=3s passed to urlopen
- [x] All 16 cherrydb tests pass

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `95fcb15e3f47b409851fceebccd0cd5fb45b3a1a`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/370#issuecomment-4468199376) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/370#issuecomment-4468199499) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/370#issuecomment-4468199681) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/370#issuecomment-4468199849)
- Key findings addressed: Zero findings — clean implementation matching spec exactly

Closes #366
Part of #363