### PR TITLE
refactor(api): migrate core error helpers (#411)

### DIFF
--- a/apps/api/src/chat/__tests__/chat.service.test.ts
+++ b/apps/api/src/chat/__tests__/chat.service.test.ts
@@ -27,6 +27,7 @@ import {
   TEST_TENANT_ID,
   TEST_USER_ID,
   getHttpExceptionCode,
+  getHttpExceptionResponse,
   getRejectedHttpException,
 } from '../../users/__tests__/user-group-service-test-utils.js';
 import { ChatController } from '../chat.controller.js';
@@ -489,6 +490,28 @@ describe('ChatService multi-space sessions', () => {
 
     expect(err.getStatus()).toBe(403);
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.PERMISSION_DENIED);
+    expect(db.inserts).toHaveLength(0);
+  });
+
+  it('returns SPACE_NOT_FOUND when creating a session for a missing space', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([]);
+
+    const err = await getRejectedHttpException(
+      service.streamCompletion({
+        tenantId: TEST_TENANT_ID,
+        spaceId: 'missing-space',
+        userId: TEST_USER_ID,
+        userGroupIds: [TEST_GROUP_ID],
+        message: 'hello',
+      }),
+    );
+
+    expect(err.getStatus()).toBe(404);
+    expect(getHttpExceptionResponse(err)).toEqual({
+      code: ErrorCode.SPACE_NOT_FOUND,
+      message: 'Space not found',
+    });
     expect(db.inserts).toHaveLength(0);
   });
 });

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
 import {
   OpenAIChatProvider,
   OpenAIEmbeddingProvider,
@@ -59,6 +59,7 @@ import {
 } from '../common/dto/pagination.dto.js';
 import { getApiLogger } from '../common/logger/logger.module.js';
 import { validateAdminOutboundProbeUrl } from '../common/outbound-probe-safety.js';
+import { throwApiError } from '../common/errors/api-error.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { GraphService } from '../graph/graph.service.js';
 import { ModelConfigService, type RerankModelConfig } from '../models/model-config.service.js';
@@ -2351,8 +2352,4 @@ function emptyUsage(): ChatUsage {
     completion_tokens: 0,
     total_tokens: 0,
   };
-}
-
-function throwApiError(code: ErrorCode, message: string, status: HttpStatus): never {
-  throw new HttpException({ code, message }, status);
 }

--- a/apps/api/src/graphify/__tests__/graphify.service.test.ts
+++ b/apps/api/src/graphify/__tests__/graphify.service.test.ts
@@ -11,6 +11,7 @@ import {
   createAuditMock,
   createSpaceRow,
   getHttpExceptionCode,
+  getHttpExceptionResponse,
   getRejectedHttpException,
   requireRecord,
 } from '../../users/__tests__/user-group-service-test-utils.js';
@@ -247,6 +248,21 @@ describe('GraphifyService', () => {
       report_format: 'markdown',
       content: '# Graph report',
       generated_at: new Date('2026-05-01T00:05:00.000Z'),
+    });
+  });
+
+  it('getReport returns NOT_FOUND when the report is missing', async () => {
+    const { service, db } = createServiceContext();
+    db.queueSelect([createRunRow({ status: 'succeeded' })]);
+    db.queueSelect([createSpaceRow()]);
+    db.queueSelect([]);
+
+    const err = await getRejectedHttpException(service.getReport('run-1', createAdminContext()));
+
+    expect(err.getStatus()).toBe(404);
+    expect(getHttpExceptionResponse(err)).toEqual({
+      code: ErrorCode.NOT_FOUND,
+      message: 'Graphify report was not found',
     });
   });
 

--- a/apps/api/src/graphify/graphify.service.ts
+++ b/apps/api/src/graphify/graphify.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { JobRepository, JobStatus, jobs, type JobRow } from '@cherrygraph/job-core';
 import {
   ErrorCode,
@@ -30,6 +30,7 @@ import {
 import { getApiLogger } from '../common/logger/logger.module.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import { AuditService } from '../audit/audit.service.js';
+import { throwApiError } from '../common/errors/api-error.js';
 
 export type GraphifyDatabase = NodePgDatabase;
 export type GraphifyRunRow = typeof graphifyRuns.$inferSelect;
@@ -1146,8 +1147,4 @@ function parseGraphifyTimeoutSeconds(): number {
 
 function throwGraphifyRunNotFound(): never {
   throwApiError(ErrorCode.GRAPHIFY_RUN_NOT_FOUND, 'Graphify run was not found', HttpStatus.NOT_FOUND);
-}
-
-function throwApiError(code: ErrorCode, message: string, status: HttpStatus): never {
-  throw new HttpException({ code, message }, status);
 }

--- a/apps/api/src/jobs/__tests__/jobs.service.test.ts
+++ b/apps/api/src/jobs/__tests__/jobs.service.test.ts
@@ -8,6 +8,7 @@ import {
   TEST_USER_ID,
   ScriptedDb,
   getHttpExceptionCode,
+  getHttpExceptionResponse,
   getRejectedHttpException,
   requireRecord,
 } from '../../users/__tests__/user-group-service-test-utils.js';
@@ -325,6 +326,59 @@ describe('JobsService', () => {
       total: 1,
       has_next: false,
     });
+  });
+
+  it('returns 422 VALIDATION_ERROR when admin job sort is invalid', async () => {
+    const { service, db } = createServiceContext();
+
+    const query = Object.assign(new AdminJobListQueryDto(), {
+      sort: 'display_name',
+    });
+    const err = await getRejectedHttpException(service.listAdminJobs(query, createAdminContext()));
+
+    expect(err.getStatus()).toBe(422);
+    expect(getHttpExceptionResponse(err)).toEqual({
+      code: ErrorCode.VALIDATION_ERROR,
+      message: 'Invalid sort field',
+    });
+    expect(db.selectFields).toHaveLength(0);
+  });
+
+  it('returns 401 UNAUTHENTICATED when tenant context is missing', async () => {
+    const { service, db } = createServiceContext();
+
+    const err = await getRejectedHttpException(
+      service.listAdminJobs(new AdminJobListQueryDto(), {
+        actorUserId: 'admin-1',
+        userId: 'admin-1',
+        actorRole: 'admin',
+      }),
+    );
+
+    expect(err.getStatus()).toBe(401);
+    expect(getHttpExceptionResponse(err)).toEqual({
+      code: ErrorCode.UNAUTHENTICATED,
+      message: 'Unauthenticated',
+    });
+    expect(db.selectFields).toHaveLength(0);
+  });
+
+  it('returns 401 UNAUTHENTICATED when user context is missing', async () => {
+    const { service, db } = createServiceContext();
+
+    const err = await getRejectedHttpException(
+      service.getJob('job-1', {
+        tenantId: TEST_TENANT_ID,
+        actorRole: 'viewer',
+      }),
+    );
+
+    expect(err.getStatus()).toBe(401);
+    expect(getHttpExceptionResponse(err)).toEqual({
+      code: ErrorCode.UNAUTHENTICATED,
+      message: 'Unauthenticated',
+    });
+    expect(db.selectFields).toHaveLength(0);
   });
 });
 

--- a/apps/api/src/jobs/jobs.service.ts
+++ b/apps/api/src/jobs/jobs.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
 import {
   JobConflictError,
   JobEventRepository,
@@ -28,6 +28,7 @@ import {
   parseSortField,
   type PaginatedResponse,
 } from '../common/dto/pagination.dto.js';
+import { throwApiError } from '../common/errors/api-error.js';
 import { DRIZZLE } from '../database/drizzle.constants.js';
 import {
   JOB_SORT_FIELDS,
@@ -537,8 +538,4 @@ function throwJobNotFound(): never {
 
 function throwJobConflict(message: string): never {
   throwApiError(ErrorCode.CONFLICT, message, HttpStatus.CONFLICT);
-}
-
-function throwApiError(code: ErrorCode, message: string, status: HttpStatus): never {
-  throw new HttpException({ code, message }, status);
 }

--- a/apps/api/src/users/__tests__/user-group-service-test-utils.ts
+++ b/apps/api/src/users/__tests__/user-group-service-test-utils.ts
@@ -302,12 +302,16 @@ export function requireRecord(value: unknown): Record<string, unknown> {
 }
 
 export function getHttpExceptionCode(err: unknown): unknown {
+  return getHttpExceptionResponse(err)?.code;
+}
+
+export function getHttpExceptionResponse(err: unknown): Record<string, unknown> | undefined {
   if (!(err instanceof HttpException)) {
     return undefined;
   }
 
   const response = err.getResponse();
-  return isRecord(response) ? response.code : undefined;
+  return isRecord(response) ? response : undefined;
 }
 
 export async function getRejectedHttpException(promise: Promise<unknown>): Promise<HttpException> {

--- a/apps/api/src/wiki/__tests__/wiki.service.test.ts
+++ b/apps/api/src/wiki/__tests__/wiki.service.test.ts
@@ -9,6 +9,7 @@ import {
   TEST_TENANT_ID,
   TEST_USER_ID,
   getHttpExceptionCode,
+  getHttpExceptionResponse,
   getRejectedHttpException,
 } from '../../users/__tests__/user-group-service-test-utils.js';
 import { WikiService, type CreateSourceLinkInput } from '../wiki.service.js';
@@ -161,6 +162,42 @@ describe('WikiService', () => {
 
     expect(err.getStatus()).toBe(409);
     expect(getHttpExceptionCode(err)).toBe(ErrorCode.VERSION_ALREADY_PUBLISHED);
+    expect(db.updates).toHaveLength(0);
+    expect(audit.push).not.toHaveBeenCalled();
+  });
+
+  it('publish returns ILLEGAL_STATUS_TRANSITION for non-draft unpublished versions', async () => {
+    const { service, db, audit } = createServiceContext();
+    db.queueSelect([{ page: createPageRow(), currentVersion: { source: 'graphify', frontmatter_json: {} } }]);
+    db.queueSelect([createVersionRow({ status: 'archived' })]);
+
+    const err = await getRejectedHttpException(
+      service.publish(TEST_TENANT_ID, TEST_SPACE_ID, 'page-1', 'version-1', undefined, TEST_USER_ID),
+    );
+
+    expect(err.getStatus()).toBe(409);
+    expect(getHttpExceptionResponse(err)).toEqual({
+      code: ErrorCode.ILLEGAL_STATUS_TRANSITION,
+      message: 'Wiki page version cannot be published',
+    });
+    expect(db.updates).toHaveLength(0);
+    expect(audit.push).not.toHaveBeenCalled();
+  });
+
+  it('unpublish returns ILLEGAL_STATUS_TRANSITION for non-published versions', async () => {
+    const { service, db, audit } = createServiceContext();
+    db.queueSelect([{ page: createPageRow(), currentVersion: { source: 'graphify', frontmatter_json: {} } }]);
+    db.queueSelect([createVersionRow({ status: 'archived' })]);
+
+    const err = await getRejectedHttpException(
+      service.unpublish(TEST_TENANT_ID, TEST_SPACE_ID, 'page-1', 'version-1', undefined, TEST_USER_ID),
+    );
+
+    expect(err.getStatus()).toBe(409);
+    expect(getHttpExceptionResponse(err)).toEqual({
+      code: ErrorCode.ILLEGAL_STATUS_TRANSITION,
+      message: 'Wiki page version cannot be unpublished',
+    });
     expect(db.updates).toHaveLength(0);
     expect(audit.push).not.toHaveBeenCalled();
   });

--- a/apps/api/src/wiki/wiki.service.ts
+++ b/apps/api/src/wiki/wiki.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable, Optional } from '@nestjs/common';
 import { diffLines, type Change } from 'diff';
 import {
   batchCreateSourceLinks as normalizeSourceLinks,
@@ -37,6 +37,7 @@ import { DRIZZLE } from '../database/drizzle.constants.js';
 import { AuditService } from '../audit/audit.service.js';
 import { getApiLogger } from '../common/logger/logger.module.js';
 import { REDIS_CLIENT, type OptionalRedisClient } from '../common/redis/redis.module.js';
+import { throwApiError } from '../common/errors/api-error.js';
 
 type WikiDatabase = NodePgDatabase;
 type WikiPageRow = typeof wikiPages.$inferSelect;
@@ -1127,8 +1128,4 @@ function splitDiffLines(change: Change): string[] {
 
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, '\\$&');
-}
-
-function throwApiError(code: ErrorCode, message: string, status: HttpStatus): never {
-  throw new HttpException({ code, message }, status);
 }

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -107,6 +107,68 @@ Issue #410 fixture:
 - [ ] 2.4 Dependent issues #411/#412: migrate local `throwApiError` helper definitions in API services/controllers to the common helper by API domain, preserving HTTP status, code, message, details, and `meta.request_id`.
   - Verification: `rg -n "function throwApiError" apps/api/src` returns only the common helper location; targeted API service/controller tests pass for migrated domains.
 
+Issue #411 fixture:
+- Issue type: refactor / migration
+- Project profile: other
+- Blast radius: high
+- Fixture level: expanded
+- Repair intensity: high
+- Change surface: `apps/api/src/{chat,wiki,graphify,jobs}/**` local error helper usage and directly affected API domain tests only
+- Must preserve: existing public routes, DTOs, SSE event names, request/response schemas, HTTP status, `ErrorCode` values, message text, absence/presence of `details`, 5xx sanitization through `HttpExceptionFilter`, and `meta.request_id` behavior
+- Must add/change: replace the domain-local `throwApiError` definitions in `chat`, `wiki`, `graphify`, and `jobs` services with the common helper from `apps/api/src/common/errors/api-error.ts`; remove `HttpException` imports that were only needed by local helpers; add or update focused regression coverage only where existing tests do not cover representative migrated paths
+- Selected risk packs:
+  - Public API / CLI / script entry: selected - migrated helpers feed existing REST/SSE API boundaries and must keep the response contract byte/shape compatible
+  - Schema / columns / units / field names: selected - `ErrorCode` is a shared API field contract even though no DB schema changes
+  - Error handling / rollback / partial outputs: selected - migration must preserve helper-thrown failure semantics, filter sanitization, and no partial behavior changes in core domains
+  - Documentation / migration notes: selected - this fixture and implementation evidence update the entropy-governance migration record for dependent issue #412
+- Risk packs considered:
+  - Config / project setup: not selected - no runtime config, env, Docker, or deployment behavior changes
+  - File IO / path safety / overwrite: not selected - no runtime file access, upload, or artifact path behavior changes
+  - Geospatial / CRS / shapefile sidecars: not selected - no geospatial code changes
+  - Time series / forcing / temporal boundaries: not selected - no temporal data behavior changes
+  - Numerical stability / conservation / NaN: not selected - no numerical code changes
+  - Solver runtime / performance / threading: not selected - no solver/runtime/threading code changes
+  - Resource limits / large input / discovery: not selected - no discovery algorithm or resource-bound behavior changes
+  - Legacy compatibility / examples: not selected - no legacy sample/runtime behavior changes
+  - Release / packaging / dependency compatibility: not selected - no package metadata or dependency changes
+- Invariant Matrix:
+  - Governing invariant: migrated core-domain API errors must emit the same client-facing status, code, message, optional details behavior, and `meta.request_id` as before; only the helper source changes from domain-local functions to the common API helper.
+  - Source-of-truth identity/contract: `packages/shared/src/errors.ts::ErrorCode`, `apps/api/src/common/errors/api-error.ts`, and `apps/api/src/common/filters/http-exception.filter.ts` response envelope.
+  - Producers: `apps/api/src/chat/chat.service.ts`, `apps/api/src/wiki/wiki.service.ts`, `apps/api/src/graphify/graphify.service.ts`, and `apps/api/src/jobs/jobs.service.ts` call sites.
+  - Validators/preflight: targeted domain service/controller tests, common filter/helper tests already established by #410, and scan commands for local helper definitions/string-code misuse.
+  - Storage/cache/query: unchanged - no DB/cache schema, Drizzle migration, query, or persistence behavior changes.
+  - Public routes/entrypoints: existing Chat, Wiki, Graphify, and Jobs REST/SSE routes whose service methods throw the migrated errors.
+  - Frontend/downstream consumers: unchanged clients consuming `{ error: { code, message, details? }, meta: { request_id } }`; compatibility is verified through API tests/scans rather than Web changes.
+  - Failure paths/rollback/stale state: representative 400/401/403/404/409/422 helper-thrown paths keep the same status/code/message; existing 500 sanitization remains owned by `HttpExceptionFilter`.
+  - Evidence/audit/readiness: OpenSpec fixture, targeted Vitest commands, `pnpm --filter @cherrygraph/api typecheck`, `pnpm --filter @cherrygraph/api lint`, and `rg` scans proving no local helper remains in migrated domains.
+  - Regression rows:
+    - Chat invalid/missing space or missing model path -> same 400/403/404/422 status and `ErrorCode` as before helper migration
+    - Wiki missing page/version or illegal publish/unpublish transition -> same 404/409 status, code, and message as before helper migration
+    - Graphify missing run/report or permission failure -> same 401/403/404 status, code, and message as before helper migration
+    - Jobs invalid sort, unauthenticated user, missing job, or cancel conflict -> same 401/404/409/422 status, code, and message as before helper migration
+    - Any migrated helper path using a 500 `INTERNAL_ERROR` -> still sanitized by existing filter behavior, with no leaked helper message/details
+    - Scan of migrated domains -> no domain-local `function throwApiError`/`const throwApiError` definitions and no raw string-code `throwApiError('...')` calls
+- Boundary-surface checklist:
+  - Shared helper roots: `apps/api/src/common/errors/api-error.ts` and `apps/api/src/common/filters/http-exception.filter.ts` remain the only helper/filter contract roots
+  - Public entrypoints: Chat, Wiki, Graphify, and Jobs REST/SSE handlers reachable through existing controllers
+  - Read/write surfaces: service-level validation/permission/conflict paths only; no persistence semantics change
+  - Failure/stale/idempotency boundaries: existing not-found, permission, validation, conflict, unauthenticated, and internal-error branches
+  - Unchanged downstream consumers: Web/API clients and existing tests relying on shared `ErrorCode` response fields
+- Required evidence:
+  - `pnpm exec vitest run apps/api/src/chat/__tests__/chat.service.test.ts apps/api/src/wiki/__tests__/wiki.service.test.ts apps/api/src/graphify/__tests__/graphify.service.test.ts apps/api/src/jobs/__tests__/jobs.service.test.ts --config vitest.config.ts --passWithNoTests=false`
+  - `pnpm --filter @cherrygraph/api test`
+  - `pnpm --filter @cherrygraph/api typecheck`
+  - `pnpm --filter @cherrygraph/api lint`
+  - `rg -n "function throwApiError|const throwApiError" apps/api/src/{chat,wiki,graphify,jobs}` returns no matches
+  - `rg -n "throwApiError\\(['\\\"]" apps/api/src/{chat,wiki,graphify,jobs}` returns no matches
+  - `openspec validate entropy-governance --strict --no-interactive`
+- Non-goals: admin/config/supporting domain helper migration covered by #412, Chat structural decomposition, route/DTO/schema/SSE changes, new error codes, broad formatting churn, or any changes inside `external/*`
+
+- [x] 2.5 Issue #411: migrate `chat`, `wiki`, `graphify`, and `jobs` services from domain-local `throwApiError` helpers to the common API helper without changing client-facing error behavior.
+  - Verification: targeted domain tests and scans in the #411 fixture pass.
+- [x] 2.6 Issue #411: run API typecheck/lint/OpenSpec validation and record implementation evidence for the migrated core domains.
+  - Verification: `pnpm --filter @cherrygraph/api typecheck`, `pnpm --filter @cherrygraph/api lint`, and `openspec validate entropy-governance --strict --no-interactive` pass.
+
 ## 3. API Chat Backend Boundary
 
 - [ ] 3.1 Add or strengthen characterization tests for Chat session lifecycle, multi-space scope validation, and permission rejection before extracting session/scope code.

--- a/progress.md
+++ b/progress.md
@@ -156,7 +156,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #410 API error foundation complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410 已新增 common API error helper、API error inventory、共享 ErrorCode 提升和 helper/filter 回归测试；PR #426 修正 JobDto 可见 `WORKER_TIMEOUT`/`TIMEOUT` timeout payload 的 shared ErrorCode 覆盖；OpenSpec strict validate 通过；后续 #411/#412 迁移剩余本地 helper |
+| entropy-governance | #411 core API helper migration complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410 已新增 common API error helper、API error inventory、共享 ErrorCode 提升和 helper/filter 回归测试；#411 已迁移 chat/wiki/graphify/jobs services 到 common `throwApiError`，目标测试 131 pass、API test 1447 pass/1 skipped、typecheck/lint/OpenSpec strict validate 通过；后续 #412 迁移 admin/config/supporting domains |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |

--- a/progress.md
+++ b/progress.md
@@ -156,7 +156,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #411 core API helper migration complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410 已新增 common API error helper、API error inventory、共享 ErrorCode 提升和 helper/filter 回归测试；#411 已迁移 chat/wiki/graphify/jobs services 到 common `throwApiError`，目标测试 131 pass、API test 1447 pass/1 skipped、typecheck/lint/OpenSpec strict validate 通过；后续 #412 迁移 admin/config/supporting domains |
+| entropy-governance | #411 core API helper migration complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410 已新增 common API error helper、API error inventory、共享 ErrorCode 提升和 helper/filter 回归测试；#411 已迁移 chat/wiki/graphify/jobs services 到 common `throwApiError`，并补齐 Round 1 Test Evidence 指定的 Chat/Wiki/Graphify/Jobs invariant rows；目标测试 138 pass、API test 1454 pass/1 skipped、typecheck/lint/OpenSpec strict validate 通过；后续 #412 迁移 admin/config/supporting domains |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |


### PR DESCRIPTION
## Summary
- Migrate Chat, Wiki, Graphify, and Jobs services from domain-local `throwApiError` helpers to the common API helper.
- Preserve existing status/code/message/details behavior and leave route/DTO/schema/SSE contracts unchanged.
- Add #411 high/expanded OpenSpec fixture, complete #411 tasks, and add focused regression evidence for representative migrated error paths.

## Verification
- `pnpm exec vitest run apps/api/src/chat/__tests__/chat.service.test.ts apps/api/src/wiki/__tests__/wiki.service.test.ts apps/api/src/graphify/__tests__/graphify.service.test.ts apps/api/src/jobs/__tests__/jobs.service.test.ts --config vitest.config.ts --passWithNoTests=false` (138 passed)
- `pnpm --filter @cherrygraph/api test` (1454 passed / 1 skipped)
- `pnpm --filter @cherrygraph/api typecheck`
- `pnpm --filter @cherrygraph/api lint`
- `rg -n "function throwApiError|const throwApiError" apps/api/src/{chat,wiki,graphify,jobs}` (no matches)
- `rg -n "throwApiError\\(['\"]" apps/api/src/{chat,wiki,graphify,jobs}` (no matches)
- `openspec validate entropy-governance --strict --no-interactive`
- `pnpm --filter @cherrygraph/web test -- apps/web/src/__tests__/overview.test.tsx` (local rerun for prior CI flake; 190 passed)

## Agent Review

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security and Performance Reviewer, Test and Evidence Coverage Reviewer, Invariant and State Compatibility Reviewer
- Reviewed head SHA: `c16e4a294a548663a5f1aaae2ea0b18cec6e3c49`
- Review evidence: [Review 1](https://github.com/DankerMu/CherryWiki/pull/427#issuecomment-4586846463) | [Review 2](https://github.com/DankerMu/CherryWiki/pull/427#issuecomment-4586846437)
- Key findings addressed: Round 1 missing representative regression evidence was fixed with Chat SPACE_NOT_FOUND, Wiki ILLEGAL_STATUS_TRANSITION, Graphify missing report, and Jobs invalid sort/unauthenticated assertions; follow-up round 2 found no code/spec/test findings.

Closes #411
Part of #408
