### PR TITLE
feat(infra): enable Docmost nginx reverse proxy (#394)

### DIFF
--- a/ops/nginx/nginx-prod.conf
+++ b/ops/nginx/nginx-prod.conf
@@ -58,8 +58,12 @@ http {
     }
 
     location /docmost/ {
-      return 503 '{"error": "Docmost is not available in Phase 1."}';
-      add_header Content-Type application/json always;
+      proxy_pass http://docmost:3000/;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
     }
   }
 }

--- a/ops/nginx/nginx.conf
+++ b/ops/nginx/nginx.conf
@@ -66,10 +66,13 @@ http {
       proxy_read_timeout 300s;
     }
 
-    # --- Phase 1: Docmost 不可用，返回明确提示 ---
     location /docmost/ {
-      return 503 '{"error": "Docmost is not available in Phase 1. It will be enabled in Phase 2."}';
-      add_header Content-Type application/json always;
+      proxy_pass http://docmost:3000/;
+      proxy_http_version 1.1;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace Phase 1 503 block with `proxy_pass http://docmost:3000/` in both dev and prod nginx configs
- Add standard proxy headers (Host, X-Real-IP, X-Forwarded-For, X-Forwarded-Proto)

Closes #394

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `235d69626345525b25a7be2dfa8fcdc11ab71a5c`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/398#issuecomment-4476935965) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/398#issuecomment-4476936999) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/398#issuecomment-4476937214) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/398#issuecomment-4476937540)
- Key findings addressed: Clean — config-only change

## Test plan

- [x] Dev config: `/docmost/` proxies to `http://docmost:3000/`
- [x] Prod config: same change applied
- [x] Proxy headers match spec (Host, X-Real-IP, X-Forwarded-For, X-Forwarded-Proto)