### PR TITLE
feat(graph): panel theme alignment — sidebar, community UX, legend (#403)

### DIFF
--- a/apps/web/src/__tests__/graph-explorer.test.tsx
+++ b/apps/web/src/__tests__/graph-explorer.test.tsx
@@ -320,7 +320,7 @@ describe('SpaceGraphExplorerPage', () => {
       'style',
       expect.stringContaining('color: var(--color-text-2)'),
     );
-    expect(screen.getByText('concept')).toHaveStyle({ color: '#fff' });
+    expect(screen.getByText('concept')).toHaveStyle({ color: 'rgba(0, 0, 0, 0.88)' });
   });
 
   it('shows empty state when no graph data is loaded', async () => {

--- a/apps/web/src/__tests__/graph-explorer.test.tsx
+++ b/apps/web/src/__tests__/graph-explorer.test.tsx
@@ -278,6 +278,51 @@ describe('SpaceGraphExplorerPage', () => {
     expect(getGraphCommunityNodesMock).toHaveBeenCalledWith('community-auth', 'space-1');
   });
 
+  it('uses theme variables for graph panels and selected community cards', async () => {
+    getGraphCommunitiesMock.mockResolvedValue({
+      communities: [createCommunity({ id: 'community-auth', label: 'Auth' })],
+    });
+    getGraphCommunityNodesMock.mockResolvedValue({
+      nodes: [createNode({ id: 'node-a', label: 'OAuth', community_id: 'community-auth' })],
+      edges: [],
+      truncated: false,
+    });
+
+    renderPage();
+
+    const searchPanel = (await screen.findByRole('heading', { name: 'Search' })).closest('div');
+    const communityPanel = (await screen.findByRole('heading', { name: 'Communities' })).closest('div')?.parentElement;
+    expect(searchPanel).toHaveAttribute(
+      'style',
+      expect.stringContaining('border: 1px solid var(--color-border)'),
+    );
+    expect(searchPanel).toHaveAttribute('style', expect.stringContaining('background: var(--color-surface)'));
+    expect(communityPanel).toHaveAttribute(
+      'style',
+      expect.stringContaining('border: 1px solid var(--color-border)'),
+    );
+    expect(communityPanel).toHaveAttribute('style', expect.stringContaining('background: var(--color-surface)'));
+
+    const communityButton = (await screen.findByText('Auth')).closest('button');
+    expect(communityButton).not.toHaveClass('ant-btn-primary');
+    fireEvent.click(communityButton!);
+
+    await waitFor(() => {
+      expect(communityButton).toHaveAttribute(
+        'style',
+        expect.stringContaining('border: 2px solid var(--color-primary)'),
+      );
+      expect(communityButton).toHaveAttribute('style', expect.stringContaining('background: var(--color-primary-mute)'));
+    });
+    expect(screen.getByText('Auth')).toHaveAttribute('style', expect.stringContaining('color: var(--color-text-1)'));
+    expect(screen.getByText('2 nodes')).toHaveAttribute('style', expect.stringContaining('color: var(--color-text-2)'));
+    expect(screen.getByText('Authentication')).toHaveAttribute(
+      'style',
+      expect.stringContaining('color: var(--color-text-2)'),
+    );
+    expect(screen.getByText('concept')).toHaveStyle({ color: '#fff' });
+  });
+
   it('shows empty state when no graph data is loaded', async () => {
     renderPage();
 

--- a/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
+++ b/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
@@ -479,19 +479,30 @@ function GraphCommunityPanel({
             return (
               <List.Item>
                 <Button
-                  type={isActive ? 'primary' : 'default'}
+                  type="default"
                   loading={isButtonLoading}
-                  style={{ width: '100%', height: 'auto', textAlign: 'left', whiteSpace: 'normal' }}
+                  style={{
+                    width: '100%',
+                    height: 'auto',
+                    textAlign: 'left',
+                    whiteSpace: 'normal',
+                    ...(isActive
+                      ? {
+                          border: '2px solid var(--color-primary)',
+                          background: 'var(--color-primary-mute)',
+                        }
+                      : {}),
+                  }}
                   disabled={isLoadingCommunityNodes && !isButtonLoading}
                   onClick={() => onSelectCommunity(isActive ? null : community.id)}
                 >
                   <div>
-                    <span>{label}</span>
-                    <Typography.Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
+                    <span style={{ color: 'var(--color-text-1)' }}>{label}</span>
+                    <Typography.Text type="secondary" style={{ display: 'block', color: 'var(--color-text-2)', fontSize: 12 }}>
                       {t('graph.community.nodeCount', { count: community.node_count })}
                     </Typography.Text>
                     {community.summary !== null && community.summary.length > 0 ? (
-                      <Typography.Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
+                      <Typography.Text type="secondary" style={{ display: 'block', color: 'var(--color-text-2)', fontSize: 12 }}>
                         {community.summary}
                       </Typography.Text>
                     ) : null}
@@ -556,7 +567,9 @@ function GraphLegend() {
     <Space wrap>
       <Typography.Text type="secondary">{t('graph.legend.title')}</Typography.Text>
       {Object.entries(GRAPH_NODE_TYPE_COLORS).map(([nodeType, color]) => (
-        <Tag key={nodeType} color={color}>{nodeType === 'default' ? t('graph.nodeType.unknown') : nodeType}</Tag>
+        <Tag key={nodeType} color={color} style={{ color: '#fff' }}>
+          {nodeType === 'default' ? t('graph.nodeType.unknown') : nodeType}
+        </Tag>
       ))}
     </Space>
   );
@@ -688,8 +701,8 @@ function graphReducer(state: GraphState, action: GraphAction): GraphState {
 }
 
 const panelStyle = {
-  border: '1px solid #e5e7eb',
+  border: '1px solid var(--color-border)',
   borderRadius: 8,
   padding: 16,
-  background: '#ffffff',
+  background: 'var(--color-surface)',
 } satisfies CSSProperties;

--- a/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
+++ b/apps/web/src/pages/graph/SpaceGraphExplorerPage.tsx
@@ -567,7 +567,7 @@ function GraphLegend() {
     <Space wrap>
       <Typography.Text type="secondary">{t('graph.legend.title')}</Typography.Text>
       {Object.entries(GRAPH_NODE_TYPE_COLORS).map(([nodeType, color]) => (
-        <Tag key={nodeType} color={color} style={{ color: '#fff' }}>
+        <Tag key={nodeType} color={color} style={{ color: 'rgba(0, 0, 0, 0.88)' }}>
           {nodeType === 'default' ? t('graph.nodeType.unknown') : nodeType}
         </Tag>
       ))}


### PR DESCRIPTION
## Summary

- panelStyle migrated from hardcoded #ffffff/#e5e7eb to var(--color-surface)/var(--color-border)
- Community selected state refined: border highlight + tinted background instead of solid green block
- Legend tags use dark text (rgba(0,0,0,0.88)) for WCAG AA contrast on pastel backgrounds
- Community text hierarchy enforced with explicit color vars

Part of #399 — final sub-issue

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security & Performance Reviewer
- Reviewed head SHA: `fd26ea5b221d28bfd73879c52c107c8e6ae29830`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/407#issuecomment-4478295587) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/407#issuecomment-4478295824) | [Review 3](https://github.com/DankerMu/CherryWiki/pull/407#issuecomment-4478296129) | [Review 4](https://github.com/DankerMu/CherryWiki/pull/407#issuecomment-4478296526)
- Key findings addressed: WCAG AA contrast fix — changed legend tag text from white to dark for >=4.5:1 ratio on pastel backgrounds.

## Test Plan

- [x] Panel tokens, active community styling, legend tag color tests pass
- [x] All 21 graph-explorer tests pass
- [x] TypeScript build clean

Closes #403