### PR TITLE
feat(chat): integrate rerank model into static_rag retrieval pipeline (#384)

### DIFF
--- a/apps/api/src/chat/__tests__/rerank.test.ts
+++ b/apps/api/src/chat/__tests__/rerank.test.ts
@@ -1,0 +1,449 @@
+import 'reflect-metadata';
+
+import type {
+  ChatProvider,
+  ChatProviderConfig,
+  EmbeddingProvider,
+  EmbeddingProviderConfig,
+} from '@cherrygraph/ai-core';
+import { indexSnapshots, model_configs, spaces } from '@cherrygraph/shared';
+import type { RetrievalResult } from '@cherrygraph/rag-core';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import type { AuditService } from '../../audit/audit.service.js';
+import { TEST_GROUP_ID, TEST_SPACE_ID, TEST_TENANT_ID, TEST_USER_ID } from '../../users/__tests__/user-group-service-test-utils.js';
+import { ChatService } from '../chat.service.js';
+import type { RerankModelConfig } from '../../models/model-config.service.js';
+
+type ModelConfigRow = typeof model_configs.$inferSelect;
+type SpaceRow = typeof spaces.$inferSelect;
+type IndexSnapshotRow = typeof indexSnapshots.$inferSelect;
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.TEST_RERANK_API_KEY;
+  Object.defineProperty(globalThis, 'fetch', {
+    value: originalFetch,
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe('ChatService static RAG rerank', () => {
+  it('reorders retrieval results on successful rerank response', async () => {
+    process.env.TEST_RERANK_API_KEY = 'rerank-secret';
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      status: 200,
+      body: {
+        results: [
+          { index: 1, relevance_score: 0.9 },
+          { index: 0, relevance_score: 0.5 },
+        ],
+      },
+    });
+    const { service, modelConfigService } = createServiceContext({
+      rerankConfig: createRerankModelConfig(),
+    });
+    const retrieveContext = bindRetrieveContext(service);
+
+    const context = await retrieveContext(createPreparedCompletion(), [createSnapshotRow()]);
+
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-b', 'chunk-a']);
+    expect(context.trace.finalContext.rerank_status).toBe('success');
+    expect(context.trace.finalContext.rerank_model_id).toBe('rerank-config');
+    expect(context.trace.finalContext.rerank_latency_ms).toBeGreaterThanOrEqual(1);
+    expect(modelConfigService.getEnabledRerankModel).toHaveBeenCalledWith(TEST_TENANT_ID);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://rerank.example/v1/rerank',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer rerank-secret',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          model: 'bge-reranker',
+          query: 'How is SSO configured?',
+          documents: ['First chunk', 'Second chunk'],
+          top_n: 2,
+        }),
+      }),
+    );
+  });
+
+  it('keeps RRF order when no rerank model is enabled', async () => {
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      status: 200,
+      body: { results: [] },
+    });
+    const { service } = createServiceContext({ rerankConfig: null });
+    const retrieveContext = bindRetrieveContext(service);
+
+    const context = await retrieveContext(createPreparedCompletion(), [createSnapshotRow()]);
+
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-a', 'chunk-b']);
+    expect(context.trace.finalContext.rerank_status).toBe('skipped');
+    expect(context.trace.finalContext.rerank_skip_reason).toBe('no_rerank_model');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps RRF order and records timeout when rerank request aborts', async () => {
+    process.env.TEST_RERANK_API_KEY = 'rerank-secret';
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    const fetchMock = vi.fn(() => Promise.reject(abortError));
+    Object.defineProperty(globalThis, 'fetch', {
+      value: fetchMock,
+      writable: true,
+      configurable: true,
+    });
+    const { service } = createServiceContext({ rerankConfig: createRerankModelConfig() });
+    const retrieveContext = bindRetrieveContext(service);
+
+    const context = await retrieveContext(createPreparedCompletion(), [createSnapshotRow()]);
+
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-a', 'chunk-b']);
+    expect(context.trace.finalContext.rerank_status).toBe('timeout');
+    expect(context.trace.finalContext.rerank_model_id).toBe('rerank-config');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps RRF order and records error when rerank API fails', async () => {
+    process.env.TEST_RERANK_API_KEY = 'rerank-secret';
+    mockFetchResponse({
+      ok: false,
+      status: 500,
+      body: { error: 'failed' },
+    });
+    const { service } = createServiceContext({ rerankConfig: createRerankModelConfig() });
+    const retrieveContext = bindRetrieveContext(service);
+
+    const context = await retrieveContext(createPreparedCompletion(), [createSnapshotRow()]);
+
+    expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-a', 'chunk-b']);
+    expect(context.trace.finalContext.rerank_status).toBe('error');
+    expect(context.trace.finalContext.rerank_model_id).toBe('rerank-config');
+  });
+
+  it('skips rerank without calling fetch when retrieval results are empty', async () => {
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      status: 200,
+      body: { results: [] },
+    });
+    const { service, db } = createServiceContext({
+      rerankConfig: createRerankModelConfig(),
+      vectorRows: [],
+      bm25Rows: [],
+    });
+    const retrieveContext = bindRetrieveContext(service);
+
+    const context = await retrieveContext(createPreparedCompletion(), [createSnapshotRow()]);
+
+    expect(context.results).toEqual([]);
+    expect(context.trace.finalContext.rerank_status).toBe('skipped');
+    expect(context.trace.finalContext.rerank_skip_reason).toBe('empty_results');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(db.selects).toHaveLength(1);
+  });
+});
+
+function createServiceContext(options: {
+  rerankConfig: RerankModelConfig | null;
+  vectorRows?: unknown[];
+  bm25Rows?: unknown[];
+}): {
+  service: ChatService;
+  db: ScriptedRerankDb;
+  modelConfigService: {
+    getEnabledRerankModel: ReturnType<typeof vi.fn<(tenantId: string) => Promise<RerankModelConfig | null>>>;
+    resolveApiKey: ReturnType<typeof vi.fn<(encryptedApiKeyRef: string | null) => string>>;
+  };
+} {
+  const db = new ScriptedRerankDb([
+    [createModelRow({ id: 'embedding-model', model_type: 'embedding' })],
+  ], [
+    { rows: options.vectorRows ?? [createSearchRow({ id: 'chunk-a', content: 'First chunk', score: 0.95 })] },
+    { rows: options.bm25Rows ?? [createSearchRow({ id: 'chunk-b', content: 'Second chunk', score: 0.9 })] },
+  ]);
+  const modelConfigService = {
+    getEnabledRerankModel: vi.fn<(tenantId: string) => Promise<RerankModelConfig | null>>(() =>
+      Promise.resolve(options.rerankConfig),
+    ),
+    resolveApiKey: vi.fn((encryptedApiKeyRef: string | null) => {
+      expect(encryptedApiKeyRef).toBe('secret:TEST_RERANK_API_KEY');
+      return process.env.TEST_RERANK_API_KEY ?? '';
+    }),
+  };
+  const service = new ChatService(
+    db.asDrizzle(),
+    { push: vi.fn() } as unknown as AuditService,
+    vi.fn((_config: ChatProviderConfig) => new UnusedChatProvider()),
+    vi.fn((_config: EmbeddingProviderConfig) => new ScriptedEmbeddingProvider()),
+    undefined,
+    undefined,
+    modelConfigService as never,
+  );
+
+  return { service, db, modelConfigService };
+}
+
+function bindRetrieveContext(service: ChatService): (
+  prepared: PreparedCompletionForRerankTest,
+  snapshots: Array<{ spaceId: string; snapshot: IndexSnapshotRow }>,
+) => Promise<RetrievedContextForRerankTest> {
+  return (service as unknown as {
+    retrieveContext: (
+      prepared: PreparedCompletionForRerankTest,
+      snapshots: Array<{ spaceId: string; snapshot: IndexSnapshotRow }>,
+      retrievalMode?: string,
+    ) => Promise<RetrievedContextForRerankTest>;
+  }).retrieveContext.bind(service);
+}
+
+class ScriptedRerankDb {
+  readonly selects: unknown[] = [];
+
+  constructor(
+    private readonly selectResults: unknown[][],
+    private readonly executeResults: Array<{ rows: unknown[] }>,
+  ) {}
+
+  asDrizzle(): never {
+    return this as never;
+  }
+
+  select(): ScriptedSelectBuilder {
+    this.selects.push(undefined);
+    return new ScriptedSelectBuilder(this.selectResults.shift() ?? []);
+  }
+
+  execute(): Promise<{ rows: unknown[] }> {
+    return Promise.resolve(this.executeResults.shift() ?? { rows: [] });
+  }
+}
+
+class ScriptedSelectBuilder implements PromiseLike<unknown[]> {
+  constructor(private readonly result: unknown[]) {}
+
+  from(): this {
+    return this;
+  }
+
+  where(): this {
+    return this;
+  }
+
+  limit(): this {
+    return this;
+  }
+
+  then<TResult1 = unknown[], TResult2 = never>(
+    onfulfilled?: ((value: unknown[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return Promise.resolve(this.result).then(onfulfilled ?? undefined, onrejected ?? undefined);
+  }
+}
+
+class ScriptedEmbeddingProvider implements EmbeddingProvider {
+  getModelId(): string {
+    return 'text-embedding-test';
+  }
+
+  embedBatch(): Promise<number[][]> {
+    return Promise.resolve([[0.1, 0.2, 0.3]]);
+  }
+}
+
+class UnusedChatProvider implements ChatProvider {
+  async *streamCompletion(): AsyncIterable<never> {
+    throw new Error('chat provider should not be used');
+  }
+}
+
+function mockFetchResponse(input: {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(() =>
+    Promise.resolve({
+      ok: input.ok,
+      status: input.status,
+      json: () => Promise.resolve(input.body),
+      body: {
+        cancel: () => Promise.resolve(),
+      },
+    }),
+  );
+  Object.defineProperty(globalThis, 'fetch', {
+    value: fetchMock,
+    writable: true,
+    configurable: true,
+  });
+
+  return fetchMock;
+}
+
+type PreparedCompletionForRerankTest = {
+  tenantId: string;
+  space: SpaceRow;
+  spaces: SpaceRow[];
+  spaceIds: string[];
+  session: {
+    id: string;
+    tenant_id: string;
+    space_id: string;
+    user_id: string;
+    title: string | null;
+    created_at: Date;
+    updated_at: Date;
+  };
+  userId: string;
+  userGroupIds: string[];
+  message: string;
+  chatModel: ModelConfigRow;
+  history: [];
+  auditContext: Record<string, never>;
+};
+
+type RetrievedContextForRerankTest = {
+  results: RetrievalResult[];
+  trace: {
+    finalContext: {
+      rerank_status?: string;
+      rerank_model_id?: string;
+      rerank_latency_ms?: number;
+      rerank_skip_reason?: string;
+    };
+  };
+};
+
+function createPreparedCompletion(): PreparedCompletionForRerankTest {
+  const space = createSpaceRow();
+
+  return {
+    tenantId: TEST_TENANT_ID,
+    space,
+    spaces: [space],
+    spaceIds: [space.id],
+    session: {
+      id: 'session-1',
+      tenant_id: TEST_TENANT_ID,
+      space_id: TEST_SPACE_ID,
+      user_id: TEST_USER_ID,
+      title: null,
+      created_at: new Date('2026-05-01T00:00:00.000Z'),
+      updated_at: new Date('2026-05-01T00:00:00.000Z'),
+    },
+    userId: TEST_USER_ID,
+    userGroupIds: [TEST_GROUP_ID],
+    message: 'How is SSO configured?',
+    chatModel: createModelRow({ model_type: 'chat' }),
+    history: [],
+    auditContext: {},
+  };
+}
+
+function createSpaceRow(overrides: Partial<SpaceRow> = {}): SpaceRow {
+  return {
+    id: TEST_SPACE_ID,
+    tenant_id: TEST_TENANT_ID,
+    name: 'Knowledge',
+    slug: 'knowledge',
+    description: null,
+    status: 'active',
+    docmost_space_id: null,
+    wiki_repo_path: '/data/wiki/space-1',
+    active_graphify_run_id: null,
+    active_index_snapshot_id: null,
+    index_consistency_status: 'healthy',
+    permission_version: 1,
+    strict_knowledge_only: true,
+    graphify_config: {},
+    database_config: { enabled: false },
+    default_publish_policy: 'editor_publish',
+    created_at: new Date('2026-05-01T00:00:00.000Z'),
+    updated_at: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createModelRow(overrides: Partial<ModelConfigRow> = {}): ModelConfigRow {
+  return {
+    id: 'chat-model',
+    tenant_id: TEST_TENANT_ID,
+    provider: 'openai',
+    model_id: 'gpt-test',
+    model_type: 'chat',
+    display_name: null,
+    base_url: null,
+    encrypted_api_key_ref: 'secret:TEST_API_KEY',
+    embedding_dim: null,
+    max_tokens: 4096,
+    rate_limit_rpm: null,
+    enabled: true,
+    visible_group_ids: [],
+    created_at: new Date('2026-05-01T00:00:00.000Z'),
+    updated_at: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function createRerankModelConfig(overrides: Partial<RerankModelConfig> = {}): RerankModelConfig {
+  return {
+    id: 'rerank-config',
+    model_id: 'bge-reranker',
+    base_url: 'https://rerank.example/v1',
+    encrypted_api_key_ref: 'secret:TEST_RERANK_API_KEY',
+    ...overrides,
+  };
+}
+
+function createSnapshotRow(overrides: Partial<IndexSnapshotRow> = {}): { spaceId: string; snapshot: IndexSnapshotRow } {
+  return {
+    spaceId: TEST_SPACE_ID,
+    snapshot: {
+      id: 'snapshot-1',
+      tenant_id: TEST_TENANT_ID,
+      space_id: TEST_SPACE_ID,
+      graphify_run_id: null,
+      wiki_repo_commit_hash: 'commit',
+      embedding_model_id: 'embedding-model',
+      chunk_count: 2,
+      node_count: 0,
+      edge_count: 0,
+      status: 'activated',
+      created_at: new Date('2026-05-01T00:00:00.000Z'),
+      activated_at: new Date('2026-05-01T00:00:00.000Z'),
+      ...overrides,
+    },
+  };
+}
+
+function createSearchRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'chunk-a',
+    content: 'First chunk',
+    wiki_page_pk: 'wiki-page-1',
+    page_id: 'page-1',
+    section_id: 'section-1',
+    source_chain_json: {
+      source_document_ids: [],
+      graph_node_ids: [],
+      graph_edge_ids: [],
+      edge_confidences: [],
+      chain_confidence: 1,
+    },
+    injection_risk: false,
+    page_title: 'Auth',
+    section_title: 'SSO',
+    score: 0.9,
+    ...overrides,
+  };
+}

--- a/apps/api/src/chat/__tests__/rerank.test.ts
+++ b/apps/api/src/chat/__tests__/rerank.test.ts
@@ -8,18 +8,31 @@ import type {
 } from '@cherrygraph/ai-core';
 import { indexSnapshots, model_configs, spaces } from '@cherrygraph/shared';
 import type { RetrievalResult } from '@cherrygraph/rag-core';
-import { describe, expect, it, vi, afterEach } from 'vitest';
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 
 import type { AuditService } from '../../audit/audit.service.js';
+import { validateAdminOutboundProbeUrl } from '../../common/outbound-probe-safety.js';
 import { TEST_GROUP_ID, TEST_SPACE_ID, TEST_TENANT_ID, TEST_USER_ID } from '../../users/__tests__/user-group-service-test-utils.js';
 import { ChatService } from '../chat.service.js';
 import type { RerankModelConfig } from '../../models/model-config.service.js';
+
+vi.mock('../../common/outbound-probe-safety.js', () => ({
+  validateAdminOutboundProbeUrl: vi.fn(),
+}));
 
 type ModelConfigRow = typeof model_configs.$inferSelect;
 type SpaceRow = typeof spaces.$inferSelect;
 type IndexSnapshotRow = typeof indexSnapshots.$inferSelect;
 
 const originalFetch = globalThis.fetch;
+const validateAdminOutboundProbeUrlMock = vi.mocked(validateAdminOutboundProbeUrl);
+
+let validatedDispatcher: { close: ReturnType<typeof vi.fn<() => Promise<void>>> };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validatedDispatcher = mockOutboundProbeValidation();
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -70,8 +83,11 @@ describe('ChatService static RAG rerank', () => {
           documents: ['First chunk', 'Second chunk'],
           top_n: 2,
         }),
+        dispatcher: validatedDispatcher,
       }),
     );
+    expect(validateAdminOutboundProbeUrlMock).toHaveBeenCalledWith('https://rerank.example/v1', { dnsTimeoutMs: 2000 });
+    expect(validatedDispatcher.close).toHaveBeenCalledTimes(1);
   });
 
   it('keeps RRF order when no rerank model is enabled', async () => {
@@ -89,6 +105,7 @@ describe('ChatService static RAG rerank', () => {
     expect(context.trace.finalContext.rerank_status).toBe('skipped');
     expect(context.trace.finalContext.rerank_skip_reason).toBe('no_rerank_model');
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(validateAdminOutboundProbeUrlMock).not.toHaveBeenCalled();
   });
 
   it('keeps RRF order and records timeout when rerank request aborts', async () => {
@@ -110,6 +127,7 @@ describe('ChatService static RAG rerank', () => {
     expect(context.trace.finalContext.rerank_status).toBe('timeout');
     expect(context.trace.finalContext.rerank_model_id).toBe('rerank-config');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(validatedDispatcher.close).toHaveBeenCalledTimes(1);
   });
 
   it('keeps RRF order and records error when rerank API fails', async () => {
@@ -127,6 +145,7 @@ describe('ChatService static RAG rerank', () => {
     expect(context.results.map((result) => result.chunkId)).toEqual(['chunk-a', 'chunk-b']);
     expect(context.trace.finalContext.rerank_status).toBe('error');
     expect(context.trace.finalContext.rerank_model_id).toBe('rerank-config');
+    expect(validatedDispatcher.close).toHaveBeenCalledTimes(1);
   });
 
   it('skips rerank without calling fetch when retrieval results are empty', async () => {
@@ -148,9 +167,23 @@ describe('ChatService static RAG rerank', () => {
     expect(context.trace.finalContext.rerank_status).toBe('skipped');
     expect(context.trace.finalContext.rerank_skip_reason).toBe('empty_results');
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(validateAdminOutboundProbeUrlMock).not.toHaveBeenCalled();
     expect(db.selects).toHaveLength(1);
   });
 });
+
+function mockOutboundProbeValidation(rawUrl = 'https://rerank.example/v1'): { close: ReturnType<typeof vi.fn<() => Promise<void>>> } {
+  const dispatcher = {
+    close: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  };
+  validateAdminOutboundProbeUrlMock.mockResolvedValue({
+    ok: true,
+    url: new URL(rawUrl),
+    dispatcher: dispatcher as unknown as NonNullable<RequestInit['dispatcher']> & { close: () => Promise<void> },
+  });
+
+  return dispatcher;
+}
 
 function createServiceContext(options: {
   rerankConfig: RerankModelConfig | null;

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -5,11 +5,12 @@ import { AgentModule } from '../agent/agent.module.js';
 import { AuditModule } from '../audit/audit.module.js';
 import { DrizzleModule } from '../database/drizzle.module.js';
 import { GraphModule } from '../graph/graph.module.js';
+import { ModelConfigModule } from '../models/model-config.module.js';
 import { CHAT_PROVIDER_FACTORY, EMBEDDING_PROVIDER_FACTORY, ChatService } from './chat.service.js';
 import { ChatController } from './chat.controller.js';
 
 @Module({
-  imports: [DrizzleModule, AuditModule, AgentModule, GraphModule],
+  imports: [DrizzleModule, AuditModule, AgentModule, GraphModule, ModelConfigModule],
   controllers: [ChatController],
   providers: [
     ChatService,

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -58,6 +58,7 @@ import {
   type PaginatedResponse,
 } from '../common/dto/pagination.dto.js';
 import { getApiLogger } from '../common/logger/logger.module.js';
+import { validateAdminOutboundProbeUrl } from '../common/outbound-probe-safety.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { GraphService } from '../graph/graph.service.js';
 import { ModelConfigService, type RerankModelConfig } from '../models/model-config.service.js';
@@ -1537,9 +1538,13 @@ export class ChatService {
     const apiKey = this.modelConfigService!.resolveApiKey(config.encrypted_api_key_ref);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), RERANK_TIMEOUT_MS);
+    const targetValidation = await validateAdminOutboundProbeUrl(config.base_url!, { dnsTimeoutMs: 2000 });
+    if (!targetValidation.ok) {
+      throw new Error(`Rerank URL validation failed: ${targetValidation.error}`);
+    }
 
     try {
-      const response = await fetch(`${config.base_url!.replace(/\/+$/, '')}/rerank`, {
+      const response = await fetch(`${targetValidation.url.toString().replace(/\/+$/, '')}/rerank`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${apiKey}`,
@@ -1552,6 +1557,7 @@ export class ChatService {
           top_n: results.length,
         }),
         signal: controller.signal,
+        dispatcher: targetValidation.dispatcher,
       });
 
       if (!response.ok) {
@@ -1568,6 +1574,7 @@ export class ChatService {
       return reorderByRerankScores(results, rerankResults);
     } finally {
       clearTimeout(timeout);
+      await targetValidation.dispatcher.close().catch(() => undefined);
     }
   }
 
@@ -2256,7 +2263,7 @@ function reorderByRerankScores(results: RetrievalResult[], rerankResults: Rerank
   }
 
   if (scoresByIndex.size === 0) {
-    throw new Error('Rerank API returned indexes outside result range');
+    throw new Error('Rerank API returned no usable scores');
   }
 
   return results

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -1536,12 +1536,13 @@ export class ChatService {
     config: RerankModelConfig,
   ): Promise<RetrievalResult[]> {
     const apiKey = this.modelConfigService!.resolveApiKey(config.encrypted_api_key_ref);
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), RERANK_TIMEOUT_MS);
     const targetValidation = await validateAdminOutboundProbeUrl(config.base_url!, { dnsTimeoutMs: 2000 });
     if (!targetValidation.ok) {
       throw new Error(`Rerank URL validation failed: ${targetValidation.error}`);
     }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), RERANK_TIMEOUT_MS);
 
     try {
       const response = await fetch(`${targetValidation.url.toString().replace(/\/+$/, '')}/rerank`, {

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -60,6 +60,7 @@ import {
 import { getApiLogger } from '../common/logger/logger.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { GraphService } from '../graph/graph.service.js';
+import { ModelConfigService, type RerankModelConfig } from '../models/model-config.service.js';
 import { decryptSpaceDatabaseConfig } from '../spaces/database-config.js';
 
 export const CHAT_PROVIDER_FACTORY = Symbol('CHAT_PROVIDER_FACTORY');
@@ -221,8 +222,26 @@ type RetrievedContext = {
       graph_hints: Array<GraphHint | GraphCandidate>;
       wiki_tokens: number;
       graph_tokens: number;
+      rerank_model_id?: string;
+      rerank_latency_ms?: number;
+      rerank_status?: RerankStatus;
+      rerank_skip_reason?: string;
     };
   };
+};
+
+type RerankStatus = 'success' | 'skipped' | 'timeout' | 'error';
+
+type RerankMeta = {
+  rerank_model_id?: string;
+  rerank_latency_ms?: number;
+  rerank_status: RerankStatus;
+  rerank_skip_reason?: string;
+};
+
+type RerankApiResult = {
+  index: number;
+  relevance_score: number;
 };
 
 export type GraphHint = {
@@ -263,6 +282,7 @@ const HISTORY_LIMIT = 10;
 const DEFAULT_MODEL_MAX_TOKENS = 8192;
 const RESPONSE_BUFFER_TOKENS = 1000;
 const RETRIEVAL_TOP_K = 8;
+const RERANK_TIMEOUT_MS = 3000;
 const AGENT_RETRIEVAL_MODES = new Set(['graph_rag', 'path_first', 'community_first']);
 
 @Injectable()
@@ -278,6 +298,7 @@ export class ChatService {
     @Optional() @Inject(EMBEDDING_PROVIDER_FACTORY) embeddingProviderFactory?: EmbeddingProviderFactory,
     @Optional() private readonly agentService?: AgentService,
     @Optional() private readonly graphService?: GraphService,
+    @Optional() private readonly modelConfigService?: ModelConfigService,
   ) {
     this.chatProviderFactory =
       chatProviderFactory ?? ((config: ChatProviderConfig): ChatProvider => new OpenAIChatProvider(config));
@@ -1392,6 +1413,8 @@ export class ChatService {
     }
 
     results = results.sort((left, right) => right.score - left.score).slice(0, RETRIEVAL_TOP_K);
+    const rerankOutcome = await this.rerankRetrievedResults(prepared, results);
+    results = rerankOutcome.results;
 
     return {
       results,
@@ -1419,9 +1442,133 @@ export class ChatService {
             (total, candidate) => total + countTokens(candidate.content, prepared.chatModel.model_id),
             0,
           ),
+          ...rerankOutcome.meta,
         },
       },
     };
+  }
+
+  private async rerankRetrievedResults(
+    prepared: PreparedCompletion,
+    results: RetrievalResult[],
+  ): Promise<{ results: RetrievalResult[]; meta: RerankMeta }> {
+    if (results.length === 0) {
+      return {
+        results,
+        meta: {
+          rerank_status: 'skipped',
+          rerank_skip_reason: 'empty_results',
+        },
+      };
+    }
+
+    if (this.modelConfigService === undefined) {
+      return {
+        results,
+        meta: {
+          rerank_status: 'skipped',
+          rerank_skip_reason: 'model_config_service_unavailable',
+        },
+      };
+    }
+
+    const startedAt = Date.now();
+    let config: RerankModelConfig | null = null;
+
+    try {
+      config = await this.modelConfigService.getEnabledRerankModel(prepared.tenantId);
+      if (config === null) {
+        return {
+          results,
+          meta: {
+            rerank_status: 'skipped',
+            rerank_skip_reason: 'no_rerank_model',
+          },
+        };
+      }
+
+      if (config.base_url === null) {
+        return {
+          results,
+          meta: {
+            rerank_model_id: config.id,
+            rerank_status: 'skipped',
+            rerank_skip_reason: 'missing_base_url',
+          },
+        };
+      }
+
+      const rankedResults = await this.callRerankApi(prepared, results, config);
+      return {
+        results: rankedResults,
+        meta: {
+          rerank_model_id: config.id,
+          rerank_latency_ms: elapsedMs(startedAt),
+          rerank_status: 'success',
+        },
+      };
+    } catch (err) {
+      const status: RerankStatus = isAbortError(err) ? 'timeout' : 'error';
+      getApiLogger().warn(
+        {
+          err,
+          tenant_id: prepared.tenantId,
+          rerank_model_id: config?.id,
+        },
+        'Rerank request failed; keeping RRF retrieval order',
+      );
+
+      return {
+        results,
+        meta: {
+          ...(config !== null ? { rerank_model_id: config.id } : {}),
+          rerank_latency_ms: elapsedMs(startedAt),
+          rerank_status: status,
+        },
+      };
+    }
+  }
+
+  private async callRerankApi(
+    prepared: PreparedCompletion,
+    results: RetrievalResult[],
+    config: RerankModelConfig,
+  ): Promise<RetrievalResult[]> {
+    const apiKey = this.modelConfigService!.resolveApiKey(config.encrypted_api_key_ref);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), RERANK_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(`${config.base_url!.replace(/\/+$/, '')}/rerank`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: config.model_id,
+          query: prepared.message,
+          documents: results.map((result) => result.content),
+          top_n: results.length,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        await response.body?.cancel().catch(() => undefined);
+        throw new Error(`Rerank API returned ${response.status}`);
+      }
+
+      const payload = (await response.json()) as { results?: unknown };
+      const rerankResults = parseRerankResults(payload.results);
+      if (rerankResults.length === 0) {
+        throw new Error('Rerank API returned no valid results');
+      }
+
+      return reorderByRerankScores(results, rerankResults);
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   private async retrieveGraphHints(prepared: PreparedCompletion): Promise<GraphHint[]> {
@@ -2078,6 +2225,66 @@ function truncateGraphContextForBudget<T extends { content: string }>(
   }
 
   return selected;
+}
+
+function parseRerankResults(value: unknown): RerankApiResult[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item): RerankApiResult[] => {
+    if (!isRecord(item)) {
+      return [];
+    }
+
+    const index = Number(item.index);
+    const relevanceScore = Number(item.relevance_score);
+    if (!Number.isInteger(index) || index < 0 || !Number.isFinite(relevanceScore)) {
+      return [];
+    }
+
+    return [{ index, relevance_score: relevanceScore }];
+  });
+}
+
+function reorderByRerankScores(results: RetrievalResult[], rerankResults: RerankApiResult[]): RetrievalResult[] {
+  const scoresByIndex = new Map<number, number>();
+  for (const item of rerankResults) {
+    if (item.index < results.length) {
+      scoresByIndex.set(item.index, item.relevance_score);
+    }
+  }
+
+  if (scoresByIndex.size === 0) {
+    throw new Error('Rerank API returned indexes outside result range');
+  }
+
+  return results
+    .map((result, index) => ({
+      result: scoresByIndex.has(index) ? { ...result, score: scoresByIndex.get(index)! } : result,
+      index,
+      rerankScore: scoresByIndex.get(index) ?? Number.NEGATIVE_INFINITY,
+    }))
+    .sort((left, right) => {
+      if (right.rerankScore !== left.rerankScore) {
+        return right.rerankScore - left.rerankScore;
+      }
+
+      return left.index - right.index;
+    })
+    .map((entry) => entry.result);
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.max(1, Date.now() - startedAt);
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function activeGraphifyRunIdsFromSnapshots(

--- a/apps/api/src/models/model-config.service.ts
+++ b/apps/api/src/models/model-config.service.ts
@@ -99,6 +99,13 @@ export type ChatModelAvailabilityResponse = {
   available: boolean;
 };
 
+export type RerankModelConfig = {
+  id: string;
+  model_id: string;
+  base_url: string | null;
+  encrypted_api_key_ref: string | null;
+};
+
 type ModelSortField = keyof Pick<
   typeof model_configs,
   'created_at' | 'updated_at' | 'provider' | 'model_id' | 'model_type' | 'display_name' | 'enabled'
@@ -488,6 +495,32 @@ export class ModelConfigService {
 
     return {
       available: normalizeCount(row?.total) > 0,
+    };
+  }
+
+  async getEnabledRerankModel(tenantId: string): Promise<RerankModelConfig | null> {
+    const [row] = await this.db
+      .select()
+      .from(model_configs)
+      .where(
+        and(
+          eq(model_configs.tenant_id, tenantId),
+          eq(model_configs.model_type, 'rerank'),
+          eq(model_configs.enabled, true),
+        ),
+      )
+      .orderBy(desc(model_configs.created_at))
+      .limit(1);
+
+    if (row === undefined) {
+      return null;
+    }
+
+    return {
+      id: row.id,
+      model_id: row.model_id,
+      base_url: resolveModelBaseUrl(row),
+      encrypted_api_key_ref: row.encrypted_api_key_ref,
     };
   }
 


### PR DESCRIPTION
## Summary

- Add `getEnabledRerankModel()` to ModelConfigService for querying enabled rerank model config
- Insert rerank step in Chat static_rag path after RRF fusion sort, before trace/context packing
- 3s timeout with graceful fallback to RRF order on any failure (timeout/4xx/5xx/invalid JSON)
- Record rerank metadata (model_id, latency_ms, status, skip_reason) in retrieval trace finalContext
- SSRF protection via validateAdminOutboundProbeUrl + dispatcher (matching probeModelEndpoint pattern)

Closes #384

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `08b83d6ad36269eeefe515183cef2fdd467f3245`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/387#issuecomment-4471139415) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/387#issuecomment-4471139569) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/387#issuecomment-4471139703) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/387#issuecomment-4471139812)
- Key findings addressed: SSRF protection added (validateAdminOutboundProbeUrl + dispatcher); timeout ordering fixed (DNS probe before timer start); error message clarified

## Test plan

- [x] Unit tests: 5 scenarios (success reorder, no model skip, timeout fallback, API error fallback, empty results skip)
- [x] Build passes (tsc --noEmit)
- [x] Full test suite: 1421 tests passed, 0 failures
- [x] SSRF protection verified with dispatcher pattern