### PR TITLE
fix(bridge): resolve dedup INTERNAL_ERROR on duplicate event_id (#375)

### DIFF
--- a/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@cherrygraph/shared';
 import crypto, { randomUUID } from 'node:crypto';
 import request, { type Response } from 'supertest';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { configureApp } from '../../main.js';
 import { getApiLogger } from '../../common/logger/logger.module.js';
@@ -21,6 +21,7 @@ import { DRIZZLE } from '../../database/drizzle.constants.js';
 import { BridgeAuthGuard } from '../bridge-auth.guard.js';
 import { BridgeEventController } from '../bridge-event.controller.js';
 import { BridgeEventService } from '../bridge-event.service.js';
+import { BridgeQueueService } from '../bridge-queue.service.js';
 import { BridgeRateLimitGuard } from '../bridge-rate-limit.guard.js';
 
 const CURRENT_SECRET = 'bridge-current-secret';
@@ -36,7 +37,12 @@ type TestResponseData = {
 type BridgeReceiverTestContext = {
   app: NestFastifyApplication;
   db: InMemoryBridgeDatabase;
+  bridgeQueue: BridgeQueueMock;
   redis: InMemoryBridgeRedis;
+};
+
+type BridgeQueueMock = {
+  enqueueBridgeJob: ReturnType<typeof vi.fn>;
 };
 
 const originalBridgeSecret = process.env.DOCMOST_BRIDGE_SECRET;
@@ -124,11 +130,57 @@ describe('Bridge receiver contract', () => {
     );
     expect(getResponseData(secondResponse)).toEqual(
       expect.objectContaining({
+        accepted: true,
         event_id: eventId,
         deduplicated: true,
       }),
     );
     expect(requireContext().db.eventCount(eventId)).toBe(1);
+  });
+
+  it('re-enqueues duplicate received events and skips duplicate processed events', async () => {
+    const testContext = requireContext();
+    const receivedEventId = randomUUID();
+    const processedEventId = randomUUID();
+
+    await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: receivedEventId,
+    })).expect(200);
+    await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: receivedEventId,
+    })).expect(200);
+
+    await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: processedEventId,
+    })).expect(200);
+    testContext.db.setEventStatus(processedEventId, 'processed');
+    await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: processedEventId,
+    })).expect(200);
+
+    const callsForReceivedEvent = testContext.bridgeQueue.enqueueBridgeJob.mock.calls.filter(
+      ([, jobData]) => isRecord(jobData) && jobData.eventId === receivedEventId,
+    );
+    const callsForProcessedEvent = testContext.bridgeQueue.enqueueBridgeJob.mock.calls.filter(
+      ([, jobData]) => isRecord(jobData) && jobData.eventId === processedEventId,
+    );
+
+    expect(callsForReceivedEvent).toHaveLength(2);
+    expect(callsForProcessedEvent).toHaveLength(1);
+  });
+
+  it('propagates non-unique database errors instead of treating them as deduplicated events', async () => {
+    const testContext = requireContext();
+    const eventId = randomUUID();
+    testContext.db.failNextBridgeEventInsert(createDatabaseError('insert/update violates foreign key', '23503'));
+
+    const response = await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: eventId,
+    })).expect(500);
+
+    expect(getResponseDataIfPresent(response)).toBeUndefined();
+    expect(testContext.db.eventCount(eventId)).toBe(0);
+    expect(testContext.bridgeQueue.enqueueBridgeJob).not.toHaveBeenCalled();
   });
 
   it('returns 429 when the per-IP Bridge rate limit is exceeded', async () => {
@@ -167,6 +219,7 @@ describe('Bridge receiver contract', () => {
 async function createBridgeReceiverTestContext(): Promise<BridgeReceiverTestContext> {
   const redis = new InMemoryBridgeRedis();
   const db = new InMemoryBridgeDatabase();
+  const bridgeQueue = createBridgeQueueMock();
   const moduleRef = await Test.createTestingModule({
     controllers: [BridgeEventController],
     providers: [
@@ -174,6 +227,7 @@ async function createBridgeReceiverTestContext(): Promise<BridgeReceiverTestCont
       BridgeRateLimitGuard,
       BridgeEventService,
       { provide: DRIZZLE, useValue: db },
+      { provide: BridgeQueueService, useValue: bridgeQueue },
       { provide: REDIS_CLIENT, useValue: redis },
     ],
   }).compile();
@@ -185,7 +239,7 @@ async function createBridgeReceiverTestContext(): Promise<BridgeReceiverTestCont
   await app.init();
   await app.getHttpAdapter().getInstance().ready();
 
-  return { app, db, redis };
+  return { app, db, bridgeQueue, redis };
 }
 
 function sendSignedBridgeEvent(
@@ -259,6 +313,19 @@ function getResponseData(response: Response): TestResponseData {
   return body as TestResponseData;
 }
 
+function getResponseDataIfPresent(response: Response): TestResponseData | undefined {
+  const body = parseResponseBody(response);
+  if (body.accepted !== true) {
+    return undefined;
+  }
+
+  if (typeof body.event_id !== 'string' || typeof body.deduplicated !== 'boolean') {
+    throw new Error('Expected raw bridge response body');
+  }
+
+  return body as TestResponseData;
+}
+
 function getErrorCode(response: Response): unknown {
   const body = parseResponseBody(response);
   return isRecord(body.error) ? body.error.code : undefined;
@@ -316,6 +383,7 @@ type StoredBridgeEvent = {
 class InMemoryBridgeDatabase {
   private readonly eventsByEventId = new Map<string, StoredBridgeEvent>();
   private pendingLookupEventId: string | undefined;
+  private nextBridgeEventInsertError: unknown;
   readonly deliveries: unknown[] = [];
 
   insert(table: unknown): unknown {
@@ -323,14 +391,21 @@ class InMemoryBridgeDatabase {
       return {
         values: (value: Record<string, unknown>) => ({
           returning: (): Promise<StoredBridgeEvent[]> => {
+            if (this.nextBridgeEventInsertError !== undefined) {
+              const error = this.nextBridgeEventInsertError;
+              this.nextBridgeEventInsertError = undefined;
+              throw error;
+            }
+
             const eventId = requireString(value.event_id, 'event_id');
             const existing = this.eventsByEventId.get(eventId);
             if (existing !== undefined) {
               this.pendingLookupEventId = eventId;
-              throw Object.assign(new Error('duplicate bridge event_id'), {
-                code: '23505',
-                constraint: 'bridge_events_event_id_unique',
-              });
+              throw createDatabaseError(
+                'duplicate bridge event_id',
+                '23505',
+                'bridge_events_event_id_unique',
+              );
             }
 
             const event: StoredBridgeEvent = {
@@ -382,6 +457,34 @@ class InMemoryBridgeDatabase {
   eventCount(eventId: string): number {
     return this.eventsByEventId.has(eventId) ? 1 : 0;
   }
+
+  failNextBridgeEventInsert(error: unknown): void {
+    this.nextBridgeEventInsertError = error;
+  }
+
+  setEventStatus(eventId: string, status: BridgeEventStatus): void {
+    const event = this.eventsByEventId.get(eventId);
+    if (event === undefined) {
+      throw new Error(`Expected event ${eventId} to exist`);
+    }
+
+    this.eventsByEventId.set(eventId, { ...event, status });
+  }
+}
+
+function createBridgeQueueMock(): BridgeQueueMock {
+  return {
+    enqueueBridgeJob: vi.fn(() => Promise.resolve()),
+  };
+}
+
+function createDatabaseError(message: string, code: string, constraint?: string): Error {
+  const cause = Object.assign(new Error(message), {
+    code,
+    ...(constraint !== undefined ? { constraint } : {}),
+  });
+
+  return new Error('Failed query', { cause });
 }
 
 function requireString(value: unknown, fieldName: string): string {

--- a/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
@@ -169,6 +169,53 @@ describe('Bridge receiver contract', () => {
     expect(callsForProcessedEvent).toHaveLength(1);
   });
 
+  it('detects unique violation via detail string fallback when constraint property is absent', async () => {
+    const testContext = requireContext();
+    const eventId = randomUUID();
+
+    await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: eventId,
+    })).expect(200);
+
+    testContext.db.overrideNextDuplicateError(createDatabaseError(
+      'duplicate key value violates unique constraint',
+      '23505',
+      undefined,
+      'Key (event_id)=(abc) already exists on bridge_events_event_id_unique',
+    ));
+
+    const response = await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: eventId,
+    })).expect(200);
+
+    expect(getResponseData(response)).toEqual(expect.objectContaining({
+      accepted: true,
+      deduplicated: true,
+    }));
+  });
+
+  it('detects unique violation through deeply wrapped cause chain (depth > 3)', async () => {
+    const testContext = requireContext();
+    const eventId = randomUUID();
+
+    await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: eventId,
+    })).expect(200);
+
+    testContext.db.overrideNextDuplicateError(
+      createDeeplyWrappedDatabaseError('duplicate key', '23505', 'bridge_events_event_id_unique', 5),
+    );
+
+    const response = await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: eventId,
+    })).expect(200);
+
+    expect(getResponseData(response)).toEqual(expect.objectContaining({
+      accepted: true,
+      deduplicated: true,
+    }));
+  });
+
   it('propagates non-unique database errors instead of treating them as deduplicated events', async () => {
     const testContext = requireContext();
     const eventId = randomUUID();
@@ -384,6 +431,7 @@ class InMemoryBridgeDatabase {
   private readonly eventsByEventId = new Map<string, StoredBridgeEvent>();
   private pendingLookupEventId: string | undefined;
   private nextBridgeEventInsertError: unknown;
+  private nextDuplicateError: unknown;
   readonly deliveries: unknown[] = [];
 
   insert(table: unknown): unknown {
@@ -401,6 +449,11 @@ class InMemoryBridgeDatabase {
             const existing = this.eventsByEventId.get(eventId);
             if (existing !== undefined) {
               this.pendingLookupEventId = eventId;
+              if (this.nextDuplicateError !== undefined) {
+                const error = this.nextDuplicateError;
+                this.nextDuplicateError = undefined;
+                throw error;
+              }
               throw createDatabaseError(
                 'duplicate bridge event_id',
                 '23505',
@@ -462,6 +515,10 @@ class InMemoryBridgeDatabase {
     this.nextBridgeEventInsertError = error;
   }
 
+  overrideNextDuplicateError(error: unknown): void {
+    this.nextDuplicateError = error;
+  }
+
   setEventStatus(eventId: string, status: BridgeEventStatus): void {
     const event = this.eventsByEventId.get(eventId);
     if (event === undefined) {
@@ -478,13 +535,23 @@ function createBridgeQueueMock(): BridgeQueueMock {
   };
 }
 
-function createDatabaseError(message: string, code: string, constraint?: string): Error {
+function createDatabaseError(message: string, code: string, constraint?: string, detail?: string): Error {
   const cause = Object.assign(new Error(message), {
     code,
     ...(constraint !== undefined ? { constraint } : {}),
+    ...(detail !== undefined ? { detail } : {}),
   });
 
   return new Error('Failed query', { cause });
+}
+
+function createDeeplyWrappedDatabaseError(message: string, code: string, constraint: string, depth: number): Error {
+  const pgError = Object.assign(new Error(message), { code, constraint });
+  let wrapped: Error = pgError;
+  for (let i = 0; i < depth; i += 1) {
+    wrapped = new Error(`wrapper level ${i}`, { cause: wrapped });
+  }
+  return wrapped;
 }
 
 function requireString(value: unknown, fieldName: string): string {

--- a/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
@@ -216,6 +216,28 @@ describe('Bridge receiver contract', () => {
     }));
   });
 
+  it('propagates 23505 errors from unrelated constraints without matching detail', async () => {
+    const testContext = requireContext();
+    const eventId = randomUUID();
+
+    await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: eventId,
+    })).expect(200);
+
+    testContext.db.overrideNextDuplicateError(createDatabaseError(
+      'duplicate key',
+      '23505',
+      undefined,
+      'Key (slug)=(test) already exists on spaces_slug_unique',
+    ));
+
+    const response = await sendSignedBridgeEvent(testContext, '/page-saved', createPayload('page.saved', {
+      event_id: eventId,
+    })).expect(500);
+
+    expect(getResponseDataIfPresent(response)).toBeUndefined();
+  });
+
   it('propagates non-unique database errors instead of treating them as deduplicated events', async () => {
     const testContext = requireContext();
     const eventId = randomUUID();

--- a/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
+++ b/apps/api/src/bridge/__tests__/bridge-receiver.test.ts
@@ -462,7 +462,7 @@ class InMemoryBridgeDatabase {
         values: (value: Record<string, unknown>) => ({
           returning: (): Promise<StoredBridgeEvent[]> => {
             if (this.nextBridgeEventInsertError !== undefined) {
-              const error = this.nextBridgeEventInsertError;
+              const error = this.nextBridgeEventInsertError as Error;
               this.nextBridgeEventInsertError = undefined;
               throw error;
             }
@@ -472,7 +472,7 @@ class InMemoryBridgeDatabase {
             if (existing !== undefined) {
               this.pendingLookupEventId = eventId;
               if (this.nextDuplicateError !== undefined) {
-                const error = this.nextDuplicateError;
+                const error = this.nextDuplicateError as Error;
                 this.nextDuplicateError = undefined;
                 throw error;
               }

--- a/apps/api/src/bridge/bridge-event.service.ts
+++ b/apps/api/src/bridge/bridge-event.service.ts
@@ -177,15 +177,23 @@ function toBridgeQueueJobData(event: BridgeEventRow): {
 }
 
 function isUniqueViolation(err: unknown, constraint: string): boolean {
+  const seen = new WeakSet<object>();
   let current: unknown = err;
 
-  for (let depth = 0; depth <= 3; depth += 1) {
-    if (!isRecord(current)) {
+  while (isRecord(current)) {
+    if (seen.has(current as object)) {
       return false;
     }
+    seen.add(current as object);
 
     if (current.code === '23505') {
-      return current.constraint === constraint || current.constraint === undefined;
+      if (current.constraint === constraint || current.constraint === undefined) {
+        return true;
+      }
+      if (typeof current.detail === 'string' && current.detail.includes(constraint)) {
+        return true;
+      }
+      return false;
     }
 
     current = current.cause;

--- a/apps/api/src/bridge/bridge-event.service.ts
+++ b/apps/api/src/bridge/bridge-event.service.ts
@@ -181,10 +181,10 @@ function isUniqueViolation(err: unknown, constraint: string): boolean {
   let current: unknown = err;
 
   while (isRecord(current)) {
-    if (seen.has(current as object)) {
+    if (seen.has(current)) {
       return false;
     }
-    seen.add(current as object);
+    seen.add(current);
 
     if (current.code === '23505') {
       if (current.constraint === constraint) {

--- a/apps/api/src/bridge/bridge-event.service.ts
+++ b/apps/api/src/bridge/bridge-event.service.ts
@@ -177,11 +177,21 @@ function toBridgeQueueJobData(event: BridgeEventRow): {
 }
 
 function isUniqueViolation(err: unknown, constraint: string): boolean {
-  if (!isRecord(err)) {
-    return false;
+  let current: unknown = err;
+
+  for (let depth = 0; depth <= 3; depth += 1) {
+    if (!isRecord(current)) {
+      return false;
+    }
+
+    if (current.code === '23505') {
+      return current.constraint === constraint || current.constraint === undefined;
+    }
+
+    current = current.cause;
   }
 
-  return err.code === '23505' && (err.constraint === constraint || err.constraint === undefined);
+  return false;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/api/src/bridge/bridge-event.service.ts
+++ b/apps/api/src/bridge/bridge-event.service.ts
@@ -187,11 +187,14 @@ function isUniqueViolation(err: unknown, constraint: string): boolean {
     seen.add(current as object);
 
     if (current.code === '23505') {
-      if (current.constraint === constraint || current.constraint === undefined) {
+      if (current.constraint === constraint) {
         return true;
       }
       if (typeof current.detail === 'string' && current.detail.includes(constraint)) {
         return true;
+      }
+      if (current.constraint !== undefined) {
+        return false;
       }
       return false;
     }


### PR DESCRIPTION
## Summary
- Fixed `isUniqueViolation()` to traverse `err.cause` chain (WeakSet-guarded) for Drizzle-wrapped PG errors
- Added `detail` string fallback per design.md for constraint detection
- Removed false-positive `constraint===undefined` shortcut (caught by independent review)
- Duplicate `event_id` webhooks now correctly return HTTP 200 `{accepted: true, deduplicated: true}` instead of HTTP 500

Closes #375

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `4fad3de8fac497511149ced7bcc5276b6d8fe76e`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/378#issuecomment-4469788377) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/378#issuecomment-4469789240) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/378#issuecomment-4469789561) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/378#issuecomment-4469789973)
- Key findings addressed: Unbounded cause-chain traversal (WeakSet guard), detail string fallback for constraint matching, false-positive constraint===undefined removal, lint compliance

## Test plan
- [x] Build passes (`npm run build`)
- [x] 18 bridge receiver tests pass
- [x] New test: duplicate event_id returns `{accepted: true, deduplicated: true}`
- [x] New test: received-status duplicate re-enqueues, processed-status skips
- [x] New test: FK error (23503) propagates as 500
- [x] New test: detail fallback matches constraint in detail string
- [x] New test: deep cause chain (depth > 3) correctly detected
- [x] New test: unrelated 23505 with non-matching detail propagates as 500