### PR TITLE
refactor(web): split chat rendering components (#419)

### DIFF
--- a/apps/web/src/__tests__/chat.test.tsx
+++ b/apps/web/src/__tests__/chat.test.tsx
@@ -72,6 +72,173 @@ describe('Chat message rendering', () => {
     expect(screen.getByText('back')).toHaveProperty('tagName', 'STRONG');
   });
 
+  it('blocks assistant markdown images and unsafe links while keeping safe external link attributes', () => {
+    renderWithRouter(
+      <ChatMessageBubble
+        message={buildMessage({
+          role: 'assistant',
+          content: '![hidden](https://example.com/a.png) [bad](javascript:alert(1)) [external](https://example.com)',
+        })}
+        spaceId="space-1"
+      />,
+    );
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    const badLink = screen.getByText('bad').closest('a');
+    expect(badLink).toBeInTheDocument();
+    expect(badLink).toHaveAttribute('href', '');
+    const externalLink = screen.getByRole('link', { name: 'external' });
+    expect(externalLink).toHaveAttribute('href', 'https://example.com');
+    expect(externalLink).toHaveAttribute('target', '_blank');
+    expect(externalLink).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  it('renders source-chain details and graph path from direct source_chain_json fields', () => {
+    const citation = buildCitation({
+      source_chain_json: {
+        source_document_ids: ['doc-1', 'doc-2'],
+        graph_node_ids: ['node-a', 'node-b'],
+        graph_edge_ids: ['edge-1'],
+        chain_confidence: 0.73,
+        confidence_label: 'INFERRED',
+        graph_path: {
+          total_confidence: 0.73,
+          nodes: [
+            { id: 'node-a', label: 'Alpha', node_type: 'Concept' },
+            { id: 'node-b', label: 'Beta', node_type: 'Topic' },
+          ],
+          edges: [{ id: 'edge-1', source_node_id: 'node-a', target_node_id: 'node-b', relationship: 'depends_on' }],
+        },
+      },
+    });
+
+    renderWithRouter(
+      <ChatMessageBubble
+        message={buildMessage({ role: 'assistant', content: 'Use [^1].', citations: [citation] })}
+        spaceId="space-1"
+      />,
+    );
+
+    const sourceChainHeader = screen.getAllByText('查看图谱路径').at(-1);
+    expect(sourceChainHeader).toBeDefined();
+    fireEvent.click(sourceChainHeader!);
+
+    expect(screen.getAllByText('查看图谱路径').length).toBeGreaterThan(0);
+    expect(screen.getByText('源文档 ID')).toBeInTheDocument();
+    expect(screen.getByText('doc-1, doc-2')).toBeInTheDocument();
+    expect(screen.getByText('图谱节点')).toBeInTheDocument();
+    expect(screen.getByText('node-a -> node-b')).toBeInTheDocument();
+    expect(screen.getByText('图谱边')).toBeInTheDocument();
+    expect(screen.getByText('edge-1')).toBeInTheDocument();
+    expect(screen.getByText('链路置信度')).toBeInTheDocument();
+    expect(screen.getAllByText('73%').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('推断').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Graph path')).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('depends_on')).toBeInTheDocument();
+  });
+
+  it('normalizes alternate nested source_chain graph path and page fallback', async () => {
+    const citation = buildCitation({
+      source_chain_json: {
+        source_chain: {
+          page_id: 'nested-target',
+          source_document_ids: ['doc-nested'],
+          graph_edge_ids: ['edge-nested'],
+          chain_confidence: '0.42',
+          graph_path_nodes: [
+            { node_key: 'person:alice', name: 'Alice', type: 'Person' },
+            'Plain target',
+          ],
+          graph_path_edges: [{ edge_id: 'edge-nested', source: 'person:alice', target: 'node-1', type: 'mentions', edge_confidence: 'AMBIGUOUS' }],
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/spaces/space-1/chat']}>
+        <Routes>
+          <Route
+            path="/spaces/:spaceId/chat"
+            element={
+              <ChatMessageBubble
+                message={buildMessage({ role: 'assistant', content: 'Nested source [^1].', citations: [citation] })}
+                spaceId="space-1"
+              />
+            }
+          />
+          <Route path="/spaces/:spaceId/wiki/:pageId" element={<h1>Nested wiki target</h1>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const sourceChainHeader = screen.getAllByText('查看图谱路径').at(-1);
+    expect(sourceChainHeader).toBeDefined();
+    fireEvent.click(sourceChainHeader!);
+
+    expect(screen.getByText('doc-nested')).toBeInTheDocument();
+    expect(screen.getByText('edge-nested')).toBeInTheDocument();
+    expect(screen.getAllByText('42%').length).toBeGreaterThan(0);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Plain target')).toBeInTheDocument();
+    expect(screen.getByText('Person')).toBeInTheDocument();
+    expect(screen.getByText('mentions')).toBeInTheDocument();
+    expect(screen.getAllByText('待确认').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: '[1]' }));
+    expect(await screen.findByRole('heading', { name: 'Nested wiki target' })).toBeInTheDocument();
+  });
+
+  it('renders tool, chart, thinking, typing, completion, and fallback error states', () => {
+    const circularInput: Record<string, unknown> = {};
+    circularInput.self = circularInput;
+
+    renderWithRouter(
+      <>
+        <ChatMessageBubble
+          message={buildMessage({
+            id: 'parts',
+            role: 'assistant',
+            content: '',
+            parts: [
+              { type: 'tool_use', id: null, name: 'Bash', input: { command: 'cherrydb query "SELECT 1"' } },
+              { type: 'tool_use', id: 'circular', name: 'Inspector', input: circularInput },
+              {
+                type: 'chart',
+                id: 'chart-1',
+                chart_type: 'bar',
+                option: { xAxis: { type: 'category' }, yAxis: {}, series: [{ type: 'bar', data: [1] }] },
+                raw: {},
+              },
+            ],
+          })}
+          spaceId="space-1"
+        />
+        <ChatMessageBubble message={buildMessage({ id: 'thinking', agentThinking: true, status: 'streaming', content: '' })} spaceId="space-1" />
+        <ChatMessageBubble
+          message={buildMessage({ id: 'typing', status: 'streaming', content: '', parts: [] })}
+          spaceId="space-1"
+        />
+        <ChatMessageBubble
+          message={buildMessage({ id: 'complete', status: 'complete', completedAt: '2026-05-01T10:00:01.000Z', latencyMs: 123 })}
+          spaceId="space-1"
+        />
+        <ChatMessageBubble message={buildMessage({ id: 'error', status: 'error' })} spaceId="space-1" />
+      </>,
+    );
+
+    expect(screen.getByText('Bash')).toBeInTheDocument();
+    expect(screen.getAllByText(/cherrydb query/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Inspector')).toBeInTheDocument();
+    expect(screen.getAllByText('[object Object]').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Chart data')).toBeInTheDocument();
+    expect(screen.getByText('bar')).toBeInTheDocument();
+    expect(screen.getByLabelText('Agent 思考中')).toBeInTheDocument();
+    expect(screen.getByLabelText('Assistant is typing')).toBeInTheDocument();
+    expect(screen.getByLabelText('Message complete')).toHaveTextContent('123ms');
+    expect(screen.getByText('响应中断，请重试')).toBeInTheDocument();
+  });
+
   it('routes citation clicks to the wiki page', async () => {
     const citation = buildCitation({ index: 1, source_chain_json: { page_id: 'target-page' } });
 

--- a/apps/web/src/pages/Chat.tsx
+++ b/apps/web/src/pages/Chat.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import ReactMarkdown from 'react-markdown';
-import { Link, Navigate, useNavigate, useParams } from 'react-router';
-import rehypeHighlight from 'rehype-highlight';
-import remarkGfm from 'remark-gfm';
-import { Alert, Button, Collapse, Empty, Input, List, message, Popconfirm, Select, Spin, Tag } from 'antd';
+import { Link, Navigate, useParams } from 'react-router';
+import { Alert, Button, Empty, Input, List, message, Popconfirm, Select, Spin, Tag } from 'antd';
 import {
   CloseOutlined,
   DeleteOutlined,
@@ -15,9 +12,6 @@ import {
   PlusOutlined,
   SendOutlined,
 } from '@ant-design/icons';
-import ChatChart from '../components/ChatChart.js';
-import { ConfidenceBadge } from '../components/ConfidenceBadge.js';
-import GraphPathViewer, { type GraphPathData, type GraphPathEdge, type GraphPathNode } from '../components/GraphPathViewer.js';
 import { formatDate } from '../components/adminUi.js';
 import { SpaceForbiddenState, useSpacePermissionGate } from '../components/SpacePermissionGate.js';
 import {
@@ -25,10 +19,6 @@ import {
   getChatErrorMessage,
   isAgentRetrievalMode,
   useChatStream,
-  type ChatCitation,
-  type ChatMessage,
-  type ChatMessagePart,
-  type ChatToolUsePart,
   type RetrievalMode,
   type SendMessageOptions,
 } from '../hooks/useChatStream.js';
@@ -40,11 +30,14 @@ import {
   normalizeRetrievalMode,
   normalizeSelectedSpaceIds,
 } from './chat/chatScopeUtils.js';
+import { ChatMessageBubble } from './chat/ChatMessageBubble.js';
 import type { AvailableChatSpace, ChatSession, ChatSettings } from './chat/types.js';
 import { useChatDatabaseGate } from './chat/useChatDatabaseGate.js';
 import { useChatModelGate } from './chat/useChatModelGate.js';
 import { useChatScopeSettings } from './chat/useChatScopeSettings.js';
 import { useChatSessions } from './chat/useChatSessions.js';
+
+export { ChatMessageBubble } from './chat/ChatMessageBubble.js';
 
 type MessageInputProps = {
   disabled: boolean;
@@ -71,12 +64,6 @@ type SessionSidebarProps = {
   onNewChat: () => void;
   onSelectSession: (sessionId: string) => void;
   onDeleteSession: (session: ChatSession) => void;
-};
-
-type ChatMessageBubbleProps = {
-  message: ChatMessage;
-  spaceId: string;
-  spaceNameById?: Record<string, string>;
 };
 
 const CHAT_SIDEBAR_COLLAPSED_KEY = 'cherry-chat-sidebar-collapsed';
@@ -676,287 +663,6 @@ export function SessionSidebar({
   );
 }
 
-export function ChatMessageBubble({ message, spaceId, spaceNameById = {} }: ChatMessageBubbleProps) {
-  const { t } = useTranslation();
-
-  return (
-    <article className={`chat-message-row ${message.role}`} aria-label={`${message.role} message`}>
-      <div className={`chat-message-bubble ${message.role}`}>
-        {message.role === 'assistant' ? (
-          <>
-            {message.agentThinking ? (
-              <AgentThinkingIndicator />
-            ) : message.status === 'streaming' && message.content.length === 0 && message.parts.length === 0 ? (
-              <TypingIndicator />
-            ) : (
-              message.content.length > 0 ? (
-                <AssistantMarkdown content={message.content} citations={message.citations} spaceId={spaceId} />
-              ) : null
-            )}
-            <ChatMessageParts parts={message.parts} />
-            <CitationPanel citations={message.citations} spaceId={spaceId} spaceNameById={spaceNameById} />
-            <CompletionIndicator message={message} />
-          </>
-        ) : (
-          <p className="chat-user-content">{message.content}</p>
-        )}
-        {message.status === 'error' ? <p className="chat-message-error">{message.error ?? t('chat.responseInterrupted')}</p> : null}
-      </div>
-    </article>
-  );
-}
-
-function AssistantMarkdown({ content, citations, spaceId }: { content: string; citations: ChatCitation[]; spaceId: string }) {
-  const navigate = useNavigate();
-  const markdown = useMemo(() => content.replace(/\[\^(\d+)]/g, '[$1](citation:$1)'), [content]);
-
-  function openCitation(index: number): void {
-    const citation = citations.find((item) => item.index === index);
-    if (citation === undefined) {
-      return;
-    }
-
-    void navigate(buildCitationPath(spaceId, citation));
-  }
-
-  return (
-    <div className="chat-markdown">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeHighlight]}
-        urlTransform={transformMarkdownUrl}
-        components={{
-          a: ({ href, children }) => {
-            if (href?.startsWith('citation:') === true) {
-              const index = Number(href.slice('citation:'.length));
-              const citation = Number.isFinite(index) ? citations.find((item) => item.index === index) : undefined;
-              return (
-                <>
-                  <button className="chat-citation-ref" type="button" onClick={() => openCitation(index)}>
-                    [{Number.isFinite(index) ? index : children}]
-                  </button>
-                  <ConfidenceBadge label={citation !== undefined ? getCitationConfidenceLabel(citation) : null} />
-                </>
-              );
-            }
-
-            return (
-              <a href={href} target="_blank" rel="noreferrer">
-                {children}
-              </a>
-            );
-          },
-          img: () => null,
-        }}
-      >
-        {markdown}
-      </ReactMarkdown>
-    </div>
-  );
-}
-
-function CitationPanel({
-  citations,
-  spaceId,
-  spaceNameById,
-}: {
-  citations: ChatCitation[];
-  spaceId: string;
-  spaceNameById: Record<string, string>;
-}) {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-
-  if (citations.length === 0) {
-    return null;
-  }
-
-  const collapseItems = [
-    {
-      key: 'citations',
-      label: t('chat.citations', { count: citations.length }),
-      children: (
-        <ol className="chat-citation-ol">
-          {citations.map((citation) => {
-            const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
-            const graphPath = getCitationGraphPath(citation);
-            const citationSpaceId = citation.space_id ?? spaceId;
-            const citationSpaceName = spaceNameById[citationSpaceId] ?? citationSpaceId;
-            return (
-              <li key={`${citation.index}-${citation.chunk_id || citation.wiki_page_pk}`}>
-                <div className="chat-citation-entry">
-                  <button
-                    className="chat-citation-card"
-                    type="button"
-                    onClick={() => {
-                      void navigate(buildCitationPath(spaceId, citation));
-                    }}
-                  >
-                    <span className="chat-citation-index">[{citation.index}]</span>
-                    <span>
-                      <strong>{citation.page_title}</strong>
-                      <small>{citation.section_title ?? t('chat.noSection')}</small>
-                    </span>
-                    {citationSpaceId !== spaceId ? <Tag color="geekblue">{t('chat.sourceSpace', { name: citationSpaceName })}</Tag> : null}
-                    <ConfidenceBadge label={getCitationConfidenceLabel(citation)} />
-                    <Tag>{formatCitationScore(citation.relevance_score)}</Tag>
-                  </button>
-                  {graphEdgeIds.length > 0 || graphPath !== null ? (
-                    <Collapse
-                      size="small"
-                      className="chat-source-chain"
-                      items={[
-                        {
-                          key: 'graphPath',
-                          label: t('chat.viewGraphPath'),
-                          children: <SourceChainDetails citation={citation} graphPath={graphPath} />,
-                        },
-                      ]}
-                    />
-                  ) : null}
-                </div>
-              </li>
-            );
-          })}
-        </ol>
-      ),
-    },
-  ];
-
-  return (
-    <Collapse
-      className="chat-citations"
-      defaultActiveKey={['citations']}
-      size="small"
-      items={collapseItems}
-    />
-  );
-}
-
-function ChatMessageParts({ parts }: { parts: ChatMessagePart[] }) {
-  if (parts.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="chat-message-parts">
-      {parts.map((part, index) => {
-        if (part.type === 'tool_use') {
-          return <ToolUsePanel key={`${part.id ?? part.name}-${index}`} part={part} />;
-        }
-
-        return <ChatChart key={part.id} option={part.option} chartType={part.chart_type} />;
-      })}
-    </div>
-  );
-}
-
-function ToolUsePanel({ part }: { part: ChatToolUsePart }) {
-  const { t } = useTranslation();
-  const command = formatToolInput(part.input);
-
-  return (
-    <Collapse
-      className="chat-tool-use"
-      size="small"
-      items={[
-        {
-          key: 'toolUse',
-          label: (
-            <span>
-              <span>{part.name}</span>{' '}
-              <code>{command}</code>
-            </span>
-          ),
-          children: <pre>{command}</pre>,
-        },
-      ]}
-      aria-label={t('chat.toolUseLabel')}
-    />
-  );
-}
-
-function CompletionIndicator({ message }: { message: ChatMessage }) {
-  const { t } = useTranslation();
-
-  if (message.role !== 'assistant' || message.status !== 'complete' || message.completedAt === null) {
-    return null;
-  }
-
-  return (
-    <div className="chat-completion-indicator" aria-label="Message complete">
-      <span>{t('chat.completed')}</span>
-      {message.latencyMs !== null ? <span>{formatLatency(message.latencyMs)}</span> : null}
-    </div>
-  );
-}
-
-function SourceChainDetails({ citation, graphPath }: { citation: ChatCitation; graphPath: GraphPathData | null }) {
-  const { t } = useTranslation();
-  const sourceDocumentIds = getCitationStringArray(citation, 'source_document_ids');
-  const graphNodeIds = getCitationStringArray(citation, 'graph_node_ids');
-  const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
-  const chainConfidence = getCitationNumber(citation, 'chain_confidence');
-
-  return (
-    <div className="chat-source-chain-body">
-      <div className="chat-source-chain-grid">
-        {sourceDocumentIds.length > 0 ? (
-          <>
-            <span>{t('chat.sourceDocIds')}</span>
-            <code>{sourceDocumentIds.join(', ')}</code>
-          </>
-        ) : null}
-        {graphNodeIds.length > 0 ? (
-          <>
-            <span>{t('chat.graphNodeIds')}</span>
-            <code>{graphNodeIds.join(' -> ')}</code>
-          </>
-        ) : null}
-        {graphEdgeIds.length > 0 ? (
-          <>
-            <span>{t('chat.graphEdgeIds')}</span>
-            <code>{graphEdgeIds.join(' -> ')}</code>
-          </>
-        ) : null}
-        {chainConfidence !== null ? (
-          <>
-            <span>{t('chat.chainConfidence')}</span>
-            <code>{formatCitationScore(chainConfidence)}</code>
-          </>
-        ) : null}
-      </div>
-      <ConfidenceBadge label={getCitationConfidenceLabel(citation)} />
-      {graphPath !== null ? <GraphPathViewer path={graphPath} /> : null}
-    </div>
-  );
-}
-
-function AgentThinkingIndicator() {
-  const { t } = useTranslation();
-
-  return (
-    <div className="chat-agent-thinking" aria-label={t('chat.agentThinking')}>
-      <span>{t('chat.agentThinking')}</span>
-      <span className="chat-thinking-dots" aria-hidden="true">
-        <i />
-        <i />
-        <i />
-      </span>
-    </div>
-  );
-}
-
-function TypingIndicator() {
-  return (
-    <div className="chat-typing-indicator" aria-label="Assistant is typing">
-      <span />
-      <span />
-      <span />
-    </div>
-  );
-}
-
 function loadSidebarCollapsed(): boolean {
   if (typeof window === 'undefined') {
     return false;
@@ -981,202 +687,6 @@ function saveSidebarCollapsed(isCollapsed: boolean): void {
   }
 }
 
-function formatToolInput(input: unknown): string {
-  if (typeof input === 'string') {
-    return input;
-  }
-
-  if (isRecord(input)) {
-    const command = readStringValue(input, 'command') ?? readStringValue(input, 'query') ?? readStringValue(input, 'input');
-    if (command !== null) {
-      return command;
-    }
-  }
-
-  try {
-    return JSON.stringify(input, null, 2);
-  } catch {
-    return String(input);
-  }
-}
-
-function formatLatency(milliseconds: number): string {
-  if (!Number.isFinite(milliseconds)) {
-    return '';
-  }
-
-  if (milliseconds >= 1000) {
-    return `${(milliseconds / 1000).toFixed(1)}s`;
-  }
-
-  return `${Math.max(0, Math.round(milliseconds))}ms`;
-}
-
-function getCitationConfidenceLabel(citation: ChatCitation): string | null {
-  const chain = getCitationSourceChain(citation);
-  const directLabel = readStringValue(chain, 'edge_confidence') ?? readStringValue(chain, 'confidence_label');
-  if (directLabel !== null) {
-    return directLabel;
-  }
-
-  const graphPath = getCitationGraphPath(citation);
-  return graphPath?.edges.find((edge) => edge.confidence_label !== null && edge.confidence_label !== undefined)?.confidence_label ?? null;
-}
-
-function getCitationStringArray(citation: ChatCitation, key: string): string[] {
-  const chain = getCitationSourceChain(citation);
-  const directValue = chain[key] ?? citation.source_chain_json[key];
-  return readStringArray(directValue);
-}
-
-function getCitationNumber(citation: ChatCitation, key: string): number | null {
-  const chain = getCitationSourceChain(citation);
-  return readNumberValue(chain, key) ?? readNumberValue(citation.source_chain_json, key);
-}
-
-function getCitationSourceChain(citation: ChatCitation): Record<string, unknown> {
-  return readRecordValue(citation.source_chain_json, 'source_chain') ?? citation.source_chain_json;
-}
-
-function getCitationGraphPath(citation: ChatCitation): GraphPathData | null {
-  const sourceChain = getCitationSourceChain(citation);
-  const pathRecord = readRecordValue(sourceChain, 'graph_path') ?? readRecordValue(citation.source_chain_json, 'graph_path');
-  const nodesValue =
-    readArrayValue(pathRecord, 'nodes') ??
-    readArrayValue(sourceChain, 'graph_path_nodes') ??
-    readArrayValue(citation.source_chain_json, 'graph_path_nodes');
-
-  if (nodesValue === null || nodesValue.length === 0) {
-    return null;
-  }
-
-  const nodes = nodesValue.map(normalizeGraphPathNode);
-  const edgesValue =
-    readArrayValue(pathRecord, 'edges') ??
-    readArrayValue(sourceChain, 'graph_path_edges') ??
-    readArrayValue(citation.source_chain_json, 'graph_path_edges') ??
-    [];
-  const edges = edgesValue.map((edge, index) => normalizeGraphPathEdge(edge, index, nodes));
-  const confidence =
-    readNumberValue(pathRecord, 'total_confidence') ??
-    readNumberValue(pathRecord, 'confidence') ??
-    readNumberValue(sourceChain, 'chain_confidence');
-  const graphPath: GraphPathData = { nodes, edges };
-
-  if (confidence !== null) {
-    graphPath.total_confidence = confidence;
-  }
-
-  return graphPath;
-}
-
-function normalizeGraphPathNode(value: unknown, index: number): GraphPathNode {
-  if (!isRecord(value)) {
-    return { id: `node-${index}`, label: String(value) };
-  }
-
-  const id =
-    readStringValue(value, 'id') ??
-    readStringValue(value, 'node_id') ??
-    readStringValue(value, 'node_key') ??
-    readStringValue(value, 'stable_key') ??
-    `node-${index}`;
-  const node: GraphPathNode = { id };
-  const label = readStringValue(value, 'label') ?? readStringValue(value, 'name');
-  const nodeKey = readStringValue(value, 'node_key');
-  const stableKey = readStringValue(value, 'stable_key');
-  const nodeType = readStringValue(value, 'node_type') ?? readStringValue(value, 'type');
-
-  if (label !== null) node.label = label;
-  if (nodeKey !== null) node.node_key = nodeKey;
-  if (stableKey !== null) node.stable_key = stableKey;
-  if (nodeType !== null) node.node_type = nodeType;
-
-  return node;
-}
-
-function normalizeGraphPathEdge(value: unknown, index: number, nodes: GraphPathNode[]): GraphPathEdge {
-  const sourceFallback = nodes[index]?.id ?? `source-${index}`;
-  const targetFallback = nodes[index + 1]?.id ?? `target-${index}`;
-
-  if (!isRecord(value)) {
-    return {
-      id: `edge-${index}`,
-      source_node_id: sourceFallback,
-      target_node_id: targetFallback,
-      relationship: String(value),
-    };
-  }
-
-  const edge: GraphPathEdge = {
-    id: readStringValue(value, 'id') ?? readStringValue(value, 'edge_id') ?? `edge-${index}`,
-    source_node_id: readStringValue(value, 'source_node_id') ?? readStringValue(value, 'source') ?? sourceFallback,
-    target_node_id: readStringValue(value, 'target_node_id') ?? readStringValue(value, 'target') ?? targetFallback,
-  };
-  const relationship = readStringValue(value, 'relationship') ?? readStringValue(value, 'relationship_type') ?? readStringValue(value, 'type');
-  const confidenceLabel = readStringValue(value, 'confidence_label') ?? readStringValue(value, 'edge_confidence');
-  const confidenceScore = readNumberValue(value, 'effective_confidence_score') ?? readNumberValue(value, 'confidence');
-
-  if (relationship !== null) edge.relationship = relationship;
-  if (confidenceLabel !== null) edge.confidence_label = confidenceLabel;
-  if (confidenceScore !== null) edge.effective_confidence_score = confidenceScore;
-
-  return edge;
-}
-
-function readRecordValue(record: Record<string, unknown> | null, key: string): Record<string, unknown> | null {
-  if (record === null) {
-    return null;
-  }
-
-  const value = record[key];
-  return isRecord(value) ? value : null;
-}
-
-function readArrayValue(record: Record<string, unknown> | null, key: string): unknown[] | null {
-  if (record === null) {
-    return null;
-  }
-
-  const value = record[key];
-  return Array.isArray(value) ? value : null;
-}
-
-function readStringValue(record: Record<string, unknown>, key: string): string | null {
-  const value = record[key];
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
-
-function readNumberValue(record: Record<string, unknown> | null, key: string): number | null {
-  if (record === null) {
-    return null;
-  }
-
-  const value = record[key];
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-
-  return null;
-}
-
-function readStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function formatSessionDescription(session: ChatSession): string {
   const updatedAt = formatDate(session.updated_at);
   const names = session.space_details?.map((space) => space.name).filter((name) => name.length > 0) ?? [];
@@ -1189,39 +699,4 @@ function getSessionTitle(session: ChatSession): string {
   }
 
   return `Chat ${session.id.slice(0, 8)}`;
-}
-
-function buildCitationPath(spaceId: string, citation: ChatCitation): string {
-  const citationSpaceId = citation.space_id ?? spaceId;
-  return `/spaces/${encodeURIComponent(citationSpaceId)}/wiki/${encodeURIComponent(getCitationPageId(citation))}`;
-}
-
-export function getCitationPageId(citation: ChatCitation): string {
-  if (typeof citation.page_id === 'string' && citation.page_id.length > 0) return citation.page_id;
-  const sourcePageId = citation.source_chain_json.page_id;
-  return typeof sourcePageId === 'string' && sourcePageId.length > 0 ? sourcePageId : citation.wiki_page_pk;
-}
-
-function formatCitationScore(score: number): string {
-  if (!Number.isFinite(score)) {
-    return '0.00';
-  }
-
-  if (score >= 0 && score <= 1) {
-    return `${Math.round(score * 100)}%`;
-  }
-
-  return score.toFixed(2);
-}
-
-function transformMarkdownUrl(url: string): string {
-  if (url.startsWith('citation:')) {
-    return url;
-  }
-
-  if (url.startsWith('https://') || url.startsWith('http://') || url.startsWith('mailto:')) {
-    return url;
-  }
-
-  return '';
 }

--- a/apps/web/src/pages/chat/AssistantMarkdown.tsx
+++ b/apps/web/src/pages/chat/AssistantMarkdown.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { useNavigate } from 'react-router';
+import rehypeHighlight from 'rehype-highlight';
+import remarkGfm from 'remark-gfm';
+import { ConfidenceBadge } from '../../components/ConfidenceBadge.js';
+import type { ChatCitation } from '../../hooks/useChatStream.js';
+import { buildCitationPath, getCitationConfidenceLabel, transformMarkdownUrl } from './sourceChainUtils.js';
+
+type AssistantMarkdownProps = {
+  content: string;
+  citations: ChatCitation[];
+  spaceId: string;
+};
+
+export function AssistantMarkdown({ content, citations, spaceId }: AssistantMarkdownProps) {
+  const navigate = useNavigate();
+  const markdown = useMemo(() => content.replace(/\[\^(\d+)]/g, '[$1](citation:$1)'), [content]);
+
+  function openCitation(index: number): void {
+    const citation = citations.find((item) => item.index === index);
+    if (citation === undefined) {
+      return;
+    }
+
+    void navigate(buildCitationPath(spaceId, citation));
+  }
+
+  return (
+    <div className="chat-markdown">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        urlTransform={transformMarkdownUrl}
+        components={{
+          a: ({ href, children }) => {
+            if (href?.startsWith('citation:') === true) {
+              const index = Number(href.slice('citation:'.length));
+              const citation = Number.isFinite(index) ? citations.find((item) => item.index === index) : undefined;
+              return (
+                <>
+                  <button className="chat-citation-ref" type="button" onClick={() => openCitation(index)}>
+                    [{Number.isFinite(index) ? index : children}]
+                  </button>
+                  <ConfidenceBadge label={citation !== undefined ? getCitationConfidenceLabel(citation) : null} />
+                </>
+              );
+            }
+
+            return (
+              <a href={href} target="_blank" rel="noreferrer">
+                {children}
+              </a>
+            );
+          },
+          img: () => null,
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/ChatMessageBubble.tsx
+++ b/apps/web/src/pages/chat/ChatMessageBubble.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from 'react-i18next';
+import type { ChatMessage } from '../../hooks/useChatStream.js';
+import { AssistantMarkdown } from './AssistantMarkdown.js';
+import { ChatMessageParts } from './ChatMessageParts.js';
+import { CitationPanel } from './CitationPanel.js';
+import { formatLatency } from './sourceChainUtils.js';
+
+type ChatMessageBubbleProps = {
+  message: ChatMessage;
+  spaceId: string;
+  spaceNameById?: Record<string, string>;
+};
+
+export function ChatMessageBubble({ message, spaceId, spaceNameById = {} }: ChatMessageBubbleProps) {
+  const { t } = useTranslation();
+
+  return (
+    <article className={`chat-message-row ${message.role}`} aria-label={`${message.role} message`}>
+      <div className={`chat-message-bubble ${message.role}`}>
+        {message.role === 'assistant' ? (
+          <>
+            {message.agentThinking ? (
+              <AgentThinkingIndicator />
+            ) : message.status === 'streaming' && message.content.length === 0 && message.parts.length === 0 ? (
+              <TypingIndicator />
+            ) : (
+              message.content.length > 0 ? (
+                <AssistantMarkdown content={message.content} citations={message.citations} spaceId={spaceId} />
+              ) : null
+            )}
+            <ChatMessageParts parts={message.parts} />
+            <CitationPanel citations={message.citations} spaceId={spaceId} spaceNameById={spaceNameById} />
+            <CompletionIndicator message={message} />
+          </>
+        ) : (
+          <p className="chat-user-content">{message.content}</p>
+        )}
+        {message.status === 'error' ? <p className="chat-message-error">{message.error ?? t('chat.responseInterrupted')}</p> : null}
+      </div>
+    </article>
+  );
+}
+
+function CompletionIndicator({ message }: { message: ChatMessage }) {
+  const { t } = useTranslation();
+
+  if (message.role !== 'assistant' || message.status !== 'complete' || message.completedAt === null) {
+    return null;
+  }
+
+  return (
+    <div className="chat-completion-indicator" aria-label="Message complete">
+      <span>{t('chat.completed')}</span>
+      {message.latencyMs !== null ? <span>{formatLatency(message.latencyMs)}</span> : null}
+    </div>
+  );
+}
+
+function AgentThinkingIndicator() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="chat-agent-thinking" aria-label={t('chat.agentThinking')}>
+      <span>{t('chat.agentThinking')}</span>
+      <span className="chat-thinking-dots" aria-hidden="true">
+        <i />
+        <i />
+        <i />
+      </span>
+    </div>
+  );
+}
+
+function TypingIndicator() {
+  return (
+    <div className="chat-typing-indicator" aria-label="Assistant is typing">
+      <span />
+      <span />
+      <span />
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/ChatMessageParts.tsx
+++ b/apps/web/src/pages/chat/ChatMessageParts.tsx
@@ -1,0 +1,52 @@
+import { Collapse } from 'antd';
+import { useTranslation } from 'react-i18next';
+import ChatChart from '../../components/ChatChart.js';
+import type { ChatMessagePart, ChatToolUsePart } from '../../hooks/useChatStream.js';
+import { formatToolInput } from './sourceChainUtils.js';
+
+type ChatMessagePartsProps = {
+  parts: ChatMessagePart[];
+};
+
+export function ChatMessageParts({ parts }: ChatMessagePartsProps) {
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="chat-message-parts">
+      {parts.map((part, index) => {
+        if (part.type === 'tool_use') {
+          return <ToolUsePanel key={`${part.id ?? part.name}-${index}`} part={part} />;
+        }
+
+        return <ChatChart key={part.id} option={part.option} chartType={part.chart_type} />;
+      })}
+    </div>
+  );
+}
+
+function ToolUsePanel({ part }: { part: ChatToolUsePart }) {
+  const { t } = useTranslation();
+  const command = formatToolInput(part.input);
+
+  return (
+    <Collapse
+      className="chat-tool-use"
+      size="small"
+      items={[
+        {
+          key: 'toolUse',
+          label: (
+            <span>
+              <span>{part.name}</span>{' '}
+              <code>{command}</code>
+            </span>
+          ),
+          children: <pre>{command}</pre>,
+        },
+      ]}
+      aria-label={t('chat.toolUseLabel')}
+    />
+  );
+}

--- a/apps/web/src/pages/chat/CitationPanel.tsx
+++ b/apps/web/src/pages/chat/CitationPanel.tsx
@@ -1,0 +1,131 @@
+import { Collapse, Tag } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+import { ConfidenceBadge } from '../../components/ConfidenceBadge.js';
+import GraphPathViewer, { type GraphPathData } from '../../components/GraphPathViewer.js';
+import type { ChatCitation } from '../../hooks/useChatStream.js';
+import {
+  buildCitationPath,
+  formatCitationScore,
+  getCitationConfidenceLabel,
+  getCitationGraphPath,
+  getCitationNumber,
+  getCitationStringArray,
+} from './sourceChainUtils.js';
+
+type CitationPanelProps = {
+  citations: ChatCitation[];
+  spaceId: string;
+  spaceNameById: Record<string, string>;
+};
+
+export function CitationPanel({ citations, spaceId, spaceNameById }: CitationPanelProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  if (citations.length === 0) {
+    return null;
+  }
+
+  const collapseItems = [
+    {
+      key: 'citations',
+      label: t('chat.citations', { count: citations.length }),
+      children: (
+        <ol className="chat-citation-ol">
+          {citations.map((citation) => {
+            const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
+            const graphPath = getCitationGraphPath(citation);
+            const citationSpaceId = citation.space_id ?? spaceId;
+            const citationSpaceName = spaceNameById[citationSpaceId] ?? citationSpaceId;
+            return (
+              <li key={`${citation.index}-${citation.chunk_id || citation.wiki_page_pk}`}>
+                <div className="chat-citation-entry">
+                  <button
+                    className="chat-citation-card"
+                    type="button"
+                    onClick={() => {
+                      void navigate(buildCitationPath(spaceId, citation));
+                    }}
+                  >
+                    <span className="chat-citation-index">[{citation.index}]</span>
+                    <span>
+                      <strong>{citation.page_title}</strong>
+                      <small>{citation.section_title ?? t('chat.noSection')}</small>
+                    </span>
+                    {citationSpaceId !== spaceId ? <Tag color="geekblue">{t('chat.sourceSpace', { name: citationSpaceName })}</Tag> : null}
+                    <ConfidenceBadge label={getCitationConfidenceLabel(citation)} />
+                    <Tag>{formatCitationScore(citation.relevance_score)}</Tag>
+                  </button>
+                  {graphEdgeIds.length > 0 || graphPath !== null ? (
+                    <Collapse
+                      size="small"
+                      className="chat-source-chain"
+                      items={[
+                        {
+                          key: 'graphPath',
+                          label: t('chat.viewGraphPath'),
+                          children: <SourceChainDetails citation={citation} graphPath={graphPath} />,
+                        },
+                      ]}
+                    />
+                  ) : null}
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      ),
+    },
+  ];
+
+  return (
+    <Collapse
+      className="chat-citations"
+      defaultActiveKey={['citations']}
+      size="small"
+      items={collapseItems}
+    />
+  );
+}
+
+function SourceChainDetails({ citation, graphPath }: { citation: ChatCitation; graphPath: GraphPathData | null }) {
+  const { t } = useTranslation();
+  const sourceDocumentIds = getCitationStringArray(citation, 'source_document_ids');
+  const graphNodeIds = getCitationStringArray(citation, 'graph_node_ids');
+  const graphEdgeIds = getCitationStringArray(citation, 'graph_edge_ids');
+  const chainConfidence = getCitationNumber(citation, 'chain_confidence');
+
+  return (
+    <div className="chat-source-chain-body">
+      <div className="chat-source-chain-grid">
+        {sourceDocumentIds.length > 0 ? (
+          <>
+            <span>{t('chat.sourceDocIds')}</span>
+            <code>{sourceDocumentIds.join(', ')}</code>
+          </>
+        ) : null}
+        {graphNodeIds.length > 0 ? (
+          <>
+            <span>{t('chat.graphNodeIds')}</span>
+            <code>{graphNodeIds.join(' -> ')}</code>
+          </>
+        ) : null}
+        {graphEdgeIds.length > 0 ? (
+          <>
+            <span>{t('chat.graphEdgeIds')}</span>
+            <code>{graphEdgeIds.join(' -> ')}</code>
+          </>
+        ) : null}
+        {chainConfidence !== null ? (
+          <>
+            <span>{t('chat.chainConfidence')}</span>
+            <code>{formatCitationScore(chainConfidence)}</code>
+          </>
+        ) : null}
+      </div>
+      <ConfidenceBadge label={getCitationConfidenceLabel(citation)} />
+      {graphPath !== null ? <GraphPathViewer path={graphPath} /> : null}
+    </div>
+  );
+}

--- a/apps/web/src/pages/chat/sourceChainUtils.ts
+++ b/apps/web/src/pages/chat/sourceChainUtils.ts
@@ -1,0 +1,233 @@
+import type { ChatCitation } from '../../hooks/useChatStream.js';
+import type { GraphPathData, GraphPathEdge, GraphPathNode } from '../../components/GraphPathViewer.js';
+
+export function buildCitationPath(spaceId: string, citation: ChatCitation): string {
+  const citationSpaceId = citation.space_id ?? spaceId;
+  return `/spaces/${encodeURIComponent(citationSpaceId)}/wiki/${encodeURIComponent(getCitationPageId(citation))}`;
+}
+
+export function getCitationPageId(citation: ChatCitation): string {
+  if (typeof citation.page_id === 'string' && citation.page_id.length > 0) return citation.page_id;
+  const sourcePageId = citation.source_chain_json.page_id;
+  return typeof sourcePageId === 'string' && sourcePageId.length > 0 ? sourcePageId : citation.wiki_page_pk;
+}
+
+export function getCitationConfidenceLabel(citation: ChatCitation): string | null {
+  const chain = getCitationSourceChain(citation);
+  const directLabel = readStringValue(chain, 'edge_confidence') ?? readStringValue(chain, 'confidence_label');
+  if (directLabel !== null) {
+    return directLabel;
+  }
+
+  const graphPath = getCitationGraphPath(citation);
+  return graphPath?.edges.find((edge) => edge.confidence_label !== null && edge.confidence_label !== undefined)?.confidence_label ?? null;
+}
+
+export function getCitationStringArray(citation: ChatCitation, key: string): string[] {
+  const chain = getCitationSourceChain(citation);
+  const directValue = chain[key] ?? citation.source_chain_json[key];
+  return readStringArray(directValue);
+}
+
+export function getCitationNumber(citation: ChatCitation, key: string): number | null {
+  const chain = getCitationSourceChain(citation);
+  return readNumberValue(chain, key) ?? readNumberValue(citation.source_chain_json, key);
+}
+
+export function getCitationGraphPath(citation: ChatCitation): GraphPathData | null {
+  const sourceChain = getCitationSourceChain(citation);
+  const pathRecord = readRecordValue(sourceChain, 'graph_path') ?? readRecordValue(citation.source_chain_json, 'graph_path');
+  const nodesValue =
+    readArrayValue(pathRecord, 'nodes') ??
+    readArrayValue(sourceChain, 'graph_path_nodes') ??
+    readArrayValue(citation.source_chain_json, 'graph_path_nodes');
+
+  if (nodesValue === null || nodesValue.length === 0) {
+    return null;
+  }
+
+  const nodes = nodesValue.map(normalizeGraphPathNode);
+  const edgesValue =
+    readArrayValue(pathRecord, 'edges') ??
+    readArrayValue(sourceChain, 'graph_path_edges') ??
+    readArrayValue(citation.source_chain_json, 'graph_path_edges') ??
+    [];
+  const edges = edgesValue.map((edge, index) => normalizeGraphPathEdge(edge, index, nodes));
+  const confidence =
+    readNumberValue(pathRecord, 'total_confidence') ??
+    readNumberValue(pathRecord, 'confidence') ??
+    readNumberValue(sourceChain, 'chain_confidence');
+  const graphPath: GraphPathData = { nodes, edges };
+
+  if (confidence !== null) {
+    graphPath.total_confidence = confidence;
+  }
+
+  return graphPath;
+}
+
+export function formatCitationScore(score: number): string {
+  if (!Number.isFinite(score)) {
+    return '0.00';
+  }
+
+  if (score >= 0 && score <= 1) {
+    return `${Math.round(score * 100)}%`;
+  }
+
+  return score.toFixed(2);
+}
+
+export function formatLatency(milliseconds: number): string {
+  if (!Number.isFinite(milliseconds)) {
+    return '';
+  }
+
+  if (milliseconds >= 1000) {
+    return `${(milliseconds / 1000).toFixed(1)}s`;
+  }
+
+  return `${Math.max(0, Math.round(milliseconds))}ms`;
+}
+
+export function formatToolInput(input: unknown): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if (isRecord(input)) {
+    const command = readStringValue(input, 'command') ?? readStringValue(input, 'query') ?? readStringValue(input, 'input');
+    if (command !== null) {
+      return command;
+    }
+  }
+
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+}
+
+export function transformMarkdownUrl(url: string): string {
+  if (url.startsWith('citation:')) {
+    return url;
+  }
+
+  if (url.startsWith('https://') || url.startsWith('http://') || url.startsWith('mailto:')) {
+    return url;
+  }
+
+  return '';
+}
+
+function getCitationSourceChain(citation: ChatCitation): Record<string, unknown> {
+  return readRecordValue(citation.source_chain_json, 'source_chain') ?? citation.source_chain_json;
+}
+
+function normalizeGraphPathNode(value: unknown, index: number): GraphPathNode {
+  if (!isRecord(value)) {
+    return { id: `node-${index}`, label: String(value) };
+  }
+
+  const id =
+    readStringValue(value, 'id') ??
+    readStringValue(value, 'node_id') ??
+    readStringValue(value, 'node_key') ??
+    readStringValue(value, 'stable_key') ??
+    `node-${index}`;
+  const node: GraphPathNode = { id };
+  const label = readStringValue(value, 'label') ?? readStringValue(value, 'name');
+  const nodeKey = readStringValue(value, 'node_key');
+  const stableKey = readStringValue(value, 'stable_key');
+  const nodeType = readStringValue(value, 'node_type') ?? readStringValue(value, 'type');
+
+  if (label !== null) node.label = label;
+  if (nodeKey !== null) node.node_key = nodeKey;
+  if (stableKey !== null) node.stable_key = stableKey;
+  if (nodeType !== null) node.node_type = nodeType;
+
+  return node;
+}
+
+function normalizeGraphPathEdge(value: unknown, index: number, nodes: GraphPathNode[]): GraphPathEdge {
+  const sourceFallback = nodes[index]?.id ?? `source-${index}`;
+  const targetFallback = nodes[index + 1]?.id ?? `target-${index}`;
+
+  if (!isRecord(value)) {
+    return {
+      id: `edge-${index}`,
+      source_node_id: sourceFallback,
+      target_node_id: targetFallback,
+      relationship: String(value),
+    };
+  }
+
+  const edge: GraphPathEdge = {
+    id: readStringValue(value, 'id') ?? readStringValue(value, 'edge_id') ?? `edge-${index}`,
+    source_node_id: readStringValue(value, 'source_node_id') ?? readStringValue(value, 'source') ?? sourceFallback,
+    target_node_id: readStringValue(value, 'target_node_id') ?? readStringValue(value, 'target') ?? targetFallback,
+  };
+  const relationship = readStringValue(value, 'relationship') ?? readStringValue(value, 'relationship_type') ?? readStringValue(value, 'type');
+  const confidenceLabel = readStringValue(value, 'confidence_label') ?? readStringValue(value, 'edge_confidence');
+  const confidenceScore = readNumberValue(value, 'effective_confidence_score') ?? readNumberValue(value, 'confidence');
+
+  if (relationship !== null) edge.relationship = relationship;
+  if (confidenceLabel !== null) edge.confidence_label = confidenceLabel;
+  if (confidenceScore !== null) edge.effective_confidence_score = confidenceScore;
+
+  return edge;
+}
+
+function readRecordValue(record: Record<string, unknown> | null, key: string): Record<string, unknown> | null {
+  if (record === null) {
+    return null;
+  }
+
+  const value = record[key];
+  return isRecord(value) ? value : null;
+}
+
+function readArrayValue(record: Record<string, unknown> | null, key: string): unknown[] | null {
+  if (record === null) {
+    return null;
+  }
+
+  const value = record[key];
+  return Array.isArray(value) ? value : null;
+}
+
+function readStringValue(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readNumberValue(record: Record<string, unknown> | null, key: string): number | null {
+  if (record === null) {
+    return null;
+  }
+
+  const value = record[key];
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -556,8 +556,8 @@ Issue #417 fixture:
   - Verification: `apps/web/src/pages/chat/useChatSessions.ts` owns session list loading, open, delete, new chat, and scope PATCH rollback/list refresh; targeted Chat Vitest passed and visible i18n keys/text remain unchanged.
 - [x] 4.3 Extract selected-space scope/settings, model availability gating, and database toggle gating into focused hook(s).
   - Verification: `apps/web/src/pages/chat/useChatScopeSettings.ts` owns available-space loading/fallback, selected-scope persistence, model availability precheck, database config gating, and permission-refresh trigger; Chat request payload tests passed with unchanged endpoints and payload fields.
-- [ ] 4.4 Future Web Chat issue: move message markdown rendering, message parts, citation panel, and source-chain rendering into focused components without changing UX or i18n keys. This is explicitly out of scope for #417.
-  - Verification: message/citation/source-chain tests pass; unsafe markdown image/link behavior remains unchanged.
+- [x] 4.4 Issue #419: move message markdown rendering, message parts, citation panel, and source-chain rendering into focused components without changing UX, i18n keys, navigation targets, or unsafe markdown behavior.
+  - Verification: `ChatMessageBubble`, `AssistantMarkdown`, `ChatMessageParts`, `CitationPanel`, and source-chain utilities now live under `apps/web/src/pages/chat/**`; `Chat.tsx` only wires the extracted rendering component. Targeted Chat Vitest passed (48 tests), including unsafe markdown image suppression/unsupported URL filtering/external link safe attributes, secondary-space citation navigation, direct and nested `source_chain_json` graph path normalization, tool/chart parts, thinking/typing/completion/error states. Full Web test passed (15 files / 201 tests), Web typecheck/lint passed, `git diff --check` passed, and OpenSpec strict validation passed.
 - [x] 4.5 Keep `Chat.tsx` as a thin page composition boundary and run targeted Web tests/typecheck.
   - Verification: `pnpm --filter @cherrygraph/web test` passed (15 files / 194 tests), `pnpm --filter @cherrygraph/web typecheck` passed, `git diff --check` passed, and `openspec validate entropy-governance --strict --no-interactive` passed.
 
@@ -607,6 +607,63 @@ Issue #418 fixture:
   - Verification: `apps/web/src/pages/chat/useChatModelGate.ts` owns `/api/models/chat-available` fail-open model precheck; `apps/web/src/pages/chat/useChatDatabaseGate.ts` owns `/api/spaces/:spaceId` database_config lookup, database toggle availability, and stale `enableDatabase` coercion. `useChatScopeSettings.ts` now keeps selected-space loading/settings persistence only. Targeted Chat tests passed (44 tests), covering no-model fail-closed/no payload, availability fail-open, database disabled/detail failure payload omission, database enabled `enable_database: true`, multi-space clearing with preserved `space_ids`, and completion metadata rendering.
 - [x] 4.7 Issue #418: run targeted Web Chat tests, full Web tests/typecheck/lint, diff check, and OpenSpec validation.
   - Verification: `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false` passed (44 tests); `pnpm --filter @cherrygraph/web test` passed (15 files / 197 tests); `pnpm --filter @cherrygraph/web typecheck` passed; `pnpm --filter @cherrygraph/web lint` passed; `git diff --check` passed; `openspec validate entropy-governance --strict --no-interactive` passed. `Chat.tsx` remains a composition boundary and only wires the focused gating hooks.
+
+Issue #419 fixture:
+- Issue type: refactor / frontend rendering boundary extraction
+- Project profile: other
+- Blast radius: medium
+- Fixture level: expanded
+- Repair intensity: high
+- Change surface: `apps/web/src/pages/Chat.tsx`, new or existing `apps/web/src/pages/chat/**` rendering component files, rendering utilities needed by those components, and `apps/web/src/__tests__/chat.test.tsx`.
+- Dependency/context: #417 extracted session/scope workflows and #418 extracted model/database gating; #419 must not reopen those hook boundaries and must only move Web Chat message, citation, and source-chain rendering out of `Chat.tsx`.
+- Must preserve: existing routes, API endpoints, request payloads, session/scope/model/database behavior, sidebar/mobile controls, Chinese/i18n text, visual layout/CSS class names, assistant markdown rendering, unsafe markdown image suppression, external link attributes, citation ref click navigation, secondary-space citation navigation, citation/source-chain labels and badges, graph path rendering, tool-use/chart message parts, typing/thinking indicators, completion metadata, and SSE rendering compatibility.
+- Must add/change: strengthen characterization tests for unsafe markdown image/link behavior and citation/source-chain rendering where coverage is implicit; extract assistant markdown/message parts/message bubble/citation panel/source-chain rendering into focused component(s) or component+utility files under `apps/web/src/pages/chat/**`; keep `Chat.tsx` as a thin page composition boundary.
+- Selected risk packs:
+  - Public UI / consumer-visible contract: selected - Chat message, citation, source-chain, tool/chart, completion, and empty/streaming indicators are primary user-visible rendering contracts.
+  - Security / unsafe content rendering: selected - assistant markdown is model/content-derived; image suppression, URL filtering, and external link attributes must remain unchanged.
+  - Navigation / identity boundaries: selected - citation refs and citation cards must continue routing to the correct route space or source space and page id fallback.
+  - Schema / field names / compatibility: selected - `ChatMessage`, `ChatCitation`, `source_chain_json`, graph path, tool-use, chart, completion metadata, and SSE-derived fields are unchanged data contracts consumed by the extracted components.
+  - Error handling / rollback / partial outputs: selected - malformed/partial rendering payloads, missing citation targets, unsupported markdown URLs, empty streaming assistant output, non-stringifiable tool input, and tool/chart fallback rendering must keep current non-crashing behavior and visible fallbacks.
+  - Documentation / migration notes: selected - this fixture records #419 as the final Web Chat rendering extraction after #417/#418 and prevents scope bleed into hooks/API/backend changes.
+- Risk packs considered:
+  - Public API / CLI / script entry: not selected - #419 does not change HTTP endpoints, request payloads, routing, CLI scripts, or backend contracts; UI-visible rendering is covered by the selected Public UI pack.
+  - Config / project setup: not selected - no env, build config, dependency, Docker, or routing config changes.
+  - File IO / path safety / overwrite: not selected - no filesystem, upload, or browser storage changes.
+  - Resource limits / large input / discovery: not selected - no new buffering, list virtualization, or payload-size behavior; component extraction must not duplicate large message/citation payloads.
+  - Geospatial / CRS / shapefile sidecars: not selected - no geospatial code changes.
+  - Time series / forcing / temporal boundaries: not selected - no temporal behavior beyond preserving completion latency formatting.
+  - Numerical stability / conservation / NaN: not selected - no numerical algorithms beyond preserving citation score/latency formatting.
+  - Solver runtime / performance / threading: not selected - no solver/runtime code changes.
+  - Legacy compatibility / examples: not selected - no legacy sample or migration surface changes.
+  - Release / packaging / dependency compatibility: not selected - no package metadata or dependency changes.
+- Invariant Matrix:
+  - Source-of-truth identity/contract: `ChatMessage`, `ChatCitation`, `ChatMessagePart`, `source_chain_json`, graph path payloads, existing `chat.*` i18n keys, current CSS class names, and `buildCitationPath`/page-id fallback behavior.
+  - Producers/validators/storage: unchanged API/SSE producers and Web stream/session hooks continue to produce the same message/citation/part objects; #419 only changes rendering consumers.
+  - Public entrypoints: `Chat.tsx` renders `ChatMessageBubble` for each message; extracted components remain internal to `apps/web/src/pages/chat/**` except exported test targets already used by tests.
+  - Read surfaces: assistant markdown content, citation arrays, source-chain JSON, graph path nodes/edges, tool-use input, chart options, completion metadata, and message status/role.
+  - Write/delete/overwrite surfaces: none.
+  - Staging/publish/rollback surfaces: none.
+  - Frontend/downstream consumers: existing Vitest tests, users clicking citation refs/cards, users expanding source-chain panels, and browser handling of external links.
+  - Failure paths: missing citation index, malformed source-chain JSON, missing graph path nodes/edges, non-finite score/latency, streaming assistant with no content, and tool input that cannot stringify.
+  - Security/safety invariants: markdown images still render nothing; non-http/mailto/citation URLs are filtered to an empty href; external links still open with safe attributes; citation pseudo-links never become external navigation.
+- Required evidence:
+  - `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false`
+  - `pnpm --filter @cherrygraph/web test`
+  - `pnpm --filter @cherrygraph/web typecheck`
+  - `pnpm --filter @cherrygraph/web lint`
+  - `git diff --check`
+  - `openspec validate entropy-governance --strict --no-interactive`
+- Regression rows:
+  - assistant markdown input `Use this [^1].` with citation `{ index: 1, source_chain_json: { page_id: "target-page" } }` -> ref renders as the same citation button plus confidence badge and clicking it navigates to `/spaces/<spaceId>/wiki/target-page`.
+  - assistant markdown input `[external](https://example.com)` -> rendered anchor keeps `target="_blank"` and `rel="noreferrer"` behavior.
+  - assistant markdown input `![x](https://example.com/a.png) [bad](javascript:alert(1))` -> image renders nothing and unsupported URL is blocked by the existing `transformMarkdownUrl` empty-href behavior.
+  - citation card input with secondary `space_id: "space-2"` and `spaceNameById.space-2` -> source-space badge text remains visible and card navigation targets `/spaces/space-2/wiki/<pageId>`.
+  - citation/source-chain input with `source_document_ids`, `graph_node_ids`, `graph_edge_ids`, `chain_confidence`, and `graph_path` nodes/edges -> expansion label `chat.viewGraphPath`, source doc/node/edge ids, confidence badge/score, and `GraphPathViewer` remain visible.
+  - citation/source-chain input with alternate nesting `{ source_chain: { graph_path_nodes, graph_path_edges } }` and missing direct `page_id` -> page-id fallback, string-array parsing, score formatting, and graph path normalization remain compatible.
+  - message parts input `{ type: "tool_use", name, input: { command } }` and `{ type: "chart", option, chart_type }` -> tool-use panel keeps existing label/class and command formatting, while chart part still renders `ChatChart` with the same option/type props.
+  - assistant status inputs `agentThinking=true`, `streaming` with empty content/parts, `complete` with `latencyMs=123`, and `error` without explicit error -> thinking indicator, typing indicator, completion latency, and `chat.responseInterrupted` fallback copy remain unchanged.
+  - page composition -> `Chat.tsx` wires extracted rendering components without owning markdown/source-chain parser logic.
+- Non-goals: backend changes, API endpoint/DTO/schema changes, SSE parser or stream hook changes, session/scope/model/database hook changes, selected-space normalization changes, visual redesign, CSS class renames, new i18n copy, dependency changes, broad formatting churn, or changes inside `external/*`.
 
 ## 5. Python Worker Protocol
 

--- a/progress.md
+++ b/progress.md
@@ -157,7 +157,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #418 Web Chat model/database gating hook split complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417 Web Chat session/scope/settings hook extraction 完成；#418 将 model availability 与 database gating 拆入 focused hooks，Chat targeted 44 tests、Web 197 tests、typecheck/lint、OpenSpec strict validate 和 diff check 通过 |
+| entropy-governance | #419 Web Chat rendering extraction complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417 Web Chat session/scope/settings hook extraction 完成；#418 model/database gating hooks 完成；#419 将 assistant markdown、message parts、citation panel、source-chain utils/rendering 拆入 `apps/web/src/pages/chat/**`，Chat targeted 48 tests、Web 201 tests、typecheck/lint、OpenSpec strict validate 和 diff check 通过 |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |


### PR DESCRIPTION
## Summary
- Split Web Chat message rendering out of `Chat.tsx` into focused components under `apps/web/src/pages/chat/**`.
- Moved assistant markdown, message parts/tool/chart rendering, citation panel, and source-chain parsing/rendering into dedicated files.
- Added regression coverage for unsafe markdown behavior, alternate source-chain payloads, graph path normalization, tool/chart parts, and assistant status rendering.

## Scope Boundaries
- No backend, API route, DTO, database schema, dependency, session/scope/model/database hook, visual redesign, CSS class rename, or i18n copy changes.
- Existing Chat request payloads, SSE rendering inputs, citation navigation targets, markdown image suppression, URL filtering, external link attributes, and source-chain labels/badges are preserved.
- Python worker protocol and entropy baseline refresh remain out of scope for #419.

## Verification
- `pnpm exec vitest run apps/web/src/__tests__/chat.test.tsx --config vitest.config.ts --passWithNoTests=false`
- `pnpm --filter @cherrygraph/web test`
- `pnpm --filter @cherrygraph/web typecheck`
- `pnpm --filter @cherrygraph/web lint`
- `git diff --check`
- `openspec validate entropy-governance --strict --no-interactive`

## Agent Review

- Reviewer agents used: fixture-review-419, fixture-review-419-follow-up, spec-compliance, correctness, security-integration, test-evidence, focused spec/test follow-up, final-review
- Reviewed head SHA: `878e30d80f49285f5354f33b99212bacd9c396b6`
- Review evidence: [Round 1 evidence](https://github.com/DankerMu/CherryWiki/pull/435#issuecomment-4589311955) | [Final review](https://github.com/DankerMu/CherryWiki/pull/435#issuecomment-4589312501)
- OpenSpec change: `entropy-governance`; fixture level: expanded; selected risk packs: Public UI / consumer-visible contract, Security / unsafe content rendering, Navigation / identity boundaries, Schema / field names / compatibility, Error handling / rollback / partial outputs, Documentation / migration notes
- Key findings addressed: Fixture review additions were completed before implementation; codeagent correctness and security/integration reviews were clean; focused spec/test evidence follow-up and final review were clean with no source fixes required.

Closes #419
