### PR TITLE
feat(worker): add shared python protocol package (#421)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,12 @@ node_modules
 !.env.example
 .git
 .github
+.agents/
+.claude/
+.codex/
+.codex*
+openspec/
+.entropy-baseline/
 .vscode
 .idea
 external
@@ -19,6 +25,10 @@ apps/ingestion-worker/.venv
 apps/url-fetcher-worker/.venv
 packages/python-worker-protocol/.venv
 apps/graphify-worker/__pycache__
+.ruff_cache/
 .pytest_cache
+**/.pytest_cache
+*.egg-info
+**/*.egg-info
 **/__pycache__
 **/*.tsbuildinfo

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,9 @@ tests
 *.md
 !README.md
 apps/graphify-worker/.venv
+apps/ingestion-worker/.venv
 apps/url-fetcher-worker/.venv
+packages/python-worker-protocol/.venv
 apps/graphify-worker/__pycache__
 .pytest_cache
 **/__pycache__

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r apps/url-fetcher-worker/requirements.txt
+          python -m pip install -e packages/python-worker-protocol
 
       - name: Build
         run: pnpm build
@@ -129,7 +130,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          if [ "${{ matrix.worker }}" = "ingestion-worker" ] || [ "${{ matrix.worker }}" = "url-fetcher-worker" ]; then
+            pip install -e ../../packages/python-worker-protocol
+          fi
           pip install ruff pytest pytest-asyncio
+
+      - name: Test shared worker protocol
+        if: matrix.worker == 'ingestion-worker'
+        run: python -m pytest ../../packages/python-worker-protocol/tests -v
 
       - name: Lint
         run: ruff check src/ tests/
@@ -189,7 +197,14 @@ jobs:
           for f in apps/*/Dockerfile ops/agent/Dockerfile; do
             if [ -f "$f" ]; then
               echo "Checking $f..."
-              docker buildx build --check -f "$f" "$(dirname "$f")" || status=1
+              case "$f" in
+                apps/ingestion-worker/Dockerfile|apps/url-fetcher-worker/Dockerfile)
+                  docker buildx build --check -f "$f" . || status=1
+                  ;;
+                *)
+                  docker buildx build --check -f "$f" "$(dirname "$f")" || status=1
+                  ;;
+              esac
             fi
           done
           exit $status

--- a/.github/workflows/live-stack-smoke.yml
+++ b/.github/workflows/live-stack-smoke.yml
@@ -13,6 +13,7 @@ on:
       - 'docker-compose.prod.yml'
       - 'package.json'
       - 'packages/job-core/**'
+      - 'packages/python-worker-protocol/**'
       - 'packages/shared/**'
       - 'pnpm-lock.yaml'
       - 'tests/smoke/**'
@@ -87,6 +88,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r apps/url-fetcher-worker/requirements.txt
+          python -m pip install -e packages/python-worker-protocol
 
       - name: Validate production Docker Compose
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .ruff_cache/
+*.egg-info/
 .venv/
 venv/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,10 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 RUN addgroup --system --gid 1000 worker \
     && adduser --system --uid 1000 --ingroup worker worker
+COPY packages/python-worker-protocol/ packages/python-worker-protocol/
 COPY apps/ingestion-worker/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./packages/python-worker-protocol
 COPY apps/ingestion-worker/src/ src/
 USER worker
 EXPOSE 9091
@@ -88,8 +90,10 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 RUN addgroup --system --gid 1000 worker \
     && adduser --system --uid 1000 --ingroup worker worker
+COPY packages/python-worker-protocol/ packages/python-worker-protocol/
 COPY apps/url-fetcher-worker/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./packages/python-worker-protocol
 COPY apps/url-fetcher-worker/src/ src/
 USER worker
 EXPOSE 9092

--- a/apps/ingestion-worker/Dockerfile
+++ b/apps/ingestion-worker/Dockerfile
@@ -8,10 +8,12 @@ WORKDIR /app
 RUN addgroup --system --gid 1000 worker \
     && adduser --system --uid 1000 --ingroup worker worker
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY packages/python-worker-protocol/ packages/python-worker-protocol/
+COPY apps/ingestion-worker/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./packages/python-worker-protocol
 
-COPY src/ src/
+COPY apps/ingestion-worker/src/ src/
 
 USER worker
 EXPOSE 9091

--- a/apps/url-fetcher-worker/Dockerfile
+++ b/apps/url-fetcher-worker/Dockerfile
@@ -8,10 +8,12 @@ WORKDIR /app
 RUN addgroup --system --gid 1000 worker \
     && adduser --system --uid 1000 --ingroup worker worker
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY packages/python-worker-protocol/ packages/python-worker-protocol/
+COPY apps/url-fetcher-worker/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir ./packages/python-worker-protocol
 
-COPY src/ src/
+COPY apps/url-fetcher-worker/src/ src/
 
 USER worker
 EXPOSE 9092

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -134,8 +134,8 @@ services:
     # Pin to release tag during deployment; :latest is build-time default.
     image: cherrywiki/ingestion-worker:latest
     build:
-      context: ./apps/ingestion-worker
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: apps/ingestion-worker/Dockerfile
     restart: unless-stopped
     mem_limit: 2g
     cpus: 2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,8 +166,8 @@ services:
 
   ingestion-worker:
     build:
-      context: ./apps/ingestion-worker
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: apps/ingestion-worker/Dockerfile
     restart: unless-stopped
     mem_limit: 2g
     cpus: 2.0
@@ -205,8 +205,8 @@ services:
 
   url-fetcher-worker:
     build:
-      context: ./apps/url-fetcher-worker
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: apps/url-fetcher-worker/Dockerfile
     restart: unless-stopped
     mem_limit: 1g
     cpus: 0.5

--- a/openspec/changes/entropy-governance/design.md
+++ b/openspec/changes/entropy-governance/design.md
@@ -282,6 +282,18 @@ fi
 pip install ruff pytest pytest-asyncio
 ```
 
+CI `node-ci` also creates a Python environment for URL fetcher smoke/integration
+coverage (`URL_FETCHER_PYTHON=python`, including
+`tests/smoke/egress-smoke.test.ts`). #421 must install the shared package in
+that setup before Node tests so the URL fetcher runtime remains importable when
+#423 later migrates it:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install -r apps/url-fetcher-worker/requirements.txt
+python -m pip install -e packages/python-worker-protocol
+```
+
 CI Dockerfile syntax checks must use repository root context for the two Python
 worker app Dockerfiles:
 
@@ -361,6 +373,7 @@ Required future #421-#423 verification:
 
 ```bash
 packages/python-worker-protocol/.venv/bin/python -m pytest packages/python-worker-protocol/tests -v
+pnpm exec vitest run tests/smoke/egress-smoke.test.ts --config vitest.config.ts --passWithNoTests=false
 apps/ingestion-worker/.venv/bin/python -m pytest apps/ingestion-worker/tests -v
 apps/url-fetcher-worker/.venv/bin/python -m pytest apps/url-fetcher-worker/tests -v
 docker buildx build --check -f apps/ingestion-worker/Dockerfile .

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -744,8 +744,8 @@ Issue #421 fixture:
   - CI/local venv commands prove `cherry_worker_protocol` is importable for both worker venvs before #422/#423 runtime migrations.
 - Non-goals: migrating `apps/ingestion-worker/src/job_client.py`, migrating `apps/url-fetcher-worker/src/job_client.py`, changing parser/fetcher/SSRF/archive/storage behavior, changing job API/server behavior, or deferring first-time shared-package wiring to #422/#423.
 
-- [ ] 5.2 Issue #421: implement `packages/python-worker-protocol/` with lifecycle protocol tests and all first-time shared-package Docker/compose/CI/venv visibility wiring required before worker migrations.
-  - Verification: #421 required evidence commands pass, including shared-package tests, both worker venv import checks, both per-worker Dockerfile root-context syntax checks, both root worker target syntax checks, both compose config checks, and OpenSpec strict validation.
+- [x] 5.2 Issue #421: implement `packages/python-worker-protocol/` with lifecycle protocol tests and all first-time shared-package Docker/compose/CI/venv visibility wiring required before worker migrations.
+  - Verification: #421 required evidence commands passed: shared package pytest (19 tests), both worker venv editable installs and import checks, URL fetcher egress smoke Vitest, both per-worker Dockerfile root-context syntax checks, both root worker target syntax checks, both compose config checks, `ruff check`/`ruff format --check` for the new package, `git diff --check`, and `openspec validate entropy-governance --strict --no-interactive`.
 
 Issue #422 fixture:
 - Issue type: refactor / ingestion worker migration

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -745,7 +745,7 @@ Issue #421 fixture:
 - Non-goals: migrating `apps/ingestion-worker/src/job_client.py`, migrating `apps/url-fetcher-worker/src/job_client.py`, changing parser/fetcher/SSRF/archive/storage behavior, changing job API/server behavior, or deferring first-time shared-package wiring to #422/#423.
 
 - [x] 5.2 Issue #421: implement `packages/python-worker-protocol/` with lifecycle protocol tests and all first-time shared-package Docker/compose/CI/venv visibility wiring required before worker migrations.
-  - Verification: #421 required evidence commands passed: shared package pytest (19 tests), both worker venv editable installs and import checks, URL fetcher egress smoke Vitest, both per-worker Dockerfile root-context syntax checks, both root worker target syntax checks, both compose config checks, `ruff check`/`ruff format --check` for the new package, `git diff --check`, and `openspec validate entropy-governance --strict --no-interactive`.
+  - Verification: #421 required evidence commands passed: shared package pytest (24 tests), both worker venv editable installs and import checks, URL fetcher smoke Vitest, both per-worker Dockerfile root-context syntax checks, both root worker target syntax checks, both compose config checks, live-stack smoke shared-package wiring, Docker root-context hygiene check, `ruff check`/`ruff format --check` for the new package, `git diff --check`, and `openspec validate entropy-governance --strict --no-interactive`.
 
 Issue #422 fixture:
 - Issue type: refactor / ingestion worker migration

--- a/openspec/changes/entropy-governance/tasks.md
+++ b/openspec/changes/entropy-governance/tasks.md
@@ -717,16 +717,17 @@ Issue #421 fixture:
 - Blast radius: medium
 - Fixture level: expanded
 - Repair intensity: medium
-- Change surface: `packages/python-worker-protocol/**`, `docker-compose.yml`, `docker-compose.prod.yml`, both Python worker app Dockerfiles, root `Dockerfile` worker targets, `.github/workflows/ci.yml`, and focused shared-package/worker import visibility tests only.
+- Change surface: `packages/python-worker-protocol/**`, `docker-compose.yml`, `docker-compose.prod.yml`, both Python worker app Dockerfiles, root `Dockerfile` worker targets, `.github/workflows/ci.yml` including both `python-ci` and the `node-ci` URL fetcher Python setup, and focused shared-package/worker import visibility tests only.
 - Dependency/context: #420 selected `packages/python-worker-protocol/` and assigned all first-time shared-package visibility/build wiring to #421. #422/#423 may not start worker migrations until #421 wiring exists.
 - Must preserve: no ingestion or URL fetch parser/fetcher/storage/runtime migration, no API/DTO/schema change, no worker job lifecycle server contract change, no dependency lockfile churn outside the Python package metadata needed by #421, and no changes inside `external/*`.
-- Must add/change: create the shared package and lifecycle protocol tests; make both workers and both root worker Docker targets able to install the package from repository root context; switch compose build contexts needed by both Python workers to root context; update CI Dockerfile syntax-check commands to use root context for the two Python worker app Dockerfiles; add the shared-package install/test command to CI/local venv verification before worker migrations.
+- Must add/change: create the shared package and lifecycle protocol tests; make both workers and both root worker Docker targets able to install the package from repository root context; switch compose build contexts needed by both Python workers to root context; update CI Dockerfile syntax-check commands to use root context for the two Python worker app Dockerfiles; add the shared-package install/test command to CI/local venv verification before worker migrations; update `node-ci` URL fetcher Python dependency setup to install `-e packages/python-worker-protocol` before `URL_FETCHER_PYTHON=python` tests.
 - Required evidence:
   - `packages/python-worker-protocol/.venv/bin/python -m pytest packages/python-worker-protocol/tests -v`
   - `apps/ingestion-worker/.venv/bin/pip install -e packages/python-worker-protocol`
   - `apps/url-fetcher-worker/.venv/bin/pip install -e packages/python-worker-protocol`
   - `apps/ingestion-worker/.venv/bin/python -c "import cherry_worker_protocol"`
   - `apps/url-fetcher-worker/.venv/bin/python -c "import cherry_worker_protocol"`
+  - `pnpm exec vitest run tests/smoke/egress-smoke.test.ts --config vitest.config.ts --passWithNoTests=false`
   - `docker buildx build --check -f apps/ingestion-worker/Dockerfile .`
   - `docker buildx build --check -f apps/url-fetcher-worker/Dockerfile .`
   - `docker buildx build --check -f Dockerfile --target ingestion-worker .`
@@ -739,6 +740,7 @@ Issue #421 fixture:
   - Both per-worker app Dockerfiles copy/install `packages/python-worker-protocol/` before copying worker `src/`, without importing parser/fetcher behavior.
   - Root `Dockerfile` `ingestion-worker` and `url-fetcher-worker` targets install `packages/python-worker-protocol/`.
   - CI Dockerfile syntax checks for `apps/ingestion-worker/Dockerfile` and `apps/url-fetcher-worker/Dockerfile` use root context, while root target checks remain present.
+  - CI `node-ci` URL fetcher Python setup installs `packages/python-worker-protocol` before Node tests that use `URL_FETCHER_PYTHON=python`.
   - CI/local venv commands prove `cherry_worker_protocol` is importable for both worker venvs before #422/#423 runtime migrations.
 - Non-goals: migrating `apps/ingestion-worker/src/job_client.py`, migrating `apps/url-fetcher-worker/src/job_client.py`, changing parser/fetcher/SSRF/archive/storage behavior, changing job API/server behavior, or deferring first-time shared-package wiring to #422/#423.
 

--- a/packages/python-worker-protocol/pyproject.toml
+++ b/packages/python-worker-protocol/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cherry-worker-protocol"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = [
+  "requests>=2.32.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8.0.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/packages/python-worker-protocol/src/cherry_worker_protocol/__init__.py
+++ b/packages/python-worker-protocol/src/cherry_worker_protocol/__init__.py
@@ -1,0 +1,17 @@
+from .job_lifecycle import (
+    InternalApiClient,
+    WorkerProtocolConfig,
+    generate_worker_id,
+    poll_jobs,
+    run_once,
+    start_heartbeat_thread,
+)
+
+__all__ = [
+    "InternalApiClient",
+    "WorkerProtocolConfig",
+    "generate_worker_id",
+    "poll_jobs",
+    "run_once",
+    "start_heartbeat_thread",
+]

--- a/packages/python-worker-protocol/src/cherry_worker_protocol/job_lifecycle.py
+++ b/packages/python-worker-protocol/src/cherry_worker_protocol/job_lifecycle.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import threading
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WorkerProtocolConfig:
+    job_type: str
+    worker_type: str
+    worker_id_prefix: str
+    failure_log_message: str
+    worker_error_type: type[BaseException] | tuple[type[BaseException], ...]
+    build_error_json: Callable[[BaseException], dict[str, Any]]
+
+
+class InternalApiClient:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_key: str | None = None,
+        session: requests.Session | None = None,
+        timeout_seconds: int = 10,
+    ) -> None:
+        self.base_url = _normalize_api_base_url(base_url)
+        self.api_key = api_key
+        self.session = session or requests.Session()
+        self.timeout_seconds = timeout_seconds
+
+    @classmethod
+    def from_env(
+        cls, *, default_base_url: str = "http://cherry-api:8080/api"
+    ) -> "InternalApiClient":
+        base_url = (
+            os.environ.get("CHERRY_API_URL")
+            or os.environ.get("API_BASE_URL")
+            or default_base_url
+        )
+        return cls(base_url, api_key=os.environ.get("WORKER_API_KEY"))
+
+    def fetch_pending_job(self, *, job_type: str) -> dict[str, Any] | None:
+        response = self.session.get(
+            f"{self.base_url}/internal/jobs/pending",
+            params={"type": job_type, "limit": 1},
+            headers=self._headers(),
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        return _parse_pending_job(_unwrap_response(response.json()))
+
+    def report_progress(
+        self, job_id: str, worker_id: str, percent: int, stage: str
+    ) -> None:
+        response = self.session.patch(
+            f"{self.base_url}/internal/jobs/{job_id}/progress",
+            json={"worker_id": worker_id, "percent": percent, "stage": stage},
+            headers=self._headers(),
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+
+    def complete_job(
+        self, job_id: str, worker_id: str, result_json: dict[str, Any]
+    ) -> None:
+        response = self.session.patch(
+            f"{self.base_url}/internal/jobs/{job_id}/complete",
+            json={"worker_id": worker_id, "result_json": result_json},
+            headers=self._headers(),
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+
+    def fail_job(
+        self,
+        job_id: str,
+        worker_id: str,
+        error_json: dict[str, Any],
+        *,
+        retryable: bool,
+    ) -> None:
+        response = self.session.patch(
+            f"{self.base_url}/internal/jobs/{job_id}/fail",
+            json={
+                "worker_id": worker_id,
+                "error_json": error_json,
+                "retryable": retryable,
+            },
+            headers=self._headers(),
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+
+    def heartbeat(
+        self, worker_id: str, active_jobs: list[str], *, worker_type: str
+    ) -> dict[str, Any]:
+        response = self.session.post(
+            f"{self.base_url}/internal/workers/heartbeat",
+            json={
+                "worker_id": worker_id,
+                "active_jobs": active_jobs,
+                "system_info": {
+                    "worker_type": worker_type,
+                    "hostname": platform.node(),
+                    "python_version": platform.python_version(),
+                    "active_job_count": len(active_jobs),
+                },
+            },
+            headers=self._headers(),
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        payload = _unwrap_response(response.json())
+        return payload if isinstance(payload, dict) else {}
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"accept": "application/json"}
+        if self.api_key:
+            headers["x-worker-key"] = self.api_key
+        return headers
+
+
+def generate_worker_id(config: WorkerProtocolConfig) -> str:
+    return os.environ.get("WORKER_ID") or f"{config.worker_id_prefix}-{uuid.uuid4()}"
+
+
+def run_once(
+    *,
+    config: WorkerProtocolConfig,
+    api_client: InternalApiClient,
+    handler: Any,
+    worker_id: str,
+    active_jobs: Any | None = None,
+) -> bool:
+    job = api_client.fetch_pending_job(job_type=config.job_type)
+    if job is None:
+        return False
+
+    job_id = _job_id(job)
+    if active_jobs is not None:
+        active_jobs.add(job_id)
+
+    def progress(percent: int, stage: str) -> None:
+        api_client.report_progress(job_id, worker_id, percent, stage)
+
+    try:
+        result = handler.handle(job, progress)
+    except Exception as exc:
+        retryable = exc.retryable if isinstance(exc, config.worker_error_type) else True
+        logger.exception(config.failure_log_message, extra={"job_id": job_id})
+        api_client.fail_job(
+            job_id,
+            worker_id,
+            config.build_error_json(exc),
+            retryable=retryable,
+        )
+    else:
+        api_client.complete_job(job_id, worker_id, result)
+    finally:
+        if active_jobs is not None:
+            active_jobs.discard(job_id)
+
+    return True
+
+
+def poll_jobs(
+    *,
+    config: WorkerProtocolConfig,
+    api_client: InternalApiClient,
+    handler: Any,
+    worker_id: str,
+    stop_event: threading.Event,
+    poll_interval: float = 5,
+    active_jobs: Any | None = None,
+) -> None:
+    while not stop_event.is_set():
+        try:
+            handled = run_once(
+                config=config,
+                api_client=api_client,
+                handler=handler,
+                worker_id=worker_id,
+                active_jobs=active_jobs,
+            )
+        except (requests.RequestException, OSError) as exc:
+            logger.warning("job polling failed: %s", exc)
+            handled = False
+        except Exception:
+            logger.exception("unexpected polling error")
+            handled = False
+
+        if not handled:
+            stop_event.wait(poll_interval)
+
+
+def start_heartbeat_thread(
+    *,
+    config: WorkerProtocolConfig,
+    api_client: InternalApiClient,
+    worker_id: str,
+    active_jobs_getter: Callable[[], list[str]],
+    stop_event: threading.Event,
+    interval_seconds: float = 30,
+) -> threading.Thread:
+    def loop() -> None:
+        while not stop_event.is_set():
+            try:
+                api_client.heartbeat(
+                    worker_id,
+                    active_jobs_getter(),
+                    worker_type=config.worker_type,
+                )
+            except Exception as exc:
+                logger.warning("worker heartbeat failed: %s", exc)
+            stop_event.wait(interval_seconds)
+
+    thread = threading.Thread(target=loop, name="worker-heartbeat", daemon=True)
+    thread.start()
+    return thread
+
+
+def _normalize_api_base_url(base_url: str) -> str:
+    trimmed = base_url.rstrip("/")
+    parsed = urlsplit(trimmed)
+    if parsed.path in {"", "/"}:
+        parsed = parsed._replace(path="/api")
+        return urlunsplit(parsed).rstrip("/")
+    return trimmed
+
+
+def _unwrap_response(payload: Any) -> Any:
+    if isinstance(payload, dict) and "data" in payload and "meta" in payload:
+        return payload["data"]
+    return payload
+
+
+def _parse_pending_job(payload: Any) -> dict[str, Any] | None:
+    if isinstance(payload, list):
+        first = payload[0] if payload else None
+        return first if isinstance(first, dict) else None
+    if isinstance(payload, dict):
+        job = payload.get("job")
+        if isinstance(job, dict):
+            return job
+        jobs = payload.get("jobs")
+        if isinstance(jobs, list):
+            first = jobs[0] if jobs else None
+            return first if isinstance(first, dict) else None
+        if "id" in payload or "job_id" in payload:
+            return payload
+    return None
+
+
+def _job_id(job: dict[str, Any]) -> str:
+    raw_job_id = job.get("job_id") or job.get("id")
+    if raw_job_id is None:
+        raise ValueError("Pending job is missing job_id")
+    return str(raw_job_id)

--- a/packages/python-worker-protocol/tests/test_job_lifecycle.py
+++ b/packages/python-worker-protocol/tests/test_job_lifecycle.py
@@ -237,6 +237,48 @@ def test_run_once_cleans_up_active_job_when_terminal_report_fails() -> None:
     assert active_jobs == set()
 
 
+def test_run_once_reports_progress_failure_and_cleans_up_active_job() -> None:
+    api = FakeApi([{"job_id": "job-1"}], progress_error=RuntimeError("api down"))
+    active_jobs: set[str] = set()
+
+    handled = run_once(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        handler=FakeHandler({"ok": True}),
+        worker_id="worker-1",
+        active_jobs=active_jobs,
+    )
+
+    assert handled is True
+    assert api.completed == []
+    assert api.failed == [
+        (
+            "job-1",
+            "worker-1",
+            {"error_type": "RuntimeError", "error_message": "api down"},
+            True,
+        )
+    ]
+    assert active_jobs == set()
+
+
+def test_run_once_propagates_failed_terminal_report_errors() -> None:
+    api = FakeApi([{"job_id": "job-1"}], fail_error=RuntimeError("api down"))
+    active_jobs: set[str] = set()
+
+    with pytest.raises(RuntimeError, match="api down"):
+        run_once(
+            config=CONFIG,
+            api_client=api,  # type: ignore[arg-type]
+            handler=FakeHandler(WorkerError("blocked", retryable=False)),
+            worker_id="worker-1",
+            active_jobs=active_jobs,
+        )
+
+    assert api.completed == []
+    assert active_jobs == set()
+
+
 def test_poll_jobs_waits_after_no_job_and_stops() -> None:
     api = FakeApi([])
     stop_event = StopAfterWaitEvent()
@@ -269,6 +311,51 @@ def test_poll_jobs_recovers_from_request_errors() -> None:
     assert stop_event.waits == [0.5]
 
 
+def test_poll_jobs_recovers_from_terminal_report_errors() -> None:
+    api = FakeApi(
+        [{"job_id": "job-1"}], complete_error=requests.RequestException("api down")
+    )
+    stop_event = StopAfterWaitEvent()
+    active_jobs: set[str] = set()
+
+    poll_jobs(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        handler=FakeHandler({"ok": True}),
+        worker_id="worker-1",
+        stop_event=stop_event,  # type: ignore[arg-type]
+        poll_interval=0.5,
+        active_jobs=active_jobs,
+    )
+
+    assert stop_event.waits == [0.5]
+    assert active_jobs == set()
+
+
+def test_poll_jobs_recovers_when_progress_failure_report_fails() -> None:
+    api = FakeApi(
+        [{"job_id": "job-1"}],
+        progress_error=RuntimeError("progress api down"),
+        fail_error=requests.RequestException("fail api down"),
+    )
+    stop_event = StopAfterWaitEvent()
+    active_jobs: set[str] = set()
+
+    poll_jobs(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        handler=FakeHandler({"ok": True}),
+        worker_id="worker-1",
+        stop_event=stop_event,  # type: ignore[arg-type]
+        poll_interval=0.5,
+        active_jobs=active_jobs,
+    )
+
+    assert stop_event.waits == [0.5]
+    assert api.completed == []
+    assert active_jobs == set()
+
+
 def test_start_heartbeat_thread_sends_configured_worker_type() -> None:
     api = FakeHeartbeatApi()
     stop_event = threading.Event()
@@ -289,6 +376,27 @@ def test_start_heartbeat_thread_sends_configured_worker_type() -> None:
     assert api.heartbeats[0] == ("worker-1", ["job-1"], "example")
 
 
+def test_start_heartbeat_thread_swallows_api_failures() -> None:
+    api = FakeHeartbeatApi(failures_before_success=1)
+    stop_event = threading.Event()
+
+    thread = start_heartbeat_thread(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        worker_id="worker-1",
+        active_jobs_getter=lambda: ["job-1"],
+        stop_event=stop_event,
+        interval_seconds=0.01,
+    )
+
+    wait_for(lambda: bool(api.heartbeats))
+    stop_event.set()
+    thread.join(timeout=1)
+
+    assert api.calls >= 2
+    assert api.heartbeats == [("worker-1", ["job-1"], "example")]
+
+
 class FakeHandler:
     def __init__(self, result_or_error: dict[str, Any] | BaseException) -> None:
         self.result_or_error = result_or_error
@@ -306,11 +414,15 @@ class FakeApi:
         jobs: list[dict[str, Any]],
         *,
         fetch_error: BaseException | None = None,
+        progress_error: BaseException | None = None,
         complete_error: BaseException | None = None,
+        fail_error: BaseException | None = None,
     ) -> None:
         self.jobs = jobs
         self.fetch_error = fetch_error
+        self.progress_error = progress_error
         self.complete_error = complete_error
+        self.fail_error = fail_error
         self.fetched_job_types: list[str] = []
         self.progress: list[tuple[str, str, int, str]] = []
         self.completed: list[tuple[str, str, dict[str, Any]]] = []
@@ -325,6 +437,8 @@ class FakeApi:
     def report_progress(
         self, job_id: str, worker_id: str, percent: int, stage: str
     ) -> None:
+        if self.progress_error is not None:
+            raise self.progress_error
         self.progress.append((job_id, worker_id, percent, stage))
 
     def complete_job(
@@ -342,16 +456,23 @@ class FakeApi:
         *,
         retryable: bool,
     ) -> None:
+        if self.fail_error is not None:
+            raise self.fail_error
         self.failed.append((job_id, worker_id, error_json, retryable))
 
 
 class FakeHeartbeatApi:
-    def __init__(self) -> None:
+    def __init__(self, *, failures_before_success: int = 0) -> None:
+        self.failures_before_success = failures_before_success
+        self.calls = 0
         self.heartbeats: list[tuple[str, list[str], str]] = []
 
     def heartbeat(
         self, worker_id: str, active_jobs: list[str], *, worker_type: str
     ) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self.failures_before_success:
+            raise RuntimeError("api down")
         self.heartbeats.append((worker_id, active_jobs, worker_type))
         return {"ok": True}
 

--- a/packages/python-worker-protocol/tests/test_job_lifecycle.py
+++ b/packages/python-worker-protocol/tests/test_job_lifecycle.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+import requests
+
+from cherry_worker_protocol import (
+    InternalApiClient,
+    WorkerProtocolConfig,
+    generate_worker_id,
+    poll_jobs,
+    run_once,
+    start_heartbeat_thread,
+)
+from cherry_worker_protocol.job_lifecycle import (
+    _normalize_api_base_url,
+    _parse_pending_job,
+)
+
+
+class WorkerError(Exception):
+    def __init__(self, message: str, *, retryable: bool) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+def build_error_json(exc: BaseException) -> dict[str, Any]:
+    return {"error_type": type(exc).__name__, "error_message": str(exc)}
+
+
+CONFIG = WorkerProtocolConfig(
+    job_type="example",
+    worker_type="example",
+    worker_id_prefix="example-worker",
+    failure_log_message="example job failed",
+    worker_error_type=WorkerError,
+    build_error_json=build_error_json,
+)
+
+
+def test_api_base_url_defaults_to_api_prefix() -> None:
+    assert (
+        _normalize_api_base_url("http://cherry-api:8080")
+        == "http://cherry-api:8080/api"
+    )
+    assert (
+        _normalize_api_base_url("http://cherry-api:8080/")
+        == "http://cherry-api:8080/api"
+    )
+    assert (
+        _normalize_api_base_url("http://cherry-api:8080/api/")
+        == "http://cherry-api:8080/api"
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ([{"job_id": "job-1"}], {"job_id": "job-1"}),
+        ({"job": {"id": "job-2"}}, {"id": "job-2"}),
+        ({"jobs": [{"job_id": "job-3"}]}, {"job_id": "job-3"}),
+        ({"id": "job-4"}, {"id": "job-4"}),
+        ([], None),
+        ({"jobs": []}, None),
+        ({"data": "not-a-job"}, None),
+    ],
+)
+def test_parse_pending_job_shapes(
+    payload: Any, expected: dict[str, Any] | None
+) -> None:
+    assert _parse_pending_job(payload) == expected
+
+
+def test_internal_api_client_uses_current_job_protocol_payloads() -> None:
+    session = FakeSession(
+        [
+            FakeResponse({"data": [{"job_id": "job-1"}], "meta": {}}),
+            FakeResponse({"ok": True}),
+            FakeResponse({"ok": True}),
+            FakeResponse({"ok": True}),
+            FakeResponse({"data": {"accepted": True}, "meta": {}}),
+        ]
+    )
+    client = InternalApiClient(
+        "http://cherry-api:8080",
+        api_key="worker-key",
+        session=session,  # type: ignore[arg-type]
+        timeout_seconds=7,
+    )
+
+    assert client.fetch_pending_job(job_type="example") == {"job_id": "job-1"}
+    client.report_progress("job-1", "worker-1", 25, "parsing")
+    client.complete_job("job-1", "worker-1", {"ok": True})
+    client.fail_job(
+        "job-2",
+        "worker-1",
+        {"error_type": "worker_error"},
+        retryable=False,
+    )
+    assert client.heartbeat("worker-1", ["job-1", "job-2"], worker_type="example") == {
+        "accepted": True
+    }
+
+    assert session.calls[0] == (
+        "GET",
+        "http://cherry-api:8080/api/internal/jobs/pending",
+        {
+            "headers": {"accept": "application/json", "x-worker-key": "worker-key"},
+            "params": {"type": "example", "limit": 1},
+            "timeout": 7,
+        },
+    )
+    assert session.calls[1][2]["json"] == {
+        "worker_id": "worker-1",
+        "percent": 25,
+        "stage": "parsing",
+    }
+    assert session.calls[2][2]["json"] == {
+        "worker_id": "worker-1",
+        "result_json": {"ok": True},
+    }
+    assert session.calls[3][2]["json"] == {
+        "worker_id": "worker-1",
+        "error_json": {"error_type": "worker_error"},
+        "retryable": False,
+    }
+    assert session.calls[4][2]["json"]["system_info"]["worker_type"] == "example"
+    assert session.calls[4][2]["json"]["system_info"]["active_job_count"] == 2
+
+
+def test_generate_worker_id_uses_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKER_ID", "explicit-worker")
+    assert generate_worker_id(CONFIG) == "explicit-worker"
+
+
+def test_generate_worker_id_uses_configured_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("WORKER_ID", raising=False)
+    assert generate_worker_id(CONFIG).startswith("example-worker-")
+
+
+def test_run_once_returns_false_when_no_job() -> None:
+    api = FakeApi([])
+    assert (
+        run_once(
+            config=CONFIG,
+            api_client=api,  # type: ignore[arg-type]
+            handler=FakeHandler({"ok": True}),
+            worker_id="worker-1",
+            active_jobs=set(),
+        )
+        is False
+    )
+    assert api.completed == []
+
+
+def test_run_once_handles_job_progress_completion_and_active_cleanup() -> None:
+    api = FakeApi([{"job_id": "job-1"}])
+    active_jobs: set[str] = set()
+
+    handled = run_once(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        handler=FakeHandler({"parsed": True}),
+        worker_id="worker-1",
+        active_jobs=active_jobs,
+    )
+
+    assert handled is True
+    assert api.fetched_job_types == ["example"]
+    assert api.progress == [("job-1", "worker-1", 50, "handling")]
+    assert api.completed == [("job-1", "worker-1", {"parsed": True})]
+    assert api.failed == []
+    assert active_jobs == set()
+
+
+def test_run_once_reports_worker_errors_with_configured_retryability() -> None:
+    api = FakeApi([{"id": "job-1"}])
+
+    handled = run_once(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        handler=FakeHandler(WorkerError("blocked", retryable=False)),
+        worker_id="worker-1",
+        active_jobs=set(),
+    )
+
+    assert handled is True
+    assert api.completed == []
+    assert api.failed == [
+        (
+            "job-1",
+            "worker-1",
+            {"error_type": "WorkerError", "error_message": "blocked"},
+            False,
+        )
+    ]
+
+
+def test_run_once_reports_unexpected_errors_as_retryable() -> None:
+    api = FakeApi([{"id": "job-1"}])
+
+    handled = run_once(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        handler=FakeHandler(RuntimeError("temporary failure")),
+        worker_id="worker-1",
+    )
+
+    assert handled is True
+    assert api.failed == [
+        (
+            "job-1",
+            "worker-1",
+            {"error_type": "RuntimeError", "error_message": "temporary failure"},
+            True,
+        )
+    ]
+
+
+def test_run_once_cleans_up_active_job_when_terminal_report_fails() -> None:
+    api = FakeApi([{"job_id": "job-1"}], complete_error=RuntimeError("api down"))
+    active_jobs: set[str] = set()
+
+    with pytest.raises(RuntimeError, match="api down"):
+        run_once(
+            config=CONFIG,
+            api_client=api,  # type: ignore[arg-type]
+            handler=FakeHandler({"ok": True}),
+            worker_id="worker-1",
+            active_jobs=active_jobs,
+        )
+
+    assert active_jobs == set()
+
+
+def test_poll_jobs_waits_after_no_job_and_stops() -> None:
+    api = FakeApi([])
+    stop_event = StopAfterWaitEvent()
+
+    poll_jobs(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        handler=FakeHandler({"ok": True}),
+        worker_id="worker-1",
+        stop_event=stop_event,  # type: ignore[arg-type]
+        poll_interval=0.25,
+    )
+
+    assert stop_event.waits == [0.25]
+
+
+def test_poll_jobs_recovers_from_request_errors() -> None:
+    api = FakeApi([], fetch_error=requests.RequestException("network"))
+    stop_event = StopAfterWaitEvent()
+
+    poll_jobs(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        handler=FakeHandler({"ok": True}),
+        worker_id="worker-1",
+        stop_event=stop_event,  # type: ignore[arg-type]
+        poll_interval=0.5,
+    )
+
+    assert stop_event.waits == [0.5]
+
+
+def test_start_heartbeat_thread_sends_configured_worker_type() -> None:
+    api = FakeHeartbeatApi()
+    stop_event = threading.Event()
+
+    thread = start_heartbeat_thread(
+        config=CONFIG,
+        api_client=api,  # type: ignore[arg-type]
+        worker_id="worker-1",
+        active_jobs_getter=lambda: ["job-1"],
+        stop_event=stop_event,
+        interval_seconds=0.01,
+    )
+
+    wait_for(lambda: bool(api.heartbeats))
+    stop_event.set()
+    thread.join(timeout=1)
+
+    assert api.heartbeats[0] == ("worker-1", ["job-1"], "example")
+
+
+class FakeHandler:
+    def __init__(self, result_or_error: dict[str, Any] | BaseException) -> None:
+        self.result_or_error = result_or_error
+
+    def handle(self, job: dict[str, Any], progress: Any) -> dict[str, Any]:
+        progress(50, "handling")
+        if isinstance(self.result_or_error, BaseException):
+            raise self.result_or_error
+        return self.result_or_error
+
+
+class FakeApi:
+    def __init__(
+        self,
+        jobs: list[dict[str, Any]],
+        *,
+        fetch_error: BaseException | None = None,
+        complete_error: BaseException | None = None,
+    ) -> None:
+        self.jobs = jobs
+        self.fetch_error = fetch_error
+        self.complete_error = complete_error
+        self.fetched_job_types: list[str] = []
+        self.progress: list[tuple[str, str, int, str]] = []
+        self.completed: list[tuple[str, str, dict[str, Any]]] = []
+        self.failed: list[tuple[str, str, dict[str, Any], bool]] = []
+
+    def fetch_pending_job(self, *, job_type: str) -> dict[str, Any] | None:
+        self.fetched_job_types.append(job_type)
+        if self.fetch_error is not None:
+            raise self.fetch_error
+        return self.jobs.pop(0) if self.jobs else None
+
+    def report_progress(
+        self, job_id: str, worker_id: str, percent: int, stage: str
+    ) -> None:
+        self.progress.append((job_id, worker_id, percent, stage))
+
+    def complete_job(
+        self, job_id: str, worker_id: str, result_json: dict[str, Any]
+    ) -> None:
+        if self.complete_error is not None:
+            raise self.complete_error
+        self.completed.append((job_id, worker_id, result_json))
+
+    def fail_job(
+        self,
+        job_id: str,
+        worker_id: str,
+        error_json: dict[str, Any],
+        *,
+        retryable: bool,
+    ) -> None:
+        self.failed.append((job_id, worker_id, error_json, retryable))
+
+
+class FakeHeartbeatApi:
+    def __init__(self) -> None:
+        self.heartbeats: list[tuple[str, list[str], str]] = []
+
+    def heartbeat(
+        self, worker_id: str, active_jobs: list[str], *, worker_type: str
+    ) -> dict[str, Any]:
+        self.heartbeats.append((worker_id, active_jobs, worker_type))
+        return {"ok": True}
+
+
+class FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def get(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.calls.append(("GET", url, kwargs))
+        return self.responses.pop(0)
+
+    def patch(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.calls.append(("PATCH", url, kwargs))
+        return self.responses.pop(0)
+
+    def post(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.calls.append(("POST", url, kwargs))
+        return self.responses.pop(0)
+
+
+class StopAfterWaitEvent:
+    def __init__(self) -> None:
+        self.stopped = False
+        self.waits: list[float] = []
+
+    def is_set(self) -> bool:
+        return self.stopped
+
+    def wait(self, timeout: float) -> bool:
+        self.waits.append(timeout)
+        self.stopped = True
+        return True
+
+
+def wait_for(predicate: Any) -> None:
+    for _ in range(100):
+        if predicate():
+            return
+        threading.Event().wait(0.01)
+    raise AssertionError("condition was not met")

--- a/progress.md
+++ b/progress.md
@@ -157,7 +157,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #421 Python worker protocol shared package foundation complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417-#419 Web Chat 拆分完成；#420 选定 `packages/python-worker-protocol/`；#421 已新增 `cherry_worker_protocol` lifecycle 包与测试，并完成 Docker/compose/CI/worker venv shared-package visibility wiring；#422 仅迁移 ingestion，#423 迁移 url-fetcher 并做最终 deployability 验证 |
+| entropy-governance | #421 Python worker protocol shared package foundation complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417-#419 Web Chat 拆分完成；#420 选定 `packages/python-worker-protocol/`；#421 已新增 `cherry_worker_protocol` lifecycle 包与测试，并完成 Docker/compose/CI/worker venv shared-package visibility wiring；PR-437 fix 补 live-stack smoke shared package 安装、Docker root-context hygiene、protocol failure-boundary tests；#422 仅迁移 ingestion，#423 迁移 url-fetcher 并做最终 deployability 验证 |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |

--- a/progress.md
+++ b/progress.md
@@ -1,7 +1,7 @@
 # CherryWiki 项目进度
 
 > 本文件是 session 间的状态接力棒。每次重大变更后更新。上限 200 行。
-> 最后更新: 2026-05-31
+> 最后更新: 2026-06-01
 
 ## 1. 系统架构一句话
 
@@ -157,7 +157,7 @@
 
 | Change | 状态 | 说明 |
 |---|---|---|
-| entropy-governance | #420 Python worker protocol decision complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417-#419 Web Chat 拆分完成；#420 决定后续用 `packages/python-worker-protocol/` 共享 Python worker lifecycle 协议，并明确 #421 先拥有全部 Docker/compose/CI/venv shared-package wiring，#422 仅迁移 ingestion，#423 迁移 url-fetcher 并做最终 deployability 验证；OpenSpec strict validate、diff check、compose config 双环境通过 |
+| entropy-governance | #421 Python worker protocol shared package foundation complete, issues #408-#424 | `.entropy-baseline/latest.json` 已记录实际项目代码熵基线并排除 `external/*`；#410/#411/#412 API error helper 迁移完成；#413-#416 API Chat backend 已拆为 bounded collaborators；#417-#419 Web Chat 拆分完成；#420 选定 `packages/python-worker-protocol/`；#421 已新增 `cherry_worker_protocol` lifecycle 包与测试，并完成 Docker/compose/CI/worker venv shared-package visibility wiring；#422 仅迁移 ingestion，#423 迁移 url-fetcher 并做最终 deployability 验证 |
 | graph-explorer-visual-overhaul | panel-theme-alignment complete, issues #400/#401/#403 | 新增 `useGraphTheme` 读取 theme CSS vars 并监听 `data-theme`；GraphCanvas 背景/边框/标签主题化；节点渲染增加默认/选中 glow、选中双环、大图默认 glow 降级；Graph Explorer 面板、Community 选中态和 Legend 对齐 theme token；`getNodeColor`/`getLinkColor` 已提取为纯函数并补充测试 |
 | wiki-version-diff | API+UI complete, pending browser verification | `GET /wiki/pages/:pageId/diff` + version history compare modal；`npm run build`、Wiki API tests 通过 |
 | fix-session-delete-cascade | complete, issue #381 | Chat session 关联 retrieval traces/model usage logs/feedback items 删除级联修复 |
@@ -169,7 +169,7 @@
 ## 9. 下一步
 
 0. **Codex 工作流与 AGENTS 规则可用** — 已安装 `agentic-issue-delivery` pack、`repo-entropy-audit`、`control-plane-auditor`，并补强仓库级协作规则
-1. **熵治理实现批次** — 继续 #421/#422/#423 Python worker protocol 共享包实现与双 worker 迁移，按 #408 依赖图推进
+1. **熵治理实现批次** — 继续 #422/#423 Python worker protocol 双 worker 迁移，按 #408 依赖图推进
 2. **继续 P0 测试** — 可立即测的 ~20 项（权限、多格式上传、SSE 事件、Model 管理）
 3. **运行 Graphify** — 容器内 Claude Code 可用，运行后解锁 Graph/Wiki/Index/Citation 相关 P0 测试
 


### PR DESCRIPTION
## Summary
- Added `packages/python-worker-protocol/` with the shared `cherry_worker_protocol` lifecycle protocol implementation and tests.
- Wired the shared package into both Python worker Dockerfiles, root worker Docker targets, compose build contexts, `python-ci`, `node-ci`, and live-stack smoke.
- Kept ingestion/url-fetcher runtime `job_client.py` migration out of scope for #422/#423.

## Scope Boundaries
- No ingestion-worker or url-fetcher-worker runtime migration in this PR.
- No parser/fetcher/SSRF/archive/storage/API/schema behavior changes.
- No changes inside `external/*`.

## Verification
- `packages/python-worker-protocol/.venv/bin/python -m pytest packages/python-worker-protocol/tests -v` (24 passed)
- `packages/python-worker-protocol/.venv/bin/ruff check packages/python-worker-protocol/src packages/python-worker-protocol/tests`
- `packages/python-worker-protocol/.venv/bin/ruff format --check packages/python-worker-protocol/src packages/python-worker-protocol/tests`
- `apps/ingestion-worker/.venv/bin/pip install -e packages/python-worker-protocol`
- `apps/ingestion-worker/.venv/bin/python -c "import cherry_worker_protocol"`
- `apps/url-fetcher-worker/.venv/bin/pip install -e packages/python-worker-protocol`
- `apps/url-fetcher-worker/.venv/bin/python -c "import cherry_worker_protocol"`
- `URL_FETCHER_PYTHON=apps/url-fetcher-worker/.venv/bin/python pnpm exec vitest run tests/smoke/ --config vitest.config.ts --passWithNoTests=false` (3 passed)
- `docker buildx build --check -f apps/ingestion-worker/Dockerfile .`
- `docker buildx build --check -f apps/url-fetcher-worker/Dockerfile .`
- `docker buildx build --check -f Dockerfile --target ingestion-worker .`
- `docker buildx build --check -f Dockerfile --target url-fetcher-worker .`
- `docker compose config --quiet`
- `docker compose -f docker-compose.prod.yml config --quiet`
- `openspec validate entropy-governance --strict --no-interactive`
- `git diff --check`

## Agent Review

- Reviewer agents used: Round 1 Cross Review, Follow-up Cross Review, Phase 7 Final Review
- Reviewed head SHA: `c1784b213f3599bda5b405bb1069b614c4c0d176`
- Review evidence: [Current Cross Review](https://github.com/DankerMu/CherryWiki/pull/437#issuecomment-4590296692) | [Current Final Review](https://github.com/DankerMu/CherryWiki/pull/437#issuecomment-4590296909)
- OpenSpec change: `entropy-governance`; fixture level: expanded; selected risk packs: Config / project setup, Release / packaging / dependency compatibility, Documentation / migration notes
- Key findings addressed: live-stack smoke shared-package install/path trigger; Docker root-context hygiene; protocol failure-boundary tests; stale OpenSpec test-count evidence refreshed; latest comprehensive and final reviews clean

Closes #421
