### PR TITLE
feat(admin): add worker status query endpoint

### DIFF
--- a/apps/api/src/admin/__tests__/admin-workers.test.ts
+++ b/apps/api/src/admin/__tests__/admin-workers.test.ts
@@ -1,0 +1,144 @@
+import 'reflect-metadata';
+
+import { PERMISSIONS_METADATA_KEY } from '@cherrygraph/auth-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AdminWorkersController } from '../admin-workers.controller.js';
+
+type RedisMock = {
+  get: ReturnType<typeof vi.fn<(key: string) => Promise<string | null>>>;
+  scan: ReturnType<typeof vi.fn<(cursor: string | number, ...args: Array<string | number>) => Promise<[string, string[]]>>>;
+  ping: ReturnType<typeof vi.fn<() => Promise<unknown>>>;
+};
+
+describe('AdminWorkersController', () => {
+  it('classifies worker statuses and returns summary counts', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T12:00:00.000Z'));
+    const redis = createRedisMock({
+      'worker:heartbeat:worker-online': heartbeat(10_000, { cpu: 0.2 }),
+      'worker:heartbeat:worker-degraded': heartbeat(60_000),
+      'worker:heartbeat:worker-stale': heartbeat(150_000),
+    });
+    const controller = new AdminWorkersController(redis);
+
+    const result = await controller.listWorkers();
+
+    expect(result).toEqual({
+      data: {
+        workers: [
+          {
+            worker_id: 'worker-online',
+            status: 'online',
+            last_seen_at: '2026-05-17T11:59:50.000Z',
+            system_info: { cpu: 0.2 },
+          },
+          {
+            worker_id: 'worker-degraded',
+            status: 'degraded',
+            last_seen_at: '2026-05-17T11:59:00.000Z',
+          },
+          {
+            worker_id: 'worker-stale',
+            status: 'stale',
+            last_seen_at: '2026-05-17T11:57:30.000Z',
+          },
+        ],
+        summary: { total: 3, online: 1, degraded: 1, stale: 1 },
+      },
+    });
+    expect(redis.scan).toHaveBeenCalledWith('0', 'MATCH', 'worker:heartbeat:*', 'COUNT', 100);
+    vi.useRealTimers();
+  });
+
+  it('returns an empty summary when Redis has no heartbeat keys', async () => {
+    const controller = new AdminWorkersController(createRedisMock({}));
+
+    await expect(controller.listWorkers()).resolves.toEqual({
+      data: {
+        workers: [],
+        summary: { total: 0, online: 0, degraded: 0, stale: 0 },
+      },
+    });
+  });
+
+  it('applies status threshold boundaries exactly', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T12:00:00.000Z'));
+    const controller = new AdminWorkersController(
+      createRedisMock({
+        'worker:heartbeat:a-online-boundary': heartbeat(29_999),
+        'worker:heartbeat:b-degraded-start': heartbeat(30_000),
+        'worker:heartbeat:c-degraded-end': heartbeat(119_999),
+        'worker:heartbeat:d-stale-start': heartbeat(120_000),
+      }),
+    );
+
+    const result = await controller.listWorkers();
+
+    expect(result.data.workers.map((worker) => [worker.worker_id, worker.status])).toEqual([
+      ['a-online-boundary', 'online'],
+      ['b-degraded-start', 'degraded'],
+      ['c-degraded-end', 'degraded'],
+      ['d-stale-start', 'stale'],
+    ]);
+    expect(result.data.summary).toEqual({ total: 4, online: 1, degraded: 2, stale: 1 });
+    vi.useRealTimers();
+  });
+
+  it('skips invalid JSON and keeps valid workers', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T12:00:00.000Z'));
+    const controller = new AdminWorkersController(
+      createRedisMock({
+        'worker:heartbeat:valid': heartbeat(10_000),
+        'worker:heartbeat:invalid': '{not json',
+        'worker:heartbeat:missing-seen-at': JSON.stringify({ system_info: { cpu: 1 } }),
+      }),
+    );
+
+    const result = await controller.listWorkers();
+
+    expect(result.data.workers).toEqual([
+      {
+        worker_id: 'valid',
+        status: 'online',
+        last_seen_at: '2026-05-17T11:59:50.000Z',
+      },
+    ]);
+    expect(result.data.summary).toEqual({ total: 1, online: 1, degraded: 0, stale: 0 });
+    vi.useRealTimers();
+  });
+
+  it('requires admin audit view permission', () => {
+    expect(Reflect.getMetadata(PERMISSIONS_METADATA_KEY, AdminWorkersController)).toEqual(['admin:audit_view']);
+  });
+
+  it('returns an empty response with an error when Redis is unavailable', async () => {
+    const controller = new AdminWorkersController(undefined);
+
+    await expect(controller.listWorkers()).resolves.toEqual({
+      data: {
+        workers: [],
+        summary: { total: 0, online: 0, degraded: 0, stale: 0 },
+      },
+      error: 'Redis unavailable',
+    });
+  });
+});
+
+function createRedisMock(values: Record<string, string>): RedisMock {
+  const keys = Object.keys(values);
+  return {
+    get: vi.fn((key) => Promise.resolve(values[key] ?? null)),
+    scan: vi.fn((cursor) => Promise.resolve(cursor === '0' ? ['0', keys] : ['0', []])),
+    ping: vi.fn(() => Promise.resolve('PONG')),
+  };
+}
+
+function heartbeat(ageMs: number, systemInfo?: Record<string, unknown>): string {
+  return JSON.stringify({
+    seen_at: new Date(Date.now() - ageMs).toISOString(),
+    ...(systemInfo !== undefined ? { system_info: systemInfo } : {}),
+  });
+}

--- a/apps/api/src/admin/admin-workers.controller.ts
+++ b/apps/api/src/admin/admin-workers.controller.ts
@@ -1,0 +1,163 @@
+import { Controller, Get, Inject, Optional } from '@nestjs/common';
+import { Permissions } from '@cherrygraph/auth-core';
+
+import { REDIS_CLIENT } from '../common/redis/redis.module.js';
+
+type WorkerStatus = 'online' | 'degraded' | 'stale';
+type WorkerInfo = {
+  worker_id: string;
+  status: WorkerStatus;
+  last_seen_at: string;
+  system_info?: Record<string, unknown>;
+};
+type WorkersSummary = { total: number; online: number; degraded: number; stale: number };
+type AdminWorkersResponse = {
+  data: {
+    workers: WorkerInfo[];
+    summary: WorkersSummary;
+  };
+  error?: string;
+};
+
+type RedisClient = {
+  get: (key: string) => Promise<string | null>;
+  scan: (cursor: string | number, ...args: Array<string | number>) => Promise<[string, string[]]>;
+  ping: () => Promise<unknown>;
+};
+
+const HEARTBEAT_KEY_PREFIX = 'worker:heartbeat:';
+const HEARTBEAT_KEY_MATCH = `${HEARTBEAT_KEY_PREFIX}*`;
+const ONLINE_THRESHOLD_MS = 30_000;
+const STALE_THRESHOLD_MS = 120_000;
+const STATUS_PRIORITY: Record<WorkerStatus, number> = {
+  online: 0,
+  degraded: 1,
+  stale: 2,
+};
+
+@Permissions('admin:audit_view')
+@Controller('admin/workers')
+export class AdminWorkersController {
+  constructor(@Optional() @Inject(REDIS_CLIENT) private readonly redis?: RedisClient) {}
+
+  @Get()
+  async listWorkers(): Promise<AdminWorkersResponse> {
+    if (this.redis === undefined) {
+      return unavailableResponse();
+    }
+
+    try {
+      const keys = await this.scanHeartbeatKeys();
+      const workers = await this.loadWorkers(keys);
+      workers.sort((a, b) => STATUS_PRIORITY[a.status] - STATUS_PRIORITY[b.status] || a.worker_id.localeCompare(b.worker_id));
+
+      return {
+        data: {
+          workers,
+          summary: summarizeWorkers(workers),
+        },
+      };
+    } catch {
+      return unavailableResponse();
+    }
+  }
+
+  private async scanHeartbeatKeys(): Promise<string[]> {
+    const keys: string[] = [];
+    let cursor = '0';
+
+    do {
+      const [nextCursor, batch] = await this.redis!.scan(cursor, 'MATCH', HEARTBEAT_KEY_MATCH, 'COUNT', 100);
+      cursor = nextCursor;
+      keys.push(...batch);
+    } while (cursor !== '0');
+
+    return keys;
+  }
+
+  private async loadWorkers(keys: string[]): Promise<WorkerInfo[]> {
+    const workers: WorkerInfo[] = [];
+    const now = Date.now();
+
+    for (const key of keys) {
+      const worker = await this.loadWorker(key, now);
+      if (worker !== null) {
+        workers.push(worker);
+      }
+    }
+
+    return workers;
+  }
+
+  private async loadWorker(key: string, now: number): Promise<WorkerInfo | null> {
+    const stored = await this.redis!.get(key);
+    if (stored === null) {
+      return null;
+    }
+
+    const parsed = parseHeartbeat(stored);
+    if (parsed === null) {
+      return null;
+    }
+
+    return {
+      worker_id: key.startsWith(HEARTBEAT_KEY_PREFIX) ? key.slice(HEARTBEAT_KEY_PREFIX.length) : key,
+      status: classifyHeartbeat(now - parsed.seenAt.getTime()),
+      last_seen_at: parsed.seenAt.toISOString(),
+      ...(parsed.systemInfo !== undefined ? { system_info: parsed.systemInfo } : {}),
+    };
+  }
+}
+
+function parseHeartbeat(stored: string): { seenAt: Date; systemInfo?: Record<string, unknown> } | null {
+  try {
+    const parsed: unknown = JSON.parse(stored);
+    if (!isRecord(parsed) || typeof parsed.seen_at !== 'string') {
+      return null;
+    }
+
+    const seenAt = new Date(parsed.seen_at);
+    if (Number.isNaN(seenAt.getTime())) {
+      return null;
+    }
+
+    return {
+      seenAt,
+      ...(isRecord(parsed.system_info) ? { systemInfo: parsed.system_info } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function classifyHeartbeat(ageMs: number): WorkerStatus {
+  if (ageMs < ONLINE_THRESHOLD_MS) {
+    return 'online';
+  }
+  if (ageMs < STALE_THRESHOLD_MS) {
+    return 'degraded';
+  }
+  return 'stale';
+}
+
+function summarizeWorkers(workers: WorkerInfo[]): WorkersSummary {
+  const summary: WorkersSummary = { total: workers.length, online: 0, degraded: 0, stale: 0 };
+  for (const worker of workers) {
+    summary[worker.status] += 1;
+  }
+  return summary;
+}
+
+function unavailableResponse(): AdminWorkersResponse {
+  return {
+    data: {
+      workers: [],
+      summary: { total: 0, online: 0, degraded: 0, stale: 0 },
+    },
+    error: 'Redis unavailable',
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/api/src/admin/admin-workers.module.ts
+++ b/apps/api/src/admin/admin-workers.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { AdminWorkersController } from './admin-workers.controller.js';
+
+@Module({
+  controllers: [AdminWorkersController],
+})
+export class AdminWorkersModule {}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { RequestContextMiddleware } from './common/middleware/request-context.mi
 import { RedisModule } from './common/redis/redis.module.js';
 import { AdminHealthModule } from './admin/admin-health.module.js';
 import { AdminIndexModule } from './admin/admin-index.module.js';
+import { AdminWorkersModule } from './admin/admin-workers.module.js';
 import { ProposalModule } from './admin/proposals/proposal.module.js';
 import { AgentModule } from './agent/agent.module.js';
 import { ApiTokenModule } from './api-tokens/api-token.module.js';
@@ -57,6 +58,7 @@ import { WikiModule } from './wiki/wiki.module.js';
     ChatModule,
     HealthModule,
     AdminHealthModule,
+    AdminWorkersModule,
     AdminIndexModule,
     ProposalModule,
   ],


### PR DESCRIPTION
## Summary

- New `GET /api/admin/workers` endpoint that aggregates worker heartbeat data from Redis
- Workers classified by heartbeat age: online (<30s), degraded (30-120s), stale (≥120s)
- Graceful handling: Redis unavailable → empty list + error field; invalid JSON → skip worker
- Response includes per-worker details and summary counts

## Changes

| File | Change |
|------|--------|
| `admin-workers.controller.ts` | New controller with status aggregation logic |
| `admin-workers.module.ts` | New module registered in AppModule |
| `admin-workers.test.ts` | 6 unit tests covering all scenarios |
| `app.module.ts` | Import AdminWorkersModule |

## Test plan

- [x] Correct status classification (online/degraded/stale)
- [x] Empty Redis → empty response with zero counts
- [x] Threshold boundaries (29999ms=online, 30000ms=degraded, 119999ms=degraded, 120000ms=stale)
- [x] Invalid JSON handling (skip bad entries, keep valid ones)
- [x] Permission guard (admin:audit_view required)
- [x] Redis unavailable → graceful empty response with error field

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `6ed5dff9e56dcd159c87ba2f87416365c62bae7e`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/389#issuecomment-4472823956) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/389#issuecomment-4472824061) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/389#issuecomment-4472824165) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/389#issuecomment-4472824257)
- Key findings addressed: All findings are minor/informational; no critical or major issues requiring changes

Closes #386