### PR TITLE
feat(graph): community node expansion endpoint + frontend (#392)

### DIFF
--- a/apps/api/src/chat/__tests__/chat.service.test.ts
+++ b/apps/api/src/chat/__tests__/chat.service.test.ts
@@ -818,7 +818,13 @@ describe('ChatService streamCompletion', () => {
     db.queueExecute([createSearchRow({ id: 'chunk-bm25', score: 0.9 })]);
     db.queueExecute([createGraphNodeRow({ id: 'node-auth', label: 'Auth', community_id: 'community-1', score: 0.9 })]);
     db.queueExecute([createCommunityRow({ id: 'community-1', label: 'Auth Cluster', summary: 'Auth service relationships' })]);
-    db.queueExecute([createGraphNodeRow({ id: 'node-api', label: 'API', community_id: 'community-1', score: 1 })]);
+    db.queueExecute([
+      {
+        nodes_json: [createGraphNodeRow({ id: 'node-api', label: 'API', community_id: 'community-1', score: 1 })],
+        edges_json: [],
+        truncated: false,
+      },
+    ]);
 
     const context = await retrieveContext(
       prepared,
@@ -956,7 +962,7 @@ describe('ChatService streamCompletion', () => {
     db.queueExecute([]);
     db.queueExecute([createGraphNodeRow({ id: 'node-auth', label: 'Auth', community_id: 'community-1', score: 0.9 })]);
     db.queueExecute([createCommunityRow({ id: 'community-1' })]);
-    db.queueExecute([]);
+    db.queueExecute([{ nodes_json: [], edges_json: [], truncated: false }]);
 
     const startedAt = performance.now();
     await retrieveContext(

--- a/apps/api/src/graph/__tests__/graph-search.test.ts
+++ b/apps/api/src/graph/__tests__/graph-search.test.ts
@@ -22,6 +22,7 @@ describe('GraphController search', () => {
     expect(getMetadata('findPath')).toEqual(['space:read']);
     expect(getMetadata('getNeighbors')).toEqual(['space:read']);
     expect(getMetadata('getCommunities')).toEqual(['space:read']);
+    expect(getMetadata('getCommunityNodes')).toEqual(['space:read']);
   });
 
   it('searches nodes with trigram score and requested space ACL', async () => {
@@ -112,6 +113,91 @@ describe('GraphController search', () => {
       ],
     });
   });
+
+  it('returns community nodes and edges within a requested readable space', async () => {
+    const { controller, db } = createGraphContext();
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([createActiveSpaceRow()]);
+    db.queueExecute([
+      {
+        nodes_json: [
+          createGraphNode({ id: 'node-a', label: 'Alpha', community_id: 'community-1' }),
+          createGraphNode({ id: 'node-b', label: 'Beta', community_id: 'community-1' }),
+        ],
+        edges_json: [
+          {
+            id: 'edge-ab',
+            source_node_id: 'node-a',
+            target_node_id: 'node-b',
+            relation_type: 'relates_to',
+            confidence_label: 'EXTRACTED',
+            effective_confidence_score: '0.81',
+            evidence_count: '2',
+            space_id: TEST_SPACE_ID,
+          },
+        ],
+        truncated: false,
+      },
+    ]);
+
+    const result = await controller.getCommunityNodes(
+      'community-1',
+      { space_id: TEST_SPACE_ID },
+      createRequest(),
+    );
+
+    expect(result).toEqual({
+      nodes: [
+        expect.objectContaining({ id: 'node-a', label: 'Alpha', community_id: 'community-1' }),
+        expect.objectContaining({ id: 'node-b', label: 'Beta', community_id: 'community-1' }),
+      ],
+      edges: [
+        {
+          id: 'edge-ab',
+          source_node_id: 'node-a',
+          target_node_id: 'node-b',
+          relationship: 'relates_to',
+          confidence_label: 'EXTRACTED',
+          effective_confidence_score: 0.81,
+          evidence_count: 2,
+          space_id: TEST_SPACE_ID,
+        },
+      ],
+      truncated: false,
+    });
+  });
+
+  it('returns an empty community node response when no active graph is available', async () => {
+    const { controller, db } = createGraphContext();
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([]);
+
+    await expect(
+      controller.getCommunityNodes('community-1', { space_id: TEST_SPACE_ID }, createRequest()),
+    ).resolves.toEqual({ nodes: [], edges: [], truncated: false });
+    expect(db.executedQueries).toHaveLength(0);
+  });
+
+  it('passes the community truncation flag through the endpoint response', async () => {
+    const { controller, db } = createGraphContext();
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([createActiveSpaceRow()]);
+    db.queueExecute([
+      {
+        nodes_json: [createGraphNode({ id: 'node-a', community_id: 'community-1' })],
+        edges_json: [],
+        truncated: true,
+      },
+    ]);
+
+    await expect(
+      controller.getCommunityNodes('community-1', { space_id: TEST_SPACE_ID }, createRequest()),
+    ).resolves.toEqual({
+      nodes: [expect.objectContaining({ id: 'node-a', community_id: 'community-1' })],
+      edges: [],
+      truncated: true,
+    });
+  });
 });
 
 function createGraphContext(): { controller: GraphController; db: ScriptedDb } {
@@ -139,6 +225,21 @@ function createRequest(spacePermissions: Record<string, string[]> = { [TEST_SPAC
 
 function createActiveSpaceRow() {
   return createSpaceRow({ active_graphify_run_id: 'run-1' });
+}
+
+function createGraphNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'node-1',
+    node_key: 'node-key',
+    stable_key: `${TEST_SPACE_ID}:concept:node`,
+    label: 'Node',
+    node_type: 'concept',
+    description: null,
+    space_id: TEST_SPACE_ID,
+    community_id: null,
+    score: 1,
+    ...overrides,
+  };
 }
 
 type RequestShape = {

--- a/apps/api/src/graph/graph.controller.ts
+++ b/apps/api/src/graph/graph.controller.ts
@@ -4,10 +4,12 @@ import { ErrorCode } from '@cherrygraph/shared';
 
 import {
   parseGraphCommunitiesQuery,
+  parseGraphCommunityNodesQuery,
   parseGraphNeighborsQuery,
   parseGraphNodeSearchQuery,
   parseGraphPathRequest,
   type GraphCommunitiesResponseDto,
+  type GraphCommunityNodesResponseDto,
   type GraphNeighborsResponseDto,
   type GraphPathListResponseDto,
   type GraphSearchResponseDto,
@@ -68,6 +70,21 @@ export class GraphController {
   ): Promise<GraphCommunitiesResponseDto> {
     const user = getAuthenticatedUser(request);
     return this.graphService.getCommunities(parseGraphCommunitiesQuery(query), buildGraphContext(request, user));
+  }
+
+  @Get('communities/:id/nodes')
+  @Permissions('space:read')
+  async getCommunityNodes(
+    @Param('id') communityId: string,
+    @Query() query: Record<string, unknown>,
+    @Req() request: RequestWithAuth,
+  ): Promise<GraphCommunityNodesResponseDto> {
+    const user = getAuthenticatedUser(request);
+    return this.graphService.getCommunityNodes(
+      communityId,
+      parseGraphCommunityNodesQuery(query),
+      buildGraphContext(request, user),
+    );
   }
 }
 

--- a/apps/api/src/graph/graph.dto.ts
+++ b/apps/api/src/graph/graph.dto.ts
@@ -89,10 +89,21 @@ export const graphCommunitiesResponseSchema = z.object({
   communities: z.array(graphCommunityResponseSchema),
 });
 
+export const graphCommunityNodesQuerySchema = z.object({
+  space_id: z.preprocess(singleValue, idSchema),
+});
+
+export const graphCommunityNodesResponseSchema = z.object({
+  nodes: z.array(graphNodeResponseSchema),
+  edges: z.array(graphEdgeResponseSchema),
+  truncated: z.boolean(),
+});
+
 export type GraphNodeSearchQueryDto = z.infer<typeof graphNodeSearchQuerySchema>;
 export type GraphPathRequestDto = z.infer<typeof graphPathRequestSchema>;
 export type GraphNeighborsQueryDto = z.infer<typeof graphNeighborsQuerySchema>;
 export type GraphCommunitiesQueryDto = z.infer<typeof graphCommunitiesQuerySchema>;
+export type GraphCommunityNodesQueryDto = z.infer<typeof graphCommunityNodesQuerySchema>;
 export type GraphNodeResponseDto = z.infer<typeof graphNodeResponseSchema>;
 export type GraphEdgeResponseDto = z.infer<typeof graphEdgeResponseSchema>;
 export type GraphPathResponseDto = z.infer<typeof graphPathResponseSchema>;
@@ -100,6 +111,7 @@ export type GraphSearchResponseDto = z.infer<typeof graphSearchResponseSchema>;
 export type GraphPathListResponseDto = z.infer<typeof graphPathListResponseSchema>;
 export type GraphNeighborsResponseDto = z.infer<typeof graphNeighborsResponseSchema>;
 export type GraphCommunitiesResponseDto = z.infer<typeof graphCommunitiesResponseSchema>;
+export type GraphCommunityNodesResponseDto = z.infer<typeof graphCommunityNodesResponseSchema>;
 
 export function parseGraphNodeSearchQuery(input: unknown): GraphNodeSearchQueryDto {
   return parseDto(graphNodeSearchQuerySchema.safeParse(input));
@@ -115,6 +127,10 @@ export function parseGraphNeighborsQuery(input: unknown): GraphNeighborsQueryDto
 
 export function parseGraphCommunitiesQuery(input: unknown): GraphCommunitiesQueryDto {
   return parseDto(graphCommunitiesQuerySchema.safeParse(input));
+}
+
+export function parseGraphCommunityNodesQuery(input: unknown): GraphCommunityNodesQueryDto {
+  return parseDto(graphCommunityNodesQuerySchema.safeParse(input));
 }
 
 function parseDto<T>(parsed: z.SafeParseReturnType<unknown, T>): T {

--- a/apps/api/src/graph/graph.service.ts
+++ b/apps/api/src/graph/graph.service.ts
@@ -21,6 +21,8 @@ import { SPACE_VIEW_PERMISSIONS } from '../shared/permission-constants.js';
 import type {
   GraphCommunitiesQueryDto,
   GraphCommunitiesResponseDto,
+  GraphCommunityNodesQueryDto,
+  GraphCommunityNodesResponseDto,
   GraphEdgeResponseDto,
   GraphNeighborsQueryDto,
   GraphNeighborsResponseDto,
@@ -142,20 +144,25 @@ export class GraphService {
 
   async getCommunityNodes(
     communityId: string,
+    input: GraphCommunityNodesQueryDto,
     context: GraphContext = {},
-  ): Promise<GraphNodeResponseDto[]> {
-    const spaceIds = await this.resolveReadableSpaceIds(undefined, context);
+  ): Promise<GraphCommunityNodesResponseDto> {
+    const spaceIds = await this.resolveReadableSpaceIds(input.space_id, context);
     if (spaceIds.length === 0) {
-      return [];
+      return { nodes: [], edges: [], truncated: false };
     }
 
     const activeRunIds = await this.resolveActiveGraphifyRunIds(spaceIds, context);
     if (activeRunIds.size === 0) {
-      return [];
+      return { nodes: [], edges: [], truncated: false };
     }
 
-    const nodes = await this.queryService.getCommunityNodes(communityId, spaceIds, activeRunIds);
-    return nodes.map(toGraphNodeResponse);
+    const result = await this.queryService.getCommunityNodes(communityId, spaceIds, activeRunIds);
+    return {
+      nodes: result.nodes.map(toGraphNodeResponse),
+      edges: result.edges.map(toGraphEdgeResponse),
+      truncated: result.truncated,
+    };
   }
 
   async getEvidenceRefs(

--- a/apps/web/src/__tests__/graph-explorer.test.tsx
+++ b/apps/web/src/__tests__/graph-explorer.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../lib/graphApi', async (importOriginal) => {
     searchGraphNodes: vi.fn(),
     getGraphNeighbors: vi.fn(),
     getGraphCommunities: vi.fn(),
+    getGraphCommunityNodes: vi.fn(),
   };
 });
 
@@ -94,6 +95,7 @@ vi.mock('../pages/graph/GraphCanvas', async (importOriginal) => {
 const searchGraphNodesMock = vi.mocked(graphApi.searchGraphNodes);
 const getGraphNeighborsMock = vi.mocked(graphApi.getGraphNeighbors);
 const getGraphCommunitiesMock = vi.mocked(graphApi.getGraphCommunities);
+const getGraphCommunityNodesMock = vi.mocked(graphApi.getGraphCommunityNodes);
 
 const TEST_USER: AuthUser = {
   id: 'user-1',
@@ -146,6 +148,7 @@ describe('SpaceGraphExplorerPage', () => {
       return Promise.reject(new Error(`Unexpected API path: ${path}`));
     });
     getGraphCommunitiesMock.mockResolvedValue({ communities: [] });
+    getGraphCommunityNodesMock.mockResolvedValue({ nodes: [], edges: [], truncated: false });
     searchGraphNodesMock.mockResolvedValue({ nodes: [], total: 0 });
     getGraphNeighborsMock.mockResolvedValue({ center_node: null, neighbors: [] });
   });
@@ -231,14 +234,22 @@ describe('SpaceGraphExplorerPage', () => {
       ],
       total: 2,
     });
+    getGraphCommunityNodesMock.mockResolvedValue({
+      nodes: [createNode({ id: 'node-a', label: 'OAuth', community_id: 'community-auth' })],
+      edges: [],
+      truncated: false,
+    });
 
     renderPage();
     runSearch('service');
     await screen.findByText('Auth');
     fireEvent.click(screen.getByText('Auth').closest('button')!);
 
-    expect(screen.getByTestId('graph-node-node-a')).toHaveAttribute('data-highlighted', 'true');
-    expect(screen.getByTestId('graph-node-node-b')).toHaveAttribute('data-highlighted', 'false');
+    await waitFor(() => {
+      expect(screen.getByTestId('graph-node-node-a')).toHaveAttribute('data-highlighted', 'true');
+      expect(screen.getByTestId('graph-node-node-b')).toHaveAttribute('data-highlighted', 'false');
+    });
+    expect(getGraphCommunityNodesMock).toHaveBeenCalledWith('community-auth', 'space-1');
   });
 
   it('shows empty state when no graph data is loaded', async () => {
@@ -322,6 +333,7 @@ describe('SpaceGraphExplorerPage', () => {
     expect(await screen.findByText('Access Denied')).toBeInTheDocument();
     expect(apiMocks.get).not.toHaveBeenCalled();
     expect(getGraphCommunitiesMock).not.toHaveBeenCalled();
+    expect(getGraphCommunityNodesMock).not.toHaveBeenCalled();
     expect(searchGraphNodesMock).not.toHaveBeenCalled();
     expect(getGraphNeighborsMock).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/graphApi.ts
+++ b/apps/web/src/lib/graphApi.ts
@@ -49,6 +49,12 @@ export type GraphCommunitiesResponse = {
   communities: GraphCommunity[];
 };
 
+export type GraphCommunityNodesResponse = {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  truncated: boolean;
+};
+
 export function searchGraphNodes(input: {
   spaceId: string;
   query: string;
@@ -76,4 +82,14 @@ export function getGraphCommunities(spaceId: string): Promise<GraphCommunitiesRe
   return api.get<GraphCommunitiesResponse>('/graph/communities', {
     space_id: spaceId,
   });
+}
+
+export function getGraphCommunityNodes(
+  communityId: string,
+  spaceId: string,
+): Promise<GraphCommunityNodesResponse> {
+  return api.get<GraphCommunityNodesResponse>(
+    `/graph/communities/${encodeURIComponent(communityId)}/nodes`,
+    { space_id: spaceId },
+  );
 }

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -757,7 +757,9 @@
       "title": "Communities",
       "empty": "No communities available",
       "clear": "Clear",
-      "nodeCount": "{{count}} nodes"
+      "nodeCount": "{{count}} nodes",
+      "truncated": "Community has too many nodes. Showing first 200.",
+      "loadError": "Failed to load community nodes"
     },
     "canvas": {
       "resetView": "Reset graph view"

--- a/apps/web/src/locales/zh-CN.json
+++ b/apps/web/src/locales/zh-CN.json
@@ -757,7 +757,9 @@
       "title": "社区",
       "empty": "暂无社区",
       "clear": "清除",
-      "nodeCount": "{{count}} 个节点"
+      "nodeCount": "{{count}} 个节点",
+      "truncated": "社区节点过多，仅显示前 200 个。",
+      "loadError": "加载社区节点失败"
     },
     "canvas": {
       "resetView": "重置图谱视图"

--- a/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
+++ b/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
@@ -6,6 +6,7 @@ import {
   Empty,
   Input,
   List,
+  message,
   Select,
   Space,
   Spin,
@@ -21,6 +22,7 @@ import { api } from '../../lib/api';
 import type { AdminSpaceDetail } from '../../lib/adminTypes';
 import {
   getGraphCommunities,
+  getGraphCommunityNodes,
   getGraphNeighbors,
   searchGraphNodes,
   type GraphCommunity,
@@ -77,6 +79,8 @@ export default function SpaceGraphExplorerPage() {
   const [hops, setHops] = useState(1);
   const [communities, setCommunities] = useState<GraphCommunity[]>([]);
   const [isLoadingCommunities, setIsLoadingCommunities] = useState(true);
+  const [isLoadingCommunityNodes, setIsLoadingCommunityNodes] = useState(false);
+  const [loadingCommunityId, setLoadingCommunityId] = useState<string | null>(null);
   const [activeCommunityId, setActiveCommunityId] = useState<string | null>(null);
   const [selection, setSelection] = useState<Selection>(null);
   const [error, setError] = useState<string | null>(null);
@@ -93,6 +97,8 @@ export default function SpaceGraphExplorerPage() {
     setHasSearched(false);
     setIsSearching(false);
     setIsExpanding(false);
+    setIsLoadingCommunityNodes(false);
+    setLoadingCommunityId(null);
     setActiveCommunityId(null);
     setSelection(null);
     setError(null);
@@ -248,6 +254,40 @@ export default function SpaceGraphExplorerPage() {
     }
   }
 
+  async function handleSelectCommunity(communityId: string | null): Promise<void> {
+    if (communityId === null || communityId === activeCommunityId) {
+      setActiveCommunityId(communityId === activeCommunityId ? null : communityId);
+      return;
+    }
+
+    const spaceSeq = spaceSeqRef.current;
+    setIsLoadingCommunityNodes(true);
+    setLoadingCommunityId(communityId);
+    setError(null);
+
+    try {
+      const result = await getGraphCommunityNodes(communityId, spaceId);
+      if (spaceSeq !== spaceSeqRef.current) {
+        return;
+      }
+      dispatch({ type: 'merge', spaceId, nodes: result.nodes, edges: result.edges });
+      setActiveCommunityId(communityId);
+      if (result.truncated) {
+        void message.warning(t('graph.community.truncated'));
+      }
+    } catch {
+      if (spaceSeq !== spaceSeqRef.current) {
+        return;
+      }
+      void message.error(t('graph.community.loadError'));
+    } finally {
+      if (spaceSeq === spaceSeqRef.current) {
+        setIsLoadingCommunityNodes(false);
+        setLoadingCommunityId(null);
+      }
+    }
+  }
+
   function closeSelection(): void {
     setSelection(null);
   }
@@ -300,8 +340,10 @@ export default function SpaceGraphExplorerPage() {
             <GraphCommunityPanel
               communities={communities}
               isLoading={isLoadingCommunities}
+              isLoadingCommunityNodes={isLoadingCommunityNodes}
+              loadingCommunityId={loadingCommunityId}
               activeCommunityId={activeCommunityId}
-              onSelectCommunity={setActiveCommunityId}
+              onSelectCommunity={(id) => { void handleSelectCommunity(id); }}
             />
           </Space>
 
@@ -323,7 +365,7 @@ export default function SpaceGraphExplorerPage() {
               activeCommunityId={activeCommunityId}
               selectedNodeId={selectedNode?.id ?? null}
               selectedEdgeId={selectedEdge?.id ?? null}
-              loading={isSearching || isExpanding}
+              loading={isSearching || isExpanding || isLoadingCommunityNodes}
               onNodeSelect={(nodeId) => setSelection({ type: 'node', id: nodeId })}
               onEdgeSelect={(edgeId) => setSelection({ type: 'edge', id: edgeId })}
             />
@@ -399,11 +441,15 @@ function GraphSearchPanel({
 function GraphCommunityPanel({
   communities,
   isLoading,
+  isLoadingCommunityNodes,
+  loadingCommunityId,
   activeCommunityId,
   onSelectCommunity,
 }: {
   communities: GraphCommunity[];
   isLoading: boolean;
+  isLoadingCommunityNodes: boolean;
+  loadingCommunityId: string | null;
   activeCommunityId: string | null;
   onSelectCommunity: (communityId: string | null) => void;
 }) {
@@ -429,11 +475,14 @@ function GraphCommunityPanel({
           renderItem={(community) => {
             const label = community.label ?? community.community_key;
             const isActive = community.id === activeCommunityId;
+            const isButtonLoading = loadingCommunityId === community.id;
             return (
               <List.Item>
                 <Button
                   type={isActive ? 'primary' : 'text'}
+                  loading={isButtonLoading}
                   style={{ width: '100%', height: 'auto', textAlign: 'left', whiteSpace: 'normal' }}
+                  disabled={isLoadingCommunityNodes && !isButtonLoading}
                   onClick={() => onSelectCommunity(isActive ? null : community.id)}
                 >
                   <div>

--- a/packages/graph-core/src/__tests__/query-service.test.ts
+++ b/packages/graph-core/src/__tests__/query-service.test.ts
@@ -150,16 +150,24 @@ describe('GraphQueryService', () => {
     const service = new GraphQueryService(
       createQueuedDb([
         [{ id: 'community-1', community_key: 'auth', label: 'Auth', summary: 'Authentication', node_count: '3' }],
-        [createNode({ community_id: 'community-1' })],
+        [
+          {
+            nodes_json: [createNode({ id: 'node-a', community_id: 'community-1' })],
+            edges_json: [createEdge({ id: 'edge-aa', source_node_id: 'node-a', target_node_id: 'node-a' })],
+            truncated: true,
+          },
+        ],
       ]).db,
     );
 
     await expect(service.getCommunities(['space-1'], activeRunIds())).resolves.toEqual([
       { id: 'community-1', community_key: 'auth', label: 'Auth', summary: 'Authentication', node_count: 3 },
     ]);
-    await expect(service.getCommunityNodes('community-1', ['space-1'], activeRunIds())).resolves.toEqual([
-      expect.objectContaining({ community_id: 'community-1' }),
-    ]);
+    await expect(service.getCommunityNodes('community-1', ['space-1'], activeRunIds())).resolves.toEqual({
+      nodes: [expect.objectContaining({ community_id: 'community-1' })],
+      edges: [expect.objectContaining({ id: 'edge-aa' })],
+      truncated: true,
+    });
   });
 
   it('returns evidence refs for the edge to page to source document chain', async () => {

--- a/packages/graph-core/src/query-service.ts
+++ b/packages/graph-core/src/query-service.ts
@@ -68,6 +68,11 @@ type RawNeighborsRow = {
   nodes_json?: unknown;
   edges_json?: unknown;
 };
+type RawCommunityNodesRow = {
+  nodes_json?: unknown;
+  edges_json?: unknown;
+  truncated?: boolean | null;
+};
 type RawCommunityRow = Omit<GraphCommunitySummary, 'node_count'> & {
   node_count?: number | string | null;
 };
@@ -80,7 +85,7 @@ const MAX_PATH_RESULTS = 50;
 const MAX_PATH_INTERMEDIATE_ROWS = 500;
 const MAX_NEIGHBOR_RESULTS = 200;
 const MAX_COMMUNITY_RESULTS = 100;
-const MAX_COMMUNITY_NODE_RESULTS = 100;
+const MAX_COMMUNITY_NODE_RESULTS = 200;
 
 export class GraphQueryService {
   constructor(private readonly db: NodePgDatabase) {}
@@ -377,32 +382,92 @@ export class GraphQueryService {
     communityId: string,
     spaceIds: string[],
     activeRunIds: ActiveGraphifyRunIds,
-  ): Promise<GraphQueryNode[]> {
+  ): Promise<{ nodes: GraphQueryNode[]; edges: GraphQueryEdge[]; truncated: boolean }> {
     const activeScope = activeGraphScope(spaceIds, activeRunIds);
     if (communityId.trim().length === 0 || activeScope.spaceIds.length === 0) {
-      return [];
+      return { nodes: [], edges: [], truncated: false };
     }
 
-    const result = await this.db.execute<RawNodeRow>(sql`
+    const result = await this.db.execute<RawCommunityNodesRow>(sql`
+      with matching_nodes as (
+        select
+          id,
+          node_key,
+          stable_key,
+          label,
+          type,
+          space_id,
+          community_id,
+          graphify_run_id,
+          count(*) over () as total_count
+        from graph_nodes
+        where community_id = ${communityId}
+          and space_id = any(${toPgTextArray(activeScope.spaceIds)}::text[])
+          and graphify_run_id = any(${toPgTextArray(activeScope.runIds)}::text[])
+        order by label asc
+        limit ${MAX_COMMUNITY_NODE_RESULTS}
+      ),
+      node_ids as (
+        select id from matching_nodes
+      ),
+      community_edges as (
+        select
+          e.id,
+          e.source_node_id,
+          e.target_node_id,
+          e.relation_type,
+          e.confidence_label,
+          e.effective_confidence_score,
+          e.evidence_count,
+          e.space_id
+        from graph_edges e
+        where e.space_id = any(${toPgTextArray(activeScope.spaceIds)}::text[])
+          and e.graphify_run_id = any(${toPgTextArray(activeScope.runIds)}::text[])
+          and e.source_node_id in (select id from node_ids)
+          and e.target_node_id in (select id from node_ids)
+        order by e.id asc
+      )
       select
-        id,
-        node_key,
-        stable_key,
-        label,
-        type as node_type,
-        null::text as description,
-        space_id,
-        community_id,
-        1 as score
-      from graph_nodes
-      where community_id = ${communityId}
-        and space_id = any(${toPgTextArray(activeScope.spaceIds)}::text[])
-        and graphify_run_id = any(${toPgTextArray(activeScope.runIds)}::text[])
-      order by label asc
-      limit ${MAX_COMMUNITY_NODE_RESULTS}
+        (
+          select coalesce(jsonb_agg(jsonb_build_object(
+            'id', n.id,
+            'node_key', n.node_key,
+            'stable_key', n.stable_key,
+            'label', n.label,
+            'node_type', n.type,
+            'description', null,
+            'space_id', n.space_id,
+            'community_id', n.community_id,
+            'score', 1
+          ) order by n.label asc), '[]'::jsonb)
+          from matching_nodes n
+        ) as nodes_json,
+        (
+          select coalesce(jsonb_agg(jsonb_build_object(
+            'id', e.id,
+            'source_node_id', e.source_node_id,
+            'target_node_id', e.target_node_id,
+            'relation_type', e.relation_type,
+            'confidence_label', e.confidence_label,
+            'effective_confidence_score', e.effective_confidence_score,
+            'evidence_count', e.evidence_count,
+            'space_id', e.space_id
+          ) order by e.id asc), '[]'::jsonb)
+          from community_edges e
+        ) as edges_json,
+        coalesce((select max(total_count) from matching_nodes), 0) > ${MAX_COMMUNITY_NODE_RESULTS} as truncated
     `);
 
-    return rowsFromResult<RawNodeRow>(result).map(toGraphQueryNode);
+    const [row] = rowsFromResult<RawCommunityNodesRow>(result);
+    if (row === undefined) {
+      return { nodes: [], edges: [], truncated: false };
+    }
+
+    return {
+      nodes: parseNodeArray(row.nodes_json).filter((node) => activeScope.spaceIds.includes(node.space_id)),
+      edges: parseEdgeArray(row.edges_json).filter((edge) => activeScope.spaceIds.includes(edge.space_id)),
+      truncated: row.truncated === true,
+    };
   }
 
   async getEvidenceRefs(edgeId: string, spaceIds: string[]): Promise<GraphEvidenceRef[]> {

--- a/packages/rag-core/src/__tests__/graph-retrieval.test.ts
+++ b/packages/rag-core/src/__tests__/graph-retrieval.test.ts
@@ -423,7 +423,11 @@ function makeGraphQueryService(
     searchNodes: vi.fn<GraphQueryService['searchNodes']>().mockResolvedValue(nodes),
     findPath: vi.fn<GraphQueryService['findPath']>().mockResolvedValue(paths),
     getCommunities: vi.fn<GraphQueryService['getCommunities']>().mockResolvedValue([]),
-    getCommunityNodes: vi.fn<GraphQueryService['getCommunityNodes']>().mockResolvedValue([]),
+    getCommunityNodes: vi.fn<GraphQueryService['getCommunityNodes']>().mockResolvedValue({
+      nodes: [],
+      edges: [],
+      truncated: false,
+    }),
   };
 
   return service as unknown as GraphQueryService & MockGraphQueryService;
@@ -440,7 +444,11 @@ function makeFullGraphQueryService(input: {
     findPath: vi.fn<GraphQueryService['findPath']>().mockResolvedValue(input.paths ?? []),
     getCommunities: vi.fn<GraphQueryService['getCommunities']>().mockResolvedValue(input.communities ?? []),
     getCommunityNodes: vi.fn<GraphQueryService['getCommunityNodes']>().mockImplementation((communityId) =>
-      Promise.resolve(input.communityNodes?.get(communityId) ?? []),
+      Promise.resolve({
+        nodes: input.communityNodes?.get(communityId) ?? [],
+        edges: [],
+        truncated: false,
+      }),
     ),
   };
 

--- a/packages/rag-core/src/graph-retrieval.ts
+++ b/packages/rag-core/src/graph-retrieval.ts
@@ -225,8 +225,8 @@ async function retrieveLocalCandidateContexts(
     );
   }
 
-  for (const communityNodes of communityNodeResults) {
-    for (const node of communityNodes) {
+  for (const communityResult of communityNodeResults) {
+    for (const node of communityResult.nodes) {
       candidateContexts.push(toNodeCandidateContext(node, searchScoreByCommunityId.get(node.community_id ?? '') ?? node.score));
     }
   }

--- a/progress.md
+++ b/progress.md
@@ -132,6 +132,7 @@
 
 | ID | 描述 | Fix |
 |---|---|---|
+| #392 | Graph Explorer 社区节点展开 | `GET /api/graph/communities/:id/nodes?space_id=` 返回社区节点、内部边和 200 节点截断标记；前端点击社区加载并 merge 到画布，支持 loading/截断提示；新增 graph-core/API/Web/RAG 回归测试；`npm run build` 通过，相关测试通过，完整 `npm test` 仅遇到一次无关 Bridge rate-limit 5s 超时，单测复跑通过 |
 | #386 | Admin Worker 状态端点 | 新增 `GET /api/admin/workers` 聚合 Redis `worker:heartbeat:*`，按 <30s/30-120s/≥120s 标记 online/degraded/stale，Redis 不可用返回空列表+错误；新增 6 个 controller 单测；`npm run build`、worker 测试、`npm run lint` 通过 |
 | #385 | Health 端点集成 enabled models 连通性探测 | `ModelConfigService.listEnabledModels()` + 可配置超时 `probeModel()`；`AdminHealthController` 新增 optional `models` 组件，5s 单模型/8s 整体超时，unhealthy models 仅使 overall degraded；新增 6 个 models 健康回归测试；`npm run build`、health 测试、`npm run lint` 通过 |
 | PR-387-R1 | Rerank API SSRF 防护与错误语义修正 | `callRerankApi` 接入 `validateAdminOutboundProbeUrl` + validated dispatcher + finally close；保留非 OK 响应 body cancel；无可用 rerank scores 错误信息改为更准确文案；`npm run build`、rerank 回归测试通过 |


### PR DESCRIPTION
## Summary

- Add `GET /api/graph/communities/:id/nodes?space_id=...` returning `{nodes, edges, truncated}`
- Extend `GraphQueryService.getCommunityNodes()` to fetch intra-community edges via CTE, limit 200 nodes
- Frontend: clicking a community loads its nodes/edges onto canvas with loading state and truncation warning
- Updated RAG retrieval callers for new return shape
- Added backend + frontend tests

Closes #392

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `77b68c44fca124c14c6f384ac2e1a23e9cd6f1d3`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/396#issuecomment-4476573131) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/396#issuecomment-4476573466) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/396#issuecomment-4476573820) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/396#issuecomment-4476574129)
- Key findings addressed: Clean — all 6 tasks and 7 spec scenarios verified DONE

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (1439 tests, 213 files)
- [x] Backend: community nodes + edges returned, truncation flag, empty community, ACL
- [x] Frontend: click loads nodes, re-click deactivates, loading state shown
- [x] RAG retrieval callers updated for new return shape