### PR TITLE
feat(graph): edge visibility enhancement — wider links, larger arrows (#402)

### DIFF
--- a/apps/web/src/pages/graph/GraphCanvas.tsx
+++ b/apps/web/src/pages/graph/GraphCanvas.tsx
@@ -222,9 +222,9 @@ export default function GraphCanvas({
           nodeRelSize={6}
           linkColor={resolveLinkColor}
           linkLabel={(link) => escapeHtml(link.relationship)}
-          linkDirectionalArrowLength={4}
+          linkDirectionalArrowLength={6}
           linkDirectionalArrowRelPos={1}
-          linkWidth={(link) => (link.id === selectedEdgeId ? 2.5 : 1.2)}
+          linkWidth={(link) => (link.id === selectedEdgeId ? 3.5 : 1.8)}
           onNodeClick={(node) => {
             if (typeof node.id === 'string') {
               onNodeSelect(node.id);


### PR DESCRIPTION
## Summary

- Default link width: 1.2 → 1.8
- Selected link width: 2.5 → 3.5
- Arrow length: 4 → 6
- Link colors already theme-aware from #400 (textTertiary default, #fab387 selected)

Part of #399

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `bfec5c6106de5ab7454e3d4bb48e10a4f1c10fd0`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/406#issuecomment-4478097290) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/406#issuecomment-4478098060) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/406#issuecomment-4478098446) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/406#issuecomment-4478098838)
- Key findings addressed: None — all reviewers clean.

## Test Plan

- [x] getLinkColor tests cover selected and default colors (from #401)
- [x] All 1439 tests pass locally
- [x] TypeScript build clean

Closes #402