### PR TITLE
fix(graph): improve community panel and canvas contrast (#393)

### DIFF
--- a/apps/web/src/pages/graph/GraphCanvas.tsx
+++ b/apps/web/src/pages/graph/GraphCanvas.tsx
@@ -109,11 +109,11 @@ export default function GraphCanvas({
   }
 
   function getLinkColor(link: LinkObject<GraphNode, GraphLink>): string {
-    return link.id === selectedEdgeId ? '#fab387' : 'rgba(180, 190, 210, 0.45)';
+    return link.id === selectedEdgeId ? '#c2410c' : 'rgba(100, 116, 139, 0.45)';
   }
 
   return (
-    <div style={{ position: 'relative', minHeight: size.height, border: '1px solid rgba(255,255,255,0.08)', borderRadius: 8, overflow: 'hidden', background: '#1e1e2e' }}>
+    <div style={{ position: 'relative', minHeight: size.height, border: '1px solid #e5e7eb', borderRadius: 8, overflow: 'hidden', background: '#f8f9fa' }}>
       <div style={{ position: 'absolute', right: 12, top: 12, zIndex: 2 }}>
         <Tooltip title={t('graph.canvas.resetView')}>
           <Button aria-label={t('graph.canvas.resetView')} icon={<FullscreenOutlined />} onClick={resetView} />
@@ -132,7 +132,7 @@ export default function GraphCanvas({
           linkTarget="target"
           width={size.width}
           height={size.height}
-          backgroundColor="#1e1e2e"
+          backgroundColor="#f8f9fa"
           nodeColor={getNodeColor}
           nodeLabel={(node) => escapeHtml(node.label)}
           nodeCanvasObject={(node, ctx, globalScale) => {
@@ -151,7 +151,7 @@ export default function GraphCanvas({
               ctx.font = `${fontSize}px Sans-Serif`;
               ctx.textAlign = 'center';
               ctx.textBaseline = 'top';
-              ctx.fillStyle = 'rgba(255, 255, 255, 0.9)';
+              ctx.fillStyle = 'rgba(30, 30, 46, 0.9)';
               ctx.fillText(displayLabel, node.x!, node.y! + size + 2);
             }
           }}

--- a/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
+++ b/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
@@ -479,7 +479,7 @@ function GraphCommunityPanel({
             return (
               <List.Item>
                 <Button
-                  type={isActive ? 'primary' : 'text'}
+                  type={isActive ? 'primary' : 'default'}
                   loading={isButtonLoading}
                   style={{ width: '100%', height: 'auto', textAlign: 'left', whiteSpace: 'normal' }}
                   disabled={isLoadingCommunityNodes && !isButtonLoading}


### PR DESCRIPTION
## Summary

- Change community panel button from `type="text"` to `type="default"` for readable text on white background
- Switch graph canvas from dark theme (#1e1e2e) to light theme (#f8f9fa) with dark labels and deeper edge colors
- Consistent with Ant Design default light theme

Closes #393

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `ccace817d91ede1e2aeb28e9b5f5220a60c6b789`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/397#issuecomment-4476773524) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/397#issuecomment-4476773730) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/397#issuecomment-4476773971) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/397#issuecomment-4476774197)
- Key findings addressed: Clean — CSS-only changes, no logic changes

## Test plan

- [x] `npm run build` passes
- [x] Web tests: 14 files, 180 tests all pass
- [x] Visual: community panel text readable in both states, canvas labels visible on light background