### PR TITLE
fix(db): add ON DELETE CASCADE to session FK constraints

### DIFF
--- a/packages/shared/src/schema/__tests__/session-delete-cascade.test.ts
+++ b/packages/shared/src/schema/__tests__/session-delete-cascade.test.ts
@@ -1,0 +1,31 @@
+import { getTableConfig, type PgTable } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import * as schema from '../index.js';
+
+describe('Chat session delete cascade schema', () => {
+  it('cascades retrieval traces when a chat session is deleted', () => {
+    expect(foreignKeyOnDelete(schema.retrievalTraces, 'retrieval_traces_conversation_id_chat_sessions_id_fk')).toBe(
+      'cascade',
+    );
+  });
+
+  it('cascades model usage logs when a chat session is deleted', () => {
+    expect(foreignKeyOnDelete(schema.modelUsageLogs, 'model_usage_logs_conversation_id_chat_sessions_id_fk')).toBe(
+      'cascade',
+    );
+  });
+
+  it('cascades feedback items when a chat message is deleted', () => {
+    expect(foreignKeyOnDelete(schema.feedbackItems, 'feedback_items_message_id_chat_messages_id_fk')).toBe('cascade');
+  });
+});
+
+function foreignKeyOnDelete(table: PgTable, foreignKeyName: string): string | undefined {
+  const tableConfig = getTableConfig(table);
+  const foreignKey = tableConfig.foreignKeys.find((candidate) => candidate.getName() === foreignKeyName);
+
+  expect(foreignKey).toBeDefined();
+
+  return foreignKey?.onDelete;
+}

--- a/packages/shared/src/schema/core.ts
+++ b/packages/shared/src/schema/core.ts
@@ -940,7 +940,7 @@ export const retrievalTraces = pgTable('retrieval_traces', {
     .notNull()
     .references(() => tenants.id),
   user_id: text('user_id').references(() => users.id),
-  conversation_id: text('conversation_id').references(() => chatSessions.id),
+  conversation_id: text('conversation_id').references(() => chatSessions.id, { onDelete: 'cascade' }),
   space_ids: text('space_ids').array().notNull(),
   query: text('query').notNull(),
   retrieval_mode: text('retrieval_mode').notNull(),
@@ -966,7 +966,7 @@ export const modelUsageLogs = pgTable(
     output_tokens: integer('output_tokens').notNull().default(0),
     latency_ms: integer('latency_ms'),
     space_id: text('space_id').references(() => spaces.id),
-    conversation_id: text('conversation_id').references(() => chatSessions.id),
+    conversation_id: text('conversation_id').references(() => chatSessions.id, { onDelete: 'cascade' }),
     created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
@@ -1050,7 +1050,7 @@ export const feedbackItems = pgTable('feedback_items', {
     .notNull()
     .references(() => tenants.id),
   user_id: text('user_id').references(() => users.id),
-  message_id: text('message_id').references(() => chatMessages.id),
+  message_id: text('message_id').references(() => chatMessages.id, { onDelete: 'cascade' }),
   space_id: text('space_id').references(() => spaces.id),
   feedback_type: text('feedback_type').notNull(),
   status: text('status').notNull().default('open'),

--- a/schemas/migrations/0019_fix_session_delete_cascade.sql
+++ b/schemas/migrations/0019_fix_session_delete_cascade.sql
@@ -1,0 +1,19 @@
+ALTER TABLE retrieval_traces
+  DROP CONSTRAINT retrieval_traces_conversation_id_fkey,
+  ADD CONSTRAINT retrieval_traces_conversation_id_fkey
+    FOREIGN KEY (conversation_id) REFERENCES chat_sessions(id) ON DELETE CASCADE;
+
+ALTER TABLE model_usage_logs
+  DROP CONSTRAINT model_usage_logs_conversation_id_fkey,
+  ADD CONSTRAINT model_usage_logs_conversation_id_fkey
+    FOREIGN KEY (conversation_id) REFERENCES chat_sessions(id) ON DELETE CASCADE;
+
+ALTER TABLE feedback_items
+  DROP CONSTRAINT feedback_items_message_id_chat_messages_id_fk,
+  ADD CONSTRAINT feedback_items_message_id_chat_messages_id_fk
+    FOREIGN KEY (message_id) REFERENCES chat_messages(id) ON DELETE CASCADE;
+
+-- Rollback: revert to NO ACTION
+-- ALTER TABLE retrieval_traces DROP CONSTRAINT retrieval_traces_conversation_id_fkey, ADD CONSTRAINT retrieval_traces_conversation_id_fkey FOREIGN KEY (conversation_id) REFERENCES chat_sessions(id);
+-- ALTER TABLE model_usage_logs DROP CONSTRAINT model_usage_logs_conversation_id_fkey, ADD CONSTRAINT model_usage_logs_conversation_id_fkey FOREIGN KEY (conversation_id) REFERENCES chat_sessions(id);
+-- ALTER TABLE feedback_items DROP CONSTRAINT feedback_items_message_id_chat_messages_id_fk, ADD CONSTRAINT feedback_items_message_id_chat_messages_id_fk FOREIGN KEY (message_id) REFERENCES chat_messages(id);

--- a/schemas/migrations/meta/_journal.json
+++ b/schemas/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778975700000,
       "tag": "0018_add_pgcrypto",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1779292800000,
+      "tag": "0019_fix_session_delete_cascade",
+      "breakpoints": true
     }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       'scripts/**/*.test.ts',
       'tests/**/*.test.ts',
     ],
-    exclude: runsExplicitWebTest ? configDefaults.exclude : [...configDefaults.exclude, 'apps/web/**'],
+    exclude: runsExplicitWebTest ? configDefaults.exclude : [...configDefaults.exclude, 'apps/web/**', 'tests/e2e/**'],
     environment: runsExplicitWebTest ? 'jsdom' : 'node',
     setupFiles: runsExplicitWebTest ? ['apps/web/src/__tests__/setup.ts'] : [],
     passWithNoTests: true,


### PR DESCRIPTION
Closes #381

## Summary

- Added `{ onDelete: 'cascade' }` to three FK references in Drizzle schema (`packages/shared/src/schema/core.ts`):
  - `retrievalTraces.conversation_id` → `chat_sessions.id`
  - `modelUsageLogs.conversation_id` → `chat_sessions.id`
  - `feedbackItems.message_id` → `chat_messages.id`
- Created migration `schemas/migrations/0019_fix_session_delete_cascade.sql` to ALTER three FK constraints to `ON DELETE CASCADE`
- Added schema regression test validating cascade declarations
- Excluded `tests/e2e/**` from root vitest config (has its own config)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `73d277836b954de6ae12f671f263db9f05c3296a`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/382#issuecomment-4470752276) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/382#issuecomment-4470752335) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/382#issuecomment-4470752419) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/382#issuecomment-4470752563)
- Key findings addressed: All reviewers clean — constraint names verified against migration 0011/0012; CASCADE data removal per design.md; FK indexes deferred as premature optimization

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (211 files, 1416 tests, 0 failures)
- [x] New `session-delete-cascade.test.ts` validates FK cascade config on all 3 tables
- [ ] E2E: delete session with traces/logs → succeeds
- [ ] E2E: delete session without traces → no regression