### PR TITLE
refactor(web): split chat model database gates (#418)

### DIFF
--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -353,7 +353,7 @@ describe('Chat bottom area layout', () => {
 
 describe('Chat model availability pre-check', () => {
   it('shows a no-model banner and disables input when chat models are unavailable', async () => {
-    stubChatFetch({ chatModelAvailable: false });
+    const fetchState = stubChatFetch({ chatModelAvailable: false });
 
     renderChatRoute();
 
@@ -361,6 +361,10 @@ describe('Chat model availability pre-check', () => {
     const textarea = screen.getByLabelText<HTMLTextAreaElement>('消息');
     expect(textarea).toBeDisabled();
     expect(screen.getByRole('button', { name: /发送/ })).toBeDisabled();
+    fireEvent.change(textarea, { target: { value: 'should not send' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(fetchState.calls.some((call) => call.path === '/api/chat/completions')).toBe(false);
   });
 
   it('shows no no-model banner and keeps input enabled when chat models are available', async () => {
@@ -796,6 +800,62 @@ describe('Phase 3 chat controls and stream events', () => {
     expect(screen.getByRole('button', { name: '数据库' })).toBeInTheDocument();
   });
 
+  it('sends no enable_database flag when database_config is disabled', async () => {
+    const fetchState = stubChatFetch({
+      databaseEnabled: false,
+      streamEvents: [{ event: 'message.completed', data: {} }],
+    });
+    renderChatRoute();
+
+    await waitForChatControlsReady(fetchState);
+    expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument();
+    await sendChatMessage('database disabled');
+
+    await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).not.toHaveProperty('enable_database'));
+  });
+
+  it('hides and clears database settings when the space detail lookup fails', async () => {
+    window.sessionStorage.setItem(
+      'cherry-chat-settings:["space-1"]',
+      JSON.stringify({ enableDeepAnalysis: false, enableDatabase: true, retrievalMode: 'wiki_only' }),
+    );
+    const fetchState = stubChatFetch({
+      databaseDetailStatus: 500,
+      streamEvents: [{ event: 'message.completed', data: {} }],
+    });
+    renderChatRoute();
+
+    await waitForChatControlsReady(fetchState);
+    expect(screen.queryByRole('button', { name: '数据库' })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(window.sessionStorage.getItem('cherry-chat-settings:["space-1"]')).toContain('"enableDatabase":false');
+    });
+    await sendChatMessage('database lookup failed');
+
+    await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).not.toHaveProperty('enable_database'));
+  });
+
+  it('sends enable_database and keeps completion metadata when database is enabled for one selected space', async () => {
+    const fetchState = stubChatFetch({
+      databaseEnabled: true,
+      streamEvents: [
+        { event: 'content', data: { delta: 'Database answer.' } },
+        { event: 'message.completed', data: { latency_ms: 123 } },
+      ],
+    });
+
+    renderChatRoute();
+    await waitForChatControlsReady(fetchState, { databaseAvailable: true });
+
+    fireEvent.click(screen.getByRole('button', { name: '数据库' }));
+    await sendChatMessage('use database');
+
+    await waitFor(() => expect(getLastChatCompletionBody(fetchState.calls)).toMatchObject({ enable_database: true }));
+    const complete = await screen.findByLabelText('Message complete');
+    expect(complete).toHaveTextContent('完成');
+    expect(complete).toHaveTextContent('123ms');
+  });
+
   it(
     'hides the database toggle and sends no enable_database flag when multiple spaces are selected',
     async () => {
@@ -1087,6 +1147,7 @@ type StubSessionDetail = {
 
 function stubChatFetch({
   databaseEnabled = false,
+  databaseDetailStatus = 200,
   chatModelAvailable = true,
   chatModelAvailableStatus = 200,
   spaces = [
@@ -1099,6 +1160,7 @@ function stubChatFetch({
   patchSessionSpacesStatus = 200,
 }: {
   databaseEnabled?: boolean;
+  databaseDetailStatus?: number;
   chatModelAvailable?: boolean;
   chatModelAvailableStatus?: number;
   spaces?: StubSpace[];
@@ -1137,7 +1199,14 @@ function stubChatFetch({
       }
 
       if (path === '/api/spaces/space-1') {
-        return Promise.resolve(jsonResponse({ data: { id: 'space-1', database_config: { enabled: databaseEnabled } } }));
+        return Promise.resolve(
+          databaseDetailStatus >= 200 && databaseDetailStatus < 300
+            ? jsonResponse({ data: { id: 'space-1', database_config: { enabled: databaseEnabled } } })
+            : jsonResponse(
+                { error: { code: 'INTERNAL_ERROR', message: 'Failed to load space detail' } },
+                databaseDetailStatus,
+              ),
+        );
       }
 
       if (path === '/api/spaces/space-1/chat/sessions' && init?.method !== 'POST') {

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -41,6 +41,8 @@ import {
   normalizeSelectedSpaceIds,
 } from './chat/chatScopeUtils.js';
 import type { AvailableChatSpace, ChatSession, ChatSettings } from './chat/types.js';
+import { useChatDatabaseGate } from './chat/useChatDatabaseGate.js';
+import { useChatModelGate } from './chat/useChatModelGate.js';
 import { useChatScopeSettings } from './chat/useChatScopeSettings.js';
 import { useChatSessions } from './chat/useChatSessions.js';
 
@@ -91,9 +93,7 @@ export default function Chat() {
   const loadSessionsRef = useRef<((background?: boolean) => Promise<void>) | undefined>(undefined);
   const {
     availableSpaces,
-    chatModelAvailable,
     chatSettings,
-    databaseAvailable,
     selectedSpaceIds,
     setAvailableSpaces,
     setSelectedSpaceIds,
@@ -105,6 +105,15 @@ export default function Chat() {
     isAllowed: gate.isAllowed,
     user,
     hasSpacePermission,
+  });
+  const chatModelAvailable = useChatModelGate(isAuthenticated && gate.isAllowed);
+  const { databaseAvailable } = useChatDatabaseGate({
+    spaceId,
+    isAuthenticated,
+    isAllowed: gate.isAllowed,
+    selectedSpaceIds,
+    chatSettings,
+    updateChatSettings,
   });
   const spaceNameById = useMemo(() => {
     const names: Record<string, string> = {};

--- a/apps/web/src/pages/chat/useChatDatabaseGate.ts
+++ b/apps/web/src/pages/chat/useChatDatabaseGate.ts
@@ -1,0 +1,68 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { api } from '../../lib/api.js';
+import { isSpaceDatabaseEnabled } from './chatScopeUtils.js';
+import type { ChatSettings, ChatSpaceDetail } from './types.js';
+
+type UseChatDatabaseGateParams = {
+  spaceId: string;
+  isAuthenticated: boolean;
+  isAllowed: boolean;
+  selectedSpaceIds: string[];
+  chatSettings: ChatSettings;
+  updateChatSettings: (settings: ChatSettings) => void;
+};
+
+export function useChatDatabaseGate({
+  spaceId,
+  isAuthenticated,
+  isAllowed,
+  selectedSpaceIds,
+  chatSettings,
+  updateChatSettings,
+}: UseChatDatabaseGateParams) {
+  const [spaceDatabaseEnabled, setSpaceDatabaseEnabled] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!isAuthenticated || spaceId.length === 0 || !isAllowed) {
+      setSpaceDatabaseEnabled(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    api
+      .get<ChatSpaceDetail>(`/spaces/${encodeURIComponent(spaceId)}`)
+      .then((space) => {
+        if (!cancelled) {
+          setSpaceDatabaseEnabled(isSpaceDatabaseEnabled(space.database_config));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSpaceDatabaseEnabled(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAllowed, isAuthenticated, spaceId]);
+
+  const databaseAvailable = useMemo(
+    () => selectedSpaceIds.length === 1 && spaceDatabaseEnabled,
+    [selectedSpaceIds.length, spaceDatabaseEnabled],
+  );
+
+  useEffect(() => {
+    if (!databaseAvailable && chatSettings.enableDatabase) {
+      updateChatSettings({ ...chatSettings, enableDatabase: false });
+    }
+  }, [chatSettings, databaseAvailable, updateChatSettings]);
+
+  return {
+    databaseAvailable,
+  };
+}

--- a/apps/web/src/pages/chat/useChatModelGate.ts
+++ b/apps/web/src/pages/chat/useChatModelGate.ts
@@ -1,18 +1,18 @@
 import { useEffect, useState } from 'react';
 
-import { api } from '../lib/api.js';
+import { api } from '../../lib/api.js';
 
 type ChatModelAvailabilityResponse = {
   available: boolean;
 };
 
-type ChatModelAvailabilityState = {
+type ChatModelGateState = {
   available: boolean;
   loading: boolean;
 };
 
-export function useChatModelAvailable(enabled = true): ChatModelAvailabilityState {
-  const [state, setState] = useState<ChatModelAvailabilityState>({ available: true, loading: enabled });
+export function useChatModelGate(enabled: boolean): ChatModelGateState {
+  const [state, setState] = useState<ChatModelGateState>({ available: true, loading: enabled });
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/pages/chat/useChatScopeSettings.ts
+++ b/apps/web/src/pages/chat/useChatScopeSettings.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useChatModelAvailable } from '../../hooks/useChatModelAvailable.js';
 import { api } from '../../lib/api.js';
 import type { AuthUser } from '../../lib/auth.js';
 import {
@@ -8,12 +7,11 @@ import {
   getChatSettingsKey,
   getKnownSpaceName,
   getUserChatSpaces,
-  isSpaceDatabaseEnabled,
   loadChatSettings,
   normalizeSelectedSpaceIds,
   saveChatSettings,
 } from './chatScopeUtils.js';
-import type { AvailableChatSpace, ChatSettings, ChatSpaceDetail } from './types.js';
+import type { AvailableChatSpace, ChatSettings } from './types.js';
 
 type UseChatScopeSettingsParams = {
   spaceId: string;
@@ -33,7 +31,6 @@ export function useChatScopeSettings({
   const [availableSpaces, setAvailableSpaces] = useState<AvailableChatSpace[]>([]);
   const [spaceRefreshVersion, setSpaceRefreshVersion] = useState(0);
   const [selectedSpaceIds, setSelectedSpaceIds] = useState<string[]>(() => normalizeSelectedSpaceIds(spaceId, [spaceId]));
-  const [spaceDatabaseEnabled, setSpaceDatabaseEnabled] = useState(false);
   const selectedSpaceSettingsKey = useMemo(() => getChatSettingsKey(selectedSpaceIds), [selectedSpaceIds]);
   const [chatSettingsState, setChatSettingsState] = useState<{ storageKey: string; settings: ChatSettings }>(() => {
     const initialSpaceIds = normalizeSelectedSpaceIds(spaceId, [spaceId]);
@@ -47,7 +44,6 @@ export function useChatScopeSettings({
     chatSettingsState.storageKey === selectedSpaceSettingsKey
       ? chatSettingsState.settings
       : loadChatSettings(selectedSpaceIds);
-  const chatModelAvailable = useChatModelAvailable(isAuthenticated && isAllowed);
 
   const updateChatSettings = useCallback(
     (settings: ChatSettings): void => {
@@ -124,40 +120,6 @@ export function useChatScopeSettings({
     });
   }, [availableSpaces, spaceId]);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!isAuthenticated || spaceId.length === 0 || !isAllowed) {
-      setSpaceDatabaseEnabled(false);
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    api
-      .get<ChatSpaceDetail>(`/spaces/${encodeURIComponent(spaceId)}`)
-      .then((space) => {
-        if (!cancelled) {
-          setSpaceDatabaseEnabled(isSpaceDatabaseEnabled(space.database_config));
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setSpaceDatabaseEnabled(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isAllowed, isAuthenticated, spaceId]);
-
-  useEffect(() => {
-    if ((!spaceDatabaseEnabled || selectedSpaceIds.length > 1) && chatSettings.enableDatabase) {
-      updateChatSettings({ ...chatSettings, enableDatabase: false });
-    }
-  }, [chatSettings, selectedSpaceIds.length, spaceDatabaseEnabled, updateChatSettings]);
-
   const resetSelectedSpacesToRoute = useCallback(() => {
     setSelectedSpaceIds(normalizeSelectedSpaceIds(spaceId, [spaceId]));
   }, [spaceId]);
@@ -166,13 +128,9 @@ export function useChatScopeSettings({
     setSpaceRefreshVersion((version) => version + 1);
   }, []);
 
-  const databaseAvailable = selectedSpaceIds.length === 1 && spaceDatabaseEnabled;
-
   return {
     availableSpaces,
-    chatModelAvailable,
     chatSettings,
-    databaseAvailable,
     selectedSpaceIds,
     setAvailableSpaces,
     setSelectedSpaceIds,

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -561,6 +561,53 @@ Issue #417 fixture:
 - [x] 4.5 Keep `Chat.tsx` as a thin page composition boundary and run targeted Web tests/typecheck.
   - Verification: `pnpm --filter @cherrygraph/web test` passed (15 files / 194 tests), `pnpm --filter @cherrygraph/web typecheck` passed, `git diff --check` passed, and `openspec validate entropy-governance --strict --no-interactive` passed.
 
+Issue #418 fixture:
+- Issue type: refactor / frontend boundary refinement
+- Project profile: other
+- Blast radius: medium
+- Fixture level: compact
+- Repair intensity: medium
+- Change surface: `apps/web/src/pages/chat/useChatScopeSettings.ts`, new or existing `apps/web/src/pages/chat/**` hooks for model/database gating, `apps/web/src/pages/Chat.tsx` wiring only if needed, and `apps/web/src/__tests__/chat.test.tsx`.
+- Dependency/context: #417 already extracted Web Chat sessions, scope/settings, model precheck, and database gating out of `Chat.tsx`; #418 must refine that boundary by splitting model availability and database gating out of the broad scope/settings hook rather than repeating #417.
+- Must preserve: existing routes, API endpoints, `/api/models/chat-available` fail-open semantics, `/api/spaces/:spaceId` database_config lookup semantics, selected-space settings persistence, model-unavailable banner/input/send disablement, database toggle visibility and `enable_database` payload gating, completion metadata rendering, Chinese/i18n text, message/citation/source-chain rendering, and visual layout.
+- Must add/change: extract model availability state and database availability/toggle coercion into focused hook(s) or hook utilities under `apps/web/src/pages/chat/**`; keep selected-space loading/settings persistence in `useChatScopeSettings`; keep `Chat.tsx` as a composition boundary; strengthen targeted tests only where current coverage does not explicitly prove gating state and request payload compatibility.
+- Selected risk packs:
+  - Public API / CLI / script entry: selected - Web Chat must keep existing model availability, space detail, and chat completion requests/payloads stable.
+  - Error handling / rollback / partial outputs: selected - model availability API failure remains fail-open, database detail failure hides/disables database, and disabling/multi-space selection clears `enableDatabase` without stale payload leakage.
+  - Documentation / migration notes: selected - this fixture records the post-#417 boundary refinement and prevents overlap with future rendering extraction.
+- Risk packs considered:
+  - Resource limits / large input / discovery: not selected - selected-space max/normalization was handled by #417 and must remain unchanged.
+  - Config / project setup: not selected - no env, build config, dependency, Docker, or routing config changes.
+  - File IO / path safety / overwrite: not selected - no filesystem access and no new browser storage semantics beyond existing chat settings persistence.
+  - Schema / columns / units / field names: not selected - no API DTO, database schema, or persisted field names change.
+  - Geospatial / CRS / shapefile sidecars: not selected - no geospatial code changes.
+  - Time series / forcing / temporal boundaries: not selected - no temporal behavior changes.
+  - Numerical stability / conservation / NaN: not selected - no numerical code changes.
+  - Solver runtime / performance / threading: not selected - no solver/runtime code changes.
+  - Legacy compatibility / examples: not selected - no legacy sample or migration surface changes.
+  - Release / packaging / dependency compatibility: not selected - no package metadata or dependency changes.
+- Required evidence:
+  - `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false`
+  - `pnpm --filter @cherrygraph/web test`
+  - `pnpm --filter @cherrygraph/web typecheck`
+  - `pnpm --filter @cherrygraph/web lint`
+  - `git diff --check`
+  - `openspec validate entropy-governance --strict --no-interactive`
+- Regression rows:
+  - chat model unavailable -> no-model banner remains visible, message input and send button stay disabled, and no chat payload is sent.
+  - model availability API failure -> no no-model banner is shown and input remains enabled (fail-open compatibility).
+  - database_config disabled -> database toggle remains hidden and `enable_database` is not sent.
+  - space detail API failure -> database toggle remains hidden, `enableDatabase` is coerced false, and later chat payload omits `enable_database`.
+  - database_config enabled with one selected space -> database toggle is visible, toggling it sends `enable_database: true`, and completion metadata behavior remains unchanged.
+  - database_config enabled then multiple spaces selected -> database toggle is hidden/cleared and the later request omits `enable_database` while preserving selected `space_ids`.
+  - unchanged sibling behavior -> session/scope/settings persistence, message markdown/tool/chart/citation/source-chain rendering, and sidebar controls continue passing existing tests.
+- Non-goals: backend changes, API endpoint/DTO/schema changes, session/scope behavior redesign, selected-space normalization changes, message/citation/source-chain component extraction (#419), visual redesign, dependency changes, broad formatting churn, or changes inside `external/*`.
+
+- [x] 4.6 Issue #418: split model availability and database gating from the broad scope/settings hook into focused Web Chat hook(s) while preserving request and UI behavior.
+  - Verification: `apps/web/src/pages/chat/useChatModelGate.ts` owns `/api/models/chat-available` fail-open model precheck; `apps/web/src/pages/chat/useChatDatabaseGate.ts` owns `/api/spaces/:spaceId` database_config lookup, database toggle availability, and stale `enableDatabase` coercion. `useChatScopeSettings.ts` now keeps selected-space loading/settings persistence only. Targeted Chat tests passed (44 tests), covering no-model fail-closed/no payload, availability fail-open, database disabled/detail failure payload omission, database enabled `enable_database: true`, multi-space clearing with preserved `space_ids`, and completion metadata rendering.
+- [x] 4.7 Issue #418: run targeted Web Chat tests, full Web tests/typecheck/lint, diff check, and OpenSpec validation.
+  - Verification: `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false` passed (44 tests); `pnpm --filter @cherrygraph/web test` passed (15 files / 197 tests); `pnpm --filter @cherrygraph/web typecheck` passed; `pnpm --filter @cherrygraph/web lint` passed; `git diff --check` passed; `openspec validate entropy-governance --strict --no-interactive` passed. `Chat.tsx` remains a composition boundary and only wires the focused gating hooks.
+
 ## 5. Python Worker Protocol
 
 - [ ] 5.1 Inspect Docker/CI/venv constraints and decide the worker protocol strategy: shared Python package, shared local module wired into both build contexts, or protocol-template enforcement.

--- a/progress.md
+++ b/progress.md
@@ -157,7 +157,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #417 Web Chat session/scope hooks complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 session/scope、retrieval/rerank、model/routing、persistence/SSE collaborators；#417 Web Chat session/scope/settings hook extraction 完成，Chat targeted 41 tests、Web 194 tests、typecheck、OpenSpec strict validate 和 diff check 通过 |
+| entropy-governance | #418 Web Chat model/database gating hook split complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417 Web Chat session/scope/settings hook extraction 完成；#418 将 model availability 与 database gating 拆入 focused hooks，Chat targeted 44 tests、Web 197 tests、typecheck/lint、OpenSpec strict validate 和 diff check 通过 |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |


### PR DESCRIPTION
## Summary
- Split Web Chat model availability precheck into `useChatModelGate` under the Chat page hook boundary.
- Split database detail lookup, database availability, and stale `enableDatabase` clearing into `useChatDatabaseGate`.
- Narrowed `useChatScopeSettings` to available-space loading, selected-space normalization, and settings persistence.
- Added Chat regression coverage for no-model no-send, model availability fail-open, database disabled/detail-failure payload omission, database enabled payload, and completion metadata compatibility.

## Scope Boundaries
- No backend, API route, DTO, database schema, dependency, or visual redesign changes.
- Session/scope behavior remains owned by #417 hooks.
- Message markdown, citation, source-chain, chart/tool rendering extraction remains out of scope for #418.

## Verification
- `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false`
- `pnpm --filter @cherrygraph/web test`
- `pnpm --filter @cherrygraph/web typecheck`
- `pnpm --filter @cherrygraph/web lint`
- `git diff --check`
- `openspec validate entropy-governance --strict --no-interactive`

## Agent Review

- Reviewer agents used: fixture-review-418, fixture-review-418-follow-up, fixture-review-418-follow-up-2, Correctness Reviewer, Test and Evidence Reviewer
- Reviewed head SHA: `368ba3b1d70e90928c1f8efe12c9d9678af7e8ec`
- Review evidence: [Round 1 evidence](https://github.com/DankerMu/CherryWiki/pull/434#issuecomment-4589157238) | [Final review](https://github.com/DankerMu/CherryWiki/pull/434#issuecomment-4589157672)
- OpenSpec change: `entropy-governance`; fixture level: compact; selected risk packs: Web Chat hook extraction, model availability gate, database availability gate, stale setting normalization, regression evidence
- Key findings addressed: Fixture review required adding a space-detail failure regression row and Web lint evidence before implementation; both were added and fixture follow-up approved. Correctness and test/evidence reviews found no merge-blocking issues.

Closes #418
