### PR TITLE
docs(worker): decide python worker protocol strategy (#420)

### DIFF
--- a/openspec/changes/entropy-governance/design.md
+++ b/openspec/changes/entropy-governance/design.md
@@ -203,7 +203,18 @@ storage, SSRF, archive, or output modules.
 
 ### Future Docker Wiring
 
+Ownership rule: #421 owns every first-time shared-package visibility/build
+wiring surface before either worker migration starts. That includes compose
+root-context changes needed by both workers, per-worker Dockerfile copy/install
+steps, root `Dockerfile` worker target installs, CI Dockerfile syntax-check
+context changes, and the shared-package venv/CI test command. #422 and #423
+must consume wiring that already exists; they must not be the first issue to
+make Docker, compose, CI, or local venv able to see
+`packages/python-worker-protocol/`.
+
 The shared package requires root build context anywhere a worker image is built.
+These Docker and compose changes are #421 scope, even though worker runtime
+imports are introduced later by #422/#423.
 
 Future `apps/ingestion-worker/Dockerfile`:
 
@@ -256,6 +267,8 @@ Future compose impact:
   `Dockerfile` target because that target will install the shared package.
 
 ### Future CI And Venv Impact
+
+#421 owns this CI and local venv wiring before worker migrations:
 
 CI `python-ci` must install the shared package before lint and tests for
 `ingestion-worker` and `url-fetcher-worker`:
@@ -316,13 +329,22 @@ because the package boundary is limited to worker-side protocol code.
 ### Downstream Issue Boundaries
 
 - #421: create `packages/python-worker-protocol/`, implement the shared
-  lifecycle contract and package tests, and add package install/build wiring
-  needed for tests and Docker syntax checks. No worker parser/fetcher migration.
+  lifecycle contract and package tests, and add all shared-package
+  visibility/build wiring before worker migrations: root-context compose changes
+  for both Python workers, per-worker Dockerfile copy/install steps, root
+  `Dockerfile` target package installs, CI Dockerfile syntax-check context
+  changes, and the shared-package venv/CI test command. No worker parser/fetcher
+  migration.
 - #422: migrate only `apps/ingestion-worker` to import and configure the shared
-  protocol. Preserve ingestion parser/storage behavior and run ingestion tests.
+  protocol after #421 wiring exists. Preserve ingestion parser/storage behavior,
+  do not introduce first-time Docker/compose/CI/venv wiring, and run ingestion
+  tests.
 - #423: migrate only `apps/url-fetcher-worker` to import and configure the
-  shared protocol, complete root/per-worker Docker and CI deployability checks,
-  and preserve SSRF/fetcher behavior.
+  shared protocol after #421 wiring exists, preserve SSRF/fetcher behavior, and
+  perform final deployability verification across root/per-worker Docker,
+  compose, CI syntax-check expectations, and both worker venv tests. #423 may
+  fix regressions in already-owned wiring but must not be the first issue to
+  wire shared-package visibility.
 
 ### Verification Matrix
 

--- a/openspec/changes/entropy-governance/design.md
+++ b/openspec/changes/entropy-governance/design.md
@@ -92,4 +92,259 @@ Scoped instructions must be more specific than root rules and cannot relax root 
 
 ## Open Questions
 
-- The worker protocol strategy is intentionally decided in the first worker issue. That issue must produce the chosen approach, affected Docker/CI/venv wiring, rollback path, and exact verification matrix before implementation issues begin.
+- None for #421-#423. Issue #420 decided the Python worker protocol strategy below.
+
+## Issue #420 Python Worker Protocol Decision
+
+Use a small shared Python package as the worker job lifecycle protocol source of
+truth.
+
+Chosen package path for downstream implementation:
+`packages/python-worker-protocol/`, exposing an importable package named
+`cherry_worker_protocol`.
+
+The ingestion and URL fetch workers will keep worker-specific parser/fetcher
+handlers, error classes, result payloads, health ports, environment variables,
+and SSRF/parser behavior in their own app trees. The shared package will own
+only the lifecycle protocol currently duplicated in both `job_client.py` files:
+API base URL normalization, pending-job polling response parsing, progress,
+completion, failure reporting, heartbeat payload shape, worker-id generation,
+`run_once`, `poll_jobs`, heartbeat thread startup, terminal-state retryability
+selection, and active-job cleanup.
+
+### Inspected Constraints
+
+- `apps/ingestion-worker/src/job_client.py` and
+  `apps/url-fetcher-worker/src/job_client.py` are structurally identical except
+  for `job_type` / heartbeat `worker_type`, handler type, worker error class,
+  log label, and worker-id prefix.
+- Current per-worker Dockerfiles use per-worker build contexts and copy only
+  local `requirements.txt` plus `src/`.
+- The root `Dockerfile` also defines `ingestion-worker` and
+  `url-fetcher-worker` targets from repository root context.
+- `docker-compose.yml` builds both Python workers from per-worker contexts.
+- `docker-compose.prod.yml` currently builds `ingestion-worker` from the
+  per-worker context but builds `url-fetcher-worker` from the root
+  `url-fetcher-worker` target.
+- `.github/workflows/ci.yml` runs the Python matrix from
+  `apps/${{ matrix.worker }}`, installs local `requirements.txt`, then runs
+  `ruff check`, `ruff format --check`, and `python -m pytest tests/ -v`.
+- CI validation also syntax-checks each `apps/*/Dockerfile` with its directory
+  as build context and syntax-checks root `Dockerfile` targets
+  `api web ingestion-worker url-fetcher-worker indexer-worker`.
+- Scoped worker `AGENTS.md` files require per-worker venv pytest commands and
+  preserving the API-compatible pending/claim, heartbeat, progress, complete,
+  fail, retryability, and active-job cleanup protocol.
+
+### Option Comparison
+
+1. Shared Python package
+
+This gives the protocol one importable implementation and one focused test
+suite. It matches the observed duplication because the current differences are
+parameters and callbacks rather than independent algorithms. Downstream issues
+must adjust Python install and Docker build contexts so both workers and both
+root targets can see the package. This is a real build/deploy change, but it is
+explicit and testable. Verdict: selected.
+
+2. Shared local module wired into both build contexts
+
+Rejected because it has the same Docker build-context problem as a package but
+without package metadata, install-time validation, or a clean import contract.
+It also makes local venv and CI behavior depend on path injection, increasing
+the chance that Docker and local test imports diverge.
+
+3. Protocol-template enforcement
+
+Rejected because current duplication is already near-identical and parameterized
+well enough to share directly. A template would avoid Docker rewiring but would
+leave two runtime implementations to drift and would not remove the main entropy
+source identified by this stage.
+
+### Future Package Contract
+
+Package layout for #421:
+
+```text
+packages/python-worker-protocol/
+  pyproject.toml
+  src/cherry_worker_protocol/
+    __init__.py
+    job_lifecycle.py
+  tests/
+    test_job_lifecycle.py
+```
+
+Public imports for migrated workers:
+
+```python
+from cherry_worker_protocol import (
+    InternalApiClient,
+    WorkerProtocolConfig,
+    generate_worker_id,
+    poll_jobs,
+    run_once,
+    start_heartbeat_thread,
+)
+```
+
+Required config fields:
+
+- `job_type`: `ingestion` or `url_fetch`
+- `worker_type`: same value used in heartbeat `system_info.worker_type`
+- `worker_id_prefix`: `ingestion-worker` or `url-fetcher-worker`
+- `failure_log_message`: `ingestion job failed` or `url_fetch job failed`
+- `worker_error_type`: `IngestionJobError` or `UrlFetchJobError`
+- `build_error_json`: worker-local error serializer
+
+The shared package must keep handler behavior generic: it calls
+`handler.handle(job, progress)` and does not import worker parser, fetcher,
+storage, SSRF, archive, or output modules.
+
+### Future Docker Wiring
+
+The shared package requires root build context anywhere a worker image is built.
+
+Future `apps/ingestion-worker/Dockerfile`:
+
+```dockerfile
+COPY packages/python-worker-protocol/ packages/python-worker-protocol/
+COPY apps/ingestion-worker/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./packages/python-worker-protocol
+COPY apps/ingestion-worker/src/ src/
+```
+
+Future `apps/url-fetcher-worker/Dockerfile`:
+
+```dockerfile
+COPY packages/python-worker-protocol/ packages/python-worker-protocol/
+COPY apps/url-fetcher-worker/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./packages/python-worker-protocol
+COPY apps/url-fetcher-worker/src/ src/
+```
+
+Future root `Dockerfile` target `ingestion-worker`:
+
+```dockerfile
+COPY packages/python-worker-protocol/ packages/python-worker-protocol/
+COPY apps/ingestion-worker/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./packages/python-worker-protocol
+COPY apps/ingestion-worker/src/ src/
+```
+
+Future root `Dockerfile` target `url-fetcher-worker`:
+
+```dockerfile
+COPY packages/python-worker-protocol/ packages/python-worker-protocol/
+COPY apps/url-fetcher-worker/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./packages/python-worker-protocol
+COPY apps/url-fetcher-worker/src/ src/
+```
+
+Future compose impact:
+
+- `docker-compose.yml` worker build contexts must become `.` for both workers,
+  with dockerfiles `apps/ingestion-worker/Dockerfile` and
+  `apps/url-fetcher-worker/Dockerfile`.
+- `docker-compose.prod.yml` must also build `ingestion-worker` from root context
+  with dockerfile `apps/ingestion-worker/Dockerfile`.
+- `docker-compose.prod.yml` may keep `url-fetcher-worker` on the root
+  `Dockerfile` target because that target will install the shared package.
+
+### Future CI And Venv Impact
+
+CI `python-ci` must install the shared package before lint and tests for
+`ingestion-worker` and `url-fetcher-worker`:
+
+```bash
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+if [ "${{ matrix.worker }}" = "ingestion-worker" ] || [ "${{ matrix.worker }}" = "url-fetcher-worker" ]; then
+  pip install -e ../../packages/python-worker-protocol
+fi
+pip install ruff pytest pytest-asyncio
+```
+
+CI Dockerfile syntax checks must use repository root context for the two Python
+worker app Dockerfiles:
+
+```bash
+docker buildx build --check -f apps/ingestion-worker/Dockerfile .
+docker buildx build --check -f apps/url-fetcher-worker/Dockerfile .
+```
+
+Root target syntax checks remain:
+
+```bash
+docker buildx build --check -f Dockerfile --target ingestion-worker .
+docker buildx build --check -f Dockerfile --target url-fetcher-worker .
+```
+
+Local venv setup after #421 must install the package into both worker venvs:
+
+```bash
+apps/ingestion-worker/.venv/bin/pip install -e packages/python-worker-protocol
+apps/url-fetcher-worker/.venv/bin/pip install -e packages/python-worker-protocol
+```
+
+The existing pytest commands remain the acceptance commands:
+
+```bash
+apps/ingestion-worker/.venv/bin/python -m pytest apps/ingestion-worker/tests -v
+apps/url-fetcher-worker/.venv/bin/python -m pytest apps/url-fetcher-worker/tests -v
+```
+
+### Rollback Path
+
+If package wiring breaks deployability during #421-#423:
+
+1. Revert the worker imports to the current worker-local `job_client.py`
+   implementation for the affected worker.
+2. Revert compose build contexts and Python CI install changes for the affected
+   worker.
+3. Keep `packages/python-worker-protocol/` only if no worker imports it; remove
+   it if no implementation issue has shipped.
+4. Re-run that worker's venv pytest command plus both compose config checks.
+
+No API, database, parser, fetcher, or queue behavior rollback is required
+because the package boundary is limited to worker-side protocol code.
+
+### Downstream Issue Boundaries
+
+- #421: create `packages/python-worker-protocol/`, implement the shared
+  lifecycle contract and package tests, and add package install/build wiring
+  needed for tests and Docker syntax checks. No worker parser/fetcher migration.
+- #422: migrate only `apps/ingestion-worker` to import and configure the shared
+  protocol. Preserve ingestion parser/storage behavior and run ingestion tests.
+- #423: migrate only `apps/url-fetcher-worker` to import and configure the
+  shared protocol, complete root/per-worker Docker and CI deployability checks,
+  and preserve SSRF/fetcher behavior.
+
+### Verification Matrix
+
+Decision-only #420 verification:
+
+```bash
+openspec validate entropy-governance --strict --no-interactive
+git diff --check
+docker compose config --quiet
+docker compose -f docker-compose.prod.yml config --quiet
+```
+
+Required future #421-#423 verification:
+
+```bash
+packages/python-worker-protocol/.venv/bin/python -m pytest packages/python-worker-protocol/tests -v
+apps/ingestion-worker/.venv/bin/python -m pytest apps/ingestion-worker/tests -v
+apps/url-fetcher-worker/.venv/bin/python -m pytest apps/url-fetcher-worker/tests -v
+docker buildx build --check -f apps/ingestion-worker/Dockerfile .
+docker buildx build --check -f apps/url-fetcher-worker/Dockerfile .
+docker buildx build --check -f Dockerfile --target ingestion-worker .
+docker buildx build --check -f Dockerfile --target url-fetcher-worker .
+docker compose config --quiet
+docker compose -f docker-compose.prod.yml config --quiet
+```

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -708,16 +708,100 @@ Issue #420 fixture:
   - CI `validate` checks both per-app Dockerfiles and root `api/web/ingestion-worker/url-fetcher-worker/indexer-worker` targets -> downstream #421-#423 must preserve `python-ci` matrix behavior and root target syntax checks.
   - local venv commands differ by worker subtree -> chosen strategy records exact ingestion/url-fetcher pytest commands and whether additional shared-package tests are required.
   - duplicated `job_client.py` protocol differs only in worker type, handler/error classes, log labels, and worker-id prefix -> chosen strategy identifies which parameters must become shared/enforced.
-  - downstream issue split remains clear -> #421 owns shared/enforced protocol implementation tests, #422 owns ingestion migration, #423 owns url-fetcher migration and deployability verification.
+  - downstream issue split remains clear -> #421 owns shared/enforced protocol implementation tests plus all first-time shared-package Docker/compose/CI/venv visibility wiring, #422 owns ingestion migration only after that wiring exists, and #423 owns url-fetcher migration plus final deployability verification rather than first-time shared-package wiring.
 - Non-goals: implementing the shared protocol, migrating either worker, changing Docker/CI files, adding dependencies, changing job lifecycle API/server behavior, changing worker parser/fetcher behavior, running full worker migrations, or touching `external/*`.
-- [ ] 5.2 Implement the shared/enforced worker job lifecycle protocol with tests for pending polling, claim, heartbeat, progress, completion, failure, retryability, lock expiry, concurrent claim, duplicate terminal calls, and active jobs cleanup.
-  - Verification: protocol tests pass in the selected package/template location.
-- [ ] 5.3 Migrate `apps/ingestion-worker` to the shared/enforced protocol and run ingestion worker tests.
-  - Verification: `apps/ingestion-worker/.venv/bin/python -m pytest apps/ingestion-worker/tests -v` passes.
-- [ ] 5.4 Migrate `apps/url-fetcher-worker` to the shared/enforced protocol and run URL fetch worker tests.
-  - Verification: `apps/url-fetcher-worker/.venv/bin/python -m pytest apps/url-fetcher-worker/tests -v` passes.
-- [ ] 5.5 Update Docker/CI/local verification wiring only where required by the chosen strategy.
-  - Verification: `docker compose config --quiet`, `docker compose -f docker-compose.prod.yml config --quiet`, and relevant CI workflow checks are updated or explicitly documented as unchanged.
+
+Issue #421 fixture:
+- Issue type: refactor / shared package foundation plus build wiring
+- Project profile: other
+- Blast radius: medium
+- Fixture level: expanded
+- Repair intensity: medium
+- Change surface: `packages/python-worker-protocol/**`, `docker-compose.yml`, `docker-compose.prod.yml`, both Python worker app Dockerfiles, root `Dockerfile` worker targets, `.github/workflows/ci.yml`, and focused shared-package/worker import visibility tests only.
+- Dependency/context: #420 selected `packages/python-worker-protocol/` and assigned all first-time shared-package visibility/build wiring to #421. #422/#423 may not start worker migrations until #421 wiring exists.
+- Must preserve: no ingestion or URL fetch parser/fetcher/storage/runtime migration, no API/DTO/schema change, no worker job lifecycle server contract change, no dependency lockfile churn outside the Python package metadata needed by #421, and no changes inside `external/*`.
+- Must add/change: create the shared package and lifecycle protocol tests; make both workers and both root worker Docker targets able to install the package from repository root context; switch compose build contexts needed by both Python workers to root context; update CI Dockerfile syntax-check commands to use root context for the two Python worker app Dockerfiles; add the shared-package install/test command to CI/local venv verification before worker migrations.
+- Required evidence:
+  - `packages/python-worker-protocol/.venv/bin/python -m pytest packages/python-worker-protocol/tests -v`
+  - `apps/ingestion-worker/.venv/bin/pip install -e packages/python-worker-protocol`
+  - `apps/url-fetcher-worker/.venv/bin/pip install -e packages/python-worker-protocol`
+  - `apps/ingestion-worker/.venv/bin/python -c "import cherry_worker_protocol"`
+  - `apps/url-fetcher-worker/.venv/bin/python -c "import cherry_worker_protocol"`
+  - `docker buildx build --check -f apps/ingestion-worker/Dockerfile .`
+  - `docker buildx build --check -f apps/url-fetcher-worker/Dockerfile .`
+  - `docker buildx build --check -f Dockerfile --target ingestion-worker .`
+  - `docker buildx build --check -f Dockerfile --target url-fetcher-worker .`
+  - `docker compose config --quiet`
+  - `docker compose -f docker-compose.prod.yml config --quiet`
+  - `openspec validate entropy-governance --strict --no-interactive`
+- Regression rows:
+  - `docker-compose.yml` and `docker-compose.prod.yml` worker builds that need the shared package use repository root context and still point at the intended worker Dockerfile/target.
+  - Both per-worker app Dockerfiles copy/install `packages/python-worker-protocol/` before copying worker `src/`, without importing parser/fetcher behavior.
+  - Root `Dockerfile` `ingestion-worker` and `url-fetcher-worker` targets install `packages/python-worker-protocol/`.
+  - CI Dockerfile syntax checks for `apps/ingestion-worker/Dockerfile` and `apps/url-fetcher-worker/Dockerfile` use root context, while root target checks remain present.
+  - CI/local venv commands prove `cherry_worker_protocol` is importable for both worker venvs before #422/#423 runtime migrations.
+- Non-goals: migrating `apps/ingestion-worker/src/job_client.py`, migrating `apps/url-fetcher-worker/src/job_client.py`, changing parser/fetcher/SSRF/archive/storage behavior, changing job API/server behavior, or deferring first-time shared-package wiring to #422/#423.
+
+- [ ] 5.2 Issue #421: implement `packages/python-worker-protocol/` with lifecycle protocol tests and all first-time shared-package Docker/compose/CI/venv visibility wiring required before worker migrations.
+  - Verification: #421 required evidence commands pass, including shared-package tests, both worker venv import checks, both per-worker Dockerfile root-context syntax checks, both root worker target syntax checks, both compose config checks, and OpenSpec strict validation.
+
+Issue #422 fixture:
+- Issue type: refactor / ingestion worker migration
+- Project profile: other
+- Blast radius: medium
+- Fixture level: expanded
+- Repair intensity: medium
+- Change surface: `apps/ingestion-worker/**` job lifecycle client/configuration and directly affected ingestion tests only.
+- Dependency/context: #421 must already provide `packages/python-worker-protocol/` and all shared-package Docker/compose/CI/venv visibility wiring. #422 consumes that wiring; it does not introduce first-time Docker/compose/CI/venv wiring.
+- Must preserve: ingestion parser/storage/archive behavior, ingestion result payloads, error serialization, health port/env behavior, job type `ingestion`, heartbeat `worker_type`, worker-id prefix, retryability, active-job cleanup, API/DTO/schema behavior, and no changes inside `external/*`.
+- Must add/change: replace ingestion-local lifecycle duplication with imports/configuration from `cherry_worker_protocol` while keeping worker-local handler and error serializer ownership in `apps/ingestion-worker`.
+- Required evidence:
+  - `apps/ingestion-worker/.venv/bin/python -m pytest apps/ingestion-worker/tests -v`
+  - `apps/ingestion-worker/.venv/bin/python -c "import cherry_worker_protocol"`
+  - `docker buildx build --check -f apps/ingestion-worker/Dockerfile .`
+  - `docker buildx build --check -f Dockerfile --target ingestion-worker .`
+  - `docker compose config --quiet`
+  - `docker compose -f docker-compose.prod.yml config --quiet`
+  - `openspec validate entropy-governance --strict --no-interactive`
+- Regression rows:
+  - Ingestion migration uses #421 wiring and does not change compose contexts, CI syntax-check contexts, root Dockerfile package install steps, or shared-package venv install commands except to fix regressions in already-owned #421 surfaces.
+  - Ingestion parser/storage/archive tests keep existing payloads and terminal-state behavior.
+- Non-goals: URL fetcher migration, first-time shared-package Docker/compose/CI/venv wiring, parser/storage redesign, API/server changes, dependency lockfile churn unrelated to the shared package, or changes inside `external/*`.
+
+- [ ] 5.3 Issue #422: migrate only `apps/ingestion-worker` to the shared protocol after #421 wiring exists.
+  - Verification: #422 required evidence commands pass, especially ingestion venv tests and ingestion Docker/root-target syntax checks using #421 wiring.
+
+Issue #423 fixture:
+- Issue type: refactor / URL fetcher migration plus final deployability verification
+- Project profile: other
+- Blast radius: medium
+- Fixture level: expanded
+- Repair intensity: medium
+- Change surface: `apps/url-fetcher-worker/**` job lifecycle client/configuration, directly affected URL fetcher tests, and final deployability verification evidence across existing #421 wiring surfaces.
+- Dependency/context: #421 owns first-time shared-package Docker/compose/CI/venv visibility wiring; #422 has migrated ingestion. #423 migrates URL fetcher and proves the full two-worker deployment surface is coherent.
+- Must preserve: URL fetcher SSRF/fetch/archive behavior, URL fetch result payloads, error serialization, health port/env behavior, job type `url_fetch`, heartbeat `worker_type`, worker-id prefix, retryability, active-job cleanup, API/DTO/schema behavior, and no changes inside `external/*`.
+- Must add/change: replace URL fetcher-local lifecycle duplication with imports/configuration from `cherry_worker_protocol`; run final deployability checks across both per-worker Dockerfiles, both root worker targets, both compose files, and both worker venv tests. Any Docker/compose/CI fix in #423 must be limited to correcting regressions in wiring already introduced by #421, not first-time shared-package visibility wiring.
+- Required evidence:
+  - `apps/url-fetcher-worker/.venv/bin/python -m pytest apps/url-fetcher-worker/tests -v`
+  - `apps/ingestion-worker/.venv/bin/python -m pytest apps/ingestion-worker/tests -v`
+  - `packages/python-worker-protocol/.venv/bin/python -m pytest packages/python-worker-protocol/tests -v`
+  - `apps/url-fetcher-worker/.venv/bin/python -c "import cherry_worker_protocol"`
+  - `apps/ingestion-worker/.venv/bin/python -c "import cherry_worker_protocol"`
+  - `docker buildx build --check -f apps/ingestion-worker/Dockerfile .`
+  - `docker buildx build --check -f apps/url-fetcher-worker/Dockerfile .`
+  - `docker buildx build --check -f Dockerfile --target ingestion-worker .`
+  - `docker buildx build --check -f Dockerfile --target url-fetcher-worker .`
+  - `docker compose config --quiet`
+  - `docker compose -f docker-compose.prod.yml config --quiet`
+  - `openspec validate entropy-governance --strict --no-interactive`
+- Regression rows:
+  - URL fetcher migration uses #421 wiring and preserves SSRF/private-network protections, fetch/archive output, and terminal-state reporting.
+  - Final deployability evidence covers both workers, both app Dockerfiles from root context, both root Dockerfile targets, both compose files, and shared-package tests.
+  - #423 does not become the first issue to add shared-package copy/install steps, compose root-context changes, CI syntax-check context changes, or worker venv package install commands.
+- Non-goals: first-time shared-package Docker/compose/CI/venv wiring, ingestion behavior changes beyond regression fixes, API/server changes, SSRF/fetcher redesign, dependency lockfile churn unrelated to the shared package, or changes inside `external/*`.
+
+- [ ] 5.4 Issue #423: migrate only `apps/url-fetcher-worker` to the shared protocol and complete final two-worker deployability verification.
+  - Verification: #423 required evidence commands pass, including URL fetcher tests, ingestion regression tests, shared-package tests, both worker import checks, all Docker syntax checks, both compose config checks, and OpenSpec strict validation.
 
 ## 6. Governance Verification
 

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -667,8 +667,49 @@ Issue #419 fixture:
 
 ## 5. Python Worker Protocol
 
-- [ ] 5.1 Inspect Docker/CI/venv constraints and decide the worker protocol strategy: shared Python package, shared local module wired into both build contexts, or protocol-template enforcement.
-  - Verification: decision note records chosen strategy, rejected alternatives, Docker/CI/venv impact, rollback path, and exact verification commands.
+- [x] 5.1 Issue #420: Inspect Docker/CI/venv constraints and decide the worker protocol strategy: shared Python package, shared local module wired into both build contexts, or protocol-template enforcement.
+  - Verification: `openspec/changes/entropy-governance/design.md` Issue #420 section selects `packages/python-worker-protocol/` as the shared package strategy and records rejected alternatives, exact future Docker copy/install/import wiring for per-worker Dockerfiles and root worker targets, CI/venv impact, rollback path, #421/#422/#423 boundaries, inspection evidence, and verification commands. Decision-only validation run: `openspec validate entropy-governance --strict --no-interactive`, `git diff --check`, `docker compose config --quiet`, and `docker compose -f docker-compose.prod.yml config --quiet`.
+
+Issue #420 fixture:
+- Issue type: decision / architecture note
+- Project profile: other
+- Blast radius: medium
+- Fixture level: compact
+- Repair intensity: medium
+- Change surface: OpenSpec/docs/progress only; inspect `apps/ingestion-worker/**`, `apps/url-fetcher-worker/**`, `.github/workflows/ci.yml`, Dockerfiles, and compose files read-only.
+- Dependency/context: #409 scoped worker AGENTS exist; #421-#423 will implement and migrate the protocol. #420 must remove strategy ambiguity without changing runtime behavior.
+- Must preserve: no worker runtime behavior change, no API/DTO/schema change, no Docker/CI rewiring, no dependency lockfile change, no worker test expectation change, and no changes inside `external/*`.
+- Must add/change: a decision note in the OpenSpec change that compares shared Python package, shared local module wired into both Docker build contexts, and protocol-template enforcement; records chosen strategy, rejected alternatives, Docker build-context impact, exact copy/install/import wiring for both per-worker Dockerfiles and root `ingestion-worker` / `url-fetcher-worker` Dockerfile targets, CI/venv impact, rollback path, downstream issue boundaries, and exact verification commands.
+- Selected risk packs:
+  - Config / project setup: selected - strategy must account for current per-worker Docker contexts, root Dockerfile syntax checks, compose validation, CI matrix, and local venv constraints.
+  - Release / packaging / dependency compatibility: selected - shared package or module choices can change Docker build contexts and Python import/install paths in later issues.
+  - Documentation / migration notes: selected - #420's output is intentionally a decision artifact that governs #421-#423.
+- Risk packs considered:
+  - Public API / CLI / script entry: not selected - no endpoint, CLI, or script behavior changes in this decision-only issue.
+  - File IO / path safety / overwrite: not selected - no runtime file IO changes.
+  - Schema / columns / units / field names: not selected - no database schema or DTO changes.
+  - Error handling / rollback / partial outputs: not selected - worker error semantics are documented for later implementation but not changed in #420.
+  - Resource limits / large input / discovery: not selected - no parsing/fetching behavior changes.
+  - Geospatial / CRS / shapefile sidecars: not selected - no geospatial code changes.
+  - Time series / forcing / temporal boundaries: not selected - no temporal behavior changes.
+  - Numerical stability / conservation / NaN: not selected - no numerical code changes.
+  - Solver runtime / performance / threading: not selected - no runtime/threading code changes in #420.
+  - Legacy compatibility / examples: not selected - no legacy sample changes.
+- Required evidence:
+  - `openspec validate entropy-governance --strict --no-interactive`
+  - `git diff --check`
+  - `docker compose config --quiet`
+  - `docker compose -f docker-compose.prod.yml config --quiet`
+  - Read-only inspection evidence for `apps/ingestion-worker/src/job_client.py`, `apps/url-fetcher-worker/src/job_client.py`, both per-worker Dockerfiles, root `Dockerfile`, `docker-compose.yml`, `docker-compose.prod.yml`, CI Python matrix, CI root Dockerfile target syntax checks, and worker AGENTS venv commands.
+- Regression rows:
+  - current worker Dockerfiles use per-worker build contexts and copy only local `requirements.txt` plus `src/` -> chosen strategy states whether future implementation must change build context or package copy/install steps.
+  - root `Dockerfile` also defines `ingestion-worker` and `url-fetcher-worker` targets while prod compose uses the root `url-fetcher-worker` target -> chosen strategy states exact future copy/install/import wiring for both root targets and per-worker Dockerfiles.
+  - CI `python-ci` matrix runs from `apps/${{ matrix.worker }}` with local requirements -> chosen strategy states exact CI impact and required follow-up wiring.
+  - CI `validate` checks both per-app Dockerfiles and root `api/web/ingestion-worker/url-fetcher-worker/indexer-worker` targets -> downstream #421-#423 must preserve `python-ci` matrix behavior and root target syntax checks.
+  - local venv commands differ by worker subtree -> chosen strategy records exact ingestion/url-fetcher pytest commands and whether additional shared-package tests are required.
+  - duplicated `job_client.py` protocol differs only in worker type, handler/error classes, log labels, and worker-id prefix -> chosen strategy identifies which parameters must become shared/enforced.
+  - downstream issue split remains clear -> #421 owns shared/enforced protocol implementation tests, #422 owns ingestion migration, #423 owns url-fetcher migration and deployability verification.
+- Non-goals: implementing the shared protocol, migrating either worker, changing Docker/CI files, adding dependencies, changing job lifecycle API/server behavior, changing worker parser/fetcher behavior, running full worker migrations, or touching `external/*`.
 - [ ] 5.2 Implement the shared/enforced worker job lifecycle protocol with tests for pending polling, claim, heartbeat, progress, completion, failure, retryability, lock expiry, concurrent claim, duplicate terminal calls, and active jobs cleanup.
   - Verification: protocol tests pass in the selected package/template location.
 - [ ] 5.3 Migrate `apps/ingestion-worker` to the shared/enforced protocol and run ingestion worker tests.

--- a/progress.md
+++ b/progress.md
@@ -157,7 +157,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #419 Web Chat rendering extraction complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417 Web Chat session/scope/settings hook extraction 完成；#418 model/database gating hooks 完成；#419 将 assistant markdown、message parts、citation panel、source-chain utils/rendering 拆入 `apps/web/src/pages/chat/**`，Chat targeted 48 tests、Web 201 tests、typecheck/lint、OpenSpec strict validate 和 diff check 通过 |
+| entropy-governance | #420 Python worker protocol decision complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417-#419 Web Chat 拆分完成；#420 决定后续用 `packages/python-worker-protocol/` 共享 Python worker lifecycle 协议，并记录 Docker/CI/venv wiring、rollback、#421/#422/#423 边界；OpenSpec strict validate、diff check、compose config 双环境通过 |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |
@@ -169,7 +169,7 @@
 ## 9. 下一步
 
 0. **Codex 工作流与 AGENTS 规则可用** — 已安装 `agentic-issue-delivery` pack、`repo-entropy-audit`、`control-plane-auditor`，并补强仓库级协作规则
-1. **熵治理实现批次** — 从 #409 scoped AGENTS 和 #410 API error inventory 开始，按 #408 依赖图推进
+1. **熵治理实现批次** — 继续 #421/#422/#423 Python worker protocol 共享包实现与双 worker 迁移，按 #408 依赖图推进
 2. **继续 P0 测试** — 可立即测的 ~20 项（权限、多格式上传、SSE 事件、Model 管理）
 3. **运行 Graphify** — 容器内 Claude Code 可用，运行后解锁 Graph/Wiki/Index/Citation 相关 P0 测试
 

--- a/progress.md
+++ b/progress.md
@@ -157,7 +157,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #420 Python worker protocol decision complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417-#419 Web Chat 拆分完成；#420 决定后续用 `packages/python-worker-protocol/` 共享 Python worker lifecycle 协议，并记录 Docker/CI/venv wiring、rollback、#421/#422/#423 边界；OpenSpec strict validate、diff check、compose config 双环境通过 |
+| entropy-governance | #420 Python worker protocol decision complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417-#419 Web Chat 拆分完成；#420 决定后续用 `packages/python-worker-protocol/` 共享 Python worker lifecycle 协议，并明确 #421 先拥有全部 Docker/compose/CI/venv shared-package wiring，#422 仅迁移 ingestion，#423 迁移 url-fetcher 并做最终 deployability 验证；OpenSpec strict validate、diff check、compose config 双环境通过 |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |


### PR DESCRIPTION
## Summary
- Added the #420 Python worker protocol strategy decision to the `entropy-governance` OpenSpec design.
- Selected `packages/python-worker-protocol/` with import package `cherry_worker_protocol` as the shared lifecycle protocol strategy.
- Recorded rejected alternatives, Docker/CI/venv wiring, rollback path, and downstream #421/#422/#423 boundaries.

## Scope Boundaries
- Decision-only PR: no worker runtime code, Docker/CI files, dependencies, lockfiles, API/DTO/schema, parser/fetcher behavior, or test expectations changed.
- Future implementation/migration remains scoped to #421/#422/#423.

## Verification
- `openspec validate entropy-governance --strict --no-interactive`
- `git diff --check`
- `docker compose config --quiet`
- `docker compose -f docker-compose.prod.yml config --quiet`

## Agent Review

- Reviewer agents used: Fixture Review, Phase 4 Cross Review, Follow-up Cross Review, Phase 7 Final Review
- Reviewed head SHA: `c7ee3f9544c35bfba38f64854a6fddf9b8cd71a1`
- Review evidence: [Fixture + Cross Review](https://github.com/DankerMu/CherryWiki/pull/436#issuecomment-4589970596) | [Follow-up + Final Review](https://github.com/DankerMu/CherryWiki/pull/436#issuecomment-4589970622)
- OpenSpec change: `entropy-governance`; fixture level: compact; selected risk packs: Config / project setup, Release / packaging / dependency compatibility, Documentation / migration notes
- Key findings addressed: fixture Docker/compose/CI constraints clarified; downstream #421/#422/#423 migration/wiring ownership clarified; latest follow-up and final reviews clean

Closes #420
