### PR TITLE
feat(infra): enable phase2 services by default (#377)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,8 +82,9 @@ HTTPS_PROXY=http://egress-proxy:3128
 NO_PROXY=cherry-api,minio,localhost,127.0.0.1
 
 # --- Compose Profiles ---
-# Enables the docmost and wiki-sync-worker services by default.
-COMPOSE_PROFILES=docmost
+# docmost and wiki-sync-worker now start by default (no profile needed).
+# Use COMPOSE_PROFILES=phase3,agent to also start the agent runtime.
+# COMPOSE_PROFILES=
 
 # --- Docmost (Phase 2) ---
 DOCMOST_BASE_URL=http://docmost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -464,7 +464,6 @@ services:
         condition: service_healthy
 
   docmost:
-    profiles: ["docmost", "phase2"]
     image: ${DOCMOST_IMAGE:-docmost/docmost:0.80.1}
     restart: unless-stopped
     environment:
@@ -492,7 +491,6 @@ services:
         condition: service_healthy
 
   wiki-sync-worker:
-    profiles: ["phase2"]
     image: node:20-slim
     restart: unless-stopped
     working_dir: /app

--- a/docs/ops/docker-compose.skeleton.yml
+++ b/docs/ops/docker-compose.skeleton.yml
@@ -170,9 +170,8 @@ services:
       minio:
         condition: service_healthy
 
-  # Phase 2 启用：Docmost ↔ Canonical Wiki Repo 同步
+  # Docmost ↔ Canonical Wiki Repo 同步（默认启动）
   wiki-sync-worker:
-    profiles: ["phase2"]
     image: your-registry/cherrygraph-wiki-sync-worker:latest
     restart: unless-stopped
     environment:
@@ -228,10 +227,8 @@ services:
       redis:
         condition: service_healthy
 
-  # Phase 2 启用：Docmost Fork 开源版 + 自建 Bridge endpoint。
-  # 默认不启动。启用方式：docker compose --profile docmost up -d docmost
+  # Docmost Fork 开源版 + Bridge endpoint（默认启动）
   docmost:
-    profiles: ["docmost", "phase2"]
     image: ${DOCMOST_IMAGE:-docmost/docmost:0.80.1}
     restart: unless-stopped
     environment:

--- a/scripts/verify-bridge-isolation.mjs
+++ b/scripts/verify-bridge-isolation.mjs
@@ -18,9 +18,7 @@ const serviceNetworks = asRecord(docmost.networks);
 const composeNetworks = asRecord(compose.networks);
 const defaultNetwork = asRecord(composeNetworks.default);
 
-if (!profiles.includes('docmost')) {
-  fail('docmost service must include the docmost profile');
-}
+// docmost now starts by default (no profile required since phase2 removal)
 
 if (ports.length > 0) {
   fail(`docmost must not publish host ports; found ${JSON.stringify(ports)}`);


### PR DESCRIPTION
## Summary
- Removed `profiles: ["phase2"]` from `wiki-sync-worker` and `profiles: ["docmost", "phase2"]` from `docmost`
- Both services now start with plain `docker compose up -d`
- Phase 3 services remain gated behind `profiles: ["phase3", "agent"]`
- Updated `.env.example`, `docs/ops/docker-compose.skeleton.yml`, and `scripts/verify-bridge-isolation.mjs`

Closes #377

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `fd525e2a3813cb24820fa4afd4a39853d21da77f`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/380#issuecomment-4469957334) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/380#issuecomment-4469957730) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/380#issuecomment-4469958260) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/380#issuecomment-4469958484)
- Key findings addressed: Skeleton docs updated, bridge isolation script fixed for unprofiled docmost

## Test plan
- [x] `docker compose config --services` lists all 13 services
- [x] Phase 3 agent still requires profile flag
- [x] `verify-bridge-isolation.mjs` passes
- [x] `.env.example` and skeleton docs updated
- [ ] `docker compose up -d` starts all services (manual verification)