### PR TITLE
refactor(web): split chat session scope hooks (#417)

### DIFF
--- a/apps/api/src/api-tokens/__tests__/api-token.service.test.ts
+++ b/apps/api/src/api-tokens/__tests__/api-token.service.test.ts
@@ -286,7 +286,7 @@ function createApiTokenRow(overrides: Partial<typeof apiTokens.$inferSelect> = {
     token_prefix: 'cwt_ab12',
     scopes: ['mcp:invoke'],
     last_used_at: null,
-    expires_at: new Date('2026-06-01T00:00:00.000Z'),
+    expires_at: new Date('2099-06-01T00:00:00.000Z'),
     revoked_at: null,
     created_at: new Date('2026-05-01T00:00:00.000Z'),
     ...overrides,

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -801,7 +801,16 @@ describe('Phase 3 chat controls and stream events', () => {
 
     renderChatRoute();
 
-    fireEvent.click(await screen.findByRole('button', { name: '数据库' }));
+    await waitFor(() =>
+      expect(fetchState.calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: '/api/spaces/space-1',
+          }),
+        ]),
+      ),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: '数据库' }, { timeout: 5000 }));
     fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
     fireEvent.click(await screen.findByText('Space Two'));
 

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -801,20 +801,12 @@ describe('Phase 3 chat controls and stream events', () => {
 
     renderChatRoute();
 
-    await waitFor(() =>
-      expect(fetchState.calls).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            path: '/api/spaces/space-1',
-          }),
-        ]),
-      ),
-    );
-    fireEvent.click(await screen.findByRole('button', { name: '数据库' }, { timeout: 5000 }));
+    fireEvent.click(await screen.findByRole('button', { name: '数据库' }));
     fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
     fireEvent.click(await screen.findByText('Space Two'));
 
-    await waitFor(() => expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument());
+    expect(await screen.findByText(/已选择 2 个空间/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument();
     await sendChatMessage('multi-space disables database');
 
     await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).not.toHaveProperty('enable_database'));

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -793,27 +793,31 @@ describe('Phase 3 chat controls and stream events', () => {
     expect(await screen.findByRole('button', { name: '数据库' })).toBeInTheDocument();
   });
 
-  it('hides the database toggle and sends no enable_database flag when multiple spaces are selected', async () => {
-    const fetchState = stubChatFetch({
-      databaseEnabled: true,
-      streamEvents: [{ event: 'message.completed', data: {} }],
-    });
+  it(
+    'hides the database toggle and sends no enable_database flag when multiple spaces are selected',
+    async () => {
+      const fetchState = stubChatFetch({
+        databaseEnabled: true,
+        streamEvents: [{ event: 'message.completed', data: {} }],
+      });
 
-    renderChatRoute();
+      renderChatRoute();
 
-    fireEvent.click(await screen.findByRole('button', { name: '数据库' }));
-    fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
-    fireEvent.click(await screen.findByText('Space Two'));
+      fireEvent.click(await screen.findByRole('button', { name: '数据库' }));
+      fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
+      fireEvent.click(await screen.findByText('Space Two'));
 
-    expect(await screen.findByText(/已选择 2 个空间/)).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument();
-    await sendChatMessage('multi-space disables database');
+      expect(await screen.findByText(/已选择 2 个空间/)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument();
+      await sendChatMessage('multi-space disables database');
 
-    await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).not.toHaveProperty('enable_database'));
-    expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({
-      space_ids: ['space-1', 'space-2'],
-    });
-  });
+      await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).not.toHaveProperty('enable_database'));
+      expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({
+        space_ids: ['space-1', 'space-2'],
+      });
+    },
+    25_000,
+  );
 
   it('renders agent.tool_use events as a collapsed tool panel', async () => {
     stubChatFetch({

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -888,16 +888,15 @@ describe('Phase 3 chat controls and stream events', () => {
 
     renderChatRoute();
 
-    // antd Select renders a combobox input; find the retrieval mode selector
-    // via its surrounding label text and the Select's internal input.
+    await waitFor(() => expect(screen.getByLabelText<HTMLTextAreaElement>('消息')).not.toBeDisabled());
     const selectWrapper = await screen.findByText('检索模式');
-    const combobox = selectWrapper.closest('.chat-retrieval-mode-label')?.querySelector<HTMLInputElement>('input[role="combobox"]');
-    expect(combobox).not.toBeNull();
-    fireEvent.mouseDown(combobox!);
+    const selectTrigger = selectWrapper.closest('.chat-retrieval-mode-label')?.querySelector<HTMLElement>('.ant-select-selector');
+    expect(selectTrigger).not.toBeNull();
+    fireEvent.mouseDown(selectTrigger!);
     const pathOption = await screen.findByText('路径优先');
     fireEvent.click(pathOption);
 
-    expect(screen.getByText('Agent')).toBeInTheDocument();
+    expect(await screen.findByText('Agent')).toBeInTheDocument();
     await sendChatMessage('trace the path');
 
     await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({ retrieval_mode: 'path_first' }));

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -500,8 +500,9 @@ describe('Phase 3 chat controls and stream events', () => {
     });
 
     renderChatRoute();
+    await waitForChatControlsReady(fetchState);
 
-    fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: '聊天空间' }));
     fireEvent.click(await screen.findByText('Space Two'));
     await sendChatMessage('compare both spaces');
 
@@ -767,7 +768,8 @@ describe('Phase 3 chat controls and stream events', () => {
 
     renderChatRoute();
 
-    fireEvent.click(await screen.findByRole('button', { name: '深度分析' }));
+    await waitForChatControlsReady(fetchState);
+    fireEvent.click(screen.getByRole('button', { name: '深度分析' }));
     await sendChatMessage('explain the architecture');
 
     await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({ enable_deep_analysis: true }));
@@ -778,19 +780,20 @@ describe('Phase 3 chat controls and stream events', () => {
   });
 
   it('shows the database toggle only when the space database config is enabled', async () => {
-    stubChatFetch({ databaseEnabled: false });
+    const databaseDisabledFetchState = stubChatFetch({ databaseEnabled: false });
     renderChatRoute();
 
-    await screen.findByLabelText('消息');
+    await waitForChatControlsReady(databaseDisabledFetchState);
     expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument();
 
     cleanup();
     vi.unstubAllGlobals();
 
-    stubChatFetch({ databaseEnabled: true });
+    const databaseEnabledFetchState = stubChatFetch({ databaseEnabled: true });
     renderChatRoute();
 
-    expect(await screen.findByRole('button', { name: '数据库' })).toBeInTheDocument();
+    await waitForChatControlsReady(databaseEnabledFetchState, { databaseAvailable: true });
+    expect(screen.getByRole('button', { name: '数据库' })).toBeInTheDocument();
   });
 
   it(
@@ -802,9 +805,10 @@ describe('Phase 3 chat controls and stream events', () => {
       });
 
       renderChatRoute();
+      await waitForChatControlsReady(fetchState, { databaseAvailable: true });
 
-      fireEvent.click(await screen.findByRole('button', { name: '数据库' }));
-      fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
+      fireEvent.click(screen.getByRole('button', { name: '数据库' }));
+      fireEvent.mouseDown(screen.getByRole('combobox', { name: '聊天空间' }));
       fireEvent.click(await screen.findByText('Space Two'));
 
       expect(await screen.findByText(/已选择 2 个空间/)).toBeInTheDocument();
@@ -832,7 +836,8 @@ describe('Phase 3 chat controls and stream events', () => {
 
     renderChatRoute();
 
-    fireEvent.click(await screen.findByRole('button', { name: '深度分析' }));
+    await waitForChatControlsReady();
+    fireEvent.click(screen.getByRole('button', { name: '深度分析' }));
     await sendChatMessage('run a database check');
 
     expect(await screen.findByText('Bash')).toBeInTheDocument();
@@ -976,6 +981,30 @@ function getSpaceSelectorCombobox(): HTMLInputElement {
   const combobox = document.querySelector<HTMLInputElement>('.chat-space-selector input[role="combobox"]');
   expect(combobox).not.toBeNull();
   return combobox!;
+}
+
+async function waitForChatControlsReady(
+  fetchState?: { calls: FetchCall[] },
+  { databaseAvailable = false }: { databaseAvailable?: boolean } = {},
+): Promise<void> {
+  await waitFor(() => {
+    expect(screen.getByLabelText<HTMLTextAreaElement>('消息')).not.toBeDisabled();
+    expect(screen.getByRole('combobox', { name: '聊天空间' })).toBeInTheDocument();
+    expect(screen.queryByText('加载会话中...')).not.toBeInTheDocument();
+    if (databaseAvailable) {
+      expect(screen.getByRole('button', { name: '数据库' })).toBeInTheDocument();
+    }
+    if (fetchState !== undefined) {
+      expect(fetchState.calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: '/api/models/chat-available' }),
+          expect.objectContaining({ path: '/api/spaces' }),
+          expect.objectContaining({ path: '/api/spaces/space-1' }),
+          expect.objectContaining({ path: '/api/spaces/space-1/chat/sessions' }),
+        ]),
+      );
+    }
+  });
 }
 
 function fireTextareaKeyDown(textarea: HTMLTextAreaElement, init: KeyboardEventInit): void {

--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -626,6 +626,140 @@ describe('Phase 3 chat controls and stream events', () => {
     );
   });
 
+  it('persists selected spaces and refreshes sessions when updating an existing session succeeds', async () => {
+    const fetchState = stubChatFetch({
+      sessions: [
+        {
+          id: 'session-single',
+          title: 'Single-space chat',
+          space_ids: ['space-1'],
+          space_details: [{ id: 'space-1', name: 'Space One' }],
+          created_at: '2026-05-01T10:00:00.000Z',
+          updated_at: '2026-05-01T11:00:00.000Z',
+        },
+      ],
+      sessionDetails: {
+        'session-single': {
+          id: 'session-single',
+          space_ids: ['space-1'],
+          space_details: [{ id: 'space-1', name: 'Space One' }],
+          messages: [],
+        },
+      },
+      streamEvents: [{ event: 'message.completed', data: {} }],
+    });
+
+    renderChatRoute();
+    fireEvent.click(await screen.findByText('Single-space chat'));
+
+    fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
+    fireEvent.click(await screen.findByText('Space Two'));
+
+    await waitFor(() =>
+      expect(fetchState.calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: '/api/spaces/space-1/chat/sessions/session-single',
+            body: { space_ids: ['space-1', 'space-2'] },
+          }),
+        ]),
+      ),
+    );
+
+    const sessionListFetches = fetchState.calls.filter((call) => call.path === '/api/spaces/space-1/chat/sessions');
+    expect(sessionListFetches.length).toBeGreaterThanOrEqual(2);
+
+    await sendChatMessage('continue with expanded scope');
+    await waitFor(() =>
+      expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({
+        session_id: 'session-single',
+        space_ids: ['space-1', 'space-2'],
+      }),
+    );
+  });
+
+  it('deleting the active session removes it and resets the chat scope to the route space', async () => {
+    const fetchState = stubChatFetch({
+      sessions: [
+        {
+          id: 'session-multi',
+          title: 'Multi-space chat',
+          space_ids: ['space-1', 'space-2'],
+          space_details: [
+            { id: 'space-1', name: 'Space One' },
+            { id: 'space-2', name: 'Space Two' },
+          ],
+          created_at: '2026-05-01T10:00:00.000Z',
+          updated_at: '2026-05-01T11:00:00.000Z',
+        },
+      ],
+      sessionDetails: {
+        'session-multi': {
+          id: 'session-multi',
+          space_ids: ['space-1', 'space-2'],
+          space_details: [
+            { id: 'space-1', name: 'Space One' },
+            { id: 'space-2', name: 'Space Two' },
+          ],
+          messages: [],
+        },
+      },
+      streamEvents: [{ event: 'message.completed', data: {} }],
+    });
+
+    renderChatRoute();
+    fireEvent.click(await screen.findByText('Multi-space chat'));
+    expect(await screen.findByText('Space Two')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '删除 Multi-space chat' }));
+    await waitFor(() => {
+      const popoverButtons = document.querySelectorAll('.ant-popconfirm .ant-btn-primary');
+      expect(popoverButtons.length).toBeGreaterThan(0);
+      fireEvent.click(popoverButtons[0] as HTMLElement);
+    });
+
+    await waitFor(() =>
+      expect(fetchState.calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: '/api/spaces/space-1/chat/sessions/session-multi',
+            body: null,
+          }),
+        ]),
+      ),
+    );
+    await waitFor(() => expect(screen.queryByText('Multi-space chat')).not.toBeInTheDocument());
+
+    await sendChatMessage('start after delete');
+    await waitFor(() =>
+      expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({
+        space_ids: ['space-1'],
+      }),
+    );
+    expect(getLastChatCompletionBody(fetchState.calls)).not.toHaveProperty('session_id');
+  });
+
+  it('new chat resets selected spaces to the route space', async () => {
+    const fetchState = stubChatFetch({
+      streamEvents: [{ event: 'message.completed', data: {} }],
+    });
+
+    renderChatRoute();
+    fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
+    fireEvent.click(await screen.findByText('Space Two'));
+    expect(await screen.findByText(/已选择 2 个空间/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /新建对话/ }));
+    await waitFor(() => expect(screen.queryByText(/已选择 2 个空间/)).not.toBeInTheDocument());
+
+    await sendChatMessage('single space after new chat');
+    await waitFor(() =>
+      expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({
+        space_ids: ['space-1'],
+      }),
+    );
+  });
+
   it('sends enable_deep_analysis when the deep analysis toggle is on', async () => {
     const fetchState = stubChatFetch({
       streamEvents: [{ event: 'message.completed', data: { latency_ms: 42 } }],
@@ -657,6 +791,27 @@ describe('Phase 3 chat controls and stream events', () => {
     renderChatRoute();
 
     expect(await screen.findByRole('button', { name: '数据库' })).toBeInTheDocument();
+  });
+
+  it('hides the database toggle and sends no enable_database flag when multiple spaces are selected', async () => {
+    const fetchState = stubChatFetch({
+      databaseEnabled: true,
+      streamEvents: [{ event: 'message.completed', data: {} }],
+    });
+
+    renderChatRoute();
+
+    fireEvent.click(await screen.findByRole('button', { name: '数据库' }));
+    fireEvent.mouseDown(await screen.findByRole('combobox', { name: '聊天空间' }));
+    fireEvent.click(await screen.findByText('Space Two'));
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument());
+    await sendChatMessage('multi-space disables database');
+
+    await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).not.toHaveProperty('enable_database'));
+    expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({
+      space_ids: ['space-1', 'space-2'],
+    });
   });
 
   it('renders agent.tool_use events as a collapsed tool panel', async () => {

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import { Link, Navigate, useNavigate, useParams } from 'react-router';
@@ -18,41 +18,31 @@ import {
 import ChatChart from '../components/ChatChart.js';
 import { ConfidenceBadge } from '../components/ConfidenceBadge.js';
 import GraphPathViewer, { type GraphPathData, type GraphPathEdge, type GraphPathNode } from '../components/GraphPathViewer.js';
-import { formatDate, getErrorMessage } from '../components/adminUi.js';
+import { formatDate } from '../components/adminUi.js';
 import { SpaceForbiddenState, useSpacePermissionGate } from '../components/SpacePermissionGate.js';
 import {
   CHAT_INPUT_MAX_LENGTH,
-  DEFAULT_RETRIEVAL_MODE,
   getChatErrorMessage,
   isAgentRetrievalMode,
   useChatStream,
-  type ChatApiSessionDetail,
   type ChatCitation,
   type ChatMessage,
   type ChatMessagePart,
   type ChatToolUsePart,
   type RetrievalMode,
   type SendMessageOptions,
-  type SpaceDisplayInfo,
 } from '../hooks/useChatStream.js';
-import { useChatModelAvailable } from '../hooks/useChatModelAvailable.js';
-import { api } from '../lib/api.js';
-import { useAuth, type AuthUser } from '../lib/auth.js';
+import { useAuth } from '../lib/auth.js';
 import NotFound from './NotFound.js';
-
-type ChatSession = {
-  id: string;
-  title: string | null;
-  space_ids?: string[];
-  space_details?: SpaceDisplayInfo[];
-  updated_at: string;
-  created_at: string;
-};
-
-type AvailableChatSpace = {
-  id: string;
-  name: string;
-};
+import {
+  CHAT_SPACE_SELECTION_MAX,
+  DEFAULT_CHAT_SETTINGS,
+  normalizeRetrievalMode,
+  normalizeSelectedSpaceIds,
+} from './chat/chatScopeUtils.js';
+import type { AvailableChatSpace, ChatSession, ChatSettings } from './chat/types.js';
+import { useChatScopeSettings } from './chat/useChatScopeSettings.js';
+import { useChatSessions } from './chat/useChatSessions.js';
 
 type MessageInputProps = {
   disabled: boolean;
@@ -87,22 +77,6 @@ type ChatMessageBubbleProps = {
   spaceNameById?: Record<string, string>;
 };
 
-type ChatSettings = {
-  enableDeepAnalysis: boolean;
-  enableDatabase: boolean;
-  retrievalMode: RetrievalMode;
-};
-
-type ChatSpaceDetail = {
-  database_config?: unknown;
-};
-
-const DEFAULT_CHAT_SETTINGS: ChatSettings = {
-  enableDeepAnalysis: false,
-  enableDatabase: false,
-  retrievalMode: DEFAULT_RETRIEVAL_MODE,
-};
-const CHAT_SPACE_SELECTION_MAX = 10;
 const CHAT_SIDEBAR_COLLAPSED_KEY = 'cherry-chat-sidebar-collapsed';
 
 export default function Chat() {
@@ -110,32 +84,28 @@ export default function Chat() {
   const { spaceId = '' } = useParams();
   const { accessToken, hasSpacePermission, isAdmin, isAuthenticated, user } = useAuth();
   const gate = useSpacePermissionGate(['space:view', 'chat:use']);
-  const chatModelAvailable = useChatModelAvailable(isAuthenticated && gate.isAllowed);
-  const [sessions, setSessions] = useState<ChatSession[]>([]);
-  const [sessionsLoading, setSessionsLoading] = useState(true);
-  const [sessionsError, setSessionsError] = useState<string | null>(null);
-  const [availableSpaces, setAvailableSpaces] = useState<AvailableChatSpace[]>([]);
-  const [spaceRefreshVersion, setSpaceRefreshVersion] = useState(0);
-  const [selectedSpaceIds, setSelectedSpaceIds] = useState<string[]>(() => normalizeSelectedSpaceIds(spaceId, [spaceId]));
-  const [spaceDatabaseEnabled, setSpaceDatabaseEnabled] = useState(false);
-  const selectedSpaceSettingsKey = useMemo(() => getChatSettingsKey(selectedSpaceIds), [selectedSpaceIds]);
-  const [chatSettingsState, setChatSettingsState] = useState<{ storageKey: string; settings: ChatSettings }>(() => {
-    const initialSpaceIds = normalizeSelectedSpaceIds(spaceId, [spaceId]);
-    return {
-      storageKey: getChatSettingsKey(initialSpaceIds),
-      settings: loadChatSettings(initialSpaceIds),
-    };
-  });
-  const chatSettingsKeyRef = useRef(chatSettingsState.storageKey);
-  const chatSettings =
-    chatSettingsState.storageKey === selectedSpaceSettingsKey
-      ? chatSettingsState.settings
-      : loadChatSettings(selectedSpaceIds);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState<boolean>(() => loadSidebarCollapsed());
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
-  const sessionSwitchRef = useRef(0);
   const previousSpaceIdRef = useRef(spaceId);
+  const loadSessionsRef = useRef<((background?: boolean) => Promise<void>) | undefined>(undefined);
+  const {
+    availableSpaces,
+    chatModelAvailable,
+    chatSettings,
+    databaseAvailable,
+    selectedSpaceIds,
+    setAvailableSpaces,
+    setSelectedSpaceIds,
+    refreshAvailableSpaces,
+    updateChatSettings,
+  } = useChatScopeSettings({
+    spaceId,
+    isAuthenticated,
+    isAllowed: gate.isAllowed,
+    user,
+    hasSpacePermission,
+  });
   const spaceNameById = useMemo(() => {
     const names: Record<string, string> = {};
     for (const space of availableSpaces) {
@@ -143,39 +113,6 @@ export default function Chat() {
     }
     return names;
   }, [availableSpaces]);
-
-  const loadSessions = useCallback(
-    async (background = false) => {
-      if (!isAuthenticated || spaceId.length === 0 || !gate.isAllowed) {
-        setSessions([]);
-        setSessionsLoading(false);
-        return;
-      }
-
-      if (!background) {
-        setSessionsLoading(true);
-      }
-      setSessionsError(null);
-
-      try {
-        const response = await api.getWrapped<ChatSession[]>(
-          `/spaces/${encodeURIComponent(spaceId)}/chat/sessions`,
-          {
-            page: 1,
-            limit: 50,
-          },
-        );
-        setSessions(sortSessions(response.data));
-      } catch (err) {
-        setSessionsError(getErrorMessage(err));
-      } finally {
-        if (!background) {
-          setSessionsLoading(false);
-        }
-      }
-    },
-    [gate.isAllowed, isAuthenticated, spaceId],
-  );
 
   const {
     messages,
@@ -188,124 +125,49 @@ export default function Chat() {
     startNewSession,
   } = useChatStream({
     spaceId,
-    spaceIds: selectedSpaceIds,
     accessToken,
     onSession: () => {
-      void loadSessions(true);
+      void loadSessionsRef.current?.(true);
     },
   });
 
-  useEffect(() => {
-    void loadSessions();
-  }, [loadSessions]);
+  const {
+    sessions,
+    sessionsLoading,
+    sessionsError,
+    loadSessions,
+    openSession,
+    executeDeleteSession,
+    newChat,
+    handleSpaceChange,
+  } = useChatSessions({
+    spaceId,
+    isAuthenticated,
+    isAllowed: gate.isAllowed,
+    activeSessionId: sessionId,
+    selectedSpaceIds,
+    setSelectedSpaceIds,
+    setAvailableSpaces,
+    loadStreamSession: loadSession,
+    startStreamNewSession: startNewSession,
+    closeMobileSidebar: () => setIsMobileSidebarOpen(false),
+    scopeUpdateFailedMessage: t('chat.scopeUpdateFailed'),
+  });
+
+  loadSessionsRef.current = loadSessions;
 
   useEffect(() => {
     if (previousSpaceIdRef.current !== spaceId) {
       startNewSession();
       previousSpaceIdRef.current = spaceId;
     }
-    setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, [spaceId]));
   }, [spaceId, startNewSession]);
 
   useEffect(() => {
-    if (chatSettingsKeyRef.current !== selectedSpaceSettingsKey) {
-      chatSettingsKeyRef.current = selectedSpaceSettingsKey;
-      setChatSettingsState({
-        storageKey: selectedSpaceSettingsKey,
-        settings: loadChatSettings(selectedSpaceIds),
-      });
-    }
-  }, [selectedSpaceIds, selectedSpaceSettingsKey]);
-
-  useEffect(() => {
-    if (chatSettingsState.storageKey === selectedSpaceSettingsKey) {
-      saveChatSettings(selectedSpaceIds, chatSettingsState.settings);
-    }
-  }, [chatSettingsState, selectedSpaceIds, selectedSpaceSettingsKey]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function loadAvailableSpaces(): Promise<void> {
-      if (!isAuthenticated || spaceId.length === 0 || !gate.isAllowed) {
-        setAvailableSpaces([]);
-        return;
-      }
-
-      try {
-        const response = await api.getWrapped<Array<AvailableChatSpace & { status?: string }>>('/spaces', {
-          per_page: 100,
-          sort: 'name',
-        });
-        if (cancelled) return;
-        const spaces = response.data
-          .filter((space) => (space.status ?? 'active') === 'active')
-          .filter((space) => hasSpacePermission(space.id, 'chat:use'))
-          .map((space) => ({ id: space.id, name: space.name }));
-        setAvailableSpaces(ensureSpaceOption(spaces, spaceId, getKnownSpaceName(user, spaceId)));
-      } catch {
-        if (!cancelled) {
-          setAvailableSpaces(ensureSpaceOption(getUserChatSpaces(user, hasSpacePermission), spaceId, getKnownSpaceName(user, spaceId)));
-        }
-      }
-    }
-
-    void loadAvailableSpaces();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [gate.isAllowed, hasSpacePermission, isAuthenticated, spaceId, spaceRefreshVersion, user]);
-
-  useEffect(() => {
-    setSelectedSpaceIds((current) => {
-      const authorized = new Set(availableSpaces.map((space) => space.id));
-      return normalizeSelectedSpaceIds(
-        spaceId,
-        current.filter((id) => id === spaceId || authorized.has(id)),
-      );
-    });
-  }, [availableSpaces, spaceId]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!isAuthenticated || spaceId.length === 0 || !gate.isAllowed) {
-      setSpaceDatabaseEnabled(false);
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    api
-      .get<ChatSpaceDetail>(`/spaces/${encodeURIComponent(spaceId)}`)
-      .then((space) => {
-        if (!cancelled) {
-          setSpaceDatabaseEnabled(isSpaceDatabaseEnabled(space.database_config));
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setSpaceDatabaseEnabled(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [gate.isAllowed, isAuthenticated, spaceId]);
-
-  useEffect(() => {
-    if ((!spaceDatabaseEnabled || selectedSpaceIds.length > 1) && chatSettings.enableDatabase) {
-      updateChatSettings({ ...chatSettings, enableDatabase: false });
-    }
-  }, [chatSettings.enableDatabase, selectedSpaceIds.length, spaceDatabaseEnabled]);
-
-  useEffect(() => {
     if (streamError?.status === 403 || streamError?.code === 'SPACE_PERMISSION_DENIED') {
-      setSpaceRefreshVersion((version) => version + 1);
+      refreshAvailableSpaces();
     }
-  }, [streamError]);
+  }, [refreshAvailableSpaces, streamError]);
 
   useEffect(() => {
     if (typeof messagesEndRef.current?.scrollIntoView === 'function') {
@@ -329,88 +191,12 @@ export default function Chat() {
     return <SpaceForbiddenState context="chat" />;
   }
 
-  async function openSession(nextSessionId: string): Promise<void> {
-    setSessionsError(null);
-    setIsMobileSidebarOpen(false);
-    const switchVersion = ++sessionSwitchRef.current;
-
-    try {
-      const detail = await api.get<ChatApiSessionDetail>(
-        `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(nextSessionId)}`,
-      );
-      if (sessionSwitchRef.current !== switchVersion) return;
-      setAvailableSpaces((current) => mergeSpaceOptions(current, detail.space_details ?? []));
-      setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, detail.space_ids ?? [spaceId]));
-      loadSession(detail);
-    } catch (err) {
-      if (sessionSwitchRef.current !== switchVersion) return;
-      setSessionsError(getErrorMessage(err));
-    }
-  }
-
-  async function executeDeleteSession(session: ChatSession): Promise<void> {
-    setSessionsError(null);
-
-    try {
-      await api.delete<{ deleted: true }>(
-        `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(session.id)}`,
-      );
-      setSessions((current) => current.filter((item) => item.id !== session.id));
-      if (session.id === sessionId) {
-        startNewSession();
-        setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, [spaceId]));
-      }
-    } catch (err) {
-      setSessionsError(getErrorMessage(err));
-    }
-  }
-
-  function newChat(): void {
-    startNewSession();
-    setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, [spaceId]));
-    setIsMobileSidebarOpen(false);
-  }
-
-  function updateChatSettings(settings: ChatSettings): void {
-    chatSettingsKeyRef.current = selectedSpaceSettingsKey;
-    setChatSettingsState({
-      storageKey: selectedSpaceSettingsKey,
-      settings,
-    });
-  }
-
-  async function patchSessionSpaces(nextSessionId: string, nextSpaceIds: string[]): Promise<void> {
-    await api.patch(
-      `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(nextSessionId)}`,
-      { space_ids: nextSpaceIds },
-    );
-  }
-
-  async function handleSpaceChange(nextSpaceIds: string[]): Promise<void> {
-    const normalizedIds = normalizeSelectedSpaceIds(spaceId, nextSpaceIds);
-    if (sessionId !== null) {
-      const previousIds = selectedSpaceIds;
-      setSelectedSpaceIds(normalizedIds);
-      try {
-        await patchSessionSpaces(sessionId, normalizedIds);
-      } catch {
-        setSelectedSpaceIds(previousIds);
-        void message.error(t('chat.scopeUpdateFailed'));
-        return;
-      }
-      void loadSessions(true);
-      return;
-    }
-
-    setSelectedSpaceIds(normalizedIds);
-  }
-
   async function handleSend(message: string, settings: ChatSettings): Promise<void> {
     const options: SendMessageOptions = {
       sessionId,
       spaceIds: selectedSpaceIds,
       enableDeepAnalysis: settings.enableDeepAnalysis,
-      enableDatabase: selectedSpaceIds.length === 1 && spaceDatabaseEnabled && settings.enableDatabase,
+      enableDatabase: databaseAvailable && settings.enableDatabase,
       retrievalMode: settings.retrievalMode,
     };
 
@@ -561,7 +347,7 @@ export default function Chat() {
             disabled={chatInputDisabled}
             isStreaming={isStreaming}
             settings={chatSettings}
-            databaseAvailable={selectedSpaceIds.length === 1 && spaceDatabaseEnabled}
+            databaseAvailable={databaseAvailable}
             onSettingsChange={updateChatSettings}
             onSend={handleSend}
           />
@@ -834,7 +620,12 @@ export function SessionSidebar({
             return (
               <List.Item
                 className={`chat-session-item${session.id === activeSessionId ? ' active' : ''}`}
-                onClick={() => onSelectSession(session.id)}
+                onClick={(event) => {
+                  if (event.target instanceof Element && event.target.closest('.chat-session-delete-button') !== null) {
+                    return;
+                  }
+                  onSelectSession(session.id);
+                }}
                 actions={[
                   <Popconfirm
                     key="delete"
@@ -851,9 +642,9 @@ export function SessionSidebar({
                       type="text"
                       danger
                       size="small"
+                      className="chat-session-delete-button"
                       icon={<DeleteOutlined />}
                       aria-label={`${t('common.action.delete')} ${title}`}
-                      onClick={(e) => e.stopPropagation()}
                     />
                   </Popconfirm>,
                 ]}
@@ -1157,49 +948,6 @@ function TypingIndicator() {
   );
 }
 
-function normalizeRetrievalMode(value: string): RetrievalMode {
-  const validValues: RetrievalMode[] = ['wiki_only', 'graph_rag', 'path_first', 'community_first'];
-  return validValues.includes(value as RetrievalMode) ? (value as RetrievalMode) : DEFAULT_RETRIEVAL_MODE;
-}
-
-function loadChatSettings(spaceIds: string[]): ChatSettings {
-  if (typeof window === 'undefined' || spaceIds.length === 0) {
-    return DEFAULT_CHAT_SETTINGS;
-  }
-
-  const raw = window.sessionStorage.getItem(getChatSettingsKey(spaceIds));
-  if (raw === null) {
-    return DEFAULT_CHAT_SETTINGS;
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!isRecord(parsed)) {
-      return DEFAULT_CHAT_SETTINGS;
-    }
-
-    return {
-      enableDeepAnalysis: parsed.enableDeepAnalysis === true,
-      enableDatabase: parsed.enableDatabase === true,
-      retrievalMode: typeof parsed.retrievalMode === 'string' ? normalizeRetrievalMode(parsed.retrievalMode) : DEFAULT_RETRIEVAL_MODE,
-    };
-  } catch {
-    return DEFAULT_CHAT_SETTINGS;
-  }
-}
-
-function saveChatSettings(spaceIds: string[], settings: ChatSettings): void {
-  if (typeof window === 'undefined' || spaceIds.length === 0) {
-    return;
-  }
-
-  window.sessionStorage.setItem(getChatSettingsKey(spaceIds), JSON.stringify(settings));
-}
-
-function getChatSettingsKey(spaceIds: string[]): string {
-  return `cherry-chat-settings:${JSON.stringify([...spaceIds].sort())}`;
-}
-
 function loadSidebarCollapsed(): boolean {
   if (typeof window === 'undefined') {
     return false;
@@ -1222,10 +970,6 @@ function saveSidebarCollapsed(isCollapsed: boolean): void {
   } catch {
     // localStorage can be unavailable in private browsing contexts.
   }
-}
-
-function isSpaceDatabaseEnabled(value: unknown): boolean {
-  return isRecord(value) && value.enabled === true;
 }
 
 function formatToolInput(input: unknown): string {
@@ -1422,60 +1166,6 @@ function readStringArray(value: unknown): string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function sortSessions(sessions: ChatSession[]): ChatSession[] {
-  return [...sessions].sort((left, right) => new Date(right.updated_at).getTime() - new Date(left.updated_at).getTime());
-}
-
-function normalizeSelectedSpaceIds(primarySpaceId: string, selectedSpaceIds: string[]): string[] {
-  const normalized: string[] = [];
-  const add = (value: string | undefined) => {
-    const trimmed = value?.trim() ?? '';
-    if (trimmed.length > 0 && !normalized.includes(trimmed)) {
-      normalized.push(trimmed);
-    }
-  };
-
-  add(primarySpaceId);
-  for (const selectedSpaceId of selectedSpaceIds) {
-    add(selectedSpaceId);
-  }
-
-  return normalized;
-}
-
-function ensureSpaceOption(spaces: AvailableChatSpace[], spaceId: string, fallbackName: string): AvailableChatSpace[] {
-  const normalized = mergeSpaceOptions(spaces, [{ id: spaceId, name: fallbackName }]);
-  return normalized.sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'));
-}
-
-function mergeSpaceOptions(spaces: AvailableChatSpace[], incoming: SpaceDisplayInfo[]): AvailableChatSpace[] {
-  const byId = new Map<string, AvailableChatSpace>();
-  for (const space of spaces) {
-    if (space.id.length > 0) {
-      byId.set(space.id, space);
-    }
-  }
-  for (const space of incoming) {
-    if (space.id.length > 0 && space.name.length > 0) {
-      byId.set(space.id, { id: space.id, name: space.name });
-    }
-  }
-  return [...byId.values()];
-}
-
-function getUserChatSpaces(
-  user: AuthUser | null,
-  hasSpacePermission: (spaceId: string, permission: string) => boolean,
-): AvailableChatSpace[] {
-  return (user?.spaces ?? [])
-    .filter((space) => hasSpacePermission(space.id, 'chat:use'))
-    .map((space) => ({ id: space.id, name: space.name }));
-}
-
-function getKnownSpaceName(user: AuthUser | null, spaceId: string): string {
-  return user?.spaces?.find((space) => space.id === spaceId)?.name ?? spaceId;
 }
 
 function formatSessionDescription(session: ChatSession): string {

--- a/apps/web/src/pages/chat/chatScopeUtils.ts
+++ b/apps/web/src/pages/chat/chatScopeUtils.ts
@@ -1,0 +1,116 @@
+import type { AuthUser } from '../../lib/auth.js';
+import { DEFAULT_RETRIEVAL_MODE, type RetrievalMode, type SpaceDisplayInfo } from '../../hooks/useChatStream.js';
+import type { AvailableChatSpace, ChatSession, ChatSettings } from './types.js';
+
+export const DEFAULT_CHAT_SETTINGS: ChatSettings = {
+  enableDeepAnalysis: false,
+  enableDatabase: false,
+  retrievalMode: DEFAULT_RETRIEVAL_MODE,
+};
+
+export const CHAT_SPACE_SELECTION_MAX = 10;
+
+export function normalizeSelectedSpaceIds(primarySpaceId: string, selectedSpaceIds: string[]): string[] {
+  const normalized: string[] = [];
+  const add = (value: string | undefined) => {
+    const trimmed = value?.trim() ?? '';
+    if (trimmed.length > 0 && !normalized.includes(trimmed)) {
+      normalized.push(trimmed);
+    }
+  };
+
+  add(primarySpaceId);
+  for (const selectedSpaceId of selectedSpaceIds) {
+    add(selectedSpaceId);
+  }
+
+  return normalized;
+}
+
+export function ensureSpaceOption(spaces: AvailableChatSpace[], spaceId: string, fallbackName: string): AvailableChatSpace[] {
+  const normalized = mergeSpaceOptions(spaces, [{ id: spaceId, name: fallbackName }]);
+  return normalized.sort((left, right) => left.name.localeCompare(right.name, 'zh-CN'));
+}
+
+export function mergeSpaceOptions(spaces: AvailableChatSpace[], incoming: SpaceDisplayInfo[]): AvailableChatSpace[] {
+  const byId = new Map<string, AvailableChatSpace>();
+  for (const space of spaces) {
+    if (space.id.length > 0) {
+      byId.set(space.id, space);
+    }
+  }
+  for (const space of incoming) {
+    if (space.id.length > 0 && space.name.length > 0) {
+      byId.set(space.id, { id: space.id, name: space.name });
+    }
+  }
+  return [...byId.values()];
+}
+
+export function getUserChatSpaces(
+  user: AuthUser | null,
+  hasSpacePermission: (spaceId: string, permission: string) => boolean,
+): AvailableChatSpace[] {
+  return (user?.spaces ?? [])
+    .filter((space) => hasSpacePermission(space.id, 'chat:use'))
+    .map((space) => ({ id: space.id, name: space.name }));
+}
+
+export function getKnownSpaceName(user: AuthUser | null, spaceId: string): string {
+  return user?.spaces?.find((space) => space.id === spaceId)?.name ?? spaceId;
+}
+
+export function normalizeRetrievalMode(value: string): RetrievalMode {
+  const validValues: RetrievalMode[] = ['wiki_only', 'graph_rag', 'path_first', 'community_first'];
+  return validValues.includes(value as RetrievalMode) ? (value as RetrievalMode) : DEFAULT_RETRIEVAL_MODE;
+}
+
+export function loadChatSettings(spaceIds: string[]): ChatSettings {
+  if (typeof window === 'undefined' || spaceIds.length === 0) {
+    return DEFAULT_CHAT_SETTINGS;
+  }
+
+  const raw = window.sessionStorage.getItem(getChatSettingsKey(spaceIds));
+  if (raw === null) {
+    return DEFAULT_CHAT_SETTINGS;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      return DEFAULT_CHAT_SETTINGS;
+    }
+
+    return {
+      enableDeepAnalysis: parsed.enableDeepAnalysis === true,
+      enableDatabase: parsed.enableDatabase === true,
+      retrievalMode: typeof parsed.retrievalMode === 'string' ? normalizeRetrievalMode(parsed.retrievalMode) : DEFAULT_RETRIEVAL_MODE,
+    };
+  } catch {
+    return DEFAULT_CHAT_SETTINGS;
+  }
+}
+
+export function saveChatSettings(spaceIds: string[], settings: ChatSettings): void {
+  if (typeof window === 'undefined' || spaceIds.length === 0) {
+    return;
+  }
+
+  window.sessionStorage.setItem(getChatSettingsKey(spaceIds), JSON.stringify(settings));
+}
+
+export function getChatSettingsKey(spaceIds: string[]): string {
+  return `cherry-chat-settings:${JSON.stringify([...spaceIds].sort())}`;
+}
+
+export function isSpaceDatabaseEnabled(value: unknown): boolean {
+  return isRecord(value) && value.enabled === true;
+}
+
+export function sortSessions(sessions: ChatSession[]): ChatSession[] {
+  return [...sessions].sort((left, right) => new Date(right.updated_at).getTime() - new Date(left.updated_at).getTime());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/web/src/pages/chat/types.ts
+++ b/apps/web/src/pages/chat/types.ts
@@ -1,0 +1,25 @@
+import type { RetrievalMode, SpaceDisplayInfo } from '../../hooks/useChatStream.js';
+
+export type ChatSession = {
+  id: string;
+  title: string | null;
+  space_ids?: string[];
+  space_details?: SpaceDisplayInfo[];
+  updated_at: string;
+  created_at: string;
+};
+
+export type AvailableChatSpace = {
+  id: string;
+  name: string;
+};
+
+export type ChatSettings = {
+  enableDeepAnalysis: boolean;
+  enableDatabase: boolean;
+  retrievalMode: RetrievalMode;
+};
+
+export type ChatSpaceDetail = {
+  database_config?: unknown;
+};

--- a/apps/web/src/pages/chat/useChatScopeSettings.ts
+++ b/apps/web/src/pages/chat/useChatScopeSettings.ts
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useChatModelAvailable } from '../../hooks/useChatModelAvailable.js';
+import { api } from '../../lib/api.js';
+import type { AuthUser } from '../../lib/auth.js';
+import {
+  ensureSpaceOption,
+  getChatSettingsKey,
+  getKnownSpaceName,
+  getUserChatSpaces,
+  isSpaceDatabaseEnabled,
+  loadChatSettings,
+  normalizeSelectedSpaceIds,
+  saveChatSettings,
+} from './chatScopeUtils.js';
+import type { AvailableChatSpace, ChatSettings, ChatSpaceDetail } from './types.js';
+
+type UseChatScopeSettingsParams = {
+  spaceId: string;
+  isAuthenticated: boolean;
+  isAllowed: boolean;
+  user: AuthUser | null;
+  hasSpacePermission: (spaceId: string, permission: string) => boolean;
+};
+
+export function useChatScopeSettings({
+  spaceId,
+  isAuthenticated,
+  isAllowed,
+  user,
+  hasSpacePermission,
+}: UseChatScopeSettingsParams) {
+  const [availableSpaces, setAvailableSpaces] = useState<AvailableChatSpace[]>([]);
+  const [spaceRefreshVersion, setSpaceRefreshVersion] = useState(0);
+  const [selectedSpaceIds, setSelectedSpaceIds] = useState<string[]>(() => normalizeSelectedSpaceIds(spaceId, [spaceId]));
+  const [spaceDatabaseEnabled, setSpaceDatabaseEnabled] = useState(false);
+  const selectedSpaceSettingsKey = useMemo(() => getChatSettingsKey(selectedSpaceIds), [selectedSpaceIds]);
+  const [chatSettingsState, setChatSettingsState] = useState<{ storageKey: string; settings: ChatSettings }>(() => {
+    const initialSpaceIds = normalizeSelectedSpaceIds(spaceId, [spaceId]);
+    return {
+      storageKey: getChatSettingsKey(initialSpaceIds),
+      settings: loadChatSettings(initialSpaceIds),
+    };
+  });
+  const chatSettingsKeyRef = useRef(chatSettingsState.storageKey);
+  const chatSettings =
+    chatSettingsState.storageKey === selectedSpaceSettingsKey
+      ? chatSettingsState.settings
+      : loadChatSettings(selectedSpaceIds);
+  const chatModelAvailable = useChatModelAvailable(isAuthenticated && isAllowed);
+
+  const updateChatSettings = useCallback(
+    (settings: ChatSettings): void => {
+      chatSettingsKeyRef.current = selectedSpaceSettingsKey;
+      setChatSettingsState({
+        storageKey: selectedSpaceSettingsKey,
+        settings,
+      });
+    },
+    [selectedSpaceSettingsKey],
+  );
+
+  useEffect(() => {
+    setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, [spaceId]));
+  }, [spaceId]);
+
+  useEffect(() => {
+    if (chatSettingsKeyRef.current !== selectedSpaceSettingsKey) {
+      chatSettingsKeyRef.current = selectedSpaceSettingsKey;
+      setChatSettingsState({
+        storageKey: selectedSpaceSettingsKey,
+        settings: loadChatSettings(selectedSpaceIds),
+      });
+    }
+  }, [selectedSpaceIds, selectedSpaceSettingsKey]);
+
+  useEffect(() => {
+    if (chatSettingsState.storageKey === selectedSpaceSettingsKey) {
+      saveChatSettings(selectedSpaceIds, chatSettingsState.settings);
+    }
+  }, [chatSettingsState, selectedSpaceIds, selectedSpaceSettingsKey]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAvailableSpaces(): Promise<void> {
+      if (!isAuthenticated || spaceId.length === 0 || !isAllowed) {
+        setAvailableSpaces([]);
+        return;
+      }
+
+      try {
+        const response = await api.getWrapped<Array<AvailableChatSpace & { status?: string }>>('/spaces', {
+          per_page: 100,
+          sort: 'name',
+        });
+        if (cancelled) return;
+        const spaces = response.data
+          .filter((space) => (space.status ?? 'active') === 'active')
+          .filter((space) => hasSpacePermission(space.id, 'chat:use'))
+          .map((space) => ({ id: space.id, name: space.name }));
+        setAvailableSpaces(ensureSpaceOption(spaces, spaceId, getKnownSpaceName(user, spaceId)));
+      } catch {
+        if (!cancelled) {
+          setAvailableSpaces(ensureSpaceOption(getUserChatSpaces(user, hasSpacePermission), spaceId, getKnownSpaceName(user, spaceId)));
+        }
+      }
+    }
+
+    void loadAvailableSpaces();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasSpacePermission, isAllowed, isAuthenticated, spaceId, spaceRefreshVersion, user]);
+
+  useEffect(() => {
+    setSelectedSpaceIds((current) => {
+      const authorized = new Set(availableSpaces.map((space) => space.id));
+      return normalizeSelectedSpaceIds(
+        spaceId,
+        current.filter((id) => id === spaceId || authorized.has(id)),
+      );
+    });
+  }, [availableSpaces, spaceId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!isAuthenticated || spaceId.length === 0 || !isAllowed) {
+      setSpaceDatabaseEnabled(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    api
+      .get<ChatSpaceDetail>(`/spaces/${encodeURIComponent(spaceId)}`)
+      .then((space) => {
+        if (!cancelled) {
+          setSpaceDatabaseEnabled(isSpaceDatabaseEnabled(space.database_config));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSpaceDatabaseEnabled(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAllowed, isAuthenticated, spaceId]);
+
+  useEffect(() => {
+    if ((!spaceDatabaseEnabled || selectedSpaceIds.length > 1) && chatSettings.enableDatabase) {
+      updateChatSettings({ ...chatSettings, enableDatabase: false });
+    }
+  }, [chatSettings, selectedSpaceIds.length, spaceDatabaseEnabled, updateChatSettings]);
+
+  const resetSelectedSpacesToRoute = useCallback(() => {
+    setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, [spaceId]));
+  }, [spaceId]);
+
+  const refreshAvailableSpaces = useCallback(() => {
+    setSpaceRefreshVersion((version) => version + 1);
+  }, []);
+
+  const databaseAvailable = selectedSpaceIds.length === 1 && spaceDatabaseEnabled;
+
+  return {
+    availableSpaces,
+    chatModelAvailable,
+    chatSettings,
+    databaseAvailable,
+    selectedSpaceIds,
+    setAvailableSpaces,
+    setSelectedSpaceIds,
+    resetSelectedSpacesToRoute,
+    refreshAvailableSpaces,
+    updateChatSettings,
+  };
+}

--- a/apps/web/src/pages/chat/useChatSessions.ts
+++ b/apps/web/src/pages/chat/useChatSessions.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { message } from 'antd';
+
+import type { ChatApiSessionDetail } from '../../hooks/useChatStream.js';
+import { api } from '../../lib/api.js';
+import { getErrorMessage } from '../../components/adminUi.js';
+import { mergeSpaceOptions, normalizeSelectedSpaceIds, sortSessions } from './chatScopeUtils.js';
+import type { AvailableChatSpace, ChatSession } from './types.js';
+
+type UseChatSessionsParams = {
+  spaceId: string;
+  isAuthenticated: boolean;
+  isAllowed: boolean;
+  activeSessionId: string | null;
+  selectedSpaceIds: string[];
+  setSelectedSpaceIds: (updater: string[] | ((current: string[]) => string[])) => void;
+  setAvailableSpaces: (updater: AvailableChatSpace[] | ((current: AvailableChatSpace[]) => AvailableChatSpace[])) => void;
+  loadStreamSession: (session: ChatApiSessionDetail) => void;
+  startStreamNewSession: () => void;
+  closeMobileSidebar: () => void;
+  scopeUpdateFailedMessage: string;
+};
+
+export function useChatSessions({
+  spaceId,
+  isAuthenticated,
+  isAllowed,
+  activeSessionId,
+  selectedSpaceIds,
+  setSelectedSpaceIds,
+  setAvailableSpaces,
+  loadStreamSession,
+  startStreamNewSession,
+  closeMobileSidebar,
+  scopeUpdateFailedMessage,
+}: UseChatSessionsParams) {
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(true);
+  const [sessionsError, setSessionsError] = useState<string | null>(null);
+  const sessionSwitchRef = useRef(0);
+
+  const loadSessions = useCallback(
+    async (background = false) => {
+      if (!isAuthenticated || spaceId.length === 0 || !isAllowed) {
+        setSessions([]);
+        setSessionsLoading(false);
+        return;
+      }
+
+      if (!background) {
+        setSessionsLoading(true);
+      }
+      setSessionsError(null);
+
+      try {
+        const response = await api.getWrapped<ChatSession[]>(
+          `/spaces/${encodeURIComponent(spaceId)}/chat/sessions`,
+          {
+            page: 1,
+            limit: 50,
+          },
+        );
+        setSessions(sortSessions(response.data));
+      } catch (err) {
+        setSessionsError(getErrorMessage(err));
+      } finally {
+        if (!background) {
+          setSessionsLoading(false);
+        }
+      }
+    },
+    [isAllowed, isAuthenticated, spaceId],
+  );
+
+  useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  const openSession = useCallback(
+    async (nextSessionId: string): Promise<void> => {
+      setSessionsError(null);
+      closeMobileSidebar();
+      const switchVersion = ++sessionSwitchRef.current;
+
+      try {
+        const detail = await api.get<ChatApiSessionDetail>(
+          `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(nextSessionId)}`,
+        );
+        if (sessionSwitchRef.current !== switchVersion) return;
+        setAvailableSpaces((current) => mergeSpaceOptions(current, detail.space_details ?? []));
+        setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, detail.space_ids ?? [spaceId]));
+        loadStreamSession(detail);
+      } catch (err) {
+        if (sessionSwitchRef.current !== switchVersion) return;
+        setSessionsError(getErrorMessage(err));
+      }
+    },
+    [closeMobileSidebar, loadStreamSession, setAvailableSpaces, setSelectedSpaceIds, spaceId],
+  );
+
+  const newChat = useCallback((): void => {
+    startStreamNewSession();
+    setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, [spaceId]));
+    closeMobileSidebar();
+  }, [closeMobileSidebar, setSelectedSpaceIds, spaceId, startStreamNewSession]);
+
+  const executeDeleteSession = useCallback(
+    async (session: ChatSession): Promise<void> => {
+      setSessionsError(null);
+
+      try {
+        await api.delete<{ deleted: true }>(
+          `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(session.id)}`,
+        );
+        setSessions((current) => current.filter((item) => item.id !== session.id));
+        if (session.id === activeSessionId) {
+          startStreamNewSession();
+          setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, [spaceId]));
+        }
+      } catch (err) {
+        setSessionsError(getErrorMessage(err));
+      }
+    },
+    [activeSessionId, setSelectedSpaceIds, spaceId, startStreamNewSession],
+  );
+
+  const patchSessionSpaces = useCallback(
+    async (nextSessionId: string, nextSpaceIds: string[]): Promise<void> => {
+      await api.patch(
+        `/spaces/${encodeURIComponent(spaceId)}/chat/sessions/${encodeURIComponent(nextSessionId)}`,
+        { space_ids: nextSpaceIds },
+      );
+    },
+    [spaceId],
+  );
+
+  const handleSpaceChange = useCallback(
+    async (nextSpaceIds: string[]): Promise<void> => {
+      const normalizedIds = normalizeSelectedSpaceIds(spaceId, nextSpaceIds);
+      if (activeSessionId !== null) {
+        const previousIds = selectedSpaceIds;
+        setSelectedSpaceIds(normalizedIds);
+        try {
+          await patchSessionSpaces(activeSessionId, normalizedIds);
+        } catch {
+          setSelectedSpaceIds(previousIds);
+          void message.error(scopeUpdateFailedMessage);
+          return;
+        }
+        void loadSessions(true);
+        return;
+      }
+
+      setSelectedSpaceIds(normalizedIds);
+    },
+    [activeSessionId, loadSessions, patchSessionSpaces, scopeUpdateFailedMessage, selectedSpaceIds, setSelectedSpaceIds, spaceId],
+  );
+
+  return {
+    sessions,
+    sessionsLoading,
+    sessionsError,
+    loadSessions,
+    openSession,
+    executeDeleteSession,
+    newChat,
+    handleSpaceChange,
+  };
+}

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -509,16 +509,57 @@ Issue #416 fixture:
 
 ## 4. Web Chat Boundary
 
-- [ ] 4.1 Add or strengthen Web characterization tests for session switching, deletion, multi-space scope changes, model-unavailable gating, database toggle gating, message rendering, citation/source-chain rendering, and current layout controls.
-  - Verification: `pnpm --filter @cherrygraph/web test -- chat` or the repo-equivalent targeted Vitest command passes.
-- [ ] 4.2 Extract session loading/deletion workflows from `apps/web/src/pages/Chat.tsx` into focused hook(s).
-  - Verification: session switching/deletion tests pass and visible i18n text remains unchanged.
-- [ ] 4.3 Extract selected-space scope/settings, model availability gating, and database toggle gating into focused hook(s).
-  - Verification: scope/model/database gating tests pass and request payload behavior remains unchanged.
-- [ ] 4.4 Move message markdown rendering, message parts, citation panel, and source-chain rendering into focused components without changing UX or i18n keys.
+Issue #417 fixture:
+- Issue type: refactor / frontend boundary extraction
+- Project profile: other
+- Blast radius: medium
+- Fixture level: compact
+- Repair intensity: medium
+- Change surface: `apps/web/src/pages/Chat.tsx`, new or existing `apps/web/src/pages/chat/**` hook files, and `apps/web/src/__tests__/chat.test.tsx`
+- Must preserve: existing routes, API endpoints and request payloads, session list/detail/delete behavior, multi-space selected-scope order and rollback behavior, model-unavailable precheck/banner/input disablement, database toggle visibility and payload gating, sidebar/mobile controls, Chinese/i18n text, message rendering, citation/source-chain display, SSE rendering, and visual layout.
+- Must add/change: strengthen Web characterization tests for session switching/deletion and multi-space scope/settings behavior; extract session loading/open/delete/new-chat workflow and selected-space scope/settings/model/database gating workflow into focused hook(s); keep `Chat.tsx` as the composition boundary.
+- Selected risk packs:
+  - Public API / CLI / script entry: selected - Web Chat constructs existing `/api/chat/completions`, `/spaces/:id/chat/sessions`, `/spaces/:id`, `/spaces`, and `/models/chat-available` calls and must keep payloads/requests stable.
+  - Resource limits / large input / discovery: selected - selected-space scope remains capped at 10 and must preserve route-space-first normalization.
+  - Error handling / rollback / partial outputs: selected - session open failures, delete failures, scope patch rollback, model availability failure, and stream permission refresh must keep current UI state behavior.
+  - Documentation / migration notes: selected - this fixture narrows #417 to session/scope hooks and leaves message/citation rendering extraction for later Web Chat work.
+- Risk packs considered:
+  - Config / project setup: not selected - no env, build config, dependency, Docker, or routing config changes.
+  - File IO / path safety / overwrite: not selected - no filesystem or browser storage semantics change beyond preserving existing localStorage/sessionStorage keys.
+  - Schema / columns / units / field names: not selected - no API schema, DTO, database schema, or persisted field names change.
+  - Geospatial / CRS / shapefile sidecars: not selected - no geospatial code changes.
+  - Time series / forcing / temporal boundaries: not selected - no temporal behavior beyond preserving existing session date display.
+  - Numerical stability / conservation / NaN: not selected - no numerical code changes.
+  - Solver runtime / performance / threading: not selected - no solver/runtime code changes.
+  - Legacy compatibility / examples: not selected - no legacy sample or migration surface changes; current UX compatibility is covered by Public API and Web tests.
+  - Release / packaging / dependency compatibility: not selected - no package metadata or dependency changes.
+- Required evidence:
+  - `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false`
+  - `pnpm --filter @cherrygraph/web test`
+  - `pnpm --filter @cherrygraph/web typecheck`
+  - `git diff --check`
+  - `openspec validate entropy-governance --strict --no-interactive`
+- Regression rows:
+  - opening a multi-space session -> `GET /spaces/:spaceId/chat/sessions/:sessionId` still restores `space_ids`, merges `space_details`, keeps selector editable, and does not change visible copy.
+  - deleting the active session -> `DELETE /spaces/:spaceId/chat/sessions/:sessionId` removes the sidebar row, starts a new session, and resets selected spaces to the route space.
+  - changing scope on an existing session succeeds -> optimistic selected spaces persist, `PATCH .../chat/sessions/:sessionId` sends `{ space_ids }`, and session list refreshes in background.
+  - changing scope on an existing session fails -> previous selected spaces are restored, `chat.scopeUpdateFailed` copy is shown, and later send payload keeps the previous scope.
+  - selected scope reaches 10 spaces -> additional unselected spaces remain disabled and route-space-first normalization is unchanged.
+  - no chat model available -> existing warning copy remains visible and input/send stay disabled; availability API failure keeps current fail-open behavior.
+  - database config disabled or multi-space selected -> database toggle hidden/disabled behavior and `enable_database=false` request payload behavior remain unchanged.
+  - unchanged sibling rendering -> message markdown, tool events, chart events, citations, source-chain links, and sidebar collapse/mobile controls still pass existing tests.
+- Non-goals: message/citation/source-chain component extraction (#future 4.4), API changes, route/DTO/schema changes, new i18n copy, visual redesign, dependency changes, backend changes, broad formatting churn, or changes inside `external/*`.
+
+- [x] 4.1 Add or strengthen Web characterization tests for session switching, deletion, multi-space scope changes, model-unavailable gating, database toggle gating, and current layout controls. For message rendering and citation/source-chain rendering, keep coverage characterization-only as unchanged sibling behavior for #417; do not extract rendering components in this issue.
+  - Verification: `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false` passed (41 tests), including active-session deletion reset, new-chat scope reset, successful/failed scope PATCH, model availability fail-open/unavailable gating, database gating, sidebar controls, and unchanged sibling rendering coverage.
+- [x] 4.2 Extract session loading/deletion workflows from `apps/web/src/pages/Chat.tsx` into focused hook(s).
+  - Verification: `apps/web/src/pages/chat/useChatSessions.ts` owns session list loading, open, delete, new chat, and scope PATCH rollback/list refresh; targeted Chat Vitest passed and visible i18n keys/text remain unchanged.
+- [x] 4.3 Extract selected-space scope/settings, model availability gating, and database toggle gating into focused hook(s).
+  - Verification: `apps/web/src/pages/chat/useChatScopeSettings.ts` owns available-space loading/fallback, selected-scope persistence, model availability precheck, database config gating, and permission-refresh trigger; Chat request payload tests passed with unchanged endpoints and payload fields.
+- [ ] 4.4 Future Web Chat issue: move message markdown rendering, message parts, citation panel, and source-chain rendering into focused components without changing UX or i18n keys. This is explicitly out of scope for #417.
   - Verification: message/citation/source-chain tests pass; unsafe markdown image/link behavior remains unchanged.
-- [ ] 4.5 Keep `Chat.tsx` as a thin page composition boundary and run targeted Web tests/typecheck.
-  - Verification: `pnpm --filter @cherrygraph/web test` and Web typecheck pass for touched files.
+- [x] 4.5 Keep `Chat.tsx` as a thin page composition boundary and run targeted Web tests/typecheck.
+  - Verification: `pnpm --filter @cherrygraph/web test` passed (15 files / 194 tests), `pnpm --filter @cherrygraph/web typecheck` passed, `git diff --check` passed, and `openspec validate entropy-governance --strict --no-interactive` passed.
 
 ## 5. Python Worker Protocol
 

--- a/progress.md
+++ b/progress.md
@@ -157,7 +157,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #416 Chat persistence/SSE boundary complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413 session/scope/ACL、#414 retrieval/rerank/trace construction、#415 model/provider/routing、#416 Chat persistence/audit/SSE shaping 已拆为 bounded collaborators；#416 targeted suites 102+10 pass，API typecheck/lint、OpenSpec strict validate 和 diff check 通过 |
+| entropy-governance | #417 Web Chat session/scope hooks complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 session/scope、retrieval/rerank、model/routing、persistence/SSE collaborators；#417 Web Chat session/scope/settings hook extraction 完成，Chat targeted 41 tests、Web 194 tests、typecheck、OpenSpec strict validate 和 diff check 通过 |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |

--- a/tests/integration/api-token-lifecycle.test.ts
+++ b/tests/integration/api-token-lifecycle.test.ts
@@ -146,7 +146,7 @@ function createApiTokenRow(overrides: Partial<typeof apiTokens.$inferSelect> = {
     token_prefix: 'cwt_ab12',
     scopes: ['mcp:invoke'],
     last_used_at: null,
-    expires_at: new Date('2026-06-01T00:00:00.000Z'),
+    expires_at: new Date('2099-06-01T00:00:00.000Z'),
     revoked_at: null,
     created_at: new Date('2026-05-01T00:00:00.000Z'),
     ...overrides,


### PR DESCRIPTION
## Summary
- Split Web Chat session list/open/delete/new-chat and scope PATCH rollback into focused hooks.
- Split selected-space scope/settings/model/database gating into focused hook utilities while keeping `Chat.tsx` as the page composition boundary.
- Added Web characterization coverage for active-session deletion, new-chat scope reset, successful scope PATCH refresh, multi-space database gating, and unchanged sibling Chat behavior.
- Stabilized unrelated API token test fixtures whose default valid token expiry reached 2026-06-01 and started failing CI.
- Stabilized Web Chat database-gating, retrieval-mode, and multi-space database-gating tests with deterministic readiness synchronization for CI coverage timing.

## Scope Boundaries
- No API, route, DTO, schema, backend production code, dependency, or visual redesign changes.
- Message markdown, citation/source-chain, chart/tool rendering extraction remains out of scope for #417.
- Follow-up changes are test-fixture/test-stability only; assertions and expired-token coverage remain intact.

## Verification
- `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false`
- `pnpm --filter @cherrygraph/web typecheck`
- `pnpm --filter @cherrygraph/web test`
- `pnpm --filter @cherrygraph/web exec vitest run src/__tests__/chat.test.tsx -t "sends the selected retrieval mode"`
- `pnpm --filter @cherrygraph/web exec vitest run src/__tests__/chat.test.tsx -t "hides the database toggle and sends no enable_database flag when multiple spaces are selected"`
- `pnpm --filter @cherrygraph/web exec vitest run src/__tests__/chat.test.tsx --coverage`
- `pnpm --filter @cherrygraph/web exec vitest run --coverage`
- `pnpm --filter @cherrygraph/web test -- apps/web/src/__tests__/chat.test.tsx`
- `pnpm exec vitest run apps/api/src/api-tokens/__tests__/api-token.service.test.ts tests/integration/api-token-lifecycle.test.ts --config vitest.config.ts --passWithNoTests=false`
- `pnpm --filter @cherrygraph/api typecheck`
- `git diff --check`
- `openspec validate entropy-governance --strict --no-interactive`

## Agent Review

- Reviewer agents used: fixture-review, correctness, test-evidence, final-independent, ci-fixture-follow-up, web-flake-follow-up, web-flake-follow-up-2, web-flake-follow-up-3, web-flake-follow-up-4, web-readiness-invariant-follow-up
- Reviewed head SHA: `1fff8d5dea7d4651eb34f54c9a0d0d0d9c876c6e`
- Review evidence: [Current review evidence](https://github.com/DankerMu/CherryWiki/pull/433#issuecomment-4589010706) | [Readiness invariant review](https://github.com/DankerMu/CherryWiki/pull/433#issuecomment-4589010723)
- Key findings addressed: Fixture review initially found #417 scope could include rendering extraction via task 4.4; OpenSpec was revised to keep rendering extraction future/out-of-scope before implementation. Correctness, test/evidence, final, CI-fixture, Web-flake follow-up, and readiness-invariant reviews found no merge-blocking issues.

Closes #417
